### PR TITLE
feat: add MiniMax MCP support as alternative to Codex MCP

### DIFF
--- a/docs/MINIMAX_MCP_GUIDE.md
+++ b/docs/MINIMAX_MCP_GUIDE.md
@@ -1,0 +1,178 @@
+# MiniMax MCP 集成指南
+
+本文档说明如何在 Auto-claude-code-research-in-sleep 项目中使用 MiniMax API 替代 OpenAI Codex MCP 进行研究审查。
+
+## 背景
+
+OpenAI Codex CLI 使用 **Responses API** (`/v1/responses`)，而 MiniMax 等第三方 API 提供商只支持 **Chat Completions API** (`/v1/chat/completions`)。因此，Codex MCP 无法直接与 MiniMax 配合使用。
+
+**解决方案**：创建自定义 MCP 服务器直接调用 MiniMax Chat Completions API。
+
+相关讨论：[GitHub #7782](https://github.com/openai/codex/discussions/7782)
+
+## 两种 Review Loop 版本
+
+| 版本 | Skill 名称 | 触发词 | 外部审查服务 |
+|------|-----------|--------|-------------|
+| 原版 | `auto-review-loop` | "auto review loop" | Codex MCP (OpenAI) |
+| MiniMax版 | `auto-review-loop-minimax` | "auto review loop minimax" | MiniMax API |
+
+### 如何选择
+
+- **使用原版**：如果你有 OpenAI API Key，且预算充足
+- **使用 MiniMax版**：如果你想使用 MiniMax API（更便宜，或已有 MiniMax 账号）
+
+## 安装步骤
+
+### 1. 创建 MCP 服务器目录
+
+```bash
+mkdir -p ~/.claude/mcp-servers/minimax-chat
+```
+
+### 2. 复制 MCP 服务器代码
+
+将 `mcp-servers/minimax-chat/server.py` 复制到：
+```
+~/.claude/mcp-servers/minimax-chat/server.py
+```
+
+### 3. 安装 Python 依赖
+
+```bash
+pip3 install httpx
+```
+
+### 4. 配置 Claude Code settings.json
+
+在 `~/.claude/settings.json` 中添加：
+
+```json
+{
+  "env": {
+    "MINIMAX_API_KEY": "你的MiniMax API Key"
+  },
+  "mcpServers": {
+    "minimax-chat": {
+      "command": "/usr/bin/python3",
+      "args": ["/Users/你的用户名/.claude/mcp-servers/minimax-chat/server.py"],
+      "env": {
+        "MINIMAX_API_KEY": "你的MiniMax API Key",
+        "MINIMAX_BASE_URL": "https://api.minimax.chat/v1",
+        "MINIMAX_MODEL": "MiniMax-M2.5"
+      }
+    }
+  }
+}
+```
+
+### 5. 重启 Claude Code
+
+重启后，MCP 服务器将自动加载。
+
+## 使用方法
+
+### 方法一：通过 MCP 工具（推荐）
+
+当 MCP 正确配置后，使用：
+
+```
+/auto-review-loop-minimax
+```
+
+Skill 会自动检测并使用 `mcp__minimax-chat__minimax_chat` 工具。
+
+### 方法二：通过 curl（备选）
+
+如果 MCP 不可用，Skill 会自动回退到使用 curl 直接调用 MiniMax API。
+
+确保环境变量 `MINIMAX_API_KEY` 已设置。
+
+## 文件结构
+
+```
+~/.claude/
+├── settings.json                    # Claude Code 全局配置
+├── mcp-servers/
+│   └── minimax-chat/
+│       └── server.py                # MiniMax MCP 服务器
+└── skills/
+    ├── auto-review-loop/
+    │   └── SKILL.md                 # 原版（Codex MCP）
+    └── auto-review-loop-minimax/
+        └── SKILL.md                 # MiniMax 版
+
+项目目录/
+├── AUTO_REVIEW.md                   # 审查日志（自动生成）
+└── REVIEW_STATE.json                # 状态持久化（自动生成）
+```
+
+## MCP 服务器特性
+
+- **双格式支持**：自动检测并支持标准 MCP 格式和 NDJSON 格式
+- **调试日志**：日志保存在 `/tmp/minimax-mcp-debug.log`
+- **错误处理**：完善的错误处理和恢复机制
+
+## 验证安装
+
+### 测试 MCP 服务器
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | \
+  MINIMAX_API_KEY="your-key" \
+  python3 ~/.claude/mcp-servers/minimax-chat/server.py
+```
+
+预期输出：
+```json
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",...}}
+```
+
+### 测试 MiniMax API 连通性
+
+```bash
+curl -s "https://api.minimax.chat/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -d '{
+    "model": "MiniMax-M2.5",
+    "messages": [{"role": "user", "content": "Say hello"}],
+    "max_tokens": 50
+  }'
+```
+
+## 常见问题
+
+### Q: MCP 工具不可用？
+
+1. 检查 `/tmp/minimax-mcp-debug.log` 日志文件
+2. 确认 `settings.json` 配置正确
+3. 确认 Python 路径正确（`/usr/bin/python3` 或 `which python3`）
+4. 重启 Claude Code
+
+### Q: API 调用失败？
+
+1. 确认 API Key 正确且有效
+2. 确认网络可访问 `https://api.minimax.chat/v1`
+3. 检查 API 余额是否充足
+4. 查看调试日志中的错误信息
+
+### Q: Skill 没有触发？
+
+确保使用正确的触发词：
+- 原版：`auto review loop`
+- MiniMax版：`auto review loop minimax`
+
+### Q: 为什么不用 Codex MCP？
+
+Codex CLI 硬编码使用 OpenAI Responses API，该 API 不被第三方提供商支持。详见 [GitHub 讨论](https://github.com/openai/codex/discussions/7782)。
+
+## 贡献
+
+欢迎提交 Issue 和 PR 来改进这个集成！
+
+## 参考资料
+
+- [OpenAI Codex Discussions #7782](https://github.com/openai/codex/discussions/7782)
+- [MiniMax 开放平台](https://platform.minimax.chat/)
+- [Claude Code 文档](https://docs.anthropic.com/claude-code)

--- a/mcp-servers/minimax-chat/server.py
+++ b/mcp-servers/minimax-chat/server.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""MiniMax Chat MCP Server - A robust MCP server that calls MiniMax Chat Completions API"""
+
+import json
+import os
+import sys
+import httpx
+
+# Force unbuffered stdout/stdin
+sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', buffering=0)
+sys.stdin = os.fdopen(sys.stdin.fileno(), 'rb', buffering=0)
+
+# Debug logging
+DEBUG_LOG = "/tmp/minimax-mcp-debug.log"
+
+def debug_log(msg):
+    """Write debug message to log file"""
+    try:
+        with open(DEBUG_LOG, "a") as f:
+            import datetime
+            f.write(f"{datetime.datetime.now()}: {msg}\n")
+            f.flush()
+    except:
+        pass
+
+debug_log("=== MCP Server Starting (v2.0) ===")
+debug_log(f"MINIMAX_API_KEY set: {bool(os.environ.get('MINIMAX_API_KEY'))}")
+debug_log(f"MINIMAX_BASE_URL: {os.environ.get('MINIMAX_BASE_URL', 'not set')}")
+debug_log(f"MINIMAX_MODEL: {os.environ.get('MINIMAX_MODEL', 'not set')}")
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+MINIMAX_BASE_URL = os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.chat/v1")
+DEFAULT_MODEL = os.environ.get("MINIMAX_MODEL", "MiniMax-M2.5")
+
+def log_error(msg):
+    try:
+        with open(DEBUG_LOG, "a") as f:
+            import datetime
+            f.write(f"{datetime.datetime.now()}: ERROR: {msg}\n")
+    except:
+        pass
+
+# Global flag for output format
+_use_ndjson = False
+
+def send_response(response):
+    """Send a JSON-RPC response using binary stdout"""
+    global _use_ndjson
+    json_str = json.dumps(response, separators=(',', ':'))
+    json_bytes = json_str.encode('utf-8')
+
+    if _use_ndjson:
+        # NDJSON format: just the JSON followed by newline
+        output = json_bytes + b'\n'
+    else:
+        # Standard MCP format: Content-Length header + body
+        header = f"Content-Length: {len(json_bytes)}\r\n\r\n".encode('utf-8')
+        output = header + json_bytes
+
+    sys.stdout.write(output)
+    sys.stdout.flush()
+    debug_log(f"Sent response ({'NDJSON' if _use_ndjson else 'MCP'}): {json_str[:200]}...")
+
+def send_notification(method, params=None):
+    """Send a JSON-RPC notification"""
+    notification = {
+        "jsonrpc": "2.0",
+        "method": method
+    }
+    if params:
+        notification["params"] = params
+    send_response(notification)
+
+def call_minimax(messages, model=None):
+    """Call MiniMax Chat Completions API"""
+    if not MINIMAX_API_KEY:
+        return None, "MINIMAX_API_KEY environment variable not set"
+
+    url = f"{MINIMAX_BASE_URL}/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {MINIMAX_API_KEY}"
+    }
+    payload = {
+        "model": model or DEFAULT_MODEL,
+        "messages": messages,
+        "max_tokens": 4096
+    }
+
+    debug_log(f"Calling MiniMax API: {url}")
+
+    try:
+        with httpx.Client(timeout=120.0) as client:
+            response = client.post(url, headers=headers, json=payload)
+            if response.status_code != 200:
+                error_msg = f"API error {response.status_code}: {response.text[:500]}"
+                debug_log(f"API error: {error_msg}")
+                return None, error_msg
+            data = response.json()
+            content = data["choices"][0]["message"]["content"]
+            debug_log(f"API success, response length: {len(content)}")
+            return content, None
+    except Exception as e:
+        debug_log(f"API exception: {str(e)}")
+        return None, str(e)
+
+def handle_request(request):
+    """Handle a JSON-RPC request"""
+    method = request.get("method", "")
+    params = request.get("params", {})
+    request_id = request.get("id")
+
+    debug_log(f"Handling method: {method}, id: {request_id}")
+
+    # Handle notifications (no id, no response needed)
+    if request_id is None:
+        debug_log(f"Notification received: {method}")
+        if method == "notifications/initialized":
+            debug_log("Client initialized successfully")
+        return None
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {
+                    "tools": {}
+                },
+                "serverInfo": {
+                    "name": "minimax-chat",
+                    "version": "2.0.0"
+                }
+            }
+        }
+
+    elif method == "ping":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {}
+        }
+
+    elif method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "tools": [{
+                    "name": "minimax_chat",
+                    "description": "Send a message to MiniMax M2.5 model and get a response. Use this for research reviews, code analysis, and general AI tasks.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "prompt": {
+                                "type": "string",
+                                "description": "The prompt to send to MiniMax"
+                            },
+                            "model": {
+                                "type": "string",
+                                "description": "Model to use (default: MiniMax-M2.5)",
+                                "default": "MiniMax-M2.5"
+                            },
+                            "system": {
+                                "type": "string",
+                                "description": "Optional system prompt"
+                            }
+                        },
+                        "required": ["prompt"]
+                    }
+                }]
+            }
+        }
+
+    elif method == "tools/call":
+        tool_name = params.get("name", "")
+        arguments = params.get("arguments", {})
+
+        if tool_name == "minimax_chat":
+            prompt = arguments.get("prompt", "")
+            model = arguments.get("model", DEFAULT_MODEL)
+            system = arguments.get("system", "")
+
+            messages = []
+            if system:
+                messages.append({"role": "system", "content": system})
+            messages.append({"role": "user", "content": prompt})
+
+            debug_log(f"Tool call: minimax_chat, prompt length: {len(prompt)}")
+            content, error = call_minimax(messages, model)
+
+            if error:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": f"Error: {error}"}],
+                        "isError": True
+                    }
+                }
+
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": [{"type": "text", "text": content}]
+                }
+            }
+
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
+        }
+
+    else:
+        debug_log(f"Unknown method: {method}")
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"Unknown method: {method}"}
+        }
+
+def read_message():
+    """Read a single JSON-RPC message from stdin. Returns None on EOF.
+
+    Supports two formats:
+    1. Standard MCP: Content-Length: N\\r\\n\\r\\n{json}
+    2. NDJSON/Line-delimited: {json}\\n
+    """
+    content_length = None
+    first_line = None
+
+    # Read first line to determine format
+    line = sys.stdin.readline()
+    if not line:  # EOF
+        return None
+
+    line = line.decode('utf-8').rstrip('\r\n')
+    debug_log(f"First line: '{line[:100]}...'")
+
+    # Check if it's a Content-Length header or direct JSON
+    if line.lower().startswith("content-length:"):
+        # Standard MCP format
+        try:
+            content_length = int(line.split(":", 1)[1].strip())
+            debug_log(f"Content-Length: {content_length}")
+        except ValueError:
+            log_error(f"Invalid Content-Length: {line}")
+            return None
+
+        # Read remaining headers until blank line
+        while True:
+            hdr = sys.stdin.readline()
+            if not hdr:
+                return None
+            hdr = hdr.decode('utf-8').rstrip('\r\n')
+            if hdr == "":
+                break
+            debug_log(f"Header: '{hdr}'")
+
+    elif line.startswith("{") or line.startswith("["):
+        # NDJSON format - the line IS the JSON
+        global _use_ndjson
+        _use_ndjson = True
+        debug_log("Detected NDJSON format (line-delimited JSON)")
+        try:
+            request = json.loads(line)
+            debug_log(f"Parsed NDJSON request: {json.dumps(request)[:200]}")
+            return request
+        except json.JSONDecodeError as e:
+            log_error(f"JSON decode error in NDJSON: {e}")
+            return None
+
+    else:
+        log_error(f"Unexpected line format: {line[:100]}")
+        return None
+
+    if content_length is None:
+        log_error("Missing Content-Length header")
+        return None
+
+    # Read the body (for standard MCP format)
+    body = sys.stdin.read(content_length)
+    if len(body) < content_length:
+        log_error(f"Incomplete body: expected {content_length}, got {len(body)}")
+        return None
+
+    try:
+        request = json.loads(body.decode('utf-8'))
+        debug_log(f"Parsed request: {json.dumps(request)[:200]}")
+        return request
+    except json.JSONDecodeError as e:
+        log_error(f"JSON decode error: {e}")
+        return None
+
+def main():
+    """Main loop - read JSON-RPC messages from stdin"""
+    debug_log("Entering main loop")
+
+    while True:
+        try:
+            request = read_message()
+            if request is None:
+                debug_log("Received EOF, exiting gracefully")
+                break
+
+            debug_log(f"Processing: {request.get('method', 'unknown')}")
+
+            response = handle_request(request)
+            if response:
+                send_response(response)
+
+        except Exception as e:
+            log_error(f"Exception in main loop: {e}")
+            debug_log(f"Exception: {e}")
+            # Try to send error response
+            try:
+                send_response({
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32603, "message": f"Internal error: {e}"}
+                })
+            except:
+                pass
+
+    debug_log("=== MCP Server Exiting ===")
+
+if __name__ == "__main__":
+    main()

--- a/skills/auto-review-loop-minimax/SKILL.md
+++ b/skills/auto-review-loop-minimax/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: auto-review-loop-minimax
+description: Autonomous multi-round research review loop using MiniMax API. Use when you want to use MiniMax instead of Codex MCP for external review. Trigger with "auto review loop minimax" or "minimax review".
+argument-hint: [topic-or-scope]
+allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill
+---
+
+# Auto Review Loop (MiniMax Version): Autonomous Research Improvement
+
+Autonomously iterate: review → implement fixes → re-review, until the external reviewer gives a positive assessment or MAX_ROUNDS is reached.
+
+## Context: $ARGUMENTS
+
+## Constants
+
+- MAX_ROUNDS = 4
+- POSITIVE_THRESHOLD: score >= 6/10, or verdict contains "accept", "sufficient", "ready for submission"
+- REVIEW_DOC: `AUTO_REVIEW.md` in project root (cumulative log)
+- REVIEWER_MODEL = `MiniMax-M2.5` — Model used via MiniMax API
+
+## API Configuration
+
+This skill uses MiniMax API for external review. Two methods are supported:
+
+### Method 1: MCP Tool (Primary)
+
+If `mcp__minimax-chat__minimax_chat` is available, use it:
+
+```
+mcp__minimax-chat__minimax_chat:
+  prompt: |
+    [Review prompt content]
+  model: "MiniMax-M2.5"
+  system: "You are a senior machine learning researcher..."
+```
+
+### Method 2: curl (Fallback)
+
+If MCP is not available, use curl directly:
+
+```bash
+curl -s "https://api.minimax.chat/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -d '{
+    "model": "MiniMax-M2.5",
+    "messages": [
+      {"role": "system", "content": "You are a senior ML researcher..."},
+      {"role": "user", "content": "[Review prompt]"}
+    ],
+    "max_tokens": 4096
+  }'
+```
+
+**API Key**: Read from `~/.claude/settings.json` under `env.MINIMAX_API_KEY`, or from environment variable.
+
+**Why MiniMax instead of Codex MCP?** Codex CLI uses OpenAI's Responses API (`/v1/responses`) which is not supported by third-party providers. See: https://github.com/openai/codex/discussions/7782
+
+## State Persistence (Compact Recovery)
+
+Long-running loops may hit the context window limit, triggering automatic compaction. To survive this, persist state to `REVIEW_STATE.json` after each round:
+
+```json
+{
+  "round": 2,
+  "status": "in_progress",
+  "last_score": 5.0,
+  "last_verdict": "not ready",
+  "pending_experiments": ["screen_name_1"],
+  "timestamp": "2026-03-13T21:00:00"
+}
+```
+
+**Write this file at the end of every Phase E** (after documenting the round). Overwrite each time — only the latest state matters.
+
+**On completion** (positive assessment or max rounds), set `"status": "completed"` so future invocations don't accidentally resume a finished loop.
+
+## Workflow
+
+### Initialization
+
+1. **Check for `REVIEW_STATE.json`** in project root:
+   - If it does not exist: **fresh start** (normal case)
+   - If it exists AND `status` is `"completed"`: **fresh start** (previous loop finished normally)
+   - If it exists AND `status` is `"in_progress"` AND `timestamp` is older than 24 hours: **fresh start** (stale state from a killed/abandoned run — delete the file and start over)
+   - If it exists AND `status` is `"in_progress"` AND `timestamp` is within 24 hours: **resume**
+     - Read the state file to recover `round`, `last_score`, `pending_experiments`
+     - Read `AUTO_REVIEW.md` to restore full context of prior rounds
+     - If `pending_experiments` is non-empty, check if they have completed (e.g., check screen sessions)
+     - Resume from the next round (round = saved round + 1)
+     - Log: "Recovered from context compaction. Resuming at Round N."
+2. Read project narrative documents, memory files, and any prior review documents
+3. Read recent experiment results (check output directories, logs)
+4. Identify current weaknesses and open TODOs from prior reviews
+5. Initialize round counter = 1 (unless recovered from state file)
+6. Create/update `AUTO_REVIEW.md` with header and timestamp
+
+### Loop (repeat up to MAX_ROUNDS)
+
+#### Phase A: Review
+
+Send comprehensive context to the external reviewer.
+
+**Check MCP availability first**, then use appropriate method:
+
+**If MCP available (Primary):**
+```
+Use mcp__minimax-chat__minimax_chat tool with:
+- system: "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
+- prompt: [Full review prompt with context]
+- model: "MiniMax-M2.5"
+```
+
+**If MCP NOT available (Fallback):**
+```bash
+curl -s "https://api.minimax.chat/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -d '{
+    "model": "MiniMax-M2.5",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
+      },
+      {
+        "role": "user",
+        "content": "[Round N/MAX_ROUNDS of autonomous review loop]\n\n[Full research context: claims, methods, results, known weaknesses]\n[Changes since last round, if any]\n[For round 2+: Summary of previous review feedback and what was addressed]\n\nPlease act as a senior ML reviewer (NeurIPS/ICML level).\n\n1. Score this work 1-10 for a top venue\n2. List remaining critical weaknesses (ranked by severity)\n3. For each weakness, specify the MINIMUM fix (experiment, analysis, or reframing)\n4. State clearly: is this READY for submission? Yes/No/Almost\n\nBe brutally honest. If the work is ready, say so clearly."
+      }
+    ],
+    "max_tokens": 4096
+  }'
+```
+
+**Note**: Each round is a standalone API call. For round 2+, include the summary of previous reviews and changes in the prompt itself.
+
+#### Phase B: Parse Assessment
+
+**CRITICAL: Save the FULL raw response** from the external reviewer verbatim (store in a variable for Phase E). Do NOT discard or summarize — the raw text is the primary record.
+
+Then extract structured fields:
+- **Score** (numeric 1-10)
+- **Verdict** ("ready" / "almost" / "not ready")
+- **Action items** (ranked list of fixes)
+
+**STOP CONDITION**: If score >= 6 AND verdict contains "ready" or "almost" → stop loop, document final state.
+
+#### Phase C: Implement Fixes (if not stopping)
+
+For each action item (highest priority first):
+
+1. **Code changes**: Write/modify experiment scripts, model code, analysis scripts
+2. **Run experiments**: Deploy to GPU server via SSH + screen/tmux
+3. **Analysis**: Run evaluation, collect results, update figures/tables
+4. **Documentation**: Update project notes and review document
+
+Prioritization rules:
+- Skip fixes requiring excessive compute (flag for manual follow-up)
+- Skip fixes requiring external data/models not available
+- Prefer reframing/analysis over new experiments when both address the concern
+- Always implement metric additions (cheap, high impact)
+
+#### Phase D: Wait for Results
+
+If experiments were launched:
+- Monitor remote sessions for completion
+- Collect results from output files and logs
+
+#### Phase E: Document Round
+
+Append to `AUTO_REVIEW.md`:
+
+```markdown
+## Round N (timestamp)
+
+### Assessment (Summary)
+- Score: X/10
+- Verdict: [ready/almost/not ready]
+- Key criticisms: [bullet list]
+
+### Reviewer Raw Response
+
+<details>
+<summary>Click to expand full reviewer response</summary>
+
+[Paste the COMPLETE raw response from the external reviewer here — verbatim, unedited.
+This is the authoritative record. Do NOT truncate or paraphrase.]
+
+</details>
+
+### Actions Taken
+- [what was implemented/changed]
+
+### Results
+- [experiment outcomes, if any]
+
+### Status
+- [continuing to round N+1 / stopping]
+```
+
+**Write `REVIEW_STATE.json`** with current round, score, verdict, and any pending experiments.
+
+Increment round counter → back to Phase A.
+
+### Termination
+
+When loop ends (positive assessment or max rounds):
+
+1. Update `REVIEW_STATE.json` with `"status": "completed"`
+2. Write final summary to `AUTO_REVIEW.md`
+3. Update project notes with conclusions
+4. If stopped at max rounds without positive assessment:
+   - List remaining blockers
+   - Estimate effort needed for each
+   - Suggest whether to continue manually or pivot
+
+## Key Rules
+
+- Be honest — include negative results and failed experiments
+- Do NOT hide weaknesses to game a positive score
+- Implement fixes BEFORE re-reviewing (don't just promise to fix)
+- If an experiment takes > 30 minutes, launch it and continue with other fixes while waiting
+- Document EVERYTHING — the review log should be self-contained
+- Update project notes after each round, not just at the end
+- For round 2+, always include previous review context in the prompt
+- Prefer MCP tool over curl when available (more reliable)
+
+## Prompt Template for Round 2+
+
+**MCP Method (Primary):**
+```
+mcp__minimax-chat__minimax_chat:
+  model: "MiniMax-M2.5"
+  system: "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
+  prompt: |
+    [Round N/MAX_ROUNDS of autonomous review loop]
+
+    ## Previous Review Summary (Round N-1)
+    - Previous Score: X/10
+    - Previous Verdict: [ready/almost/not ready]
+    - Previous Key Weaknesses: [list]
+
+    ## Changes Since Last Review
+    1. [Action 1]: [result]
+    2. [Action 2]: [result]
+    3. [Action 3]: [result]
+
+    ## Updated Results
+    [paste updated metrics/tables]
+
+    ## Current Research Context
+    [brief summary of claims, methods, current state]
+
+    Please re-score and re-assess:
+    1. Score this work 1-10 for a top venue
+    2. List remaining critical weaknesses (ranked by severity)
+    3. For each weakness, specify the MINIMUM fix
+    4. State clearly: is this READY for submission? Yes/No/Almost
+
+    Be brutally honest. If the work is ready, say so clearly.
+```
+
+**curl Fallback:**
+```bash
+curl -s "https://api.minimax.chat/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -d '{
+    "model": "MiniMax-M2.5",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a senior machine learning researcher serving as a reviewer for top-tier conferences like NeurIPS, ICML, and ICLR. Provide rigorous, constructive feedback."
+      },
+      {
+        "role": "user",
+        "content": "[Round N/MAX_ROUNDS of autonomous review loop]\n\n## Previous Review Summary (Round N-1)\n- Previous Score: X/10\n- Previous Verdict: [ready/almost/not ready]\n- Previous Key Weaknesses: [list]\n\n## Changes Since Last Review\n1. [Action 1]: [result]\n2. [Action 2]: [result]\n3. [Action 3]: [result]\n\n## Updated Results\n[paste updated metrics/tables]\n\n## Current Research Context\n[brief summary of claims, methods, current state]\n\nPlease re-score and re-assess:\n1. Score this work 1-10 for a top venue\n2. List remaining critical weaknesses (ranked by severity)\n3. For each weakness, specify the MINIMUM fix\n4. State clearly: is this READY for submission? Yes/No/Almost\n\nBe brutally honest. If the work is ready, say so clearly."
+      }
+    ],
+    "max_tokens": 4096
+  }'
+```


### PR DESCRIPTION
## Summary

This PR adds MiniMax MCP support as an alternative to Codex MCP for users who want to use MiniMax API instead of OpenAI API for external research review.

## Background

OpenAI Codex CLI uses the **Responses API** (`/v1/responses`), which is not supported by third-party API providers like MiniMax (they only support Chat Completions API `/v1/chat/completions`). This makes Codex MCP incompatible with MiniMax and similar providers.

Related discussion: https://github.com/openai/codex/discussions/7782

## Changes

### 1. New Skill: `auto-review-loop-minimax`
- Location: `skills/auto-review-loop-minimax/SKILL.md`
- Trigger: "auto review loop minimax" or "minimax review"
- Uses MiniMax API via MCP (primary) or curl (fallback)

### 2. MCP Server: `minimax-chat`
- Location: `mcp-servers/minimax-chat/server.py`
- Custom MCP server that calls MiniMax Chat Completions API

### 3. Documentation: `MINIMAX_MCP_GUIDE.md`
- Location: `docs/MINIMAX_MCP_GUIDE.md`
- Installation and configuration guide

## File Structure

```
skills/auto-review-loop-minimax/SKILL.md  # NEW
mcp-servers/minimax-chat/server.py         # NEW
docs/MINIMAX_MCP_GUIDE.md                  # NEW
```

## Usage

```
/auto-review-loop-minimax
```