### PR TITLE
Add arXiv skill and download helper

### DIFF
--- a/skills/arxiv/SKILL.md
+++ b/skills/arxiv/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: arxiv
+description: Search, download, and summarize academic papers from arXiv. Use when user says "search arxiv", "download paper", "fetch arxiv", "arxiv search", "get paper pdf", or wants to find and save papers from arXiv to the local paper library.
+argument-hint: [query-or-arxiv-id]
+allowed-tools: Bash(*), Read, Write
+---
+
+# arXiv Paper Search & Download
+
+Search topic or arXiv paper ID: $ARGUMENTS
+
+## Constants
+
+- **PAPER_DIR** - Local directory to save downloaded PDFs. Default: `papers/` in the current project directory.
+- **MAX_RESULTS = 10** - Default number of search results.
+- **FETCH_SCRIPT** - `tools/arxiv_fetch.py` relative to the ARIS install, or the same path relative to the current project. Fall back to inline Python if not found.
+
+> Overrides (append to arguments):
+> - `/arxiv "attention mechanism" - max: 20` - return up to 20 results
+> - `/arxiv "2301.07041" - download` - download a specific paper by ID
+> - `/arxiv "query" - dir: literature/` - save PDFs to a custom directory
+> - `/arxiv "query" - download: all` - download all result PDFs
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for directives:
+
+- **Query or ID**: main search term or a bare arXiv ID such as `2301.07041` or `cs/0601001`
+- **`- max: N`**: override MAX_RESULTS (e.g., `- max: 20`)
+- **`- dir: PATH`**: override PAPER_DIR (e.g., `- dir: literature/`)
+- **`- download`**: download the first result's PDF after listing
+- **`- download: all`**: download PDFs for all results
+
+If the argument matches an arXiv ID pattern (`YYMM.NNNNN` or `category/NNNNNNN`), skip the search and go directly to Step 3.
+
+### Step 2: Search arXiv
+
+Locate the fetch script:
+
+```bash
+SCRIPT=$(python3 -c "
+import pathlib
+candidates = [
+    pathlib.Path('tools/arxiv_fetch.py'),
+    pathlib.Path.home() / '.claude' / 'skills' / 'arxiv' / 'arxiv_fetch.py',
+]
+for p in candidates:
+    if p.exists():
+        print(p)
+        break
+" 2>/dev/null)
+```
+
+**If SCRIPT is found**, run:
+
+```bash
+python3 "$SCRIPT" search "QUERY" --max MAX_RESULTS
+```
+
+**If SCRIPT is not found**, fall back to inline Python:
+
+```bash
+python3 - <<'PYEOF'
+import json
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+
+NS = "http://www.w3.org/2005/Atom"
+query = urllib.parse.quote("QUERY")
+url = (f"http://export.arxiv.org/api/query"
+       f"?search_query={query}&start=0&max_results=MAX_RESULTS"
+       f"&sortBy=relevance&sortOrder=descending")
+with urllib.request.urlopen(url, timeout=30) as r:
+    root = ET.fromstring(r.read())
+papers = []
+for entry in root.findall(f"{{{NS}}}entry"):
+    aid = entry.findtext(f"{{{NS}}}id", "").split("/abs/")[-1].split("v")[0]
+    title = (entry.findtext(f"{{{NS}}}title", "") or "").strip().replace("\n", " ")
+    abstract = (entry.findtext(f"{{{NS}}}summary", "") or "").strip().replace("\n", " ")
+    authors = [a.findtext(f"{{{NS}}}name", "") for a in entry.findall(f"{{{NS}}}author")]
+    published = entry.findtext(f"{{{NS}}}published", "")[:10]
+    cats = [c.get("term", "") for c in entry.findall(f"{{{NS}}}category")]
+    papers.append({
+        "id": aid,
+        "title": title,
+        "authors": authors,
+        "abstract": abstract,
+        "published": published,
+        "categories": cats,
+        "pdf_url": f"https://arxiv.org/pdf/{aid}.pdf",
+        "abs_url": f"https://arxiv.org/abs/{aid}",
+    })
+print(json.dumps(papers, ensure_ascii=False, indent=2))
+PYEOF
+```
+
+Present results as a table:
+
+```text
+| # | arXiv ID   | Title               | Authors        | Date       | Category |
+|---|------------|---------------------|----------------|------------|----------|
+| 1 | 2301.07041 | Attention Is All... | Vaswani et al. | 2017-06-12 | cs.LG    |
+```
+
+### Step 3: Fetch Details for a Specific ID
+
+When a single paper ID is requested (either directly or from Step 2):
+
+```bash
+python3 "$SCRIPT" search "id:ARXIV_ID" --max 1
+# or fallback:
+python3 -c "
+import urllib.request, xml.etree.ElementTree as ET
+NS = 'http://www.w3.org/2005/Atom'
+url = 'http://export.arxiv.org/api/query?id_list=ARXIV_ID'
+with urllib.request.urlopen(url, timeout=30) as r:
+    root = ET.fromstring(r.read())
+# print full details ...
+"
+```
+
+Display: title, all authors, categories, full abstract, published date, PDF URL, abstract URL.
+
+### Step 4: Download PDFs
+
+When download is requested, for each paper ID to download:
+
+```bash
+# Using fetch script:
+python3 "$SCRIPT" download ARXIV_ID --dir PAPER_DIR
+
+# Fallback:
+mkdir -p PAPER_DIR && python3 -c "
+import pathlib
+import sys
+import urllib.request
+
+out = pathlib.Path('PAPER_DIR/ARXIV_ID.pdf')
+if out.exists():
+    print(f'Already exists: {out}')
+    sys.exit(0)
+req = urllib.request.Request(
+    'https://arxiv.org/pdf/ARXIV_ID.pdf',
+    headers={'User-Agent': 'arxiv-skill/1.0'},
+)
+with urllib.request.urlopen(req, timeout=60) as r:
+    out.write_bytes(r.read())
+print(f'Downloaded: {out} ({out.stat().st_size // 1024} KB)')
+"
+```
+
+After each download:
+
+- Confirm file size > 10 KB (reject smaller files - likely an error HTML page)
+- Add a 1-second delay between consecutive downloads to avoid rate limiting
+- Report: `Downloaded: papers/2301.07041.pdf (842 KB)`
+
+### Step 5: Summarize
+
+For each paper (downloaded or fetched by API):
+
+```markdown
+## [Title]
+
+- **arXiv**: [ID] - [abs_url]
+- **Authors**: [full author list]
+- **Date**: [published]
+- **Categories**: [cs.LG, cs.AI, ...]
+- **Abstract**: [full abstract]
+- **Key contributions** (extracted from abstract):
+  - [contribution 1]
+  - [contribution 2]
+  - [contribution 3]
+- **Local PDF**: papers/[ID].pdf (if downloaded)
+```
+
+### Step 6: Final Output
+
+Summarize what was done:
+
+- `Found N papers for "query"`
+- `Downloaded: papers/2301.07041.pdf (842 KB)` (for each download)
+- Any warnings (rate limit hit, file too small, already exists)
+
+Suggest follow-up skills:
+
+```text
+/research-lit "topic"     - multi-source review: Zotero + Obsidian + local PDFs + web
+/novelty-check "idea"     - verify your idea is novel against these papers
+```
+
+## Key Rules
+
+- Always show the arXiv ID prominently - users need it for citations and reproducibility
+- Verify downloaded PDFs: file must be > 10 KB; warn and delete if smaller
+- Rate limit: wait 1 second between consecutive PDF downloads; retry once after 5 seconds on HTTP 429
+- Never overwrite an existing PDF at the same path - skip it and report "already exists"
+- Handle both arXiv ID formats: new (`2301.07041`) and old (`cs/0601001`)
+- PAPER_DIR is created automatically if it does not exist
+- If the arXiv API is unreachable, report the error clearly and suggest using `/research-lit` with `- sources: web` as a fallback

--- a/tools/arxiv_fetch.py
+++ b/tools/arxiv_fetch.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""CLI helper for searching and downloading arXiv papers.
+
+Used by the ``arxiv`` skill (skills/arxiv/SKILL.md).
+
+Commands
+--------
+search    Search arXiv and print results as JSON.
+download  Download a paper PDF by arXiv ID.
+
+Examples
+--------
+python3 tools/arxiv_fetch.py search "attention mechanism" --max 10
+python3 tools/arxiv_fetch.py search "id:2301.07041" --max 1
+python3 tools/arxiv_fetch.py download 2301.07041 --dir papers
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+_API_BASE = "http://export.arxiv.org/api/query"
+_USER_AGENT = (
+    "arxiv-skill/1.0 "
+    "(github.com/wanshuiyin/Auto-claude-code-research-in-sleep)"
+)
+_MIN_PDF_BYTES = 10_240
+_NEW_STYLE_ID_RE = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$")
+_OLD_STYLE_ID_RE = re.compile(r"^[A-Za-z.-]+/\d{7}(v\d+)?$")
+
+
+def _normalize_id(arxiv_id: str) -> str:
+    """Strip URL/version noise and return a clean arXiv ID."""
+    value = arxiv_id.strip()
+    if "/abs/" in value:
+        value = value.split("/abs/", 1)[1]
+    if value.startswith("id:"):
+        value = value[3:]
+    if "v" in value.split(".")[-1]:
+        value = value.rsplit("v", 1)[0]
+    return value
+
+
+def _looks_like_arxiv_id(value: str) -> bool:
+    """Return True when the input resembles a modern or legacy arXiv ID."""
+    value = value.strip()
+    return bool(_NEW_STYLE_ID_RE.match(value) or _OLD_STYLE_ID_RE.match(value))
+
+
+def _api_url(query: str, max_results: int, start: int) -> str:
+    """Build the arXiv API URL for a search query or specific ID lookup."""
+    query = query.strip()
+    if query.startswith("id:"):
+        params = {"id_list": _normalize_id(query)}
+    elif _looks_like_arxiv_id(query):
+        params = {"id_list": _normalize_id(query)}
+    else:
+        params = {
+            "search_query": query,
+            "start": start,
+            "max_results": max_results,
+            "sortBy": "relevance",
+            "sortOrder": "descending",
+        }
+    return f"{_API_BASE}?{urllib.parse.urlencode(params)}"
+
+
+def _fetch_atom(url: str) -> ET.Element:
+    """Fetch an arXiv Atom feed and return the parsed XML root."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return ET.fromstring(resp.read())
+
+
+def _parse_entry(entry: ET.Element) -> dict:
+    """Extract structured fields from a single Atom <entry> element."""
+    raw_id = entry.findtext(f"{{{_ATOM_NS}}}id", "")
+    arxiv_id = _normalize_id(raw_id)
+    title = (entry.findtext(f"{{{_ATOM_NS}}}title", "") or "").strip().replace("\n", " ")
+    abstract = (entry.findtext(f"{{{_ATOM_NS}}}summary", "") or "").strip().replace("\n", " ")
+    published = (entry.findtext(f"{{{_ATOM_NS}}}published", "") or "")[:10]
+    updated = (entry.findtext(f"{{{_ATOM_NS}}}updated", "") or "")[:10]
+    authors = [
+        author.findtext(f"{{{_ATOM_NS}}}name", "")
+        for author in entry.findall(f"{{{_ATOM_NS}}}author")
+    ]
+    categories = [
+        category.get("term", "")
+        for category in entry.findall(f"{{{_ATOM_NS}}}category")
+        if category.get("term")
+    ]
+    return {
+        "id": arxiv_id,
+        "title": title,
+        "authors": authors,
+        "abstract": abstract,
+        "published": published,
+        "updated": updated,
+        "categories": categories,
+        "pdf_url": f"https://arxiv.org/pdf/{arxiv_id}.pdf",
+        "abs_url": f"https://arxiv.org/abs/{arxiv_id}",
+    }
+
+
+def search(query: str, max_results: int = 10, start: int = 0) -> list[dict]:
+    """Search arXiv and return a list of paper dictionaries."""
+    url = _api_url(query, max_results=max_results, start=start)
+    root = _fetch_atom(url)
+    return [_parse_entry(entry) for entry in root.findall(f"{{{_ATOM_NS}}}entry")]
+
+
+def download(arxiv_id: str, output_dir: str = "papers") -> dict:
+    """Download a paper PDF and return metadata about the saved file."""
+    clean_id = _normalize_id(arxiv_id)
+    safe_id = clean_id.replace("/", "_")
+
+    dest_dir = Path(output_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"{safe_id}.pdf"
+
+    if dest.exists():
+        return {
+            "id": clean_id,
+            "path": str(dest),
+            "size_kb": dest.stat().st_size // 1024,
+            "skipped": True,
+        }
+
+    pdf_url = f"https://arxiv.org/pdf/{clean_id}.pdf"
+    req = urllib.request.Request(pdf_url, headers={"User-Agent": _USER_AGENT})
+
+    for attempt in (1, 2):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                data = resp.read()
+            break
+        except urllib.error.HTTPError as exc:
+            if exc.code == 429 and attempt == 1:
+                time.sleep(5)
+                continue
+            raise
+    else:
+        raise RuntimeError(f"Failed to download {pdf_url} after retries")
+
+    if len(data) < _MIN_PDF_BYTES:
+        raise ValueError(
+            f"Downloaded file is only {len(data)} bytes - likely an error page, not a PDF"
+        )
+
+    dest.write_bytes(data)
+    return {
+        "id": clean_id,
+        "path": str(dest),
+        "size_kb": len(data) // 1024,
+        "skipped": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Search and download arXiv papers.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    search_parser = subparsers.add_parser("search", help="Search arXiv papers")
+    search_parser.add_argument(
+        "query",
+        help="Search query or arXiv ID (bare ID or id:ARXIV_ID).",
+    )
+    search_parser.add_argument(
+        "--max",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Maximum number of results (default: 10).",
+    )
+    search_parser.add_argument(
+        "--start",
+        type=int,
+        default=0,
+        help="Start offset for pagination (default: 0).",
+    )
+
+    download_parser = subparsers.add_parser("download", help="Download a paper PDF by arXiv ID")
+    download_parser.add_argument(
+        "id",
+        help="arXiv paper ID, e.g. 2301.07041 or cs/0601001",
+    )
+    download_parser.add_argument(
+        "--dir",
+        default="papers",
+        metavar="DIR",
+        help="Output directory (default: papers).",
+    )
+    download_parser.add_argument(
+        "--delay",
+        type=float,
+        default=1.0,
+        help="Seconds to sleep after download (default: 1.0).",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "search":
+        results = search(args.query, max_results=args.max, start=args.start)
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "download":
+        result = download(args.id, output_dir=args.dir)
+        if result.get("skipped"):
+            print(json.dumps({**result, "message": "already exists, skipped"}, ensure_ascii=False))
+        else:
+            time.sleep(args.delay)
+            print(json.dumps(result, ensure_ascii=False))
+        return 0
+
+    raise ValueError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a standalone `/arxiv` skill for searching, inspecting, and downloading papers from arXiv
- add `tools/arxiv_fetch.py`, a standard-library helper for arXiv search and PDF download
- keep this PR scoped to the two arXiv files requested in the previous review

## Testing
- `python tools/arxiv_fetch.py search "2301.07041" --max 1`
- `python tools/arxiv_fetch.py download 2301.07041 --dir tmp-arxiv-test --delay 0`
- `python -m py_compile tools/arxiv_fetch.py`
