### PR TITLE
fix: restore Codex skill parity with latest skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Custom [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for 
 
 ## 📢 What's New
 
-- **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🤖 **[Codex CLI native skills](skills/skills-codex/)** — all 24 ARIS skills rewritten for [OpenAI Codex CLI](https://github.com/openai/codex) using `spawn_agent` subagents (replaces MCP calls). Drop-in `skills/skills-codex/` directory + LaTeX templates. Community contribution by [@Falling-Flower](https://github.com/Falling-Flower)
+- **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🤖 **[Codex CLI native skills](skills/skills-codex/)** — full ARIS skill set mirrored for [OpenAI Codex CLI](https://github.com/openai/codex), including `grant-proposal`, `paper-illustration`, and `experiment-bridge`. Drop-in `skills/skills-codex/` directory + LaTeX templates. Community contribution by [@Falling-Flower](https://github.com/Falling-Flower)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 📝 **[`grant-proposal`](skills/grant-proposal/SKILL.md)** — Draft structured grant proposals from research ideas. Supports 9 agencies: KAKENHI (Japan), NSF (US), NSFC (China, incl. 面上/青年/优青/杰青/海外优青/重点), ERC (EU), DFG, SNSF, ARC, NWO, and generic. Chains `/research-lit` → `/novelty-check` → `/research-review` → `/paper-illustration`. Community contribution by [@dengzhe-hou](https://github.com/dengzhe-hou)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🎨 **[`paper-illustration`](skills/paper-illustration/SKILL.md)** — AI-generated publication-quality architecture diagrams and method figures. Claude plans → Gemini renders → iterative refinement until score ≥ 9. Integrated into Workflow 3 (`illustration: true`, requires `GEMINI_API_KEY`). Built on [PaperBanana](https://github.com/dwzhu-pku/PaperBanana). Community contribution by [@Joseph-li343](https://github.com/Joseph-li343)
   <details><summary>Preview demo</summary><br><img src="assets/paper_illustration_demo.png" width="600" alt="paper-illustration demo" /></details>
@@ -100,7 +100,7 @@ See [full setup guide](#%EF%B8%8F-setup) for details and [alternative model comb
 
 ## ✨ Features
 
-- 📊 **20 composable skills** — mix and match, or chain into full pipelines (`/idea-discovery`, `/auto-review-loop`, `/paper-writing`, `/research-pipeline`)
+- 📊 **31 composable skills** — mix and match, or chain into full pipelines (`/idea-discovery`, `/auto-review-loop`, `/paper-writing`, `/research-pipeline`)
 - 🔍 **Literature & novelty** — multi-source paper search (**[Zotero](#-zotero-integration-optional)** + **[Obsidian](#-obsidian-integration-optional)** + **local PDFs** + arXiv/Scholar) + cross-model novelty verification
 - 💡 **Idea discovery** — literature survey → brainstorm 8-12 ideas → novelty check → GPU pilot experiments → ranked report
 - 🔄 **Auto review loop** — 4-round autonomous review, 5/10 → 7.5/10 overnight with 20+ GPU experiments
@@ -180,7 +180,7 @@ Domain-specific skills and external projects contributed by the community. PRs w
 | 📊 [CitationClaw](https://github.com/VisionXLab/CitationClaw) | General | Citation impact analysis — input paper title → citation crawling, scholar identification, tiered analysis, HTML dashboard |
 | 🐾 [OpenClaw Adaptation Guide](docs/OPENCLAW_ADAPTATION.md) | General | Use ARIS workflow methodology in [OpenClaw](https://github.com/All-Hands-AI/OpenHands) — skill-to-stage mapping, file-based orchestration, no Claude Code CLI needed |
 | 🎨 [`paper-illustration`](skills/paper-illustration/SKILL.md) | General | AI-generated architecture diagrams via Gemini. Built on [PaperBanana](https://github.com/dwzhu-pku/PaperBanana). Integrated into Workflow 3 |
-| 🤖 [`skills-codex`](skills/skills-codex/) | General | All 24 ARIS skills rewritten for Codex CLI using `spawn_agent`. Drop-in replacement for Codex users |
+| 🤖 [`skills-codex`](skills/skills-codex/) | General | Full ARIS skill set mirrored for Codex CLI, including `experiment-bridge`, `grant-proposal`, and `paper-illustration` |
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -28,7 +28,7 @@
 
 ## 📢 最近更新
 
-- **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🤖 **[Codex CLI 原生 skills](skills/skills-codex/)** — 全部 24 个 ARIS skill 重写为 [OpenAI Codex CLI](https://github.com/openai/codex) 版本，用 `spawn_agent` 替代 MCP 调用。即插即用 `skills/skills-codex/` + LaTeX 模板。社区贡献 by [@Falling-Flower](https://github.com/Falling-Flower)
+- **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🤖 **[Codex CLI 原生 skills](skills/skills-codex/)** — 完整 ARIS skill 集合的 Codex CLI 版本，现已补齐 `grant-proposal`、`paper-illustration` 和 `experiment-bridge`。即插即用 `skills/skills-codex/` + LaTeX 模板。社区贡献 by [@Falling-Flower](https://github.com/Falling-Flower)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 📝 **[`grant-proposal`](skills/grant-proposal/SKILL.md)** — 从研究 idea 自动生成结构化基金申请书。支持 9 个资助机构：科研費/KAKENHI（日本）、NSF（美国）、国自然/NSFC（含面上/青年/优青/杰青/海外优青/重点）、ERC（欧盟）、DFG、SNSF、ARC、NWO 及通用格式。串联 `/research-lit` → `/novelty-check` → `/research-review` → `/paper-illustration`。社区贡献 by [@dengzhe-hou](https://github.com/dengzhe-hou)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🎨 **[`paper-illustration`](skills/paper-illustration/SKILL.md)** — AI 生成出版级架构图/方法示意图。Claude 规划 → Gemini 渲染 → 迭代优化至 ≥9 分。集成到工作流 3（`illustration: true`，需 `GEMINI_API_KEY`）。基于 [PaperBanana](https://github.com/dwzhu-pku/PaperBanana)。社区贡献 by [@Joseph-li343](https://github.com/Joseph-li343)
   <details><summary>预览 demo</summary><br><img src="assets/paper_illustration_demo.png" width="600" alt="paper-illustration 示例" /></details>
@@ -99,7 +99,7 @@ claude
 
 ## ✨ 功能亮点
 
-- 📊 **20 个可组合 skill** — 自由混搭，或串联为完整流水线（`/idea-discovery`、`/auto-review-loop`、`/paper-writing`、`/research-pipeline`）
+- 📊 **31 个可组合 skill** — 自由混搭，或串联为完整流水线（`/idea-discovery`、`/auto-review-loop`、`/paper-writing`、`/research-pipeline`）
 - 🔍 **文献 & 查新** — 多源论文搜索（**[Zotero](#-zotero-集成可选)** + **[Obsidian](#-obsidian-集成可选)** + **本地 PDF** + arXiv/Scholar）+ 跨模型查新验证
 - 💡 **Idea 发现** — 文献调研 → 头脑风暴 8-12 个 idea → 查新 → GPU pilot 实验 → 排名报告
 - 🔄 **自动 review 循环** — 4 轮自主审稿，一夜从 5/10 提升到 7.5/10，自动跑 20+ 组 GPU 实验
@@ -179,7 +179,7 @@ claude
 | 📊 [CitationClaw](https://github.com/VisionXLab/CitationClaw) | 通用 | 引用影响力分析——论文标题 → 引用爬取、学者识别、HTML 报告 |
 | 🐾 [OpenClaw 适配指南](docs/OPENCLAW_ADAPTATION.md) | 通用 | 在 [OpenClaw](https://github.com/All-Hands-AI/OpenHands) 中使用 ARIS 工作流 |
 | 🎨 [`paper-illustration`](skills/paper-illustration/SKILL.md) | 通用 | AI 生成架构图（Gemini）。基于 [PaperBanana](https://github.com/dwzhu-pku/PaperBanana)，集成到工作流 3 |
-| 🤖 [`skills-codex`](skills/skills-codex/) | 通用 | 全部 24 个 ARIS skill 的 Codex CLI 版本，用 `spawn_agent` 替代 MCP。Codex 用户即插即用 |
+| 🤖 [`skills-codex`](skills/skills-codex/) | 通用 | 完整 ARIS skill 集合的 Codex CLI 版本，已补齐 `experiment-bridge`、`grant-proposal`、`paper-illustration` |
 
 </details>
 

--- a/skills/skills-codex/README_CN.md
+++ b/skills/skills-codex/README_CN.md
@@ -1,22 +1,22 @@
-# skills-pr 说明
+# skills-codex 说明
 
 ## 1. 这个包是什么
 
-这是一个面向 **Codex** 的技能包目录，已经按你当前确认的范围整理好：
+这是一个面向 **Codex** 的技能包目录，当前版本已经与主线 `skills/` 对齐：
 
-- 保留与 `.claude/skills` **同名** 的全部技能
-- 额外加入一个强化后的通信领域检索技能：`comm-lit-review`
+- 保留与 `.claude/skills` **同名** 的完整技能集
+- 同步包含主线新增的 `experiment-bridge`、`grant-proposal`、`paper-illustration`
 
 数量对比：
 
-- `.claude/skills` 原始技能数：`27`
-- 本包技能数：`28`
-- 相比 `.claude` 仅新增：`comm-lit-review`
+- `.claude/skills` 当前技能数：`31`
+- 本包技能数：`31`
+- 与 `.claude/skills`：一一对应，无额外私有技能
 
 本包路径结构是：
 
 ```text
-skills-pr/
+skills/skills-codex/
   <skill-name>/
     SKILL.md
     ...
@@ -28,8 +28,8 @@ skills-pr/
 
 本包没有把当前 `~/.codex/skills` 里的所有内容都打进去，而是只保留：
 
-- `.claude` 中已有的同名技能
-- 新增强化技能 `comm-lit-review`
+- 主线 `skills/` 中已有的同名技能
+- 这些技能所需的最小资源目录
 
 因此，本包 **不包含**：
 
@@ -60,9 +60,9 @@ skills-pr/
 
 这意味着它比原始 `.claude` 版本更完整，更接近“可直接用于生成论文模板”的状态。
 
-### 2.4 新增 `comm-lit-review`
+### 2.4 `comm-lit-review`
 
-这是这次额外强化的技能，定位是：
+这是保留在主线同步集里的领域强化技能，定位是：
 
 - 通信 / 无线 / NTN / 卫星 / Wi-Fi / 传输控制 / 资源分配等方向的文献检索
 - 默认按通信领域口径做信息检索，而不是走通用文献检索逻辑
@@ -142,14 +142,14 @@ skills-pr/
 
 ```bash
 mkdir -p ~/.codex/skills
-cp -a skills-pr/* ~/.codex/skills/
+cp -a skills/skills-codex/* ~/.codex/skills/
 ```
 
-如果你当前就在 `skills-pr` 的上级目录，也可以用绝对路径：
+如果你当前就在仓库根目录，也可以用绝对路径：
 
 ```bash
 mkdir -p ~/.codex/skills
-cp -a /path/to/skills-pr/* ~/.codex/skills/
+cp -a /path/to/Auto-claude-code-research-in-sleep/skills/skills-codex/* ~/.codex/skills/
 ```
 
 ### 4.2 安装后建议
@@ -216,7 +216,7 @@ Skill is valid!
 这个包适合：
 
 - 从 `.claude` 风格技能迁移到 Codex
-- 保留原有技能集合不扩散
-- 只额外加入一个通信领域强化检索技能
+- 保留与主线 `skills/` 一致的技能集合
+- 在 Codex 环境中直接使用与 Claude 侧对齐的工作流
 
 如果后面你还想继续精简或扩展，可以基于这个目录继续做白名单管理。

--- a/skills/skills-codex/experiment-bridge/SKILL.md
+++ b/skills/skills-codex/experiment-bridge/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: experiment-bridge
+description: "Workflow 1.5: Bridge between idea discovery and auto review. Reads EXPERIMENT_PLAN.md, implements experiment code, deploys to GPU, collects initial results. Use when user says \"实现实验\", \"implement experiments\", \"bridge\", \"从计划到跑实验\", \"deploy the plan\", or has an experiment plan ready to execute."
+---
+
+# Workflow 1.5: Experiment Bridge
+
+Implement and deploy experiments from plan: **$ARGUMENTS**
+
+## Overview
+
+This skill bridges Workflow 1 (idea discovery + method refinement) and Workflow 2 (auto review loop). It takes the experiment plan and turns it into running experiments with initial results.
+
+```
+Workflow 1 output:                    This skill:                        Workflow 2 input:
+refine-logs/EXPERIMENT_PLAN.md   →   implement → deploy → collect   →   initial results ready
+refine-logs/EXPERIMENT_TRACKER.md     code        /run-experiment        for /auto-review-loop
+refine-logs/FINAL_PROPOSAL.md
+```
+
+## Constants
+
+- **AUTO_DEPLOY = true** — Automatically deploy experiments after implementation. Set `false` to review code before deploying.
+- **SANITY_FIRST = true** — Run the sanity-stage experiment first (smallest, fastest) before launching the rest. Catches setup bugs early.
+- **MAX_PARALLEL_RUNS = 4** — Maximum number of experiments to deploy in parallel (limited by available GPUs).
+
+> Override: `/experiment-bridge "EXPERIMENT_PLAN.md" — auto deploy: false, max parallel: 2`
+
+## Inputs
+
+This skill expects one or more of:
+
+1. **`refine-logs/EXPERIMENT_PLAN.md`** (best) — claim-driven experiment roadmap from `/experiment-plan`
+2. **`refine-logs/EXPERIMENT_TRACKER.md`** — run-by-run execution table
+3. **`refine-logs/FINAL_PROPOSAL.md`** — method description for implementation context
+4. **`IDEA_REPORT.md`** — fallback if refine-logs don't exist
+
+If none exist, ask the user what experiments to implement.
+
+## Workflow
+
+### Phase 1: Parse the Experiment Plan
+
+Read `EXPERIMENT_PLAN.md` and extract:
+
+1. **Run order and milestones** — which experiments run first (sanity → baseline → main → ablation → polish)
+2. **For each experiment block:**
+   - Dataset / split / task
+   - Compared systems and variants
+   - Metrics to compute
+   - Setup details (backbone, hyperparameters, seeds)
+   - Success criterion
+   - Priority (MUST-RUN vs NICE-TO-HAVE)
+3. **Compute budget** — total estimated GPU-hours
+4. **Method details** from `FINAL_PROPOSAL.md` — what exactly to implement
+
+Present a brief summary:
+
+```
+📋 Experiment plan loaded:
+- Milestones: [N] (sanity → baseline → main → ablation)
+- Must-run experiments: [N]
+- Nice-to-have: [N]
+- Estimated GPU-hours: [X]
+
+Proceeding to implementation.
+```
+
+### Phase 2: Implement Experiment Code
+
+For each milestone (in order), write the experiment scripts:
+
+1. **Check existing code** — scan the project for existing experiment scripts, model code, data loaders. Reuse as much as possible.
+
+2. **Implement missing pieces:**
+   - Training scripts with proper argparse (all hyperparameters configurable)
+   - Evaluation scripts computing the specified metrics
+   - Data loading / preprocessing if needed
+   - Baseline implementations if not already present
+   - Fixed random seeds for reproducibility
+   - Results saved to JSON/CSV for later analysis
+   - Proper logging (wandb if configured in AGENTS.md)
+
+3. **Follow the plan's run order** — implement sanity-stage experiments first, then baselines, then main method, then ablations.
+
+4. **Self-review before deploying:**
+   - Are all hyperparameters from EXPERIMENT_PLAN.md reflected in argparse?
+   - Is the random seed fixed and controllable?
+   - Are results saved in a parseable format (JSON/CSV)?
+   - Does the code match FINAL_PROPOSAL.md's method description?
+
+### Phase 3: Sanity Check (if SANITY_FIRST = true)
+
+Before deploying the full experiment suite, run the sanity-stage experiment:
+
+```
+/run-experiment [sanity experiment command]
+```
+
+Wait for completion. Verify:
+- Training loop runs without errors
+- Metrics are computed and saved correctly
+- GPU memory usage is within bounds
+- Output format matches expectations
+
+If sanity fails → fix the code, re-run. Do not proceed to full deployment with broken code.
+
+### Phase 4: Deploy Full Experiments
+
+Deploy experiments following the plan's milestone order:
+
+```
+/run-experiment [experiment commands]
+```
+
+For each milestone:
+1. Deploy experiments in parallel (up to MAX_PARALLEL_RUNS)
+2. Use `/monitor-experiment` to track progress
+3. Collect results as experiments complete
+
+**🚦 Checkpoint (if AUTO_DEPLOY = false):**
+
+```
+🔧 Code implementation complete. Ready to deploy:
+
+Milestone 0 (sanity): [status — passed/pending]
+Milestone 1 (baseline): [N experiments, ~X GPU-hours]
+Milestone 2 (main method): [N experiments, ~X GPU-hours]
+Milestone 3 (ablations): [N experiments, ~X GPU-hours]
+
+Total estimated: ~X GPU-hours on [N] GPUs
+
+Deploy now? Or review the code first?
+```
+
+### Phase 5: Collect Initial Results
+
+As experiments complete:
+
+1. **Parse output files** (JSON/CSV/logs) for key metrics
+2. **Update `refine-logs/EXPERIMENT_TRACKER.md`** — fill in Status and Notes columns
+3. **Check success criteria** from EXPERIMENT_PLAN.md — did each experiment meet its bar?
+4. **Write initial results summary:**
+
+```markdown
+# Initial Experiment Results
+
+**Date**: [today]
+**Plan**: refine-logs/EXPERIMENT_PLAN.md
+
+## Results by Milestone
+
+### M0: Sanity — PASSED
+- [result]
+
+### M1: Baselines
+| Run | System | Key Metric | Status |
+|-----|--------|-----------|--------|
+| R001 | baseline_1 | X.XX | DONE |
+
+### M2: Main Method
+| Run | System | Key Metric | Status |
+|-----|--------|-----------|--------|
+| R003 | our_method | X.XX | DONE |
+
+### M3: Ablations
+...
+
+## Summary
+- [X/Y] must-run experiments completed
+- Main result: [positive/negative/inconclusive]
+- Ready for /auto-review-loop: [YES/NO]
+
+## Next Step
+→ /auto-review-loop "[topic]"
+```
+
+### Phase 6: Handoff
+
+Present final status:
+
+```
+🔬 Experiment bridge complete:
+- Implemented: [N] experiment scripts
+- Deployed: [N] experiments on [M] GPUs
+- Completed: [X/Y] must-run, [A/B] nice-to-have
+- Main result: [one sentence]
+
+Results: refine-logs/EXPERIMENT_RESULTS.md
+Tracker: refine-logs/EXPERIMENT_TRACKER.md
+
+Ready for Workflow 2:
+→ /auto-review-loop "[topic]"
+```
+
+## Key Rules
+
+- **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
+- **Follow the plan.** Do not invent experiments not in EXPERIMENT_PLAN.md. If you think something is missing, note it but don't add it.
+- **Sanity first.** Never deploy a full suite without verifying the sanity stage passes.
+- **Reuse existing code.** Scan the project before writing new scripts. Extend, don't duplicate.
+- **Save everything as JSON/CSV.** The auto-review-loop needs parseable results, not just terminal output.
+- **Update the tracker.** `EXPERIMENT_TRACKER.md` should reflect real status after each run completes.
+- **Don't wait forever.** If an experiment exceeds 2x its estimated time, flag it and move on to the next milestone.
+- **Budget awareness.** Track GPU-hours against the plan's budget. Warn if approaching the limit.
+
+## Composing with Other Skills
+
+```
+/idea-discovery "direction"          ← Workflow 1: find + refine + plan
+/experiment-bridge                   ← you are here (Workflow 1.5: implement + deploy)
+/auto-review-loop "topic"            ← Workflow 2: review + iterate
+/paper-writing "NARRATIVE_REPORT.md" ← Workflow 3: write the paper
+
+Or use /research-pipeline for the full end-to-end flow (includes this bridge).
+```

--- a/skills/skills-codex/grant-proposal/SKILL.md
+++ b/skills/skills-codex/grant-proposal/SKILL.md
@@ -1,0 +1,618 @@
+---
+name: grant-proposal
+description: "Draft a structured grant proposal from research ideas and literature. Supports KAKENHI (Japan), NSF (US), NSFC (China, including 面上/青年/优青/杰青/海外优青/重点), ERC (EU), DFG (Germany), SNSF (Switzerland), ARC (Australia), NWO (Netherlands), and generic formats. Use when user says \"write grant\", \"grant proposal\", \"申請書\", \"write KAKENHI\", \"科研費\", \"基金申请\", \"写基金\", \"NSF proposal\", or wants to turn research ideas into a funding application."
+---
+
+# Grant Proposal: From Research Ideas to Fundable Application
+
+Draft a grant proposal based on: **$ARGUMENTS**
+
+## Overview
+
+This skill turns validated research ideas into a structured, reviewer-ready grant proposal. It chains sub-skills into a grant-specific pipeline:
+
+```
+/research-lit → /novelty-check → [structure design] → [draft] → /research-review → [revise] → GRANT_PROPOSAL.md
+  (survey)      (verify gap)     (aims + matrix)     (prose)    (panel review)     (fix)      (done!)
+```
+
+**This is a parallel branch, not part of the linear Workflow 1→1.5→2→3 pipeline.** After `/idea-discovery` produces validated ideas, the user can either:
+- Go to `/experiment-bridge` → `/auto-review-loop` → `/paper-writing` (implement & publish)
+- Go to `/grant-proposal` (write funding application first, then implement after funding)
+
+```
+                    ┌→ /experiment-bridge → /auto-review-loop → /paper-writing  (publish track)
+/idea-discovery ────┤
+                    └→ /grant-proposal → [get funded] → /experiment-bridge → ...  (funding track)
+```
+
+Grant proposals argue for **future work** (feasibility + potential), not completed work (results + claims). This skill handles the unique requirements of grant writing: narrative arc design, reviewer-facing structure, budget justification, timeline planning, and agency-specific formatting.
+
+## Constants
+
+- **GRANT_TYPE = `KAKENHI`** — Default grant type. Supported: `KAKENHI`, `NSF`, `NSFC`, `ERC`, `DFG`, `SNSF`, `ARC`, `NWO`, `GENERIC`. Override via argument (e.g., `/grant-proposal "topic — NSF"`).
+- **GRANT_SUBTYPE = `auto`** — Sub-type within the grant agency. Examples: KAKENHI `Start-up`/`Wakate`/`Kiban-B`; NSFC `Youth`/`Excellent-Youth`/`Distinguished`/`Overseas`/`Key`; NSF `CAREER`/`CRII`/`Standard`. Auto-detected from argument or defaults to the most common sub-type.
+- **REVIEWER_MODEL = `gpt-5.4`** — Model used via a secondary Codex agent for proposal review. Must be an OpenAI model (e.g., `gpt-5.4`, `o3`, `gpt-4o`).
+- **OUTPUT_FORMAT = `markdown`** — Output format. Supported: `markdown`, `latex`. LaTeX uses grant-specific templates when available.
+- **MAX_REVIEW_ROUNDS = 2** — Maximum external review-revise cycles before finalizing.
+- **OUTPUT_DIR = `grant-proposal/`** — Directory for generated proposal files.
+- **LANGUAGE = `auto`** — Output language. Auto-detected from grant type: KAKENHI→Japanese, NSF→English, NSFC→Chinese, ERC→English, DFG→English (or German), SNSF→English, ARC→English, NWO→English. Override explicitly if needed.
+- **AUTO_PROCEED = false** — At each checkpoint, **always wait for explicit user confirmation** before proceeding. Grant proposals require PI-specific judgment at every stage. Set `true` only if user explicitly requests fully autonomous mode.
+
+> 💡 These are defaults. Override by telling the skill, e.g., `/grant-proposal "topic — NSF CAREER, latex output"` or `/grant-proposal "topic — NSFC Youth, language: English"`.
+
+## Grant Type Specifications
+
+### KAKENHI (Japan — JSPS)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | 研究目的 (Research Objective), 研究計画・方法 (Plan & Methods), 準備状況 (Preparation Status), 人権の保護 (Ethics, if applicable) |
+| **Sub-types** | 基盤研究 A/B/C (Kiban), 若手研究 (Wakate), 研究活動スタート支援 (Start-up), 国際共同研究 (International), 学術変革領域 (Transformative), 挑戦的研究 (Challenging), DC1/DC2 (doctoral) |
+| **Language** | Japanese (English technical terms acceptable) |
+| **Review criteria** | 学術的重要性 (academic significance), 独創性 (originality), 研究計画の妥当性 (plan feasibility), 研究遂行能力 (PI capability) |
+| **Cultural norms** | Explicit yearly milestones (Year 1 / Year 2), budget justification integrated into plan, emphasize 社会的意義 (societal significance), concrete expected outputs (papers, datasets), reference KAKEN database for related funded projects |
+
+### NSF (US)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | Project Summary (1p), Project Description (15p max), References Cited, Biographical Sketch, Budget Justification, Data Management Plan |
+| **Sub-types** | Standard Grant, CAREER (early career), CRII (research initiation), RAPID, EAGER |
+| **Language** | English |
+| **Review criteria** | Intellectual Merit, Broader Impacts |
+| **Cultural norms** | Aim-based structure (Aim 1/2/3), preliminary data strongly expected, broader impacts must be concrete and specific (not generic "benefit society"), Results from Prior Support section |
+
+### NSFC (China — 国家自然科学基金)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | 立项依据 (Rationale & Significance), 研究内容 (Content), 研究目标 (Objectives), 研究方案 (Plan & Methods), 可行性分析 (Feasibility), 创新性 (Innovation Points), 预期成果 (Expected Outcomes), 研究基础 (PI Foundation & Track Record) |
+| **Sub-types** | 面上项目 (General Program) — emphasis on scientific problem and research accumulation; 青年基金 (Young Scientists Fund) — age ≤35, emphasis on independence and growth potential; 优秀青年基金/优青 (Excellent Young Scientists) — age ≤38, emphasis on outstanding achievements; 杰出青年基金/杰青 (Distinguished Young Scientists) — age ≤45, emphasis on international-leading level; 海外优青 (Overseas Excellent Young Scientists) — emphasis on overseas experience and return contribution plan; 重点项目 (Key Program) — emphasis on systematic in-depth research |
+| **Language** | Chinese |
+| **Review criteria** | 科学意义 (scientific significance), 创新性 (innovation), 可行性 (feasibility), 研究队伍 (team qualification) |
+| **Cultural norms** | Heavy emphasis on 国际前沿 (international frontier) positioning, detailed feasibility analysis, explicit citation of applicant's prior publications, 研究基础 section is critical for demonstrating PI capability |
+
+### ERC (EU — European Research Council)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | Extended Synopsis (5p), Scientific Proposal Part B2 (15p) |
+| **Sub-types** | Starting Grant (2-7 years post-PhD), Consolidator Grant (7-12 years), Advanced Grant (established leaders) |
+| **Language** | English |
+| **Review criteria** | Ground-breaking nature, Methodology, PI track record |
+| **Cultural norms** | Emphasis on "high-risk/high-gain", methodology table with WP/deliverables/milestones, Gantt chart expected, strong PI narrative |
+
+### DFG (Germany — Deutsche Forschungsgemeinschaft)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | State of the Art, Objectives, Work Programme, Bibliography, CV |
+| **Language** | English or German |
+| **Review criteria** | Scientific quality, Originality, Feasibility, PI qualification |
+
+### SNSF (Switzerland — Swiss National Science Foundation)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | Summary, Research Plan, Timetable, Budget |
+| **Language** | English |
+| **Review criteria** | Scientific relevance, Originality, Feasibility, Track record |
+
+### ARC (Australia — Australian Research Council)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | Project Description, Feasibility, Benefit, Budget |
+| **Language** | English |
+| **Review criteria** | Research quality, Feasibility, Benefit to Australia |
+
+### NWO (Netherlands — Dutch Research Council)
+
+| Field | Detail |
+|-------|--------|
+| **Sections** | Summary, Proposed Research, Knowledge Utilisation |
+| **Language** | English |
+| **Review criteria** | Scientific quality, Innovative character, Knowledge utilisation |
+
+### GENERIC
+
+For any grant not listed above. User provides section names, page limits, and review criteria via argument:
+
+```
+/grant-proposal "topic — GENERIC, sections: Background|Methods|Impact, language: English"
+```
+
+## State Persistence (Compact Recovery)
+
+Grant proposal drafting is a long task that may trigger context compaction. Persist state to `grant-proposal/GRANT_STATE.json` after each phase:
+
+```json
+{
+  "phase": 2,
+  "grant_type": "KAKENHI",
+  "grant_subtype": "Start-up",
+  "language": "Japanese",
+  "agent_id": "019cfcf4-...",
+  "gap_statement": "...",
+  "aims_count": 3,
+  "status": "in_progress",
+  "timestamp": "2026-03-18T15:00:00"
+}
+```
+
+**Write this file at the end of every phase.** On invocation, check for this file:
+- If absent or `status: "completed"` → fresh start
+- If `status: "in_progress"` and within 24h → **resume** from saved phase (read `GRANT_PROPOSAL.md` and `GRANT_REVIEW.md` to restore context)
+- If older than 24h → fresh start (stale state)
+
+On completion, set `"status": "completed"`.
+
+## Workflow
+
+### Phase 0: Input Parsing & Context Gathering
+
+Parse `$ARGUMENTS` to extract:
+
+1. **Research direction/idea** — may reference existing files or be a freeform description
+2. **Grant type** — detect from keywords (e.g., "科研費"→KAKENHI, "NSF"→NSF, "国自然"→NSFC, "基金"→NSFC)
+3. **Grant sub-type** — detect from keywords (e.g., "Start-up", "若手", "青年", "CAREER", "优青", "海外优青")
+4. **Overrides** — output format, language, review rounds
+
+Then gather context from the project directory:
+
+1. Read `IDEA_REPORT.md` if it exists (from `/idea-discovery`)
+2. Read `refine-logs/FINAL_PROPOSAL.md` if it exists (from `/research-refine`)
+3. Read `refine-logs/EXPERIMENT_PLAN.md` if it exists (from `/experiment-plan`)
+4. Read `AUTO_REVIEW.md` if it exists (from `/auto-review-loop` — prior review feedback is gold for grants)
+5. Read `NARRATIVE_REPORT.md` or `STORY.md` if they exist
+6. Read any existing literature notes or survey documents
+7. Scan for the user's publication list (e.g., `publications.md`, `cv.md`, `bio.md`, `CV.pdf`)
+8. Check for `grant-proposal/GRANT_STATE.json` (resume from prior interrupted run)
+
+If insufficient context exists:
+- No research idea at all → suggest running `/idea-discovery` first
+- No literature survey → will invoke `/research-lit` inline in Phase 1
+- No publication list → leave PI qualification section with `[TODO: Add publications]` placeholders
+- Has AUTO_REVIEW.md → extract reviewer feedback and use it to strengthen the feasibility narrative
+
+### Phase 1: Literature & Landscape Positioning
+
+Invoke `/research-lit` to ground the proposal in real literature, then search for competing funded projects:
+
+```
+/research-lit "$ARGUMENTS"
+```
+
+**What this does:**
+- Reuse existing surveys if `/research-lit` was already run and notes exist
+- Otherwise invoke `/research-lit` for multi-source literature search (arXiv, Scholar, Zotero, local PDFs)
+- Search for **funded projects** in the same area via WebSearch:
+  - KAKENHI → KAKEN database (https://kaken.nii.ac.jp/)
+  - NSF → NSF Award Search (https://www.nsf.gov/awardsearch/)
+  - NSFC → NSFC funded projects
+  - Other agencies → general web search
+- Identify competing groups and their recent publications
+- Run `/novelty-check` on the proposed research direction to verify the gap is real:
+  ```
+  /novelty-check "[proposed gap statement]"
+  ```
+- Build the **gap statement** — the single most important sentence in the proposal:
+  ```
+  "Despite progress in [X], [specific gap] remains unaddressed because [reason].
+  This proposal addresses this by [approach], which will [expected impact]."
+  ```
+
+**🚦 Checkpoint:** Present the landscape summary and gap statement to the user:
+
+```
+📚 Literature & landscape analysis complete:
+- [key findings from literature]
+- [competing funded projects found]
+- Gap statement: "[the gap statement]"
+
+Does this accurately capture the positioning? Should I adjust before designing the proposal structure?
+```
+
+**⛔ STOP HERE and wait for user response.** Do NOT auto-proceed unless AUTO_PROCEED=true was explicitly set by the user.
+
+Options for the user:
+- Reply **"go"** or **"ok"** → proceed to Phase 2 with current positioning
+- Reply with **adjustments** (e.g., "focus more on X", "the gap should emphasize Y") → refine and re-present
+- Reply **"stop"** → end the skill, save current progress to `grant-proposal/DRAFT_NOTES.md`
+
+**State**: Write `GRANT_STATE.json` with `phase: 1` and the gap statement.
+
+### Phase 2: Narrative Structure & Aims Design
+
+Design the proposal's logical architecture before writing any prose.
+
+#### 2.1 Define Specific Aims (2-4)
+
+Each aim must satisfy:
+- **Independently valuable** — if one aim fails, others still produce publishable results
+- **Logically connected** — Aim 1 enables Aim 2, Aim 2 informs Aim 3
+- **Concrete deliverables** — each aim maps to specific outputs (papers, datasets, tools, benchmarks)
+- **Feasible within budget and timeline**
+
+#### 2.2 Build Claims-Aims-Evidence Matrix
+
+```markdown
+| Aim | Key Claim | Preliminary Evidence | Proposed Validation | Risk Level | Deliverable |
+|-----|-----------|---------------------|--------------------|-----------:|-------------|
+| Aim 1 | [claim] | [pilot data, prior work] | [experiments] | LOW | [paper, dataset] |
+| Aim 2 | [claim] | [theoretical basis] | [experiments] | MEDIUM | [paper, tool] |
+```
+
+#### 2.3 Design the Narrative Arc
+
+Grant proposals follow a fundamentally different arc from papers:
+
+```
+Problem → Why Now → What We Propose → Why It Will Work → What We Will Deliver
+         (not: Problem → Method → Results → Implications)
+```
+
+- **Problem**: What gap exists and why it matters (scientific + societal)
+- **Why Now**: What recent developments make this the right time (new data, new methods, new need)
+- **What We Propose**: The specific aims and approach
+- **Why It Will Work**: Preliminary data, PI track record, team expertise, feasibility arguments
+- **What We Will Deliver**: Concrete outputs, timeline, expected publications
+
+#### 2.4 Timeline & Milestones
+
+Design year-by-year (or quarter-by-quarter) plan:
+
+```markdown
+### Year 1
+- Q1-Q2: [Aim 1 tasks]
+- Q3-Q4: [Aim 1 completion + Aim 2 start]
+- Expected outputs: [papers, datasets]
+
+### Year 2
+- Q1-Q2: [Aim 2 completion + Aim 3]
+- Q3-Q4: [Aim 3 completion + synthesis]
+- Expected outputs: [papers, tools, final report]
+```
+
+#### 2.5 Structural Review
+
+Invoke `/research-review` to get critical feedback on the proposal structure before drafting:
+
+```
+/research-review "[GRANT_TYPE] [GRANT_SUBTYPE] proposal structure:
+Gap: [gap statement]
+Aims: [aims list with claims-evidence matrix]
+Timeline: [timeline]
+— reviewer persona: [GRANT_TYPE] review panelist"
+```
+
+**What this does:**
+- GPT-5.4 xhigh acts as a grant review panelist (not a paper reviewer)
+- Evaluates aims independence, narrative arc, risk identification, timeline realism
+- Identifies the single biggest reviewer concern
+- Provides actionable fixes ranked by severity
+
+Apply structural feedback before proceeding to drafting.
+
+**🚦 Checkpoint:** Present the proposal structure to the user:
+
+```
+🏗️ Proposal structure designed:
+- Gap: [gap statement]
+- Aim 1: [title] — Risk: LOW
+- Aim 2: [title] — Risk: MEDIUM
+- Aim 3: [title] — Risk: LOW
+- Timeline: [summary]
+- Reviewer feedback: [key points from GPT-5.4]
+
+Proceed to section drafting? Or adjust the structure?
+```
+
+**⛔ STOP HERE. This is the most critical checkpoint — the proposal structure determines everything downstream.**
+
+Options for the user:
+- Reply **"go"** or **"ok"** → proceed to Phase 3 (section drafting)
+- Reply with **structural changes** (e.g., "merge Aim 2 and 3", "add an aim about X", "reduce to 2 aims") → redesign and re-present
+- Reply **"back"** → return to Phase 1 to adjust the gap/positioning
+- Reply **"stop"** → save current structure to `grant-proposal/DRAFT_NOTES.md`
+
+**State**: Write `GRANT_STATE.json` with `phase: 2`, aims summary, and the reviewer agent id.
+
+### Phase 3: Section Drafting
+
+Draft each section according to the grant type template. Write **complete prose**, not outlines or placeholders.
+
+**What this does:**
+- Writes all required sections in the agency-specific language and tone
+- Pulls content from IDEA_REPORT.md, FINAL_PROPOSAL.md, and literature notes
+- Uses `/paper-illustration` for figure generation (if user requests)
+- Leaves `[TODO]` only for PI-specific information, `[AMOUNT]` for budget figures
+- Outputs `grant-proposal/GRANT_PROPOSAL.md`
+
+#### Drafting Order (optimized for narrative coherence)
+
+1. **Specific Aims / Research Objective** — the "abstract" of the grant. Write first, refine last.
+2. **Background / Significance / State of the Art** — establish the problem and gap.
+3. **Research Plan / Methods** — per aim, with feasibility arguments.
+4. **Figures** — generate key diagrams (see below).
+5. **Timeline & Milestones** — year-by-year deliverables.
+6. **PI Qualification / Preparation Status** — track record, team, infrastructure.
+7. **Budget Justification** — narrative only (leave dollar/yen amounts as `[AMOUNT]` placeholders).
+8. **Broader Impacts / Societal Significance** — if required by the grant type.
+
+#### Figure Generation
+
+Grant proposals benefit greatly from clear diagrams. Generate the following figures using SVG or matplotlib (save to `grant-proposal/figures/`):
+
+1. **全体構成図 / Overview Diagram** — Show the relationship between aims (Aim 1 → Aim 2 → Aim 3), shared resources (participants, stimuli, pipeline), and outputs. This is the single most important figure.
+2. **実験パラダイム図 / Experimental Paradigm** — Visual schematic of each paradigm (stimulus timing, conditions, EEG recording).
+3. **年次計画 / Timeline Gantt Chart** — Year-by-year (or H1/H2) milestones with deliverables.
+
+For AI-generated publication-quality figures, invoke `/paper-illustration`:
+
+```
+/paper-illustration "Overview diagram showing [aims relationship + shared resources] for grant proposal"
+```
+
+For simpler diagrams (flowcharts, Gantt charts), generate clean SVG or matplotlib directly via code.
+
+**🚦 Figure Checkpoint:** Before generating, ask which figures the user wants:
+
+```
+🎨 The following figures would strengthen this proposal:
+1. 全体構成図 / Overview — aims relationship + shared resources
+2. 実験パラダイム図 / Paradigm — stimulus timing + conditions
+3. 年次計画 / Gantt — timeline with milestones
+
+Which should I generate? (e.g., "1 and 3", "all", "skip")
+```
+
+**⛔ Wait for user response.** Generate only the requested figures.
+
+#### Grant-Specific Drafting Guidelines
+
+**KAKENHI:**
+- Write in formal Japanese academic style (である調, not です/ます調)
+- Use 「」for Japanese quotations, bold for emphasis
+- Structure: 研究の学術的背景 → 研究期間内に何をどこまで明らかにするか → 本研究の学術的な特色・独創性
+- Include explicit 年次計画 (yearly plan) with concrete milestones
+- Emphasize 社会的意義 (societal significance)
+- Reference related KAKEN-funded projects to show awareness of the field
+
+**NSF:**
+- Write in clear, direct English
+- Use Aim-based structure with bold headings
+- Preliminary data paragraphs for each Aim (with figure references)
+- Broader Impacts must be concrete: specific outreach activities, broadening participation plans
+- Include Results from Prior Support (if PI has prior NSF funding)
+
+**NSFC:**
+- Write in formal Chinese academic style
+- 立项依据 must position work at 国际前沿 (international frontier)
+- 创新性 section must list numbered innovation points (创新点)
+- 研究基础 must cite PI's own publications (with IF and citations if possible)
+- 可行性分析 must address: technical feasibility, team capability, time feasibility, equipment/conditions
+
+**ERC:**
+- Write a compelling "high-risk/high-gain" narrative
+- Extended Synopsis must be self-contained and compelling
+- Include Work Package table with deliverables and milestones
+- Gantt chart (describe in text, or generate as figure)
+
+#### For Each Section
+
+1. **Pull relevant content** from IDEA_REPORT.md, FINAL_PROPOSAL.md, literature notes
+2. **Write complete prose** — no `[TODO]` except for PI-specific information
+3. **Include figure/table placeholders** where appropriate (e.g., `[Figure 1: System architecture]`)
+4. **Cite references properly** — use citation keys, will build bibliography later
+5. **Match the agency's tone and style** — formal Japanese for KAKENHI, direct English for NSF, etc.
+
+### Phase 4: External Review
+
+Invoke `/research-review` on the complete draft for grant-type-specific evaluation:
+
+```
+/research-review "Complete [GRANT_TYPE] [GRANT_SUBTYPE] proposal draft. Evaluate as a [GRANT_TYPE] review panelist using official criteria. [PASTE FULL PROPOSAL TEXT]"
+```
+
+**What this does:**
+- GPT-5.4 xhigh acts as a grant review panelist
+- Scores each section 1-5 using agency-specific criteria
+- Identifies fatal flaws and recommends funding/revisions/rejection
+- Provides ranked action items for improvement
+- All feedback saved to `grant-proposal/GRANT_REVIEW.md`
+
+> ⚠️ **External review fallback**: If reviewer agents are unavailable, skip external review. Note "External review skipped — no reviewer agent available. Consider running `/auto-review-loop-llm` separately." in `GRANT_REVIEW.md`. The proposal is still usable without external review.
+
+If `/research-review` is invoked (preferred), it handles the external review internally. If you run the reviewer directly, use `spawn_agent` for Round 1 and `send_input` for follow-up rounds.
+
+#### Round 1 (full draft review):
+
+```
+spawn_agent:
+  reasoning_effort: xhigh
+  message: |
+    Review this complete [GRANT_TYPE] [GRANT_SUBTYPE] proposal draft.
+
+    Act as a [GRANT_TYPE] review panelist. Evaluate using the official criteria:
+
+    [INSERT GRANT-TYPE-SPECIFIC CRITERIA — see Grant Type Specifications above]
+
+    For each section:
+    1. Score 1-5 (5 = excellent)
+    2. Strongest aspect
+    3. Most critical weakness
+    4. Specific fix suggestion (actionable, not vague)
+
+    Overall assessment:
+    - Would you recommend funding? (Yes / Yes with revisions / No)
+    - Single most impactful change to improve funding chances?
+    - Any fatal flaws?
+
+    [PASTE FULL PROPOSAL TEXT]
+```
+
+Save the returned reviewer agent id in `GRANT_STATE.json` if you want to continue the same dialogue in Round 2.
+
+#### Round 2+ (after revisions):
+
+If MAX_REVIEW_ROUNDS > 1 and revisions were applied:
+
+```
+send_input:
+  agent_id: [saved from Round 1]
+  message: |
+    [Round N review of revised [GRANT_TYPE] [GRANT_SUBTYPE] proposal]
+
+    Since your last review, I have applied the following changes:
+    1. [Change 1]: [what was done]
+    2. [Change 2]: [what was done]
+    3. [Change 3]: [what was done]
+
+    Please re-evaluate. Same format: section scores, overall assessment, remaining weaknesses.
+    Focus on whether the CRITICAL and MAJOR issues from Round 1 have been adequately addressed.
+
+    [PASTE REVISED PROPOSAL TEXT]
+```
+
+### Phase 5: Revision & Output
+
+#### 5.1 Apply Reviewer Feedback
+
+Parse reviewer feedback into severity levels:
+- **CRITICAL** — fatal flaws that would lead to rejection. Fix immediately.
+- **MAJOR** — significant weaknesses. Fix before submission.
+- **MINOR** — suggestions for improvement. Fix if time allows.
+
+Implement CRITICAL and MAJOR fixes. If MAX_REVIEW_ROUNDS > 1, re-submit for another round via `send_input`.
+
+#### 5.2 Generate Output
+
+**Markdown output** (default):
+
+```
+grant-proposal/
+├── GRANT_PROPOSAL.md          # Complete proposal, all sections
+├── GRANT_REVIEW.md            # Review history and reviewer feedback
+├── GRANT_STATE.json           # State persistence file
+├── figures/                   # Generated diagrams (if any)
+└── references.bib             # Bibliography (if citations were used)
+```
+
+**LaTeX output** (when OUTPUT_FORMAT = latex):
+
+```
+grant-proposal/
+├── main.tex                   # Master file
+├── sections/
+│   ├── aims.tex               # Specific Aims / Research Objective
+│   ├── background.tex         # Background / Significance
+│   ├── research_plan.tex      # Research Plan / Methods
+│   ├── timeline.tex           # Timeline & Milestones
+│   ├── pi_qualification.tex   # PI Qualification / Track Record
+│   └── budget.tex             # Budget Justification (if applicable)
+├── references.bib
+└── figures/                   # Any generated diagrams
+```
+
+#### 5.3 Final Checks
+
+Before declaring done:
+
+- [ ] All sections required by the grant type are present and complete
+- [ ] Gap statement is clear and appears early in the proposal
+- [ ] Each aim is independently valuable and logically connected
+- [ ] Timeline includes concrete yearly milestones and deliverables
+- [ ] PI qualification section has content (or clear `[TODO]` placeholders)
+- [ ] Budget justification uses `[AMOUNT]` placeholders (no fabricated numbers)
+- [ ] Language matches the grant type (Japanese for KAKENHI, Chinese for NSFC, etc.)
+- [ ] No leftover `[TODO]` markers except for PI-specific information
+- [ ] References are real (no hallucinated citations)
+- [ ] Review feedback has been addressed (CRITICAL and MAJOR items)
+
+**🚦 Final Checkpoint:** Present the completed proposal summary:
+
+```
+📝 Grant proposal draft complete:
+- Type: [GRANT_TYPE] [GRANT_SUBTYPE]
+- Language: [language]
+- Aims: [N] aims covering [summary]
+- Timeline: [N] years
+- Review score: [summary from GPT-5.4]
+- Output: grant-proposal/GRANT_PROPOSAL.md
+
+Files saved to grant-proposal/. Please review and customize:
+1. PI qualification section (add your publications and track record)
+2. Budget amounts (replace [AMOUNT] placeholders)
+3. Any [TODO] markers for personal information
+
+What would you like to do next?
+- "figures" → generate proposal diagrams
+- "review again" → run another round of external review
+- "latex" → convert to LaTeX format
+- "done" → finalize
+```
+
+## Key Rules
+
+- **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
+
+- **Do NOT fabricate budget amounts.** Generate narrative budget justification only. Leave specific dollar/yen/yuan/euro amounts as `[AMOUNT]` placeholders for the user to fill in.
+- **Do NOT fabricate PI information.** If no publication list is available, leave `[TODO: Add publications]` placeholders. Never invent papers, grants, or credentials.
+- **Do NOT hallucinate citations.** Use references from literature survey. Mark uncertain citations with `[VERIFY]`.
+- **Grant ≠ paper.** A grant argues for future work (feasibility + potential). A paper argues for completed work (results + claims). Write accordingly — emphasize "what we will do" and "why it will work", not "what we found."
+- **Aims must be independently valuable.** If Aim 2 fails, Aim 1 and Aim 3 should still produce publishable results.
+- **Preliminary data de-risks.** Include any pilot results, existing datasets, or prior publications that demonstrate feasibility.
+- **Reviewer-facing structure.** Bold key sentences. Use numbered lists for clarity. Make the reviewer's job easy.
+- **Cultural norms matter.** KAKENHI expects 社会的意義; NSF expects Broader Impacts; NSFC expects 国际前沿 positioning. Missing these is a red flag for reviewers.
+- **Feishu notifications are optional.** If `~/.codex/feishu.json` exists, send `checkpoint` at each phase transition and `pipeline_done` at final output. If absent, skip silently.
+
+## Parameter Pass-Through
+
+Parameters can be passed inline with `—` separator. They flow to sub-skills when invoked:
+
+```
+/grant-proposal "topic — KAKENHI Start-up, sources: zotero, arxiv download: true"
+```
+
+| Parameter | Default | Description | Passed to |
+|-----------|---------|-------------|-----------|
+| `grant type` | KAKENHI | Agency (KAKENHI/NSF/NSFC/ERC/DFG/SNSF/ARC/NWO/GENERIC) | — |
+| `grant subtype` | auto | Sub-type (Start-up/Wakate/CAREER/Youth/etc.) | — |
+| `output format` | markdown | `markdown` or `latex` | — |
+| `language` | auto | Output language override | — |
+| `max review rounds` | 2 | External review cycles | — |
+| `sources` | all | Literature sources | → `/research-lit` |
+| `arxiv download` | false | Download arXiv PDFs | → `/research-lit` |
+| `reviewer model` | gpt-5.4 | Codex review model | → reviewer agent |
+| `auto proceed` | false | Skip checkpoints | — |
+
+## Composing with Other Skills
+
+### Sub-skills used by this skill
+
+| Sub-skill | Phase | Purpose |
+|-----------|:-----:|---------|
+| `/research-lit` | 1 | Literature survey (if not already done) |
+| `/novelty-check` | 1 | Verify the gap is real |
+| `/research-review` | 2, 4 | Structural review + full draft review |
+| `/paper-illustration` | 3 | Generate proposal figures (optional) |
+
+### Funding Track (this skill's primary use case)
+
+```
+/idea-discovery "direction"              ← Workflow 1: find validated ideas
+/research-refine "idea"                  ← sharpen the method
+/grant-proposal "idea — KAKENHI"         ← this skill: write the grant proposal
+                                          ← [submit & get funded]
+/experiment-bridge                       ← implement experiments with funding
+/auto-review-loop "results"              ← Workflow 2: iterate until submission-ready
+/paper-writing                           ← Workflow 3: write the paper
+```
+
+### Publish Track (skip this skill)
+
+```
+/idea-discovery → /experiment-bridge → /auto-review-loop → /paper-writing → submit
+```

--- a/skills/skills-codex/paper-illustration/SKILL.md
+++ b/skills/skills-codex/paper-illustration/SKILL.md
@@ -1,0 +1,690 @@
+---
+name: paper-illustration
+description: "Generate publication-quality AI illustrations for academic papers using Gemini image generation. Creates architecture diagrams, method illustrations with Codex-supervised iterative refinement loop. Use when user says \"生成图表\", \"画架构图\", \"AI绘图\", \"paper illustration\", \"generate diagram\", or needs visual figures for papers."
+---
+
+# Paper Illustration: Multi-Stage Codex-Supervised Figure Generation
+
+Generate publication-quality illustrations using a **multi-stage workflow** with **Codex as the STRICT supervisor/reviewer**.
+
+## Core Design Philosophy
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                    MULTI-STAGE ITERATIVE WORKFLOW                        │
+├──────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   User Request                                                           │
+│       │                                                                  │
+│       ▼                                                                  │
+│   ┌─────────────┐                                                        │
+│   │   Codex    │ ◄─── Step 1: Parse request, create initial prompt     │
+│   │  (Planner)  │                                                        │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │   Gemini    │ ◄─── Step 2: Optimize layout description               │
+│   │ (gemini-3-pro)│      - Refine component positioning                    │
+│   │  Layout     │      - Optimize spacing and grouping                   │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │   Gemini    │ ◄─── Step 3: CVPR/NeurIPS style verification          │
+│   │ (gemini-3-pro)│      - Check color palette compliance                  │
+│   │  Style      │      - Verify arrow and font standards                 │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │ Paperbanana │ ◄─── Step 4: Render final image                       │
+│   │ (gemini-3-  │      - High-quality image generation                   │
+│   │ pro-image)  │      - Internal codename: Nano Banana Pro              │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │   Codex    │ ◄─── Step 5: STRICT visual review + SCORE (1-10)      │
+│   │  (Reviewer) │      - Verify EVERY arrow direction                    │
+│   │   STRICT!   │      - Verify EVERY block content                      │
+│   └──────┬──────┘      - Verify aesthetics & visual appeal               │
+│          │                                                               │
+│          ▼                                                               │
+│   Score ≥ 9? ──YES──► Accept & Output                                    │
+│          │                                                               │
+│          NO                                                              │
+│          │                                                               │
+│          ▼                                                               │
+│   Generate SPECIFIC improvement feedback ──► Loop back to Step 2        │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Constants
+
+- **IMAGE_MODEL = `gemini-3-pro-image-preview`** — Paperbanana (Nano Banana Pro) for image rendering
+- **REASONING_MODEL = `gemini-3-pro-preview`** — Gemini for layout optimization and style checking
+- **MAX_ITERATIONS = 5** — Maximum refinement rounds
+- **TARGET_SCORE = 9** — Minimum acceptable score (1-10) — RAISED FOR QUALITY
+- **OUTPUT_DIR = `figures/ai_generated/`** — Output directory
+- **API_KEY_ENV = `GEMINI_API_KEY`** — Environment variable
+
+## CVPR/ICLR/NeurIPS Top-Tier Conference Style Guide
+
+**What "CVPR Style" Actually Means:**
+
+### Visual Standards
+- **Clean white background** — No decorative patterns or gradients (unless subtle)
+- **Sans-serif fonts** — Arial, Helvetica, or Computer Modern; minimum 14pt
+- **Subtle color palette** — Not rainbow colors; use 3-5 coordinated colors
+- **Print-friendly** — Must be readable in grayscale (many reviewers print papers)
+- **Professional borders** — Thin (2-3px), solid colors, not flashy
+
+### Layout Standards
+- **Horizontal flow** — Left-to-right is the standard for pipelines
+- **Clear grouping** — Use subtle background boxes to group related modules
+- **Consistent sizing** — Similar components should have similar sizes
+- **Balanced whitespace** — Not cramped, not sparse
+
+### Arrow Standards (MOST CRITICAL)
+- **Thick strokes** — 4-6px minimum (thin arrows disappear when printed)
+- **Clear arrowheads** — Large, filled triangular heads
+- **Dark colors** — Black or dark gray (#333333); avoid colored arrows
+- **Labeled** — Every arrow should indicate what data flows through it
+- **No crossings** — Reorganize layout to avoid arrow crossings
+- **CORRECT DIRECTION** — Arrows must point to the RIGHT target!
+
+### Visual Appeal (科研风格 - Professional Academic Style)
+
+**目标：既不保守也不花哨，找到平衡点**
+
+#### ✅ 应该有的视觉元素：
+- **Subtle gradient fills** — 淡雅的渐变填充（同色系从浅到深），不是炫彩
+- **Rounded corners** — 圆角矩形（6-10px radius），现代感但不夸张
+- **Clear visual hierarchy** — 通过大小、颜色深浅区分层次
+- **Consistent color coding** — 统一的配色方案（3-4种主色）
+- **Internal structure** — 大模块内部显示子组件（如Encoder内部的layer结构）
+- **Professional typography** — 清晰的标签，适当的字号层次
+
+#### ✅ 配色建议（学术专业）：
+- **Inputs**: 柔和的绿色系 (#10B981 / #34D399)
+- **Encoders**: 专业的蓝色系 (#2563EB / #3B82F6)
+- **Fusion**: 优雅的紫色系 (#7C3AED / #8B5CF6)
+- **Outputs**: 温暖的橙色系 (#EA580C / #F97316)
+- **Arrows**: 黑色或深灰 (#333333 / #1F2937)
+- **Background**: 纯白 (#FFFFFF)，不要花纹
+
+#### ❌ 要避免的过度装饰：
+- ❌ Rainbow color schemes (彩虹配色)
+- ❌ Heavy drop shadows (重阴影效果)
+- ❌ 3D effects / perspective (3D透视)
+- ❌ Excessive gradients (夸张的多色渐变)
+- ❌ Clip art / cartoon icons (卡通图标)
+- ❌ Decorative patterns in background (背景花纹)
+- ❌ Glowing effects (发光效果)
+- ❌ Too many small icons (过多小图标)
+
+#### ✓ 理想的视觉效果：
+- 一眼看上去**专业、清晰**
+- 有**适度的视觉吸引力**，但不抢眼
+- 符合**CVPR/NeurIPS论文**的审美标准
+- **打印友好**（灰度模式下也能清晰辨认）
+- 像**精心设计**的学术图表，而不是PPT模板
+
+### What to AVOID (CRITICAL)
+- ❌ Rainbow color schemes (too many colors)
+- ❌ Thin, hairline arrows (arrows must be THICK)
+- ❌ Unlabeled connections
+- ❌ Plain boring rectangles (add some visual interest)
+- ❌ **Over-decorated with shadows/glows/icons** (too flashy)
+- ❌ Small text that's unreadable when printed
+- ❌ **WRONG arrow directions** — This is UNACCEPTABLE!
+
+## Scope
+
+| Figure Type | Quality | Examples |
+|-------------|---------|----------|
+| **Architecture diagrams** | Excellent | Model architecture, pipeline, encoder-decoder |
+| **Method illustrations** | Excellent | Conceptual diagrams, algorithm flowcharts |
+| **Conceptual figures** | Good | Comparison diagrams, taxonomy trees |
+
+**Not for:** Statistical plots (use `/paper-figure`), photo-realistic images
+
+## Workflow: MUST EXECUTE ALL STEPS
+
+### Step 0: Pre-flight Check
+
+```bash
+# Check API key
+if [ -z "$GEMINI_API_KEY" ]; then
+    echo "ERROR: GEMINI_API_KEY not set"
+    echo "Get your key from: https://aistudio.google.com/app/apikey"
+    echo "Set it: export GEMINI_API_KEY='your-key'"
+    exit 1
+fi
+
+# Create output directory
+mkdir -p figures/ai_generated
+```
+
+### Step 1: Codex Plans the Figure (YOU ARE HERE)
+
+**CRITICAL: Codex must first analyze the user's request and create a detailed prompt.**
+
+Parse the input: **$ARGUMENTS**
+
+Codex's task:
+1. Understand what figure the user wants
+2. Identify all components, connections, data flow
+3. Create a **detailed, structured prompt** for Gemini
+4. Include style requirements AND visual appeal requirements
+
+**Prompt Template for Codex to generate:**
+
+```
+Create a PROFESSIONAL, VISUALLY APPEALING publication-quality academic diagram following CVPR/ICLR/NeurIPS standards.
+
+## Visual Style: 科研风格 (Academic Professional Style)
+### 目标：平衡 — 既不保守也不花哨
+
+#### DO (应该有):
+- **Subtle gradients** — 同色系淡雅渐变（如 #2563EB → #3B82F6），不是多色炫彩
+- **Rounded corners** — 圆角矩形（6-10px），现代感
+- **Clear visual hierarchy** — 通过大小、深浅区分层次
+- **Internal structure** — 大模块内显示子组件结构
+- **Consistent color coding** — 统一的3-4色方案
+- **Professional polish** — 精致但不夸张
+
+#### DON'T (不要有):
+- ❌ Rainbow/multi-color gradients (彩虹渐变)
+- ❌ Heavy drop shadows (重阴影)
+- ❌ 3D effects / perspective (3D效果)
+- ❌ Glowing effects (发光效果)
+- ❌ Excessive decorative icons (过多装饰图标)
+- ❌ Plain boring rectangles (完全平淡的方块)
+
+#### 理想效果：
+像顶会论文中精心设计的架构图 — 专业、清晰、有适度的视觉吸引力
+
+## Figure Type
+[Architecture Diagram / Pipeline / Comparison / etc.]
+
+## Components to Include (BE SPECIFIC ABOUT CONTENT)
+1. [Component 1]:
+   - Label: "[exact text]"
+   - Sub-label: "[smaller text below]"
+   - Position: [left/center/right, top/middle/bottom]
+   - Style: [border color, fill, internal structure]
+2. [Component 2]: ...
+
+## Layout
+- Direction: [left-to-right / top-to-bottom]
+- Spacing: [tight / normal / loose]
+- Grouping: [how components should be grouped]
+
+## Connections (BE EXPLICIT ABOUT DIRECTION)
+EXACT arrow specifications:
+1. [Component A] → [Component B]: Arrow goes FROM A TO B, label it "[data type]"
+2. [Component C] → [Component D]: Arrow goes FROM C TO D, label it "[data type]"
+...
+VERIFY: Each arrow must point to the CORRECT target!
+
+## Style Requirements (CVPR/ICLR/NeurIPS Standard)
+
+### Visual Style
+- Color palette: Professional academic colors
+  - Inputs: Green (#10B981)
+  - Encoders: Blue (#2563EB)
+  - Fusion modules: Purple (#7C3AED)
+  - Outputs: Orange (#EA580C)
+- Font: Sans-serif (Arial/Helvetica), minimum 14pt, bold for labels
+- Background: Clean white, no patterns
+- Blocks: Rounded rectangles (8-12px radius), subtle gradient fill, colored border (2-3px)
+- Subtle shadows for depth effect
+- Print-friendly (must work in grayscale)
+
+### CRITICAL: Arrow & Data Flow Requirements
+1. **ALL arrows must be VERY THICK** - minimum 5-6px stroke width
+2. **ALL arrows must have CLEAR arrowheads** - large, visible triangular heads
+3. **ALL arrows must be BLACK or DARK GRAY** - not colored
+4. **Label EVERY arrow** with what data flows through it
+5. **VERIFY arrow direction** - each arrow MUST point to the correct target
+6. **No ambiguous connections** - every arrow should have a clear source and destination
+
+### Logic Clarity Requirements
+1. **Data flow must be immediately obvious** - viewer should understand the pipeline in 5 seconds
+2. **No crossing arrows** - reorganize layout to avoid arrow crossings
+3. **Consistent direction** - maintain left-to-right or top-to-bottom flow throughout
+4. **Group related components** - use subtle background boxes or spacing to group modules
+5. **Clear hierarchy** - main components larger, sub-components smaller
+
+## Additional Requirements
+[Any specific requirements from user]
+```
+
+### Step 2: Gemini Layout Optimization (gemini-3-pro)
+
+**Codex sends the initial prompt to Gemini (gemini-3-pro) for layout optimization.**
+
+```bash
+#!/bin/bash
+# Step 2: Optimize layout using Gemini gemini-3-pro
+# This step refines component positioning and spacing
+
+set -e
+
+OUTPUT_DIR="figures/ai_generated"
+mkdir -p "$OUTPUT_DIR"
+
+API_KEY="${GEMINI_API_KEY}"
+URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key=$API_KEY"
+
+# The initial prompt from Codex
+INITIAL_PROMPT='[Codex fills in the detailed prompt here]'
+
+# Layout optimization request
+LAYOUT_REQUEST="You are an expert in academic figure layout design for CVPR/NeurIPS papers.
+
+Analyze this figure request and provide an OPTIMIZED LAYOUT DESCRIPTION:
+
+$INITIAL_PROMPT
+
+Provide:
+1. **Optimized Component Positions**: Exact positions (left/center/right, top/middle/bottom) for each component
+2. **Spacing Recommendations**: Specific spacing between components
+3. **Grouping Strategy**: Which components should be visually grouped together
+4. **Arrow Routing**: Optimal paths for arrows to avoid crossings
+5. **Visual Hierarchy**: Size recommendations for main vs sub-components
+
+Output a DETAILED layout specification that will be used for rendering."
+
+# Build JSON payload
+python3 << PYTHON
+import json
+payload = {
+    "contents": [{"parts": [{"text": '''$LAYOUT_REQUEST'''}]}]
+}
+with open("/tmp/gemini_layout_request.json", "w") as f:
+    json.dump(payload, f, indent=2)
+print("Layout request created")
+PYTHON
+
+# Call Gemini gemini-3-pro-preview for layout optimization (DIRECT connection, no proxy)
+RESPONSE=$(curl -s --max-time 90 \
+  -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d @/tmp/gemini_layout_request.json)
+
+# Extract layout description
+LAYOUT_DESCRIPTION=$(echo "$RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+try:
+    print(data['candidates'][0]['content']['parts'][0]['text'])
+except:
+    print('Error extracting layout')
+")
+
+echo "=== Layout Optimization Complete ==="
+echo "$LAYOUT_DESCRIPTION"
+echo "$LAYOUT_DESCRIPTION" > "$OUTPUT_DIR/layout_description.txt"
+```
+
+### Step 3: Gemini Style Verification (gemini-3-pro)
+
+**Codex sends the optimized layout to Gemini for CVPR/NeurIPS style verification.**
+
+```bash
+#!/bin/bash
+# Step 3: Verify and enhance style compliance using Gemini gemini-3-pro
+
+API_KEY="${GEMINI_API_KEY}"
+URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key=$API_KEY"
+
+# Read layout from previous step
+LAYOUT=$(cat figures/ai_generated/layout_description.txt)
+
+# Style verification request
+STYLE_REQUEST="You are a CVPR/NeurIPS paper figure reviewer specializing in visual standards.
+
+Review and ENHANCE this figure specification for top-tier conference compliance:
+
+$LAYOUT
+
+Ensure compliance with:
+1. **Color Palette**: Use professional academic colors (green for inputs, blue for encoders, purple for fusion, orange for outputs)
+2. **Arrow Standards**: Thick (5-6px), black/dark gray, clear arrowheads, all labeled
+3. **Font Standards**: Sans-serif, minimum 14pt, readable in print
+4. **Visual Appeal (科研风格)**:
+   - ✅ Subtle same-color gradients, rounded corners (6-10px), internal structure visible
+   - ❌ NO heavy shadows, NO glowing effects, NO rainbow gradients
+
+Output an ENHANCED figure specification with explicit style instructions for rendering."
+
+# Build JSON payload
+python3 << PYTHON
+import json
+payload = {
+    "contents": [{"parts": [{"text": '''$STYLE_REQUEST'''}]}]
+}
+with open("/tmp/gemini_style_request.json", "w") as f:
+    json.dump(payload, f, indent=2)
+print("Style request created")
+PYTHON
+
+# Call Gemini gemini-3-pro-preview for style verification (DIRECT connection, no proxy)
+RESPONSE=$(curl -s --max-time 90 \
+  -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d @/tmp/gemini_style_request.json)
+
+# Extract style-enhanced specification
+STYLE_SPEC=$(echo "$RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+try:
+    print(data['candidates'][0]['content']['parts'][0]['text'])
+except:
+    print('Error extracting style spec')
+")
+
+echo "=== Style Verification Complete ==="
+echo "$STYLE_SPEC"
+echo "$STYLE_SPEC" > "figures/ai_generated/style_spec.txt"
+```
+
+### Step 4: Paperbanana Image Rendering (gemini-3-pro-image-preview)
+
+**Codex sends the optimized, style-verified specification to Paperbanana for rendering.**
+
+```bash
+#!/bin/bash
+# Step 4: Render image using Paperbanana (gemini-3-pro-image-preview)
+# Internal codename: Nano Banana Pro
+# Use DIRECT connection (no proxy) - proxy causes SSL errors
+
+set -e
+
+OUTPUT_DIR="figures/ai_generated"
+mkdir -p "$OUTPUT_DIR"
+
+API_KEY="${GEMINI_API_KEY}"
+URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent?key=$API_KEY"
+
+# Read the style-enhanced specification from previous step
+STYLE_SPEC=$(cat figures/ai_generated/style_spec.txt)
+
+# Add rendering instructions
+RENDER_PROMPT="Render a publication-quality academic diagram based on this specification:
+
+$STYLE_SPEC
+
+RENDERING REQUIREMENTS:
+- Output a clean, professional diagram suitable for CVPR/NeurIPS submission
+- Use vector-quality rendering with sharp edges and clear text
+- Ensure all elements are properly aligned and spaced
+- The diagram should be immediately understandable at a glance"
+
+# Build JSON payload using Python for proper escaping
+python3 << PYTHON
+import json
+payload = {
+    "contents": [{"parts": [{"text": '''$RENDER_PROMPT'''}]}],
+    "generationConfig": {"responseModalities": ["TEXT", "IMAGE"]}
+}
+with open("/tmp/gemini_request.json", "w") as f:
+    json.dump(payload, f, indent=2)
+print("JSON payload created")
+PYTHON
+
+# Call Paperbanana API WITHOUT proxy (direct connection works better)
+RESPONSE=$(curl -s --max-time 180 \
+  -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d @/tmp/gemini_request.json)
+
+# Check for error
+if echo "$RESPONSE" | grep -q '"error"'; then
+    echo "API Error:"
+    echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+    exit 1
+fi
+
+# Extract and save image
+echo "$RESPONSE" | python3 << 'PYTHON'
+import sys, json, base64
+from pathlib import Path
+
+output_dir = Path("figures/ai_generated")
+data = json.load(sys.stdin)
+
+try:
+    parts = data['candidates'][0]['content']['parts']
+    iteration = 1  # Codex increments this each iteration
+
+    for part in parts:
+        if 'text' in part:
+            print(f"\n[Paperbanana]: {part['text'][:200]}...")
+        elif 'inlineData' in part:
+            img_data = base64.b64decode(part['inlineData']['data'])
+            img_path = output_dir / f"figure_v{iteration}.png"
+            with open(img_path, "wb") as f:
+                f.write(img_data)
+            print(f"\n✅ Image saved: {img_path}")
+            print(f"   Size: {len(img_data)/1024:.1f} KB")
+
+except Exception as e:
+    print(f"Parse error: {e}")
+    print(f"Raw response: {str(data)[:500]}")
+PYTHON
+```
+
+### Step 5: Codex STRICT Visual Review & Scoring (MANDATORY)
+
+**Codex MUST read the generated image and perform a STRICT review:**
+
+1. **Visual Analysis**: What does the image show in detail?
+2. **Strengths**: What's good about it?
+3. **STRICT Verification**: Check EVERY item below
+4. **Score**: Rate 1-10 (10 = perfect) — BE STRICT!
+
+**STRICT Review Template:**
+
+```markdown
+## Codex's STRICT Review of Figure v{N}
+
+### What I See
+[Describe the generated image in DETAIL - every block, every arrow]
+
+### Strengths
+- [Strength 1]
+- [Strength 2]
+
+### ═══════════════════════════════════════════════════════════════
+### STRICT VERIFICATION CHECKLIST (ALL must pass for score ≥ 9)
+### ═══════════════════════════════════════════════════════════════
+
+#### A. Arrow Correctness Verification (CRITICAL - any failure = score ≤ 6)
+Check EACH arrow:
+- [ ] Arrow 1: [Source] → [Target] — Does it point to the CORRECT target?
+- [ ] Arrow 2: [Source] → [Target] — Does it point to the CORRECT target?
+- [ ] Arrow 3: [Source] → [Target] — Does it point to the CORRECT target?
+- [ ] Arrow 4: [Source] → [Target] — Does it point to the CORRECT target?
+- [ ] Arrow 5: [Source] → [Target] — Does it point to the CORRECT target?
+- [ ] Arrow 6: [Source] → [Target] — Does it point to the CORRECT target?
+
+#### B. Block Content Verification (any failure = score ≤ 7)
+Check EACH block:
+- [ ] Block 1 "[Name]": Has correct label? Has sub-label? Content correct?
+- [ ] Block 2 "[Name]": Has correct label? Has sub-label? Content correct?
+- [ ] Block 3 "[Name]": Has correct label? Has sub-label? Content correct?
+- [ ] Block 4 "[Name]": Has correct label? Has sub-label? Content correct?
+- [ ] Block 5 "[Name]": Has correct label? Has sub-label? Content correct?
+- [ ] Block 6 "[Name]": Has correct label? Has sub-label? Content correct?
+- [ ] Block 7 "[Name]": Has correct label? Has sub-label? Content correct?
+
+#### C. Arrow Visibility (any failure = score ≤ 7)
+- [ ] ALL arrows are THICK (≥5px visible stroke)
+- [ ] ALL arrows have CLEAR arrowheads (large triangular heads)
+- [ ] ALL arrows are BLACK or DARK GRAY (not light colors)
+- [ ] NO arrows are too thin or invisible
+
+#### D. Arrow Labels (any failure = score ≤ 7)
+- [ ] EVERY arrow has a text label
+- [ ] Labels are readable (not too small)
+- [ ] Labels correctly describe the data flowing
+
+#### E. Visual Appeal (科研风格 - Balanced Academic Style) (any failure = score ≤ 8)
+- [ ] **有适度视觉吸引力** — 有subtle渐变或圆角，但不夸张
+- [ ] **不是平淡方块** — 有一定设计感
+- [ ] **不过度装饰** — 没有重阴影、发光效果、彩虹配色
+- [ ] **专业学术风格** — 像CVPR论文中的图表，不是PPT模板
+- [ ] **Internal structure visible** — 大模块内部显示子组件结构
+- [ ] **Color palette: 3-4种协调色** — 不是彩虹，也不是纯黑白
+
+#### E2. Visual Appeal - RED FLAGS (immediate score ≤ 7 if found)
+- [ ] **NO heavy drop shadows** (重阴影 = too flashy)
+- [ ] **NO glowing effects** (发光效果 = too flashy)
+- [ ] **NO rainbow gradients** (彩虹渐变 = unprofessional)
+- [ ] **NO excessive decorative icons** (过多装饰图标 = distracting)
+
+#### F. Layout & Flow (any failure = score ≤ 7)
+- [ ] Clean horizontal left-to-right flow
+- [ ] No arrow crossings
+- [ ] Data flow traceable in 5 seconds
+- [ ] Balanced spacing (not cramped, not sparse)
+
+#### G. Style Compliance
+- [ ] CVPR/NeurIPS professional style
+- [ ] Color palette appropriate (not rainbow)
+- [ ] Font readable
+- [ ] Print-friendly (grayscale test)
+
+### ═══════════════════════════════════════════════════════════════
+
+### Issues Found (BE SPECIFIC)
+1. [Issue 1]: [EXACTLY what is wrong] → [How to fix]
+2. [Issue 2]: [EXACTLY what is wrong] → [How to fix]
+3. [Issue 3]: [EXACTLY what is wrong] → [How to fix]
+
+### Score: X/10
+
+### STRICT Score Breakdown Guide:
+- **10**: Perfect. No issues. Publication-ready masterpiece. 视觉风格完美平衡。
+- **9**: Excellent. Minor issues that don't affect understanding. 可以直接使用。
+- **8**: Good but has noticeable issues. 视觉上太平淡或太花哨都需要改进。
+- **7**: Usable but has clear problems. 箭头或内容有问题。
+- **6**: Has arrow direction errors (箭头指向错误) OR missing major components.
+- **1-5**: Major issues. Unacceptable.
+
+### Visual Style Scoring (视觉风格评分):
+- **太花哨 (Too flashy)**: 重阴影、发光效果、彩虹配色 → score ≤ 7
+- **太平淡 (Too plain)**: 纯黑白方块、无任何视觉设计 → score ≤ 8
+- **恰到好处 (Balanced)**: 适度渐变、圆角、清晰层次 → score 9-10
+
+### Verdict
+[ ] ACCEPT (score ≥ 9 AND all critical checks pass)
+[ ] REFINE (score < 9 OR any critical check fails)
+
+**If REFINE: List the EXACT issues that must be fixed**
+```
+
+### Step 6: Decision Point
+
+```
+IF score >= 9 AND all critical checks pass:
+    → Accept figure, generate LaTeX snippet, DONE
+ELSE IF iteration < MAX_ITERATIONS:
+    → Generate SPECIFIC improvement prompt based on EXACT issues
+    → Go to Step 2 (Gemini Layout) with refined prompt
+ELSE:
+    → Max iterations reached, show best version
+    → Ask user if they want to continue or accept
+```
+
+### Step 7: Generate Improvement Prompt (for refinement)
+
+**Codex generates TARGETED improvement prompt with EXACT issues:**
+
+```
+Refine this academic diagram. This is iteration {N}.
+
+## ═══════════════════════════════════════════════════════════════
+## CRITICAL: Fix These EXACT Issues (from previous review)
+## ═══════════════════════════════════════════════════════════════
+
+### Arrow Direction Errors (MUST FIX):
+1. [EXACT issue]: Arrow from [A] to [B] is pointing to wrong target. It should point to [C] instead.
+2. [EXACT issue]: ...
+
+### Missing Arrow Labels (MUST FIX):
+1. Arrow from [A] to [B] is missing label "[data type]"
+2. ...
+
+### Block Content Issues (MUST FIX):
+1. Block "[Name]" has wrong label. Should be "[correct label]"
+2. ...
+
+### Visual Appeal Issues (SHOULD FIX):
+1. Blocks are too plain. Add [gradients/shadows/internal structure]
+2. ...
+
+## Keep These Good Elements:
+- [What to preserve from previous version]
+
+## Generate the improved figure with ALL issues fixed.
+```
+
+### Step 8: Final Output
+
+When figure is accepted (score ≥ 9):
+
+```latex
+% === AI-Generated Figure ===
+\begin{figure*}[t]
+    \centering
+    \includegraphics[width=0.95\textwidth]{figures/ai_generated/figure_final.png}
+    \caption{[Caption based on user's original request].}
+    \label{fig:[label]}
+\end{figure*}
+```
+
+## Key Rules (MUST FOLLOW - STRICT)
+
+1. **NEVER skip the review step** — Always read and STRICTLY score the image
+2. **NEVER accept score < 9** — Keep refining until excellence
+3. **VERIFY EVERY ARROW DIRECTION** — Wrong direction = automatic fail (score ≤ 6)
+4. **VERIFY EVERY BLOCK CONTENT** — Wrong content = automatic fail (score ≤ 7)
+5. **BE SPECIFIC in feedback** — "Arrow from A to B points to wrong target C" not "arrow is wrong"
+6. **SAVE all iterations** — Keep version history for comparison
+7. **Codex is the STRICT boss** — Accept only excellence, not "good enough"
+8. **ARROW CORRECTNESS IS NON-NEGOTIABLE** — Any wrong arrow direction = reject
+9. **VISUAL APPEAL MATTERS** — Plain boring figures = score ≤ 8
+10. **Target score is 9** — Not 8, not "good enough"
+11. **USE MULTI-STAGE WORKFLOW** — Codex → Gemini Layout → Gemini Style → Paperbanana → Codex Review
+12. **USE CORRECT MODELS** — gemini-3-pro for reasoning, gemini-3-pro-image-preview for rendering
+
+## Output Structure
+
+```
+figures/ai_generated/
+├── layout_description.txt  # Step 2: Gemini layout optimization output
+├── style_spec.txt          # Step 3: Gemini style verification output
+├── figure_v1.png           # Iteration 1 (Paperbanana render)
+├── figure_v2.png           # Iteration 2
+├── figure_v3.png           # Iteration 3
+├── figure_final.png        # Accepted version (copy of best, score ≥ 9)
+├── latex_include.tex       # LaTeX snippet
+└── review_log.json         # All review scores and STRICT feedback
+```
+
+## Model Summary
+
+| Stage | Model | Purpose |
+|-------|-------|---------|
+| Step 1 | Codex | Parse request, create initial prompt |
+| Step 2 | gemini-3-pro | Layout optimization (positioning, spacing, grouping) |
+| Step 3 | gemini-3-pro | CVPR/NeurIPS style verification |
+| Step 4 | gemini-3-pro-image-preview (Paperbanana) | High-quality image rendering |
+| Step 5 | Codex | STRICT visual review and scoring |

--- a/skills/skills-codex/paper-writing/SKILL.md
+++ b/skills/skills-codex/paper-writing/SKILL.md
@@ -90,13 +90,29 @@ Invoke `/paper-figure` to generate data-driven plots and tables:
 
 **Output:** `figures/` directory with PDFs, generation scripts, and LaTeX snippets.
 
-> **Scope:** Auto-generates ~60% of figures (data plots, comparison tables). Architecture diagrams, pipeline figures, and qualitative result grids must be created manually and placed in `figures/` before proceeding. See `/paper-figure` SKILL.md for details.
+#### Phase 2b: AI Illustration Generation (when `illustration: true`)
+
+**Skip this step entirely if `illustration` is not set or is `false`.**
+
+If the paper plan includes architecture diagrams, pipeline figures, or method illustrations, invoke `/paper-illustration`:
+
+```
+/paper-illustration "[method description from PAPER_PLAN.md or NARRATIVE_REPORT.md]"
+```
+
+**What this does:**
+- Codex plans the layout → Gemini optimizes → Nano Banana Pro renders → Codex reviews (score ≥ 9)
+- Output: `figures/ai_generated/*.png` — publication-quality method diagrams
+- Requires `GEMINI_API_KEY` environment variable
+
+> **Without `illustration: true`:** Architecture diagrams must still be created manually (draw.io, Figma, TikZ) and placed in `figures/` before proceeding — same as before.
 
 **Checkpoint:** List generated vs manual figures.
 
 ```
 📊 Figures complete:
-- Auto-generated: [list]
+- Data plots (auto): [list]
+- AI illustrations (auto): [list, if illustration: true]
 - Manual (need your input): [list]
 - LaTeX snippets: figures/latex_includes.tex
 
@@ -269,4 +285,3 @@ then /paper-writing for the final writing step.
 | 5. Improvement | 15-30 min | Yes ✅ |
 
 **Total: ~45-90 min** for a full paper from narrative report to polished PDF.
-

--- a/skills/skills-codex/research-lit/SKILL.md
+++ b/skills/skills-codex/research-lit/SKILL.md
@@ -12,7 +12,7 @@ Research topic: $ARGUMENTS
 - **PAPER_LIBRARY** — Local directory containing user's paper collection (PDFs). Check these paths in order:
   1. `papers/` in the current project directory
   2. `literature/` in the current project directory
-  3. Custom path specified by user in `CLAUDE.md` under `## Paper Library`
+  3. Custom path specified by user in `AGENTS.md` under `## Paper Library`
 - **MAX_LOCAL_PAPERS = 20** — Maximum number of local PDFs to scan (read first 3 pages each). If more are found, prioritize by filename relevance to the topic.
 - **ARXIV_DOWNLOAD = false** — When `true`, download top 3-5 most relevant arXiv PDFs to PAPER_LIBRARY after search. When `false` (default), only fetch metadata (title, abstract, authors) via arXiv API — no files are downloaded.
 - **ARXIV_MAX_DOWNLOAD = 5** — Maximum number of PDFs to download when `ARXIV_DOWNLOAD = true`.

--- a/skills/skills-codex/run-experiment/SKILL.md
+++ b/skills/skills-codex/run-experiment/SKILL.md
@@ -11,12 +11,12 @@ Deploy and run ML experiment: $ARGUMENTS
 
 ### Step 1: Detect Environment
 
-Read the project's `CLAUDE.md` to determine the experiment environment:
+Read the project's `AGENTS.md` to determine the experiment environment:
 
 - **Local GPU**: Look for local CUDA/MPS setup info
 - **Remote server**: Look for SSH alias, conda env, code directory
 
-If no server info is found in `CLAUDE.md`, ask the user.
+If no server info is found in `AGENTS.md`, ask the user.
 
 ### Step 2: Pre-flight Check
 
@@ -38,7 +38,7 @@ Free GPU = memory.used < 500 MiB.
 
 ### Step 3: Sync Code (Remote Only)
 
-Check the project's `CLAUDE.md` for a `code_sync` setting. If not specified, default to `rsync`.
+Check the project's `AGENTS.md` for a `code_sync` setting. If not specified, default to `rsync`.
 
 #### Option A: rsync (default)
 
@@ -47,7 +47,7 @@ Only sync necessary files — NOT data, checkpoints, or large files:
 rsync -avz --include='*.py' --exclude='*' <local_src>/ <server>:<remote_dst>/
 ```
 
-#### Option B: git (when `code_sync: git` is set in CLAUDE.md)
+#### Option B: git (when `code_sync: git` is set in AGENTS.md)
 
 Push local changes to remote repo, then pull on the server:
 ```bash
@@ -59,6 +59,46 @@ ssh <server> "cd <remote_dst> && git pull"
 ```
 
 Benefits: version-tracked, multi-server sync with one push, no rsync include/exclude rules needed.
+
+### Step 3.5: W&B Integration (when `wandb: true` in AGENTS.md)
+
+**Skip this step entirely if `wandb` is not set or is `false` in AGENTS.md.**
+
+Before deploying, ensure the experiment scripts have W&B logging:
+
+1. **Check if wandb is already in the script** — look for `import wandb` or `wandb.init`. If present, skip to Step 4.
+
+2. **If not present, add W&B logging** to the training script:
+   ```python
+   import wandb
+   wandb.init(project=WANDB_PROJECT, name=EXP_NAME, config={...hyperparams...})
+
+   # Inside training loop:
+   wandb.log({"train/loss": loss, "train/lr": lr, "step": step})
+
+   # After eval:
+   wandb.log({"eval/loss": eval_loss, "eval/ppl": ppl, "eval/accuracy": acc})
+
+   # At end:
+   wandb.finish()
+   ```
+
+3. **Metrics to log** (add whichever apply to the experiment):
+   - `train/loss` — training loss per step
+   - `train/lr` — learning rate
+   - `eval/loss`, `eval/ppl`, `eval/accuracy` — eval metrics per epoch
+   - `gpu/memory_used` — GPU memory (via `torch.cuda.max_memory_allocated()`)
+   - `speed/samples_per_sec` — throughput
+   - Any custom metrics the experiment already computes
+
+4. **Verify wandb login on the target machine:**
+   ```bash
+   ssh <server> "wandb status"  # should show logged in
+   # If not logged in:
+   ssh <server> "wandb login <WANDB_API_KEY>"
+   ```
+
+> The W&B project name and API key come from `AGENTS.md` (see example below). The experiment name is auto-generated from the script name + timestamp.
 
 ### Step 4: Deploy
 
@@ -109,9 +149,9 @@ After deployment is verified, check `~/.codex/feishu.json`:
 - Report back: which GPU, which screen/process, what command, estimated time
 - If multiple experiments, launch them in parallel on different GPUs
 
-## Project Config Example
+## AGENTS.md Example
 
-Users should add their server info to their project's `CLAUDE.md`:
+Users should add their server info to their project's `AGENTS.md`:
 
 ```markdown
 ## Remote Server
@@ -120,9 +160,13 @@ Users should add their server info to their project's `CLAUDE.md`:
 - Conda: `eval "$(/opt/conda/bin/conda shell.bash hook)" && conda activate research`
 - Code dir: `/home/user/experiments/`
 - code_sync: rsync          # default. Or set to "git" for git push/pull workflow
+- wandb: false              # set to "true" to auto-add W&B logging to experiment scripts
+- wandb_project: my-project # W&B project name (required if wandb: true)
+- wandb_entity: my-team     # W&B team/user (optional, uses default if omitted)
 
 ## Local Environment
 - Mac MPS / Linux CUDA
 - Conda env: `ml` (Python 3.10 + PyTorch)
 ```
 
+> **W&B setup**: Run `wandb login` on your server once (or set `WANDB_API_KEY` env var). The skill reads project/entity from `AGENTS.md` and adds `wandb.init()` + `wandb.log()` to your training scripts automatically. Dashboard: `https://wandb.ai/<entity>/<project>`.


### PR DESCRIPTION
## Summary
- restore Codex skill parity with the latest Claude-side `skills/` catalog
- add missing Codex-pack skills for `experiment-bridge`, `grant-proposal`, and `paper-illustration`
- sync existing Codex workflow/docs so the pack matches the latest main-branch behavior

## What changed
- added these missing Codex-pack skills under `skills/skills-codex/`
  - `experiment-bridge`
  - `grant-proposal`
  - `paper-illustration`
- updated `skills/skills-codex/paper-writing/SKILL.md`
  - restores the `illustration: true` path
  - wires Workflow 3 to `/paper-illustration`
  - documents `GEMINI_API_KEY` + `figures/ai_generated/*.png`
- updated `skills/skills-codex/run-experiment/SKILL.md`
  - switches Codex-pack config references to `AGENTS.md`
  - restores the W&B integration guidance in parity with the latest Claude-side skill
- updated `skills/skills-codex/research-lit/SKILL.md`
  - switches paper-library config lookup from `CLAUDE.md` to `AGENTS.md`
- updated Codex-pack docs and repo README entries
  - removes stale "24 skills" claims
  - documents that the Codex pack now covers the full current ARIS skill set

## Validation
- verified directory parity: `skills/` and `skills/skills-codex/` both contain 31 skills in this branch
- verified `skills/skills-codex/` no longer contains:
  - `mcp__codex__codex`
  - `mcp__codex__codex-reply`
  - `CLAUDE.md`
  - `~/.claude/`
- verified Workflow 3 Codex docs now reference `/paper-illustration`

## Notes
- direct push to upstream `origin` was not permitted for my account, so this PR comes from my fork branch instead
