### PR TITLE
Add Codex-to-Claude reviewer bridge for Codex skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Custom [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for 
 
 ## 📢 What's New
 
+- **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🔁 **[Codex + Claude reviewer bridge](docs/CODEX_CLAUDE_REVIEW_GUIDE.md)** — keep Codex as the executor, use Claude Code CLI as the reviewer through a local `claude-review` MCP bridge, and switch long paper/review prompts to async polling (`review_start` / `review_reply_start` / `review_status`)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🖱️ **[Cursor adaptation guide](docs/CURSOR_ADAPTATION.md)** — use ARIS skills in [Cursor](https://www.cursor.com/) with `@`-reference, MCP setup, and state file recovery. Community contribution by [@YecanLee](https://github.com/YecanLee)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🤖 **[Codex CLI native skills](skills/skills-codex/)** — full 31-skill ARIS set for [Codex CLI](https://github.com/openai/codex) using `spawn_agent`. Community contributions by [@Falling-Flower](https://github.com/Falling-Flower) & [@No-518](https://github.com/No-518)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 📝 **[`grant-proposal`](skills/grant-proposal/SKILL.md)** — Draft structured grant proposals from research ideas. Supports 9 agencies: KAKENHI (Japan), NSF (US), NSFC (China, incl. 面上/青年/优青/杰青/海外优青/重点), ERC (EU), DFG, SNSF, ARC, NWO, and generic. Chains `/research-lit` → `/novelty-check` → `/research-review` → `/paper-illustration`. Community contribution by [@dengzhe-hou](https://github.com/dengzhe-hou)
@@ -96,6 +97,8 @@ claude
 > ```
 
 > **Important:** Codex MCP uses the model from `~/.codex/config.toml`, not from skill files. Make sure it says `model = "gpt-5.4"` (recommended). Other options: `gpt-5.3-codex`, `gpt-5.2-codex`, `o3`. Run `codex setup` or edit the file directly.
+
+> **Want Codex to execute but Claude Code to review?** See [`docs/CODEX_CLAUDE_REVIEW_GUIDE.md`](docs/CODEX_CLAUDE_REVIEW_GUIDE.md). That path installs the base `skills/skills-codex/*`, then overlays `skills/skills-codex-claude-review/*`, and routes review-heavy skills through the local `claude-review` MCP bridge.
 
 See [full setup guide](#%EF%B8%8F-setup) for details and [alternative model combinations](#-alternative-model-combinations) if you don't have Claude/OpenAI API.
 
@@ -1036,8 +1039,11 @@ Don't have Claude / OpenAI API access? You can swap in other models — same cro
 | **Alt D** | Kimi-K2.5 / Qwen3.5+ | GLM-5 / MiniMax-M2.5 | No | No | [ALI_CODING_PLAN_GUIDE](docs/ALI_CODING_PLAN_GUIDE.md) |
 | **Alt E** 🆓 | DeepSeek-V3.1 / Qwen3-Coder | DeepSeek-R1 / Qwen3-235B | No | No | [MODELSCOPE_GUIDE](docs/MODELSCOPE_GUIDE.md) |
 | **Alt F** | Codex CLI (GPT-5.4) | Codex `spawn_agent` (GPT-5.4) | No | Yes | [skills-codex/](skills/skills-codex/) |
+| **Alt G** 🆕 | Codex CLI | Claude Code CLI (`claude-review` MCP) | No* | No* | [CODEX_CLAUDE_REVIEW_GUIDE](docs/CODEX_CLAUDE_REVIEW_GUIDE.md) |
 
-**Alt C** supports tested providers: GLM (Z.ai), Kimi (Moonshot), LongCat (Meituan) as executors; DeepSeek, MiniMax as reviewers. Any OpenAI-compatible API should also work via the generic [`llm-chat`](mcp-servers/llm-chat/) MCP server. **Alt D** uses [Alibaba Coding Plan](https://bailian.console.aliyun.com/) — one API key for both executor and reviewer, 4 models included (Kimi, Qwen, GLM, MiniMax). **Alt E** uses [ModelScope](https://www.modelscope.cn/) — **free** (2000 calls/day), one key, no automation restrictions.
+**Alt C** supports tested providers: GLM (Z.ai), Kimi (Moonshot), LongCat (Meituan) as executors; DeepSeek, MiniMax as reviewers. Any OpenAI-compatible API should also work via the generic [`llm-chat`](mcp-servers/llm-chat/) MCP server. **Alt D** uses [Alibaba Coding Plan](https://bailian.console.aliyun.com/) — one API key for both executor and reviewer, 4 models included (Kimi, Qwen, GLM, MiniMax). **Alt E** uses [ModelScope](https://www.modelscope.cn/) — **free** (2000 calls/day), one key, no automation restrictions. **Alt G** keeps Codex as executor but swaps the reviewer to Claude Code CLI via the local `claude-review` MCP bridge, with async polling for long paper/review prompts.
+
+\* Alt G normally relies on local Codex CLI and Claude Code CLI logins. Direct API keys are optional, not required.
 
 ### Alt A: GLM + GPT
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -28,6 +28,7 @@
 
 ## 📢 最近更新
 
+- **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🔁 **[Codex + Claude 审稿 bridge](docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md)** — 保持 Codex 作为执行者，通过本地 `claude-review` MCP bridge 让 Claude Code CLI 担任审稿人，并把长论文 / 长 review prompt 切到异步轮询（`review_start` / `review_reply_start` / `review_status`）
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🖱️ **[Cursor 适配指南](docs/CURSOR_ADAPTATION.md)** — 在 [Cursor](https://www.cursor.com/) 中使用 ARIS skills，`@` 引用、MCP 配置、状态文件恢复。社区贡献 by [@YecanLee](https://github.com/YecanLee)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🤖 **[Codex CLI 原生 skills](skills/skills-codex/)** — 完整 31 个 ARIS skill 的 Codex CLI 版本，用 `spawn_agent`。社区贡献 by [@Falling-Flower](https://github.com/Falling-Flower) & [@No-518](https://github.com/No-518)
 - **2026-03-18** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 📝 **[`grant-proposal`](skills/grant-proposal/SKILL.md)** — 从研究 idea 自动生成结构化基金申请书。支持 9 个资助机构：科研費/KAKENHI（日本）、NSF（美国）、国自然/NSFC（含面上/青年/优青/杰青/海外优青/重点）、ERC（欧盟）、DFG、SNSF、ARC、NWO 及通用格式。串联 `/research-lit` → `/novelty-check` → `/research-review` → `/paper-illustration`。社区贡献 by [@dengzhe-hou](https://github.com/dengzhe-hou)
@@ -95,6 +96,8 @@ claude
 > ```
 
 > **重要：** Codex MCP 使用的模型取决于 `~/.codex/config.toml`，而非 skill 文件中的设置。请确认其中写的是 `model = "gpt-5.4"`（推荐）。其他可用模型：`gpt-5.3-codex`、`gpt-5.2-codex`、`o3`。运行 `codex setup` 或直接编辑该文件。
+
+> **想让 Codex 执行、Claude Code 审稿？** 见 [`docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md`](docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md)。这条路径会先安装基础 `skills/skills-codex/*`，再叠加 `skills/skills-codex-claude-review/*`，并通过本地 `claude-review` MCP bridge 转发 review-heavy skill 的审稿请求。
 
 详见[完整安装指南](#%EF%B8%8F-安装)和[替代模型组合](#-替代模型组合)（无需 Claude/OpenAI API）。
 
@@ -931,8 +934,11 @@ Skills 就是普通的 Markdown 文件，fork 后随意改：
 | **方案 D** | Kimi-K2.5 / Qwen3.5+ | GLM-5 / MiniMax-M2.5 | 否 | 否 | [ALI_CODING_PLAN_GUIDE](docs/ALI_CODING_PLAN_GUIDE.md) |
 | **方案 E** 🆓 | DeepSeek-V3.1 / Qwen3-Coder | DeepSeek-R1 / Qwen3-235B | 否 | 否 | [MODELSCOPE_GUIDE](docs/MODELSCOPE_GUIDE.md) |
 | **方案 F** | Codex CLI (GPT-5.4) | Codex `spawn_agent` (GPT-5.4) | 否 | 是 | [skills-codex/](skills/skills-codex/) |
+| **方案 G** 🆕 | Codex CLI | Claude Code CLI（`claude-review` MCP） | 否* | 否* | [CODEX_CLAUDE_REVIEW_GUIDE_CN](docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md) |
 
-**方案 C** 已适配的提供商：GLM（Z.ai）、Kimi（Moonshot）、LongCat（美团）作为执行器；DeepSeek、MiniMax 作为审查器。任何 OpenAI 兼容 API 理论上均可通过通用 [`llm-chat`](mcp-servers/llm-chat/) MCP 服务器接入。**方案 D** 使用[阿里百炼 Coding Plan](https://bailian.console.aliyun.com/)——一个 API Key 包含 4 款模型（Kimi、Qwen、GLM、MiniMax），双端点配置。**方案 E** 使用 [ModelScope（魔搭社区）](https://www.modelscope.cn/)——**免费**（2000 次/天），一个 Key，无自动化限制。
+**方案 C** 已适配的提供商：GLM（Z.ai）、Kimi（Moonshot）、LongCat（美团）作为执行器；DeepSeek、MiniMax 作为审查器。任何 OpenAI 兼容 API 理论上均可通过通用 [`llm-chat`](mcp-servers/llm-chat/) MCP 服务器接入。**方案 D** 使用[阿里百炼 Coding Plan](https://bailian.console.aliyun.com/)——一个 API Key 包含 4 款模型（Kimi、Qwen、GLM、MiniMax），双端点配置。**方案 E** 使用 [ModelScope（魔搭社区）](https://www.modelscope.cn/)——**免费**（2000 次/天），一个 Key，无自动化限制。**方案 G** 保持 Codex 作为执行者，但把审稿人切换成通过本地 `claude-review` MCP bridge 暴露出来的 Claude Code CLI，并用异步轮询处理长论文 / 长 review prompt。
+
+\* 方案 G 通常依赖本地 Codex CLI 和 Claude Code CLI 的登录态；不强制要求 API key。
 
 ### 方案 A: GLM + GPT
 

--- a/docs/CODEX_CLAUDE_REVIEW_GUIDE.md
+++ b/docs/CODEX_CLAUDE_REVIEW_GUIDE.md
@@ -1,0 +1,116 @@
+# Codex + Claude Reviewer Guide
+
+Run ARIS with:
+
+- **Codex** as the main executor
+- **Claude Code CLI** as the reviewer
+- the local `claude-review` MCP bridge as the transport layer
+
+This guide is **additive** to the upstream Codex-native path. It does not replace `skills/skills-codex/`.
+
+## Architecture
+
+- Base skill set: `skills/skills-codex/`
+- Reviewer override layer: `skills/skills-codex-claude-review/`
+- Reviewer bridge: `mcp-servers/claude-review/`
+
+The install order matters:
+
+1. install `skills/skills-codex/*`
+2. install `skills/skills-codex-claude-review/*`
+3. register `claude-review` MCP
+
+## Install
+
+```bash
+git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git
+cd Auto-claude-code-research-in-sleep
+
+mkdir -p ~/.codex/skills
+cp -a skills/skills-codex/* ~/.codex/skills/
+cp -a skills/skills-codex-claude-review/* ~/.codex/skills/
+
+mkdir -p ~/.codex/mcp-servers/claude-review
+cp mcp-servers/claude-review/server.py ~/.codex/mcp-servers/claude-review/server.py
+codex mcp add claude-review -- python3 ~/.codex/mcp-servers/claude-review/server.py
+```
+
+If your Claude login depends on a shell helper such as `claude-aws`, use the wrapper:
+
+```bash
+cp mcp-servers/claude-review/run_with_claude_aws.sh ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+chmod +x ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+codex mcp add claude-review -- ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+```
+
+Optional reviewer model override:
+
+```bash
+codex mcp remove claude-review
+codex mcp add claude-review --env CLAUDE_REVIEW_MODEL=claude-opus-4-1 -- python3 ~/.codex/mcp-servers/claude-review/server.py
+```
+
+## Verify
+
+1. Check MCP registration:
+
+```bash
+codex mcp list
+```
+
+2. Check Claude CLI login:
+
+```bash
+claude -p "Reply with exactly READY" --output-format json --tools ""
+```
+
+3. Start Codex in your project:
+
+```bash
+codex -C /path/to/your/project
+```
+
+## What gets overridden
+
+The overlay only replaces review-heavy skills:
+
+- `research-review`
+- `novelty-check`
+- `research-refine`
+- `auto-review-loop`
+- `paper-plan`
+- `paper-figure`
+- `paper-write`
+- `auto-paper-improvement-loop`
+
+Everything else still comes from the upstream `skills/skills-codex/` package.
+
+## Async reviewer flow
+
+For long paper or project reviews, use:
+
+- `review_start`
+- `review_reply_start`
+- `review_status`
+
+Why: in this host path, the review hop is:
+
+`Codex -> claude-review MCP -> local Claude CLI -> Claude backend`
+
+That extra local CLI hop is what makes long synchronous reviewer calls more likely to hit the observed Codex-hosted MCP timeout.
+
+## Project config
+
+No special project config file is required for this path.
+
+- keep using your existing `CLAUDE.md`
+- keep your current project layout
+- only switch the installed Codex skill files and MCP registration
+
+## Maintenance
+
+Regenerate the overlay package with:
+
+```bash
+python3 tools/generate_codex_claude_review_overrides.py
+```

--- a/docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md
+++ b/docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md
@@ -1,0 +1,116 @@
+# Codex + Claude 审稿人指南
+
+让 ARIS 以以下方式运行：
+
+- **Codex** 作为主执行者
+- **Claude Code CLI** 作为审稿人
+- 通过本地 `claude-review` MCP bridge 连接两者
+
+这条路径是对上游 Codex 原生方案的**增量叠加**，不会替代 `skills/skills-codex/`。
+
+## 架构
+
+- 基础技能包：`skills/skills-codex/`
+- 审稿覆盖层：`skills/skills-codex-claude-review/`
+- 审稿 bridge：`mcp-servers/claude-review/`
+
+安装顺序必须保持：
+
+1. 先安装 `skills/skills-codex/*`
+2. 再安装 `skills/skills-codex-claude-review/*`
+3. 最后注册 `claude-review` MCP
+
+## 安装
+
+```bash
+git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git
+cd Auto-claude-code-research-in-sleep
+
+mkdir -p ~/.codex/skills
+cp -a skills/skills-codex/* ~/.codex/skills/
+cp -a skills/skills-codex-claude-review/* ~/.codex/skills/
+
+mkdir -p ~/.codex/mcp-servers/claude-review
+cp mcp-servers/claude-review/server.py ~/.codex/mcp-servers/claude-review/server.py
+codex mcp add claude-review -- python3 ~/.codex/mcp-servers/claude-review/server.py
+```
+
+如果你的 Claude 登录依赖 `claude-aws` 之类的 shell helper，请改用 wrapper：
+
+```bash
+cp mcp-servers/claude-review/run_with_claude_aws.sh ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+chmod +x ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+codex mcp add claude-review -- ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+```
+
+如果你想固定 Claude 审稿模型：
+
+```bash
+codex mcp remove claude-review
+codex mcp add claude-review --env CLAUDE_REVIEW_MODEL=claude-opus-4-1 -- python3 ~/.codex/mcp-servers/claude-review/server.py
+```
+
+## 验证
+
+1. 检查 MCP 注册：
+
+```bash
+codex mcp list
+```
+
+2. 检查 Claude CLI 登录：
+
+```bash
+claude -p "Reply with exactly READY" --output-format json --tools ""
+```
+
+3. 在项目中启动 Codex：
+
+```bash
+codex -C /path/to/your/project
+```
+
+## 哪些技能会被覆盖
+
+覆盖层只替换 review-heavy 技能：
+
+- `research-review`
+- `novelty-check`
+- `research-refine`
+- `auto-review-loop`
+- `paper-plan`
+- `paper-figure`
+- `paper-write`
+- `auto-paper-improvement-loop`
+
+其余技能仍然来自上游原生 `skills/skills-codex/`。
+
+## 异步 reviewer 流程
+
+对于长论文或长项目审稿，请使用：
+
+- `review_start`
+- `review_reply_start`
+- `review_status`
+
+原因是这条宿主链路里的 review hop 更长：
+
+`Codex -> claude-review MCP -> 本地 Claude CLI -> Claude 后端`
+
+多出来的本地 CLI hop，正是长同步 reviewer 调用更容易撞上 Codex 侧 MCP 超时的主要原因。
+
+## 项目配置
+
+这条路径不要求你新建特殊项目配置文件。
+
+- 继续使用现有 `CLAUDE.md`
+- 保持原有项目目录结构
+- 只需要切换 Codex 安装的技能文件和 MCP 注册
+
+## 维护
+
+重新生成这个 overlay 包：
+
+```bash
+python3 tools/generate_codex_claude_review_overrides.py
+```

--- a/mcp-servers/claude-review/README.md
+++ b/mcp-servers/claude-review/README.md
@@ -1,0 +1,93 @@
+# Claude Review MCP
+
+Bridge Codex-first ARIS workflows to the local Claude Code CLI.
+
+## What it does
+
+- Keeps **Codex** as the executor
+- Uses **Claude Code CLI** as the external reviewer
+- Exposes synchronous MCP tools:
+  - `review`
+  - `review_reply`
+- Exposes asynchronous MCP tools for long reviewer prompts:
+  - `review_start`
+  - `review_reply_start`
+  - `review_status`
+
+The synchronous tools return a JSON string containing `threadId` and `response`.
+The asynchronous start tools return a JSON string containing `jobId` and `status`, and `review_status` later returns the final `threadId` and `response`.
+
+## Install into Codex
+
+```bash
+mkdir -p ~/.codex/mcp-servers/claude-review
+cp mcp-servers/claude-review/server.py ~/.codex/mcp-servers/claude-review/server.py
+codex mcp add claude-review -- python3 ~/.codex/mcp-servers/claude-review/server.py
+```
+
+If your Claude Code login depends on a shell function such as `claude-aws`, use the wrapper instead:
+
+```bash
+mkdir -p ~/.codex/mcp-servers/claude-review
+cp mcp-servers/claude-review/server.py ~/.codex/mcp-servers/claude-review/server.py
+cp mcp-servers/claude-review/run_with_claude_aws.sh ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+chmod +x ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+codex mcp add claude-review -- ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+```
+
+## Environment Variables
+
+- `CLAUDE_BIN`: Claude CLI path, defaults to `claude`
+- `CLAUDE_REVIEW_MODEL`: optional reviewer model override
+- `CLAUDE_REVIEW_SYSTEM`: optional default system prompt
+- `CLAUDE_REVIEW_TOOLS`: Claude tools override, defaults to empty string
+- `CLAUDE_REVIEW_TIMEOUT_SEC`: subprocess timeout, defaults to `600`
+
+## Notes
+
+- The bridge runs Claude in non-interactive `-p` mode.
+- By default the reviewer gets **no tools**. This matches the original ARIS pattern where the external reviewer only sees the prompt context prepared by the executor.
+- `threadId` is the native Claude session id and can be passed directly to `review_reply`.
+- `jobId` is a bridge-local background task id stored on disk under `~/.codex/state/claude-review/jobs/` by default, so status can be resumed across MCP server restarts.
+
+## When to use sync vs async
+
+- Use `review` / `review_reply` for short prompts that comfortably finish within the host MCP tool timeout.
+- Use `review_start` / `review_reply_start` + `review_status` for long paper or project reviews. This avoids the observed `Codex -> tools/call` timeout around 120 seconds.
+
+## Async flow
+
+Start a long review:
+
+```json
+{
+  "name": "review_start",
+  "arguments": {
+    "prompt": "Review this paper draft..."
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "jobId": "5d8d0a9c5a2f4f42ae44f6f0c2d73f6f",
+  "status": "queued",
+  "done": false
+}
+```
+
+Poll later:
+
+```json
+{
+  "name": "review_status",
+  "arguments": {
+    "jobId": "5d8d0a9c5a2f4f42ae44f6f0c2d73f6f",
+    "waitSeconds": 20
+  }
+}
+```
+
+When complete, `review_status` returns the same reviewer payload fields as the synchronous tools, including `threadId`, `response`, `model`, and `stop_reason`.

--- a/mcp-servers/claude-review/run_with_claude_aws.sh
+++ b/mcp-servers/claude-review/run_with_claude_aws.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env zsh
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER_DEBUG_LOG="${CLAUDE_REVIEW_WRAPPER_DEBUG_LOG:-/tmp/claude-review-wrapper.log}"
+
+log_wrapper() {
+  {
+    print -r -- "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+  } >>"$WRAPPER_DEBUG_LOG" 2>/dev/null || true
+}
+
+exec 3>&1
+exec 1>/dev/null
+
+export DISABLE_AUTO_TITLE=true
+export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+
+log_wrapper "wrapper start"
+log_wrapper "PATH=$PATH"
+
+if command -v claude-aws >/dev/null 2>&1; then
+  export CLAUDE_BIN="$(command -v claude-aws)"
+  log_wrapper "using claude-aws command: $CLAUDE_BIN"
+elif [ -f "$HOME/.config/claude-bedrock/claude-bedrock-env.sh" ]; then
+  # Fall back to the Bedrock helper when the wrapper command is unavailable.
+  source "$HOME/.config/claude-bedrock/claude-bedrock-env.sh"
+  if ! typeset -f claude_bedrock_use_sonnet >/dev/null 2>&1; then
+    exec 1>&3 3>&-
+    echo "claude_bedrock_use_sonnet helper not found in ~/.config/claude-bedrock/claude-bedrock-env.sh" >&2
+    exit 1
+  fi
+  claude_bedrock_use_sonnet
+  if ! command -v claude >/dev/null 2>&1; then
+    exec 1>&3 3>&-
+    echo "claude command not found in PATH after sourcing claude-bedrock-env.sh" >&2
+    exit 127
+  fi
+  export CLAUDE_BIN="$(command -v claude)"
+  log_wrapper "using claude command with Bedrock env: $CLAUDE_BIN"
+else
+  exec 1>&3 3>&-
+  echo "Neither claude-aws command nor ~/.config/claude-bedrock/claude-bedrock-env.sh is available" >&2
+  exit 1
+fi
+
+exec 1>&3 3>&-
+log_wrapper "exec python3 $SCRIPT_DIR/server.py"
+exec python3 "$SCRIPT_DIR/server.py"

--- a/mcp-servers/claude-review/server.py
+++ b/mcp-servers/claude-review/server.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Claude review MCP server for Codex-first ARIS workflows.
+
+This server exposes a narrow review-only interface over Claude Code CLI so
+Codex can remain the executor while Claude acts as the external reviewer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)
+sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)
+
+SERVER_NAME = os.environ.get("CLAUDE_REVIEW_SERVER_NAME", "claude-review")
+CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
+DEFAULT_MODEL = os.environ.get("CLAUDE_REVIEW_MODEL", "")
+DEFAULT_SYSTEM = os.environ.get("CLAUDE_REVIEW_SYSTEM", "")
+DEFAULT_TOOLS = os.environ.get("CLAUDE_REVIEW_TOOLS", "")
+DEFAULT_TIMEOUT_SEC = int(os.environ.get("CLAUDE_REVIEW_TIMEOUT_SEC", "600"))
+DEBUG_LOG = Path(os.environ.get("CLAUDE_REVIEW_DEBUG_LOG", f"/tmp/{SERVER_NAME}-mcp-debug.log"))
+STATE_DIR = Path(
+    os.environ.get(
+        "CLAUDE_REVIEW_STATE_DIR",
+        str(Path.home() / ".codex" / "state" / SERVER_NAME),
+    )
+)
+JOBS_DIR = STATE_DIR / "jobs"
+
+_use_ndjson = False
+TERMINAL_JOB_STATES = {"completed", "failed"}
+
+
+def debug_log(message: str) -> None:
+    try:
+        DEBUG_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with DEBUG_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(f"{message}\n")
+    except OSError:
+        pass
+
+
+def send_response(response: dict[str, Any]) -> None:
+    global _use_ndjson
+
+    payload = json.dumps(response, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    debug_log(f"SEND {payload.decode('utf-8', errors='replace')}")
+    if _use_ndjson:
+        sys.stdout.write(payload + b"\n")
+    else:
+        header = f"Content-Length: {len(payload)}\r\n\r\n".encode("utf-8")
+        sys.stdout.write(header + payload)
+    sys.stdout.flush()
+
+
+def read_message() -> dict[str, Any] | None:
+    global _use_ndjson
+
+    line = sys.stdin.readline()
+    if not line:
+        return None
+
+    line_text = line.decode("utf-8").rstrip("\r\n")
+    if line_text.lower().startswith("content-length:"):
+        try:
+            content_length = int(line_text.split(":", 1)[1].strip())
+        except ValueError:
+            return None
+
+        while True:
+            header_line = sys.stdin.readline()
+            if not header_line:
+                return None
+            if header_line in {b"\r\n", b"\n"}:
+                break
+
+        body = sys.stdin.read(content_length)
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            return None
+
+    if line_text.startswith("{") or line_text.startswith("["):
+        _use_ndjson = True
+        try:
+            return json.loads(line_text)
+        except json.JSONDecodeError:
+            return None
+
+    return None
+
+
+def find_claude_bin() -> str | None:
+    if Path(CLAUDE_BIN).is_file():
+        return CLAUDE_BIN
+    return shutil.which(CLAUDE_BIN)
+
+
+def parse_claude_json(raw_stdout: str) -> tuple[dict[str, Any] | None, str | None]:
+    lines = [line.strip() for line in raw_stdout.splitlines() if line.strip()]
+    if not lines:
+        return None, "Claude CLI returned empty output"
+
+    for candidate in reversed(lines):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload, None
+
+    return None, "Claude CLI did not return JSON output"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    temp_path.replace(path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def job_state_path(job_id: str) -> Path:
+    return JOBS_DIR / f"{job_id}.json"
+
+
+def is_pid_alive(pid: int | None) -> bool:
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def serialize_job(job: dict[str, Any]) -> dict[str, Any]:
+    result = job.get("result") or {}
+    return {
+        "jobId": job.get("jobId"),
+        "status": job.get("status"),
+        "done": job.get("status") in TERMINAL_JOB_STATES,
+        "threadId": result.get("threadId"),
+        "response": result.get("response"),
+        "model": result.get("model"),
+        "duration_ms": result.get("duration_ms"),
+        "stop_reason": result.get("stop_reason"),
+        "error": job.get("error"),
+        "createdAt": job.get("createdAt"),
+        "startedAt": job.get("startedAt"),
+        "completedAt": job.get("completedAt"),
+        "updatedAt": job.get("updatedAt"),
+        "resumeHint": "Call review_status with this jobId until done=true.",
+    }
+
+
+def build_command(
+    prompt: str,
+    *,
+    session_id: str | None = None,
+    model: str | None = None,
+    system: str | None = None,
+    tools: str | None = None,
+) -> list[str]:
+    bin_path = find_claude_bin()
+    if not bin_path:
+        raise FileNotFoundError(f"Claude CLI not found: {CLAUDE_BIN}")
+
+    cmd = [bin_path, "-p", prompt, "--output-format", "json", "--permission-mode", "plan"]
+
+    if session_id:
+        cmd.extend(["--resume", session_id])
+
+    selected_model = model or DEFAULT_MODEL
+    if selected_model:
+        cmd.extend(["--model", selected_model])
+
+    selected_system = system or DEFAULT_SYSTEM
+    if selected_system:
+        cmd.extend(["--system-prompt", selected_system])
+
+    selected_tools = DEFAULT_TOOLS if tools is None else tools
+    cmd.extend(["--tools", selected_tools])
+    return cmd
+
+
+def run_claude_review(
+    prompt: str,
+    *,
+    session_id: str | None = None,
+    model: str | None = None,
+    system: str | None = None,
+    tools: str | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        cmd = build_command(
+            prompt,
+            session_id=session_id,
+            model=model,
+            system=system,
+            tools=tools,
+        )
+    except FileNotFoundError as exc:
+        return None, str(exc)
+
+    debug_log(f"RUN {' '.join(cmd)}")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=DEFAULT_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return None, f"Claude review timed out after {DEFAULT_TIMEOUT_SEC} seconds"
+
+    payload, parse_error = parse_claude_json(result.stdout)
+    if parse_error:
+        stderr = result.stderr.strip()
+        message = parse_error if not stderr else f"{parse_error}. stderr: {stderr}"
+        return None, message
+
+    assert payload is not None
+    if result.returncode != 0 or payload.get("is_error"):
+        message = str(payload.get("result") or payload.get("error") or result.stderr.strip() or "Claude review failed")
+        return None, message
+
+    thread_id = payload.get("session_id")
+    response_text = str(payload.get("result", "")).strip()
+    model_name = payload.get("model", "") or model or DEFAULT_MODEL
+    return {
+        "threadId": thread_id,
+        "response": response_text,
+        "model": model_name,
+        "duration_ms": payload.get("duration_ms"),
+        "stop_reason": payload.get("stop_reason"),
+    }, None
+
+
+def start_async_review(
+    prompt: str,
+    *,
+    session_id: str | None = None,
+    model: str | None = None,
+    system: str | None = None,
+    tools: str | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    job_id = uuid.uuid4().hex
+    created_at = utc_now()
+    job = {
+        "jobId": job_id,
+        "status": "queued",
+        "createdAt": created_at,
+        "startedAt": None,
+        "completedAt": None,
+        "updatedAt": created_at,
+        "error": None,
+        "result": None,
+        "workerPid": None,
+        "request": {
+            "prompt": prompt,
+            "threadId": session_id,
+            "model": model,
+            "system": system,
+            "tools": tools,
+        },
+    }
+
+    job_path = job_state_path(job_id)
+    write_json(job_path, job)
+
+    try:
+        worker = subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), "--run-job", job_id],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        job["status"] = "failed"
+        job["completedAt"] = utc_now()
+        job["updatedAt"] = job["completedAt"]
+        job["error"] = f"Failed to launch background review worker: {exc}"
+        write_json(job_path, job)
+        return None, job["error"]
+
+    job["workerPid"] = worker.pid
+    job["updatedAt"] = utc_now()
+    write_json(job_path, job)
+    debug_log(f"JOB_START job_id={job_id} worker_pid={worker.pid}")
+    return serialize_job(job), None
+
+
+def get_review_status(job_id: str, *, wait_seconds: int = 0) -> tuple[dict[str, Any] | None, str | None]:
+    job_path = job_state_path(job_id)
+    if not job_path.exists():
+        return None, f"Unknown jobId: {job_id}"
+
+    deadline = time.monotonic() + max(wait_seconds, 0)
+    while True:
+        job = read_json(job_path)
+        if job.get("status") in {"queued", "running"} and not is_pid_alive(job.get("workerPid")):
+            job["status"] = "failed"
+            job["error"] = "Background review worker exited before writing a final result"
+            job["completedAt"] = utc_now()
+            job["updatedAt"] = job["completedAt"]
+            write_json(job_path, job)
+        if job.get("status") in TERMINAL_JOB_STATES:
+            return serialize_job(job), None
+        if time.monotonic() >= deadline:
+            return serialize_job(job), None
+        time.sleep(min(0.5, max(deadline - time.monotonic(), 0.0)))
+
+
+def run_async_job(job_id: str) -> int:
+    job_path = job_state_path(job_id)
+    if not job_path.exists():
+        debug_log(f"JOB_MISSING job_id={job_id}")
+        return 1
+
+    job = read_json(job_path)
+    job["status"] = "running"
+    job["startedAt"] = utc_now()
+    job["updatedAt"] = job["startedAt"]
+    job["workerPid"] = os.getpid()
+    write_json(job_path, job)
+    debug_log(f"JOB_RUNNING job_id={job_id} worker_pid={os.getpid()}")
+
+    request = job.get("request") or {}
+    try:
+        payload, error = run_claude_review(
+            str(request.get("prompt", "")),
+            session_id=request.get("threadId"),
+            model=request.get("model"),
+            system=request.get("system"),
+            tools=request.get("tools"),
+        )
+    except Exception as exc:
+        payload = None
+        error = f"Background review crashed: {exc}"
+        debug_log(traceback.format_exc())
+
+    finished_at = utc_now()
+    job = read_json(job_path)
+    job["updatedAt"] = finished_at
+    job["completedAt"] = finished_at
+    if error:
+        job["status"] = "failed"
+        job["error"] = error
+        job["result"] = None
+        debug_log(f"JOB_FAILED job_id={job_id} error={error}")
+        write_json(job_path, job)
+        return 1
+
+    job["status"] = "completed"
+    job["error"] = None
+    job["result"] = payload
+    debug_log(f"JOB_COMPLETED job_id={job_id} thread_id={(payload or {}).get('threadId')}")
+    write_json(job_path, job)
+    return 0
+
+
+def tool_success(request_id: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False)}],
+        },
+    }
+
+
+def tool_error(request_id: Any, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "content": [{"type": "text", "text": json.dumps({"error": message}, ensure_ascii=False)}],
+            "isError": True,
+        },
+    }
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    request_id = request.get("id")
+    method = request.get("method", "")
+    params = request.get("params", {})
+    debug_log(f"REQUEST id={request_id!r} method={method} params={json.dumps(params, ensure_ascii=False)}")
+
+    if request_id is None:
+        if method in {"notifications/initialized", "initialized"}:
+            return None
+        return None
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": "1.0.0"},
+            },
+        }
+
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {}}
+
+    if method == "resources/list":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"resources": []}}
+
+    if method == "resources/templates/list":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"resourceTemplates": []}}
+
+    if method in {"notifications/initialized", "initialized"}:
+        return {"jsonrpc": "2.0", "id": request_id, "result": {}}
+
+    if method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "tools": [
+                    {
+                        "name": "review",
+                        "description": "Run a fresh Claude Code review and return JSON containing threadId and response.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "prompt": {"type": "string", "description": "Reviewer prompt"},
+                                "system": {"type": "string", "description": "Optional system prompt"},
+                                "model": {"type": "string", "description": "Optional Claude model override"},
+                                "tools": {"type": "string", "description": "Optional Claude tools override, empty string disables tools"},
+                            },
+                            "required": ["prompt"],
+                        },
+                    },
+                    {
+                        "name": "review_reply",
+                        "description": "Continue a previous Claude Code review session using threadId/session_id.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "threadId": {"type": "string", "description": "Claude session id from a previous review call"},
+                                "thread_id": {"type": "string", "description": "Alias of threadId"},
+                                "prompt": {"type": "string", "description": "Follow-up reviewer prompt"},
+                                "system": {"type": "string", "description": "Optional system prompt override"},
+                                "model": {"type": "string", "description": "Optional Claude model override"},
+                                "tools": {"type": "string", "description": "Optional Claude tools override, empty string disables tools"},
+                            },
+                            "required": ["prompt"],
+                        },
+                    },
+                    {
+                        "name": "review_start",
+                        "description": "Start a background Claude Code review job and return a resumable jobId immediately.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "prompt": {"type": "string", "description": "Reviewer prompt"},
+                                "system": {"type": "string", "description": "Optional system prompt"},
+                                "model": {"type": "string", "description": "Optional Claude model override"},
+                                "tools": {"type": "string", "description": "Optional Claude tools override, empty string disables tools"},
+                            },
+                            "required": ["prompt"],
+                        },
+                    },
+                    {
+                        "name": "review_reply_start",
+                        "description": "Start a background follow-up review job in an existing Claude thread and return a resumable jobId immediately.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "threadId": {"type": "string", "description": "Claude session id from a previous review call"},
+                                "thread_id": {"type": "string", "description": "Alias of threadId"},
+                                "prompt": {"type": "string", "description": "Follow-up reviewer prompt"},
+                                "system": {"type": "string", "description": "Optional system prompt override"},
+                                "model": {"type": "string", "description": "Optional Claude model override"},
+                                "tools": {"type": "string", "description": "Optional Claude tools override, empty string disables tools"},
+                            },
+                            "required": ["prompt"],
+                        },
+                    },
+                    {
+                        "name": "review_status",
+                        "description": "Check whether a background review job has finished and fetch the final result when available.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "jobId": {"type": "string", "description": "Background review job id"},
+                                "job_id": {"type": "string", "description": "Alias of jobId"},
+                                "waitSeconds": {"type": "integer", "description": "Optional bounded wait before returning status"},
+                            },
+                            "required": ["jobId"],
+                        },
+                    },
+                ]
+            },
+        }
+
+    if method == "tools/call":
+        name = params.get("name", "")
+        args = params.get("arguments", {}) or {}
+
+        if name == "review":
+            payload, error = run_claude_review(
+                str(args.get("prompt", "")),
+                model=args.get("model"),
+                system=args.get("system"),
+                tools=args.get("tools"),
+            )
+            return tool_error(request_id, error) if error else tool_success(request_id, payload or {})
+
+        if name == "review_reply":
+            thread_id = args.get("threadId") or args.get("thread_id")
+            if not thread_id:
+                return tool_error(request_id, "threadId or thread_id is required")
+            payload, error = run_claude_review(
+                str(args.get("prompt", "")),
+                session_id=str(thread_id),
+                model=args.get("model"),
+                system=args.get("system"),
+                tools=args.get("tools"),
+            )
+            return tool_error(request_id, error) if error else tool_success(request_id, payload or {})
+
+        if name == "review_start":
+            payload, error = start_async_review(
+                str(args.get("prompt", "")),
+                model=args.get("model"),
+                system=args.get("system"),
+                tools=args.get("tools"),
+            )
+            return tool_error(request_id, error) if error else tool_success(request_id, payload or {})
+
+        if name == "review_reply_start":
+            thread_id = args.get("threadId") or args.get("thread_id")
+            if not thread_id:
+                return tool_error(request_id, "threadId or thread_id is required")
+            payload, error = start_async_review(
+                str(args.get("prompt", "")),
+                session_id=str(thread_id),
+                model=args.get("model"),
+                system=args.get("system"),
+                tools=args.get("tools"),
+            )
+            return tool_error(request_id, error) if error else tool_success(request_id, payload or {})
+
+        if name == "review_status":
+            job_id = args.get("jobId") or args.get("job_id")
+            if not job_id:
+                return tool_error(request_id, "jobId or job_id is required")
+            wait_seconds_raw = args.get("waitSeconds", 0)
+            try:
+                wait_seconds = int(wait_seconds_raw)
+            except (TypeError, ValueError):
+                return tool_error(request_id, "waitSeconds must be an integer")
+            payload, error = get_review_status(str(job_id), wait_seconds=max(wait_seconds, 0))
+            return tool_error(request_id, error) if error else tool_success(request_id, payload or {})
+
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {name}"},
+        }
+
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32601, "message": f"Unknown method: {method}"},
+    }
+
+
+def main() -> None:
+    if len(sys.argv) == 3 and sys.argv[1] == "--run-job":
+        raise SystemExit(run_async_job(sys.argv[2]))
+
+    debug_log(f"=== {SERVER_NAME} starting ===")
+    while True:
+        try:
+            request = read_message()
+            if request is None:
+                debug_log("EOF")
+                break
+            response = handle_request(request)
+            if response is not None:
+                send_response(response)
+        except Exception:
+            debug_log(traceback.format_exc())
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skills-codex-claude-review/README.md
+++ b/skills/skills-codex-claude-review/README.md
@@ -1,0 +1,75 @@
+# skills-codex-claude-review
+
+This package is a **thin override layer** for users who want:
+
+- **Codex** as the main executor
+- **Claude Code** as the reviewer
+- the local `claude-review` MCP bridge instead of a second Codex reviewer
+
+It is designed to sit on top of the upstream Codex-native package at `skills/skills-codex/`.
+
+## What this package contains
+
+- Only the review-heavy skill overrides that need a different reviewer backend
+- No duplicate templates or resource directories
+- No replacement for the base `skills/skills-codex/` installation
+
+Current overrides:
+
+- `research-review`
+- `novelty-check`
+- `research-refine`
+- `auto-review-loop`
+- `paper-plan`
+- `paper-figure`
+- `paper-write`
+- `auto-paper-improvement-loop`
+
+## Install
+
+1. Install the base Codex-native skills first:
+
+```bash
+mkdir -p ~/.codex/skills
+cp -a skills/skills-codex/* ~/.codex/skills/
+```
+
+2. Install the Claude-review overrides second:
+
+```bash
+cp -a skills/skills-codex-claude-review/* ~/.codex/skills/
+```
+
+3. Register the local reviewer bridge:
+
+```bash
+mkdir -p ~/.codex/mcp-servers/claude-review
+cp mcp-servers/claude-review/server.py ~/.codex/mcp-servers/claude-review/server.py
+codex mcp add claude-review -- python3 ~/.codex/mcp-servers/claude-review/server.py
+```
+
+If your Claude setup depends on a shell helper such as `claude-aws`, use the wrapper instead:
+
+```bash
+cp mcp-servers/claude-review/run_with_claude_aws.sh ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+chmod +x ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+codex mcp add claude-review -- ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+```
+
+## Why this exists
+
+The upstream `skills/skills-codex/` path already supports Codex-native execution with a second Codex reviewer via `spawn_agent`.
+
+This package adds a different split:
+
+- executor: Codex
+- reviewer: Claude Code CLI
+- transport: `claude-review` MCP
+
+For long paper and review prompts, the reviewer path uses:
+
+- `review_start`
+- `review_reply_start`
+- `review_status`
+
+This avoids the observed Codex-hosted timeout issue when Claude is invoked synchronously through a local bridge.

--- a/skills/skills-codex-claude-review/README_CN.md
+++ b/skills/skills-codex-claude-review/README_CN.md
@@ -1,0 +1,75 @@
+# skills-codex-claude-review 说明
+
+这是一个**薄覆盖层**，适用于想采用以下组合的用户：
+
+- **Codex** 作为主执行者
+- **Claude Code** 作为审稿人
+- 用本地 `claude-review` MCP bridge 替代“第二个 Codex reviewer”
+
+它不是新造一套完整技能包，而是叠加在上游已有的 `skills/skills-codex/` 之上。
+
+## 这个包包含什么
+
+- 只包含需要切换 reviewer backend 的 review-heavy skill 覆盖文件
+- 不重复打包模板和资源目录
+- 不替代基础的 `skills/skills-codex/` 安装
+
+当前覆盖的技能：
+
+- `research-review`
+- `novelty-check`
+- `research-refine`
+- `auto-review-loop`
+- `paper-plan`
+- `paper-figure`
+- `paper-write`
+- `auto-paper-improvement-loop`
+
+## 安装方式
+
+1. 先安装上游原生 Codex 技能包：
+
+```bash
+mkdir -p ~/.codex/skills
+cp -a skills/skills-codex/* ~/.codex/skills/
+```
+
+2. 再安装这个 Claude-review 覆盖层：
+
+```bash
+cp -a skills/skills-codex-claude-review/* ~/.codex/skills/
+```
+
+3. 注册本地 reviewer bridge：
+
+```bash
+mkdir -p ~/.codex/mcp-servers/claude-review
+cp mcp-servers/claude-review/server.py ~/.codex/mcp-servers/claude-review/server.py
+codex mcp add claude-review -- python3 ~/.codex/mcp-servers/claude-review/server.py
+```
+
+如果你的 Claude 依赖 `claude-aws` 之类的 shell helper，再改用 wrapper：
+
+```bash
+cp mcp-servers/claude-review/run_with_claude_aws.sh ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+chmod +x ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+codex mcp add claude-review -- ~/.codex/mcp-servers/claude-review/run_with_claude_aws.sh
+```
+
+## 为什么需要这个包
+
+上游 `skills/skills-codex/` 已经支持 Codex 原生执行，并通过 `spawn_agent` 使用第二个 Codex 做 reviewer。
+
+这个覆盖层新增的是另一种分工：
+
+- 执行者：Codex
+- 审稿人：Claude Code CLI
+- 传输层：`claude-review` MCP
+
+对于长论文和长 review prompt，这条 reviewer 路径会改用：
+
+- `review_start`
+- `review_reply_start`
+- `review_status`
+
+这样可以绕开 Codex 宿主下，本地 Claude bridge 同步等待时更容易出现的超时问题。

--- a/skills/skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: "auto-paper-improvement-loop"
+description: "Autonomously improve a generated paper via Claude review through claude-review MCP → implement fixes → recompile, for 2 rounds. Use when user says \\"改论文\\", \\"improve paper\\", \\"论文润色循环\\", \\"auto improve\\", or wants to iteratively polish a generated paper."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Auto Paper Improvement Loop: Review → Fix → Recompile
+
+Autonomously improve the paper at: **$ARGUMENTS**
+
+## Context
+
+This skill is designed to run **after** Workflow 3 (`/paper-plan` → `/paper-figure` → `/paper-write` → `/paper-compile`). It takes a compiled paper and iteratively improves it through external LLM review.
+
+Unlike `/auto-review-loop` (which iterates on **research** — running experiments, collecting data, rewriting narrative), this skill iterates on **paper writing quality** — fixing theoretical inconsistencies, softening overclaims, adding missing content, and improving presentation.
+
+## Constants
+
+- **MAX_ROUNDS = 2** — Two rounds of review→fix→recompile. Empirically, Round 1 catches structural issues (4→6/10), Round 2 catches remaining presentation issues (6→7/10). Diminishing returns beyond 2 rounds for writing-only improvements.
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+- **REVIEW_LOG = `PAPER_IMPROVEMENT_LOG.md`** — Cumulative log of all rounds, stored in paper directory.
+- **HUMAN_CHECKPOINT = false** — When `true`, pause after each round's review and present score + weaknesses to the user. The user can approve fixes, provide custom modification instructions, skip specific fixes, or stop early. When `false` (default), runs fully autonomously.
+
+> 💡 Override: `/auto-paper-improvement-loop "paper/" — human checkpoint: true`
+
+## Inputs
+
+1. **Compiled paper** — `paper/main.pdf` + LaTeX source files
+2. **All section `.tex` files** — concatenated for review prompt
+
+## State Persistence (Compact Recovery)
+
+If the context window fills up mid-loop, Codex auto-compacts. To recover, this skill writes `PAPER_IMPROVEMENT_STATE.json` after each round:
+
+```json
+{
+  "current_round": 1,
+  "thread_id": "019ce736-...",
+  "last_score": 6,
+  "status": "in_progress",
+  "timestamp": "2026-03-13T21:00:00"
+}
+```
+
+**On startup**: if `PAPER_IMPROVEMENT_STATE.json` exists with `"status": "in_progress"` AND `timestamp` is within 24 hours, read it + `PAPER_IMPROVEMENT_LOG.md` to recover context, then resume from the next round. Otherwise (file absent, `"status": "completed"`, or older than 24 hours), start fresh.
+
+**After each round**: overwrite the state file. **On completion**: set `"status": "completed"`.
+
+## Workflow
+
+### Step 0: Preserve Original
+
+```bash
+cp paper/main.pdf paper/main_round0_original.pdf
+```
+
+### Step 1: Collect Paper Text
+
+Concatenate all section files into a single text block for the review prompt:
+
+```bash
+# Collect all sections in order
+for f in paper/sections/*.tex; do
+    echo "% === $(basename $f) ==="
+    cat "$f"
+done > /tmp/paper_full_text.txt
+```
+
+### Step 2: Round 1 Review
+
+Send the full paper text to Claude review:
+
+```
+mcp__claude-review__review_start:
+  prompt: |
+    You are reviewing a [VENUE] paper. Please provide a detailed, structured review.
+
+    ## Full Paper Text:
+    [paste concatenated sections]
+
+    ## Review Instructions
+    Please act as a senior ML reviewer ([VENUE] level). Provide:
+    1. **Overall Score** (1-10, where 6 = weak accept, 7 = accept)
+    2. **Summary** (2-3 sentences)
+    3. **Strengths** (bullet list, ranked)
+    4. **Weaknesses** (bullet list, ranked: CRITICAL > MAJOR > MINOR)
+    5. **For each CRITICAL/MAJOR weakness**: A specific, actionable fix
+    6. **Missing References** (if any)
+    7. **Verdict**: Ready for submission? Yes / Almost / No
+
+    Focus on: theoretical rigor, claims vs evidence alignment, writing clarity,
+    self-containedness, notation consistency.
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+Save the returned `jobId`, poll `mcp__claude-review__review_status` until `done=true`, then save the completed `threadId` for Round 2.
+
+### Step 2b: Human Checkpoint (if enabled)
+
+**Skip if `HUMAN_CHECKPOINT = false`.**
+
+Present the review results and wait for user input:
+
+```
+📋 Round 1 review complete.
+
+Score: X/10 — [verdict]
+Key weaknesses (by severity):
+1. [CRITICAL] ...
+2. [MAJOR] ...
+3. [MINOR] ...
+
+Reply "go" to implement all fixes, give custom instructions, "skip 2" to skip specific fixes, or "stop" to end.
+```
+
+Parse user response same as `/auto-review-loop`: approve / custom instructions / skip / stop.
+
+### Step 3: Implement Round 1 Fixes
+
+Parse the review and implement fixes by severity:
+
+**Priority order:**
+1. CRITICAL fixes (assumption mismatches, internal contradictions)
+2. MAJOR fixes (overclaims, missing content, notation issues)
+3. MINOR fixes (if time permits)
+
+**Common fix patterns:**
+
+| Issue | Fix Pattern |
+|-------|-------------|
+| Assumption-model mismatch | Rewrite assumption to match the model, add formal proposition bridging the gap |
+| Overclaims | Soften language: "validate" → "demonstrate practical relevance", "comparable" → "qualitatively competitive" |
+| Missing metrics | Add quantitative table with honest parameter counts and caveats |
+| Theorem not self-contained | Add "Interpretation" paragraph listing all dependencies |
+| Notation confusion | Rename conflicting symbols globally, add Notation paragraph |
+| Missing references | Add to `references.bib`, cite in appropriate locations |
+| Theory-practice gap | Explicitly frame theory as idealized; add synthetic validation subsection |
+
+### Step 4: Recompile Round 1
+
+```bash
+cd paper && latexmk -C && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex
+cp main.pdf main_round1.pdf
+```
+
+Verify: 0 undefined references, 0 undefined citations.
+
+### Step 5: Round 2 Review
+
+Use `mcp__claude-review__review_reply_start` with the saved completed `threadId`:
+
+```
+mcp__claude-review__review_reply_start:
+  threadId: [saved from Round 1]
+  prompt: |
+    [Round 2 update]
+
+    Since your last review, we have implemented:
+    1. [Fix 1]: [description]
+    2. [Fix 2]: [description]
+    ...
+
+    Please re-score and re-assess. Same format:
+    Score, Summary, Strengths, Weaknesses, Actionable fixes, Verdict.
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+### Step 5b: Human Checkpoint (if enabled)
+
+**Skip if `HUMAN_CHECKPOINT = false`.** Same as Step 2b — present Round 2 review, wait for user input.
+
+### Step 6: Implement Round 2 Fixes
+
+Same process as Step 3. Typical Round 2 fixes:
+- Add controlled synthetic experiments validating theory
+- Further soften any remaining overclaims
+- Formalize informal arguments (e.g., truncation → formal proposition)
+- Strengthen limitations section
+
+### Step 7: Recompile Round 2
+
+```bash
+cd paper && latexmk -C && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex
+cp main.pdf main_round2.pdf
+```
+
+### Step 8: Format Check
+
+After the final recompilation, run a format compliance check:
+
+```bash
+# 1. Page count vs venue limit
+PAGES=$(pdfinfo paper/main.pdf | grep Pages | awk '{print $2}')
+echo "Pages: $PAGES (limit: 9 main body for ICLR/NeurIPS)"
+
+# 2. Overfull hbox warnings (content exceeding margins)
+OVERFULL=$(grep -c "Overfull" paper/main.log 2>/dev/null || echo 0)
+echo "Overfull hbox warnings: $OVERFULL"
+grep "Overfull" paper/main.log 2>/dev/null | head -10
+
+# 3. Underfull hbox warnings (loose spacing)
+UNDERFULL=$(grep -c "Underfull" paper/main.log 2>/dev/null || echo 0)
+echo "Underfull hbox warnings: $UNDERFULL"
+
+# 4. Bad boxes summary
+grep -c "badness" paper/main.log 2>/dev/null || echo "0 badness warnings"
+```
+
+**Auto-fix patterns:**
+
+| Issue | Fix |
+|-------|-----|
+| Overfull hbox in equation | Wrap in `\resizebox` or split with `\split`/`aligned` |
+| Overfull hbox in table | Reduce font (`\small`/`\footnotesize`) or use `\resizebox{\linewidth}{!}{...}` |
+| Overfull hbox in text | Rephrase sentence or add `\allowbreak` / `\-` hints |
+| Over page limit | Move content to appendix, compress tables, reduce figure sizes |
+| Underfull hbox (loose) | Rephrase for better line filling or add `\looseness=-1` |
+
+If any overfull hbox > 10pt is found, fix it and recompile before documenting.
+
+### Step 9: Document Results
+
+Create `PAPER_IMPROVEMENT_LOG.md` in the paper directory:
+
+```markdown
+# Paper Improvement Log
+
+## Score Progression
+
+| Round | Score | Verdict | Key Changes |
+|-------|-------|---------|-------------|
+| Round 0 (original) | X/10 | No/Almost/Yes | Baseline |
+| Round 1 | Y/10 | No/Almost/Yes | [summary of fixes] |
+| Round 2 | Z/10 | No/Almost/Yes | [summary of fixes] |
+
+## Round 1 Review & Fixes
+
+<details>
+<summary>Claude review Review (Round 1)</summary>
+
+[Full raw review text, verbatim]
+
+</details>
+
+### Fixes Implemented
+1. [Fix description]
+2. [Fix description]
+...
+
+## Round 2 Review & Fixes
+
+<details>
+<summary>Claude review Review (Round 2)</summary>
+
+[Full raw review text, verbatim]
+
+</details>
+
+### Fixes Implemented
+1. [Fix description]
+2. [Fix description]
+...
+
+## PDFs
+- `main_round0_original.pdf` — Original generated paper
+- `main_round1.pdf` — After Round 1 fixes
+- `main_round2.pdf` — Final version after Round 2 fixes
+```
+
+### Step 9: Summary
+
+Report to user:
+- Score progression table
+- Number of CRITICAL/MAJOR/MINOR issues fixed per round
+- Final page count
+- Remaining issues (if any)
+
+### Feishu Notification (if configured)
+
+After each round's review AND at final completion, check `~/.codex/feishu.json`:
+- **After each round**: Send `review_scored` — "Round N: X/10 — [key changes]"
+- **After final round**: Send `pipeline_done` — score progression table + final page count
+- If config absent or mode `"off"`: skip entirely (no-op)
+
+## Output
+
+```
+paper/
+├── main_round0_original.pdf    # Original
+├── main_round1.pdf             # After Round 1
+├── main_round2.pdf             # After Round 2 (final)
+├── main.pdf                    # = main_round2.pdf
+└── PAPER_IMPROVEMENT_LOG.md    # Full review log with scores
+```
+
+## Key Rules
+
+- **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
+
+- **Preserve all PDF versions** — user needs to compare progression
+- **Save FULL raw review text** — do not summarize or truncate Claude reviewer responses
+- **Use `mcp__claude-review__review_reply_start` plus `mcp__claude-review__review_status`** for Round 2 to maintain conversation context
+- **Always recompile after fixes** — verify 0 errors before proceeding
+- **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
+- **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
+- **Global consistency** — when renaming notation or softening claims, check ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions)
+
+## Typical Score Progression
+
+Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
+
+| Round | Score | Key Improvements |
+|-------|-------|-----------------|
+| Round 0 | 4/10 (content) | Baseline: assumption-model mismatch, overclaims, notation issues |
+| Round 1 | 6/10 (content) | Fixed assumptions, softened claims, added interpretation, renamed notation |
+| Round 2 | 7/10 (content) | Added synthetic validation, formal truncation proposition, stronger limitations |
+| Round 3 | 5→8.5/10 (format) | Removed hero fig, appendix, compressed conclusion, fixed overfull hbox |
+
+**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final: 8 pages main body, 0 overfull hbox, ICLR-compliant.

--- a/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
+++ b/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: "auto-review-loop"
+description: "Autonomous multi-round research review loop. Repeatedly reviews using Claude Code via claude-review MCP, implements fixes, and re-reviews until positive assessment or max rounds reached. Use when user says \"auto review loop\", \"review until it passes\", or wants autonomous iterative improvement."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Auto Review Loop: Autonomous Research Improvement
+
+Autonomously iterate: review → implement fixes → re-review, until the external reviewer gives a positive assessment or MAX_ROUNDS is reached.
+
+## Context: $ARGUMENTS
+
+## Constants
+
+- MAX_ROUNDS = 4
+- POSITIVE_THRESHOLD: score >= 6/10, or verdict contains "accept", "sufficient", "ready for submission"
+- REVIEW_DOC: `AUTO_REVIEW.md` in project root (cumulative log)
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+- **HUMAN_CHECKPOINT = false** — When `true`, pause after each round's review (Phase B) and present the score + weaknesses to the user. Wait for user input before proceeding to Phase C. The user can: approve the suggested fixes, provide custom modification instructions, skip specific fixes, or stop the loop early. When `false` (default), the loop runs fully autonomously.
+
+> 💡 Override: `/auto-review-loop "topic" — human checkpoint: true`
+
+## State Persistence (Compact Recovery)
+
+Long-running loops may hit the context window limit, triggering automatic compaction. To survive this, persist state to `REVIEW_STATE.json` after each round:
+
+```json
+{
+  "round": 2,
+  "thread_id": "019cd392-...",
+  "status": "in_progress",
+  "last_score": 5.0,
+  "last_verdict": "not ready",
+  "pending_experiments": ["screen_name_1"],
+  "timestamp": "2026-03-13T21:00:00"
+}
+```
+
+**Write this file at the end of every Phase E** (after documenting the round). Overwrite each time — only the latest state matters.
+
+**On completion** (positive assessment or max rounds), set `"status": "completed"` so future invocations don't accidentally resume a finished loop.
+
+## Workflow
+
+### Initialization
+
+1. **Check for `REVIEW_STATE.json`** in project root:
+   - If it does not exist: **fresh start** (normal case, identical to behavior before this feature existed)
+   - If it exists AND `status` is `"completed"`: **fresh start** (previous loop finished normally)
+   - If it exists AND `status` is `"in_progress"` AND `timestamp` is older than 24 hours: **fresh start** (stale state from a killed/abandoned run — delete the file and start over)
+   - If it exists AND `status` is `"in_progress"` AND `timestamp` is within 24 hours: **resume**
+     - Read the state file to recover `round`, `thread_id`, `last_score`, `pending_experiments`
+     - Read `AUTO_REVIEW.md` to restore full context of prior rounds
+     - If `pending_experiments` is non-empty, check if they have completed (e.g., check screen sessions)
+     - Resume from the next round (round = saved round + 1)
+     - Log: "Recovered from context compaction. Resuming at Round N."
+2. Read project narrative documents, memory files, and any prior review documents
+3. Read recent experiment results (check output directories, logs)
+4. Identify current weaknesses and open TODOs from prior reviews
+5. Initialize round counter = 1 (unless recovered from state file)
+6. Create/update `AUTO_REVIEW.md` with header and timestamp
+
+### Loop (repeat up to MAX_ROUNDS)
+
+#### Phase A: Review
+
+Send comprehensive context to the external reviewer:
+
+```
+mcp__claude-review__review_start:
+  prompt: |
+    [Round N/MAX_ROUNDS of autonomous review loop]
+
+    [Full research context: claims, methods, results, known weaknesses]
+    [Changes since last round, if any]
+
+    Please act as a senior ML reviewer (NeurIPS/ICML level).
+
+    1. Score this work 1-10 for a top venue
+    2. List remaining critical weaknesses (ranked by severity)
+    3. For each weakness, specify the MINIMUM fix (experiment, analysis, or reframing)
+    4. State clearly: is this READY for submission? Yes/No/Almost
+
+    Be brutally honest. If the work is ready, say so clearly.
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+If this is round 2+, use `mcp__claude-review__review_reply_start` with the saved completed `threadId`, then poll `mcp__claude-review__review_status` with the returned `jobId` until `done=true` to maintain continuity.
+
+#### Phase B: Parse Assessment
+
+**CRITICAL: Save the FULL raw response** from the external reviewer verbatim (store in a variable for Phase E). Do NOT discard or summarize — the raw text is the primary record.
+
+Then extract structured fields:
+- **Score** (numeric 1-10)
+- **Verdict** ("ready" / "almost" / "not ready")
+- **Action items** (ranked list of fixes)
+
+**STOP CONDITION**: If score >= 6 AND verdict contains "ready" or "almost" → stop loop, document final state.
+
+#### Human Checkpoint (if enabled)
+
+**Skip this step entirely if `HUMAN_CHECKPOINT = false`.**
+
+When `HUMAN_CHECKPOINT = true`, present the review results and wait for user input:
+
+```
+📋 Round N/MAX_ROUNDS review complete.
+
+Score: X/10 — [verdict]
+Top weaknesses:
+1. [weakness 1]
+2. [weakness 2]
+3. [weakness 3]
+
+Suggested fixes:
+1. [fix 1]
+2. [fix 2]
+3. [fix 3]
+
+Options:
+- Reply "go" or "continue" → implement all suggested fixes
+- Reply with custom instructions → implement your modifications instead
+- Reply "skip 2" → skip fix #2, implement the rest
+- Reply "stop" → end the loop, document current state
+```
+
+Wait for the user's response. Parse their input:
+- **Approval** ("go", "continue", "ok", "proceed"): proceed to Phase C with all suggested fixes
+- **Custom instructions** (any other text): treat as additional/replacement guidance for Phase C. Merge with reviewer suggestions where appropriate
+- **Skip specific fixes** ("skip 1,3"): remove those fixes from the action list
+- **Stop** ("stop", "enough", "done"): terminate the loop, jump to Termination
+
+#### Feishu Notification (if configured)
+
+After parsing the score, check if `~/.codex/feishu.json` exists and mode is not `"off"`:
+- Send a `review_scored` notification: "Round N: X/10 — [verdict]" with top 3 weaknesses
+- If **interactive** mode and verdict is "almost": send as checkpoint, wait for user reply on whether to continue or stop
+- If config absent or mode off: skip entirely (no-op)
+
+#### Phase C: Implement Fixes (if not stopping)
+
+For each action item (highest priority first):
+
+1. **Code changes**: Write/modify experiment scripts, model code, analysis scripts
+2. **Run experiments**: Deploy to GPU server via SSH + screen/tmux
+3. **Analysis**: Run evaluation, collect results, update figures/tables
+4. **Documentation**: Update project notes and review document
+
+Prioritization rules:
+- Skip fixes requiring excessive compute (flag for manual follow-up)
+- Skip fixes requiring external data/models not available
+- Prefer reframing/analysis over new experiments when both address the concern
+- Always implement metric additions (cheap, high impact)
+
+#### Phase D: Wait for Results
+
+If experiments were launched:
+- Monitor remote sessions for completion
+- Collect results from output files and logs
+
+#### Phase E: Document Round
+
+Append to `AUTO_REVIEW.md`:
+
+```markdown
+## Round N (timestamp)
+
+### Assessment (Summary)
+- Score: X/10
+- Verdict: [ready/almost/not ready]
+- Key criticisms: [bullet list]
+
+### Reviewer Raw Response
+
+<details>
+<summary>Click to expand full reviewer response</summary>
+
+[Paste the COMPLETE raw response from the external reviewer here — verbatim, unedited.
+This is the authoritative record. Do NOT truncate or paraphrase.]
+
+</details>
+
+### Actions Taken
+- [what was implemented/changed]
+
+### Results
+- [experiment outcomes, if any]
+
+### Status
+- [continuing to round N+1 / stopping]
+```
+
+**Write `REVIEW_STATE.json`** with current round, agent id, score, verdict, and any pending experiments.
+
+Increment round counter → back to Phase A.
+
+### Termination
+
+When loop ends (positive assessment or max rounds):
+
+1. Update `REVIEW_STATE.json` with `"status": "completed"`
+2. Write final summary to `AUTO_REVIEW.md`
+3. Update project notes with conclusions
+4. If stopped at max rounds without positive assessment:
+   - List remaining blockers
+   - Estimate effort needed for each
+   - Suggest whether to continue manually or pivot
+5. **Feishu notification** (if configured): Send `pipeline_done` with final score progression table
+
+## Key Rules
+
+- **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
+
+- Always ask the Claude reviewer for strict, high-rigor feedback.
+- Save the completed `threadId` from the first `mcp__claude-review__review_status` result, then use `mcp__claude-review__review_reply_start` plus `mcp__claude-review__review_status` for subsequent rounds
+- Be honest — include negative results and failed experiments
+- Do NOT hide weaknesses to game a positive score
+- Implement fixes BEFORE re-reviewing (don't just promise to fix)
+- If an experiment takes > 30 minutes, launch it and continue with other fixes while waiting
+- Document EVERYTHING — the review log should be self-contained
+- Update project notes after each round, not just at the end
+
+## Prompt Template for Round 2+
+
+```
+mcp__claude-review__review_reply_start:
+  threadId: [saved from round 1]
+  prompt: |
+    [Round N update]
+
+    Since your last review, we have:
+    1. [Action 1]: [result]
+    2. [Action 2]: [result]
+    3. [Action 3]: [result]
+
+    Updated results table:
+    [paste metrics]
+
+    Please re-score and re-assess. Are the remaining concerns addressed?
+    Same format: Score, Verdict, Remaining Weaknesses, Minimum Fixes.
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.

--- a/skills/skills-codex-claude-review/novelty-check/SKILL.md
+++ b/skills/skills-codex-claude-review/novelty-check/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: "novelty-check"
+description: "Verify research idea novelty against recent literature. Use when user says \"查新\", \"novelty check\", \"有没有人做过\", \"check novelty\", or wants to verify a research idea is novel before implementing."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Novelty Check Skill
+
+Check whether a proposed method/idea has already been done in the literature: **$ARGUMENTS**
+
+## Constants
+
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+
+## Instructions
+
+Given a method description, systematically verify its novelty:
+
+### Phase A: Extract Key Claims
+1. Read the user's method description
+2. Identify 3-5 core technical claims that would need to be novel:
+   - What is the method?
+   - What problem does it solve?
+   - What is the mechanism?
+   - What makes it different from obvious baselines?
+
+### Phase B: Multi-Source Literature Search
+For EACH core claim, search using ALL available sources:
+
+1. **Web Search** (via `WebSearch`):
+   - Search arXiv, Google Scholar, Semantic Scholar
+   - Use specific technical terms from the claim
+   - Try at least 3 different query formulations per claim
+   - Include year filters for 2024-2026
+
+2. **Known paper databases**: Check against:
+   - ICLR 2025/2026, NeurIPS 2025, ICML 2025/2026
+   - Recent arXiv preprints (2025-2026)
+
+3. **Read abstracts**: For each potentially overlapping paper, WebFetch its abstract and related work section
+
+### Phase C: Cross-Model Verification
+Call REVIEWER_MODEL via `mcp__claude-review__review_start` with high-rigor review:
+```
+mcp__claude-review__review_start:
+  prompt: |
+    [Full novelty briefing + prior work list + specific novelty questions]
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+Prompt should include:
+- The proposed method description
+- All papers found in Phase B
+- Ask: "Is this method novel? What is the closest prior work? What is the delta?"
+
+### Phase D: Novelty Report
+Output a structured report:
+
+```markdown
+## Novelty Check Report
+
+### Proposed Method
+[1-2 sentence description]
+
+### Core Claims
+1. [Claim 1] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
+2. [Claim 2] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
+...
+
+### Closest Prior Work
+| Paper | Year | Venue | Overlap | Key Difference |
+|-------|------|-------|---------|----------------|
+
+### Overall Novelty Assessment
+- Score: X/10
+- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON
+- Key differentiator: [what makes this unique, if anything]
+- Risk: [what a reviewer would cite as prior work]
+
+### Suggested Positioning
+[How to frame the contribution to maximize novelty perception]
+```
+
+### Important Rules
+- Be BRUTALLY honest — false novelty claims waste months of research time
+- "Applying X to Y" is NOT novel unless the application reveals surprising insights
+- Check both the method AND the experimental setting for novelty
+- If the method is not novel but the FINDING would be, say so explicitly
+- Always check the most recent 6 months of arXiv — the field moves fast

--- a/skills/skills-codex-claude-review/paper-figure/SKILL.md
+++ b/skills/skills-codex-claude-review/paper-figure/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: "paper-figure"
+description: "Generate publication-quality figures and tables from experiment results. Use when user says \\"画图\\", \\"作图\\", \\"generate figures\\", \\"paper figures\\", or needs plots for a paper."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Paper Figure: Publication-Quality Plots from Experiment Data
+
+Generate all figures and tables for a paper based on: **$ARGUMENTS**
+
+## Scope: What This Skill Can and Cannot Do
+
+| Category | Can auto-generate? | Examples |
+|----------|-------------------|----------|
+| **Data-driven plots** | ✅ Yes | Line plots (training curves), bar charts (method comparison), scatter plots, heatmaps, box/violin plots |
+| **Comparison tables** | ✅ Yes | LaTeX tables comparing prior bounds, method features, ablation results |
+| **Multi-panel figures** | ✅ Yes | Subfigure grids combining multiple plots (e.g., 3×3 dataset × method) |
+| **Architecture/pipeline diagrams** | ❌ No — manual | Model architecture, data flow diagrams, system overviews. At best can generate a rough TikZ skeleton, but **expect to draw these yourself** using tools like draw.io, Figma, or TikZ |
+| **Generated image grids** | ❌ No — manual | Grids of generated samples (e.g., GAN/diffusion outputs). These come from running your model, not from this skill |
+| **Photographs / screenshots** | ❌ No — manual | Real-world images, UI screenshots, qualitative examples |
+
+**In practice:** For a typical ML paper, this skill handles ~60% of figures (all data plots + tables). The remaining ~40% (hero figure, architecture diagram, qualitative results) need to be created manually and placed in `figures/` before running `/paper-write`. The skill will detect these as "existing figures" and preserve them.
+
+## Constants
+
+- **STYLE = `publication`** — Visual style preset. Options: `publication` (default, clean for print), `poster` (larger fonts), `slide` (bold colors)
+- **DPI = 300** — Output resolution
+- **FORMAT = `pdf`** — Output format. Options: `pdf` (vector, best for LaTeX), `png` (raster fallback)
+- **COLOR_PALETTE = `tab10`** — Default matplotlib color cycle. Options: `tab10`, `Set2`, `colorblind` (deuteranopia-safe)
+- **FONT_SIZE = 10** — Base font size (matches typical conference body text)
+- **FIG_DIR = `figures/`** — Output directory for generated figures
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+
+## Inputs
+
+1. **PAPER_PLAN.md** — figure plan table (from `/paper-plan`)
+2. **Experiment data** — JSON files, CSV files, or screen logs in `figures/` or project root
+3. **Existing figures** — any manually created figures to preserve
+
+If no PAPER_PLAN.md exists, scan for data files and ask the user which figures to generate.
+
+## Workflow
+
+### Step 1: Read Figure Plan
+
+Parse the Figure Plan table from PAPER_PLAN.md:
+
+```markdown
+| ID | Type | Description | Data Source | Priority |
+|----|------|-------------|-------------|----------|
+| Fig 1 | Architecture | ... | manual | HIGH |
+| Fig 2 | Line plot | ... | figures/exp.json | HIGH |
+```
+
+Identify:
+- Which figures can be auto-generated from data
+- Which need manual creation (architecture diagrams, etc.)
+- Which are comparison tables (generate as LaTeX)
+
+### Step 2: Set Up Plotting Environment
+
+Create a shared style configuration script:
+
+```python
+# paper_plot_style.py — shared across all figure scripts
+import matplotlib.pyplot as plt
+import matplotlib
+matplotlib.rcParams.update({
+    'font.size': FONT_SIZE,
+    'font.family': 'serif',
+    'font.serif': ['Times New Roman', 'Times', 'DejaVu Serif'],
+    'axes.labelsize': FONT_SIZE,
+    'axes.titlesize': FONT_SIZE + 1,
+    'xtick.labelsize': FONT_SIZE - 1,
+    'ytick.labelsize': FONT_SIZE - 1,
+    'legend.fontsize': FONT_SIZE - 1,
+    'figure.dpi': DPI,
+    'savefig.dpi': DPI,
+    'savefig.bbox': 'tight',
+    'savefig.pad_inches': 0.05,
+    'axes.grid': False,
+    'axes.spines.top': False,
+    'axes.spines.right': False,
+    'text.usetex': False,  # set True if LaTeX is available
+    'mathtext.fontset': 'stix',
+})
+
+# Color palette
+COLORS = plt.cm.tab10.colors  # or Set2, or colorblind-safe
+
+def save_fig(fig, name, fmt=FORMAT):
+    """Save figure to FIG_DIR with consistent naming."""
+    fig.savefig(f'{FIG_DIR}/{name}.{fmt}')
+    print(f'Saved: {FIG_DIR}/{name}.{fmt}')
+```
+
+### Step 3: Auto-Select Figure Type
+
+Use this decision tree for data-driven figures (inspired by Imbad0202/academic-research-skills):
+
+| Data Pattern | Recommended Type | Size |
+|-------------|-----------------|------|
+| X=time/steps, Y=metric | Line plot | 0.48\textwidth |
+| Methods × 1 metric | Bar chart | 0.48\textwidth |
+| Methods × multiple metrics | Grouped bar / radar | 0.95\textwidth |
+| Two continuous variables | Scatter plot | 0.48\textwidth |
+| Matrix / grid values | Heatmap | 0.48\textwidth |
+| Distribution comparison | Box/violin plot | 0.48\textwidth |
+| Multi-dataset results | Multi-panel (subfigure) | 0.95\textwidth |
+| Prior work comparison | LaTeX table | — |
+
+### Step 4: Generate Each Figure
+
+For each figure in the plan, create a standalone Python script:
+
+**Line plots** (training curves, scaling):
+```python
+# gen_fig2_training_curves.py
+from paper_plot_style import *
+import json
+
+with open('figures/exp_results.json') as f:
+    data = json.load(f)
+
+fig, ax = plt.subplots(1, 1, figsize=(5, 3.5))
+ax.plot(data['steps'], data['fac_loss'], label='Factorized', color=COLORS[0])
+ax.plot(data['steps'], data['crf_loss'], label='CRF-LR', color=COLORS[1])
+ax.set_xlabel('Training Steps')
+ax.set_ylabel('Cross-Entropy Loss')
+ax.legend(frameon=False)
+save_fig(fig, 'fig2_training_curves')
+```
+
+**Bar charts** (comparison, ablation):
+```python
+fig, ax = plt.subplots(1, 1, figsize=(5, 3))
+methods = ['Baseline', 'Method A', 'Method B', 'Ours']
+values = [82.3, 85.1, 86.7, 89.2]
+bars = ax.bar(methods, values, color=[COLORS[i] for i in range(len(methods))])
+ax.set_ylabel('Accuracy (%)')
+# Add value labels on bars
+for bar, val in zip(bars, values):
+    ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.3,
+            f'{val:.1f}', ha='center', va='bottom', fontsize=FONT_SIZE-1)
+save_fig(fig, 'fig3_comparison')
+```
+
+**Comparison tables** (LaTeX, for theory papers):
+```latex
+\begin{table}[t]
+\centering
+\caption{Comparison of estimation error bounds. $n$: sample size, $D$: ambient dim, $d$: latent dim, $K$: subspaces, $n_k$: modes.}
+\label{tab:bounds}
+\begin{tabular}{lccc}
+\toprule
+Method & Rate & Depends on $D$? & Multi-modal? \\
+\midrule
+\citet{MinimaxOkoAS23} & $n^{-s'/D}$ & Yes (curse) & No \\
+\citet{ScoreMatchingdistributionrecovery} & $n^{-2/d}$ & No & No \\
+\textbf{Ours} & $\sqrt{\sum n_k d_k / n}$ & No & Yes \\
+\bottomrule
+\end{tabular}
+\end{table}
+```
+
+**Architecture/pipeline diagrams** (MANUAL — outside this skill's scope):
+- These require manual creation using draw.io, Figma, Keynote, or TikZ
+- This skill can generate a rough TikZ skeleton as a starting point, but **do not expect publication-quality results**
+- If the figure already exists in `figures/`, preserve it and generate only the LaTeX `\includegraphics` snippet
+- Flag as `[MANUAL]` in the figure plan and `latex_includes.tex`
+
+### Step 5: Run All Scripts
+
+```bash
+# Run all figure generation scripts
+for script in gen_fig*.py; do
+    python "$script"
+done
+```
+
+Verify all output files exist and are non-empty.
+
+### Step 6: Generate LaTeX Include Snippets
+
+For each figure, output the LaTeX code to include it:
+
+```latex
+% === Fig 2: Training Curves ===
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.48\textwidth]{figures/fig2_training_curves.pdf}
+    \caption{Training curves comparing factorized and CRF-LR denoising.}
+    \label{fig:training_curves}
+\end{figure}
+```
+
+Save all snippets to `figures/latex_includes.tex` for easy copy-paste into the paper.
+
+### Step 7: Figure Quality Review with REVIEWER_MODEL
+
+Send figure descriptions and captions to GPT-5.4 for review:
+
+```
+mcp__claude-review__review_start:
+  prompt: |
+    Review these figure/table plans for a [VENUE] submission.
+
+    For each figure:
+    1. Is the caption informative and self-contained?
+    2. Does the figure type match the data being shown?
+    3. Is the comparison fair and clear?
+    4. Any missing baselines or ablations?
+    5. Would a different visualization be more effective?
+
+    [list all figures with captions and descriptions]
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+### Step 8: Quality Checklist
+
+Before finishing, verify each figure (from pedrohcgs/claude-code-my-workflow):
+
+- [ ] Font size readable at printed paper size (not too small)
+- [ ] Colors distinguishable in grayscale (print-friendly)
+- [ ] **No title inside figures** — titles go only in LaTeX `\caption{}` (from pedrohcgs)
+- [ ] Legend does not overlap data
+- [ ] Axis labels have units where applicable
+- [ ] Axis labels are publication-quality (not variable names like `emp_rate`)
+- [ ] Figure width fits single column (0.48\textwidth) or full width (0.95\textwidth)
+- [ ] PDF output is vector (not rasterized text)
+- [ ] No matplotlib default title (remove `plt.title` for publications)
+- [ ] Serif font matches paper body text (Times / Computer Modern)
+- [ ] Colorblind-accessible (if using colorblind palette)
+
+## Output
+
+```
+figures/
+├── paper_plot_style.py          # shared style config
+├── gen_fig1_architecture.py     # per-figure scripts
+├── gen_fig2_training_curves.py
+├── gen_fig3_comparison.py
+├── fig1_architecture.pdf        # generated figures
+├── fig2_training_curves.pdf
+├── fig3_comparison.pdf
+├── latex_includes.tex           # LaTeX snippets for all figures
+└── TABLE_*.tex                  # standalone table LaTeX files
+```
+
+## Key Rules
+
+- **Every figure must be reproducible** — save the generation script alongside the output
+- **Do NOT hardcode data** — always read from JSON/CSV files
+- **Use vector format (PDF)** for all plots — PNG only as fallback
+- **No decorative elements** — no background colors, no 3D effects, no chart junk
+- **Consistent style across all figures** — same fonts, colors, line widths
+- **Colorblind-safe** — verify with https://davidmathlogic.com/colorblind/ if needed
+- **One script per figure** — easy to re-run individual figures when data changes
+- **No titles inside figures** — captions are in LaTeX only
+- **Comparison tables count as figures** — generate them as standalone .tex files
+
+## Figure Type Reference
+
+| Type | When to Use | Typical Size |
+|------|------------|--------------|
+| Line plot | Training curves, scaling trends | 0.48\textwidth |
+| Bar chart | Method comparison, ablation | 0.48\textwidth |
+| Grouped bar | Multi-metric comparison | 0.95\textwidth |
+| Scatter plot | Correlation analysis | 0.48\textwidth |
+| Heatmap | Attention, confusion matrix | 0.48\textwidth |
+| Box/violin | Distribution comparison | 0.48\textwidth |
+| Architecture | System overview | 0.95\textwidth |
+| Multi-panel | Combined results (subfigures) | 0.95\textwidth |
+| Comparison table | Prior bounds vs. ours (theory) | full width |
+
+## Acknowledgements
+
+Design pattern (type × style matrix) inspired by [baoyu-skills](https://github.com/jimliu/baoyu-skills). Publication style defaults and figure rules from [pedrohcgs/claude-code-my-workflow](https://github.com/pedrohcgs/claude-code-my-workflow). Visualization decision tree from [Imbad0202/academic-research-skills](https://github.com/Imbad0202/academic-research-skills).

--- a/skills/skills-codex-claude-review/paper-plan/SKILL.md
+++ b/skills/skills-codex-claude-review/paper-plan/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: "paper-plan"
+description: "Generate a structured paper outline from review conclusions and experiment results. Use when user says \\"写大纲\\", \\"paper outline\\", \\"plan the paper\\", \\"论文规划\\", or wants to create a paper plan before writing."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Paper Plan: From Review Conclusions to Paper Outline
+
+Generate a structured, section-by-section paper outline from: **$ARGUMENTS**
+
+## Constants
+
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+- **TARGET_VENUE = `ICLR`** — Default venue. User can override (e.g., `/paper-plan "topic" — venue: NeurIPS`). Supported: `ICLR`, `NeurIPS`, `ICML`.
+- **MAX_PAGES** — Main body page limit, measured from first page to end of Conclusion section (excluding references, appendix, and acknowledgements). ICLR=9, NeurIPS=9, ICML=8.
+
+## Inputs
+
+The skill expects one or more of these in the project directory:
+
+1. **NARRATIVE_REPORT.md** or **STORY.md** — research narrative with claims and evidence
+2. **GPT54_AUTO_REVIEW.md** — auto-review loop conclusions
+3. **Experiment results** — JSON files in `figures/`, screen logs, tables
+4. **IDEA_REPORT.md** — from idea-discovery pipeline (if applicable)
+
+If none exist, ask the user to describe the paper's contribution in 3-5 sentences.
+
+## Workflow
+
+### Step 1: Extract Claims and Evidence
+
+Read all available narrative documents and extract:
+
+1. **Core claims** (3-5 main contributions)
+2. **Evidence** for each claim (which experiments, which metrics, which figures)
+3. **Known weaknesses** (from reviewer feedback)
+4. **Suggested framing** (from review conclusions)
+
+Build a **Claims-Evidence Matrix**:
+
+```markdown
+| Claim | Evidence | Status | Section |
+|-------|----------|--------|---------|
+| [claim 1] | [exp A, metric B] | Supported | §3.2 |
+| [claim 2] | [exp C] | Partially supported | §4.1 |
+```
+
+### Step 2: Determine Paper Type and Structure
+
+Based on TARGET_VENUE and paper content, classify and select structure.
+
+**IMPORTANT**: The section count is FLEXIBLE (5-8 sections). Choose what fits the content best. The templates below are starting points, not rigid constraints.
+
+**Empirical/Diagnostic paper:**
+```
+1. Introduction (1.5 pages)
+2. Related Work (1 page)
+3. Method / Setup (1.5 pages)
+4. Experiments (3 pages)
+5. Analysis / Discussion (1 page)
+6. Conclusion (0.5 pages)
+```
+
+**Theory + Experiments paper:**
+```
+1. Introduction (1.5 pages)
+2. Related Work (1 page)
+3. Preliminaries & Modeling (1.5 pages)
+4. Experiments (1.5 pages)
+5. Theory Part A (1.5 pages)
+6. Theory Part B (1.5 pages)
+7. Conclusion (0.5 pages)
+— Total: 9 pages
+```
+Theory papers often need 7 sections (splitting theory into estimation + optimization, or setup + analysis). The total page budget MUST sum to MAX_PAGES.
+
+Theory papers should:
+- Include **proof sketch** locations (not just theorem statements)
+- Plan a **comparison table** of prior theoretical bounds vs. this paper's bounds
+- Identify which proofs go in appendix vs. main body
+
+**Method paper:**
+```
+1. Introduction (1.5 pages)
+2. Related Work (1 page)
+3. Method (2 pages)
+4. Experiments (2.5 pages)
+5. Ablation / Analysis (1 page)
+6. Conclusion (0.5 pages)
+```
+
+### Step 3: Section-by-Section Planning
+
+For each section, specify:
+
+```markdown
+### §0 Abstract
+- **One-sentence problem**: [what gap this paper addresses]
+- **Approach**: [what we do, in one sentence]
+- **Key result**: [most compelling quantitative finding]
+- **Implication**: [why it matters]
+- **Estimated length**: 150-250 words
+- **Self-contained check**: can a reader understand this without the paper?
+
+### §1 Introduction
+- **Opening hook**: [1-2 sentences that motivate the problem]
+- **Gap**: [what's missing in prior work]
+- **Key questions**: [the research questions this paper answers]
+- **Contributions**: [numbered list, matching Claims-Evidence Matrix]
+- **Hero figure**: [describe what Figure 1 should show — MUST include clear comparison if applicable]
+- **Estimated length**: 1.5 pages
+- **Key citations**: [3-5 papers to cite here]
+
+### §2 Related Work
+- **Subtopics**: [2-4 categories of related work]
+- **Positioning**: [how this paper differs from each category]
+- **Minimum length**: 1 full page (at least 3-4 paragraphs with substantive synthesis)
+- **Must NOT be just a list** — synthesize, compare, and position
+
+### §3 Method / Setup / Preliminaries
+- **Notation**: [key symbols and their meanings]
+- **Problem formulation**: [formal setup]
+- **Method description**: [algorithm, model, or experimental design]
+- **Formal statements**: [theorems, propositions if applicable]
+- **Proof sketch locations**: [which key steps appear here vs. appendix]
+- **Estimated length**: 1.5-2 pages
+
+### §4 Experiments / Main Results
+- **Figures planned**:
+  - Fig 1: [description, type: bar/line/table/architecture, WHAT COMPARISON it shows]
+  - Fig 2: [description]
+  - Table 1: [what it shows, which methods/baselines compared]
+- **Data source**: [which JSON files / experiment results]
+
+### §5 Conclusion
+- **Restatement**: [contributions rephrased, not copy-pasted from intro]
+- **Limitations**: [honest assessment — reviewers value this]
+- **Future work**: [1-2 concrete directions]
+- **Estimated length**: 0.5 pages
+```
+
+### Step 4: Figure Plan
+
+List every figure and table:
+
+```markdown
+## Figure Plan
+
+| ID | Type | Description | Data Source | Priority |
+|----|------|-------------|-------------|----------|
+| Fig 1 | Hero/Architecture | System overview + comparison | manual | HIGH |
+| Fig 2 | Line plot | Training curves comparison | figures/exp_A.json | HIGH |
+| Fig 3 | Bar chart | Ablation results | figures/ablation.json | MEDIUM |
+| Table 1 | Comparison table | Main results vs. baselines | figures/main_results.json | HIGH |
+| Table 2 | Theory comparison | Prior bounds vs. ours | manual | HIGH (theory papers) |
+```
+
+**CRITICAL for Figure 1 / Hero Figure**: Describe in detail what the figure should contain, including:
+- Which methods are being compared
+- What the visual difference should demonstrate
+- Caption draft that clearly states the comparison
+
+### Step 5: Citation Scaffolding
+
+For each section, list required citations:
+
+```markdown
+## Citation Plan
+- §1 Intro: [paper1], [paper2], [paper3] (problem motivation)
+- §2 Related: [paper4]-[paper10] (categorized by subtopic)
+- §3 Method: [paper11] (baseline), [paper12] (technique we build on)
+```
+
+**Citation rules** (from claude-scholar + Imbad0202/academic-research-skills):
+1. NEVER generate BibTeX from memory — always verify via search or existing .bib files
+2. Every citation must be verified: correct authors, year, venue
+3. Flag any citation you're unsure about with `[VERIFY]`
+4. Prefer published versions over arXiv preprints when available
+
+### Step 6: Cross-Review with REVIEWER_MODEL
+
+Send the complete outline to Claude review for feedback:
+
+```
+mcp__claude-review__review_start:
+  prompt: |
+    Review this paper outline for a [VENUE] submission.
+    [full outline including Claims-Evidence Matrix]
+
+    Score 1-10 on:
+    1. Logical flow — does the story build naturally?
+    2. Claim-evidence alignment — every claim backed?
+    3. Missing experiments or analysis
+    4. Positioning relative to prior work
+    5. Page budget feasibility (MAX_PAGES = main body to Conclusion end, excluding refs/appendix)
+
+    For each weakness, suggest the MINIMUM fix.
+    Be specific and actionable — "add X" not "consider more experiments".
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+Apply feedback before finalizing.
+
+### Step 7: Output
+
+Save the final outline to `PAPER_PLAN.md` in the project root:
+
+```markdown
+# Paper Plan
+
+**Title**: [working title]
+**Venue**: [target venue]
+**Type**: [empirical/theory/method]
+**Date**: [today]
+**Page budget**: [MAX_PAGES] pages (main body to Conclusion end, excluding references & appendix)
+**Section count**: [N] (must match the number of section files that will be created)
+
+## Claims-Evidence Matrix
+[from Step 1]
+
+## Structure
+[from Step 2-3, section by section]
+
+## Figure Plan
+[from Step 4, with detailed hero figure description]
+
+## Citation Plan
+[from Step 5]
+
+## Reviewer Feedback
+[from Step 6, summarized]
+
+## Next Steps
+- [ ] /paper-figure to generate all figures
+- [ ] /paper-write to draft LaTeX
+- [ ] /paper-compile to build PDF
+```
+
+## Key Rules
+
+- **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
+
+- **Do NOT generate author information** — leave author block as placeholder or anonymous
+- **Be honest about evidence gaps** — mark claims as "needs experiment" rather than overclaiming
+- **Page budget is hard** — if content exceeds MAX_PAGES, suggest what to move to appendix
+- **MAX_PAGES counts main body only** — from first page to end of Conclusion. References and appendix are NOT counted.
+- **Venue-specific norms** — all three venues (ICLR/NeurIPS/ICML) use `natbib` (`\citep`/`\citet`)
+- **Claims-Evidence Matrix is the backbone** — every claim must map to evidence, every experiment must support a claim
+- **Figures need detailed descriptions** — especially the hero figure, which must clearly specify comparisons and visual expectations
+- **Section count is flexible** — 5-8 sections depending on paper type. Don't force content into a rigid 5-section template.
+
+## Acknowledgements
+
+Outline methodology inspired by [Research-Paper-Writing-Skills](https://github.com/Master-cai/Research-Paper-Writing-Skills) (claim-evidence mapping), [claude-scholar](https://github.com/Galaxy-Dawn/claude-scholar) (citation verification), and [Imbad0202/academic-research-skills](https://github.com/Imbad0202/academic-research-skills) (claim verification protocol).

--- a/skills/skills-codex-claude-review/paper-write/SKILL.md
+++ b/skills/skills-codex-claude-review/paper-write/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: "paper-write"
+description: "Draft LaTeX paper section by section from an outline. Use when user says \\"写论文\\", \\"write paper\\", \\"draft LaTeX\\", \\"开始写\\", or wants to generate LaTeX content from a paper plan."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Paper Write: Section-by-Section LaTeX Generation
+
+Draft a LaTeX paper based on: **$ARGUMENTS**
+
+## Constants
+
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+- **TARGET_VENUE = `ICLR`** — Default venue. Supported: `ICLR`, `NeurIPS`, `ICML`. Determines style file and formatting.
+- **ANONYMOUS = true** — If true, use anonymous author block. Set `false` for camera-ready.
+- **MAX_PAGES = 9** — Main body page limit. Counts from first page to end of Conclusion section. References and appendix are NOT counted.
+- **DBLP_BIBTEX = true** — Fetch real BibTeX from DBLP/CrossRef instead of LLM-generated entries. Eliminates hallucinated citations. Zero install required. Set `false` to use legacy behavior (LLM search + `[VERIFY]` markers).
+
+## Inputs
+
+1. **PAPER_PLAN.md** — outline with claims-evidence matrix, section plan, figure plan (from `/paper-plan`)
+2. **NARRATIVE_REPORT.md** — the research narrative (primary source of content)
+3. **Generated figures** — PDF/PNG files in `figures/` (from `/paper-figure`)
+4. **LaTeX includes** — `figures/latex_includes.tex` (from `/paper-figure`)
+5. **Bibliography** — existing `.bib` file, or will create one
+
+If no PAPER_PLAN.md exists, ask the user to run `/paper-plan` first or provide a brief outline.
+
+## Templates
+
+### Venue-Specific Setup
+
+The skill includes conference templates in `templates/`. Select based on TARGET_VENUE:
+
+**ICLR:**
+```latex
+\documentclass{article}
+\usepackage{iclr2026_conference,times}
+% \iclrfinalcopy  % Uncomment for camera-ready
+```
+
+**NeurIPS:**
+```latex
+\documentclass{article}
+\usepackage[preprint]{neurips_2025}
+% \usepackage[final]{neurips_2025}  % Camera-ready
+```
+
+**ICML:**
+```latex
+\documentclass[accepted]{icml2025}
+% Use [accepted] for camera-ready
+```
+
+### Project Structure
+
+Generate this file structure:
+
+```
+paper/
+├── main.tex                    # master file (includes sections)
+├── iclr2026_conference.sty     # or neurips_2025.sty / icml2025.sty
+├── math_commands.tex           # shared math macros
+├── references.bib              # bibliography (filtered — only cited entries)
+├── sections/
+│   ├── 0_abstract.tex
+│   ├── 1_introduction.tex
+│   ├── 2_related_work.tex
+│   ├── 3_method.tex            # or preliminaries, setup, etc.
+│   ├── 4_experiments.tex
+│   ├── 5_conclusion.tex
+│   └── A_appendix.tex          # proof details, extra experiments
+└── figures/                    # symlink or copy from project figures/
+```
+
+**Section files are FLEXIBLE**: If the paper plan has 6-8 sections, create corresponding files (e.g., `4_theory.tex`, `5_experiments.tex`, `6_analysis.tex`, `7_conclusion.tex`).
+
+## Workflow
+
+### Step 0: Backup and Clean
+
+If `paper/` already exists, back up to `paper-backup-{timestamp}/` before overwriting. Never silently destroy existing work.
+
+**CRITICAL: Clean stale files.** When changing section structure (e.g., 5 sections → 7 sections), delete section files that are no longer referenced by `main.tex`. Stale files (e.g., old `5_conclusion.tex` left behind when conclusion moved to `7_conclusion.tex`) cause confusion and waste space.
+
+### Step 1: Initialize Project
+
+1. Create `paper/` directory
+2. Copy venue template from `templates/` — the template already includes:
+   - All standard packages (amsmath, hyperref, cleveref, booktabs, etc.)
+   - Theorem environments with `\crefname{assumption}` fix
+   - Anonymous author block
+3. Generate `math_commands.tex` with paper-specific notation
+4. Create section files matching PAPER_PLAN structure
+
+**Author block (anonymous mode):**
+```latex
+\author{Anonymous Authors}
+```
+
+### Step 2: Generate math_commands.tex
+
+Create shared math macros based on the paper's notation:
+
+```latex
+% math_commands.tex — shared notation
+\newcommand{\R}{\mathbb{R}}
+\newcommand{\E}{\mathbb{E}}
+\DeclareMathOperator*{\argmin}{arg\,min}
+\DeclareMathOperator*{\argmax}{arg\,max}
+% Add paper-specific notation here
+```
+
+### Step 3: Write Each Section
+
+Process sections in order. For each section:
+
+1. **Read the plan** — what claims, evidence, citations belong here
+2. **Read NARRATIVE_REPORT.md** — extract relevant content, findings, and quantitative results
+3. **Draft content** — write complete LaTeX (not placeholders)
+4. **Insert figures/tables** — use snippets from `figures/latex_includes.tex`
+5. **Add citations** — use `\citep{}` / `\citet{}` (all three venues use `natbib`)
+
+#### Section-Specific Guidelines
+
+**§0 Abstract:**
+- Must be self-contained (understandable without reading the paper)
+- Structure: problem → approach → key result → implication
+- Include one concrete quantitative result
+- 150-250 words (check venue limit)
+- No citations, no undefined acronyms
+- No `\begin{abstract}` — that's in main.tex
+
+**§1 Introduction:**
+- Open with a compelling hook (1-2 sentences, problem motivation)
+- State the gap clearly ("However, ...")
+- List contributions as a numbered or bulleted list
+- End with a brief roadmap ("The rest of this paper is organized as...")
+- Include the main result figure if space allows
+- Target: 1.5 pages
+
+**§2 Related Work:**
+- **MINIMUM 1 full page** (3-4 substantive paragraphs). Short related work sections are a common reviewer complaint.
+- Organize by category using `\paragraph{Category Name.}`
+- Each category: 1 paragraph summarizing the line of work + 1-2 sentences positioning this paper
+- Do NOT just list papers — synthesize and compare
+- End each paragraph with how this paper relates/differs
+
+**§3 Method / Preliminaries / Setup:**
+- Define notation early (reference math_commands.tex)
+- Use `\begin{definition}`, `\begin{theorem}` environments for formal statements
+- For theory papers: include proof sketches of key results in main body, full proofs in appendix
+- For theory papers: include a **comparison table** of prior bounds vs. this paper
+- Include algorithm pseudocode if applicable (`algorithm2e` or `algorithmic`)
+- Target: 1.5-2 pages
+
+**§4 Experiments:**
+- Start with experimental setup (datasets, baselines, metrics, implementation details)
+- Main results table/figure first
+- Then ablations and analysis
+- Every claim from the introduction must have supporting evidence here
+- Target: 2.5-3 pages
+
+**§5 Conclusion:**
+- Summarize contributions (NOT copy-paste from intro — rephrase)
+- Limitations (be honest — reviewers appreciate this)
+- Future work (1-2 concrete directions)
+- Ethics statement and reproducibility statement (if venue requires)
+- Target: 0.5 pages
+
+**Appendix:**
+- Proof details (full proofs of main-body theorems)
+- Additional experiments, ablations
+- Implementation details, hyperparameter tables
+- Additional visualizations
+
+### Step 4: Build Bibliography
+
+**CRITICAL: Only include entries that are actually cited in the paper.**
+
+1. Scan all `\citep{}` and `\citet{}` references in the drafted sections
+2. Build a citation key list
+3. For each citation key:
+   - Check existing `.bib` files in the project/narrative docs
+   - If not found and **DBLP_BIBTEX = true**, use the verified fetch chain below
+   - If not found and **DBLP_BIBTEX = false**, search arXiv/Scholar for correct BibTeX
+   - **NEVER fabricate BibTeX entries** — mark unknown ones with `[VERIFY]` comment
+4. Write `references.bib` containing ONLY cited entries (no bloat)
+
+#### Verified BibTeX Fetch (when DBLP_BIBTEX = true)
+
+Three-step fallback chain — zero install, zero auth, all real BibTeX:
+
+**Step A: DBLP (best quality — full venue, pages, editors)**
+```bash
+# 1. Search by title + first author
+curl -s "https://dblp.org/search/publ/api?q=TITLE+AUTHOR&format=json&h=3"
+# 2. Extract DBLP key from result (e.g., conf/nips/VaswaniSPUJGKP17)
+# 3. Fetch real BibTeX
+curl -s "https://dblp.org/rec/{key}.bib"
+```
+
+**Step B: CrossRef DOI (fallback — works for arXiv preprints)**
+```bash
+# If paper has a DOI or arXiv ID (arXiv DOI = 10.48550/arXiv.{id})
+curl -sLH "Accept: application/x-bibtex" "https://doi.org/{doi}"
+```
+
+**Step C: Mark `[VERIFY]` (last resort)**
+If both DBLP and CrossRef return nothing, mark the entry with `% [VERIFY]` comment. Do NOT fabricate.
+
+**Why this matters:** LLM-generated BibTeX frequently hallucinates venue names, page numbers, or even co-authors. DBLP and CrossRef return publisher-verified metadata. Upstream skills (`/research-lit`, `/novelty-check`) may mention papers from LLM memory — this fetch chain is the gate that prevents hallucinated citations from entering the final `.bib`.
+
+**Automated bib cleaning** — use this Python pattern to extract only cited entries:
+
+```python
+import re
+# 1. Grep all \citep{...} and \citet{...} from all .tex files
+# 2. Extract unique keys (handle multi-cite like \citep{a,b,c})
+# 3. Parse the full .bib file, keep only entries whose key is in the cited set
+# 4. Write the filtered bib
+```
+
+This prevents bib bloat (e.g., 948 lines → 215 lines in testing).
+
+**Citation verification rules (from claude-scholar + Imbad0202):**
+1. Every BibTeX entry must have: author, title, year, venue/journal
+2. Prefer published venue versions over arXiv preprints (if published)
+3. Use consistent key format: `{firstauthor}{year}{keyword}` (e.g., `ho2020denoising`)
+4. Double-check year and venue for every entry
+5. Remove duplicate entries (same paper with different keys)
+
+### Step 5: De-AI Polish (from kgraph57/paper-writer-skill)
+
+After drafting all sections, scan for common AI writing patterns and fix them:
+
+**Content patterns to fix:**
+- Significance inflation ("groundbreaking", "revolutionary" → use measured language)
+- Formulaic transitions ("In this section, we..." → remove or vary)
+- Generic conclusions ("This work opens exciting new avenues" → be specific)
+
+**Language patterns to fix (watch words):**
+- Replace: delve, pivotal, landscape, tapestry, underscore, noteworthy, intriguingly
+- Remove filler: "It is worth noting that", "Importantly,", "Notably,"
+- Avoid rule-of-three lists ("X, Y, and Z" appearing repeatedly)
+- Don't start consecutive sentences with "This" or "We"
+
+### Step 6: Cross-Review with REVIEWER_MODEL
+
+Send the complete draft to Claude review:
+
+```
+mcp__claude-review__review_start:
+  prompt: |
+    Review this [VENUE] paper draft (main body, excluding appendix).
+
+    Focus on:
+    1. Does each claim from the intro have supporting evidence?
+    2. Is the writing clear, concise, and free of AI-isms?
+    3. Any logical gaps or unclear explanations?
+    4. Does it fit within [MAX_PAGES] pages (to end of Conclusion)?
+    5. Is related work sufficiently comprehensive (≥1 page)?
+    6. For theory papers: are proof sketches adequate?
+    7. Are figures/tables clearly described and properly referenced?
+
+    For each issue, specify: severity (CRITICAL/MAJOR/MINOR), location, and fix.
+
+    [paste full draft text]
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+Apply CRITICAL and MAJOR fixes. Document MINOR issues for the user.
+
+### Step 7: Reverse Outline Test (from Research-Paper-Writing-Skills)
+
+After drafting all sections:
+
+1. **Extract topic sentences** — pull the first sentence of every paragraph
+2. **Read them in sequence** — they should form a coherent narrative on their own
+3. **Check claim coverage** — every claim from the Claims-Evidence Matrix must appear
+4. **Check evidence mapping** — every experiment/figure must support a stated claim
+5. **Fix gaps** — if a topic sentence doesn't advance the story, rewrite the paragraph
+
+### Step 8: Final Checks
+
+Before declaring done:
+
+- [ ] All `\ref{}` and `\label{}` match (no undefined references)
+- [ ] All `\citep{}` / `\citet{}` have corresponding BibTeX entries
+- [ ] No author information in anonymous mode
+- [ ] Figure/table numbering is correct
+- [ ] Page count within MAX_PAGES (main body to Conclusion end)
+- [ ] No TODO/FIXME/XXX markers left in the text
+- [ ] No `[VERIFY]` markers left unchecked
+- [ ] Abstract is self-contained (understandable without reading the paper)
+- [ ] Title is specific and informative (not generic)
+- [ ] Related work is ≥1 full page
+- [ ] references.bib contains ONLY cited entries (no bloat)
+- [ ] **No stale section files** — every .tex in `sections/` is `\input`ed by `main.tex`
+- [ ] **Section files match main.tex** — file numbering and `\input` paths are consistent
+
+## Key Rules
+
+- **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
+
+- **Do NOT generate author names, emails, or affiliations** — use anonymous block or placeholder
+- **Write complete sections, not outlines** — the output should be compilable LaTeX
+- **One file per section** — modular structure for easy editing
+- **Every claim must cite evidence** — cross-reference the Claims-Evidence Matrix
+- **Compile-ready** — the output should compile with `latexmk` without errors (modulo missing figures)
+- **No over-claiming** — use hedging language ("suggests", "indicates") for weak evidence
+- **Venue style matters** — all three venues (ICLR/NeurIPS/ICML) use `natbib` (`\citep`/`\citet`)
+- **Page limit = main body to Conclusion** — references and appendix do NOT count
+- **Clean bib** — references.bib must only contain entries that are actually `\cite`d
+- **Section count is flexible** — match PAPER_PLAN structure, don't force into 5 sections
+- **Backup before overwrite** — never destroy existing `paper/` directory without backing up
+
+## Writing Quality Reference
+
+Principles from [Research-Paper-Writing-Skills](https://github.com/Master-cai/Research-Paper-Writing-Skills):
+
+1. **One message per paragraph** — each paragraph makes exactly one point
+2. **Topic sentence first** — the first sentence states the paragraph's message
+3. **Explicit transitions** — connect paragraphs with logical connectors
+4. **Reverse outline test** — extract topic sentences; they should form a coherent narrative
+
+De-AI patterns from [kgraph57/paper-writer-skill](https://github.com/kgraph57/paper-writer-skill):
+
+5. **No AI watch words** — delve, pivotal, landscape, tapestry, underscore
+6. **No significance inflation** — groundbreaking, revolutionary, paradigm shift
+7. **No formulaic structures** — vary sentence openings and transitions
+
+## Acknowledgements
+
+Writing methodology adapted from [Research-Paper-Writing-Skills](https://github.com/Master-cai/Research-Paper-Writing-Skills) (CCF award-winning methodology). Citation verification from [claude-scholar](https://github.com/Galaxy-Dawn/claude-scholar) and [Imbad0202/academic-research-skills](https://github.com/Imbad0202/academic-research-skills). De-AI polish from [kgraph57/paper-writer-skill](https://github.com/kgraph57/paper-writer-skill). Backup mechanism from [baoyu-skills](https://github.com/jimliu/baoyu-skills).

--- a/skills/skills-codex-claude-review/research-refine/SKILL.md
+++ b/skills/skills-codex-claude-review/research-refine/SKILL.md
@@ -1,0 +1,665 @@
+---
+name: "research-refine"
+description: "Turn a vague research direction into a problem-anchored, elegant, frontier-aware, implementation-oriented method plan via iterative GPT-5.4 review. Use when the user says \"refine my approach\", \"帮我细化方案\", \"decompose this problem\", \"打磨idea\", \"refine research plan\", \"细化研究方案\", or wants a concrete research method that stays simple, focused, and top-venue ready instead of a vague or overbuilt idea."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Research Refine: Problem-Anchored, Elegant, Frontier-Aware Plan Refinement
+
+Refine and concretize: **$ARGUMENTS**
+
+## Overview
+
+Use this skill when the research problem is already visible but the technical route is still fuzzy. The goal is not to produce a bloated proposal or a benchmark shopping list. The goal is to turn a vague direction into a **problem -> focused method -> minimal validation** document that is concrete enough to implement, elegant enough to feel paper-worthy, and current enough to resonate in the foundation-model era.
+
+Four principles dominate this skill:
+
+1. **Do not lose the original problem.** Freeze an immutable **Problem Anchor** and reuse it in every round.
+2. **The smallest adequate mechanism wins.** Prefer the minimal intervention that directly fixes the bottleneck.
+3. **One paper, one dominant contribution.** Prefer one sharp thesis plus at most one supporting contribution.
+4. **Modern leverage is a prior, not a decoration.** When LLM / VLM / Diffusion / RL / distillation / inference-time scaling naturally fit the bottleneck, use them concretely. Do not bolt them on as buzzwords.
+
+```
+User input (PROBLEM + vague APPROACH)
+  -> Phase 0 (Claude): Freeze Problem Anchor
+  -> Phase 1 (Claude): Scan grounding papers -> identify technical gap -> choose the sharpest route -> write focused proposal
+  -> Phase 2 (Codex/GPT-5.4): Review for fidelity, specificity, contribution quality, and frontier leverage
+  -> Phase 3 (Claude): Anchor check + simplicity check -> revise method -> rewrite full proposal
+  -> Phase 4 (Codex, same agent): Re-evaluate revised proposal
+  -> Repeat Phase 3-4 until OVERALL SCORE >= 9 or MAX_ROUNDS reached
+  -> Phase 5: Save full history to refine-logs/
+  -> Optional handoff: /experiment-plan for a detailed execution-ready experiment roadmap
+```
+
+## Constants
+
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+- **MAX_ROUNDS = 5** — Maximum review-revise rounds.
+- **SCORE_THRESHOLD = 9** — Minimum overall score to stop.
+- **OUTPUT_DIR = `refine-logs/`** — Directory for round files and final report.
+- **MAX_LOCAL_PAPERS = 15** — Maximum local papers/notes to scan for grounding.
+- **MAX_CORE_EXPERIMENTS = 3** — Default cap for core validation blocks inside this skill.
+- **MAX_PRIMARY_CLAIMS = 2** — Soft cap for paper-level claims. Prefer one dominant claim plus one supporting claim.
+- **MAX_NEW_TRAINABLE_COMPONENTS = 2** — Soft cap for genuinely new trainable pieces. Exceed only if the paper breaks otherwise.
+
+> Override via argument if needed, e.g. `/research-refine "problem | approach" -- max rounds: 3, threshold: 9`.
+
+## Output Structure
+
+```
+refine-logs/
+├── round-0-initial-proposal.md
+├── round-1-review.md
+├── round-1-refinement.md
+├── round-2-review.md
+├── round-2-refinement.md
+├── ...
+├── REVIEW_SUMMARY.md
+├── FINAL_PROPOSAL.md
+├── REFINEMENT_REPORT.md
+└── score-history.md
+```
+
+Every `round-N-refinement.md` must contain a **full anchored proposal**, not just incremental fixes.
+
+## Workflow
+
+### Phase 0: Freeze the Problem Anchor
+
+Before proposing anything, extract the user's immutable bottom-line problem. This anchor must be copied verbatim into every proposal and every refinement round.
+
+Write:
+
+- **Bottom-line problem**: What technical problem must be solved?
+- **Must-solve bottleneck**: What specific weakness in current methods is unacceptable?
+- **Non-goals**: What is explicitly *not* the goal of this project?
+- **Constraints**: Compute, data, time, tooling, venue, deployment limits.
+- **Success condition**: What evidence would make the user say "yes, this method addresses the actual problem"?
+
+If later reviewer feedback would change the problem being solved, mark that as **drift** and push back or adapt carefully.
+
+### Phase 1: Build the Initial Proposal
+
+#### Step 1.1: Scan Grounding Material
+
+Check `papers/` and `literature/` first. Read only the relevant parts needed to answer:
+
+- What mechanism do current methods use?
+- Where exactly do they fail for this problem?
+- Which recent LLM / VLM / Diffusion / RL era techniques are actually relevant here?
+- What training objectives, representations, or interfaces are reusable?
+- What details distinguish a real method from a renamed high-level idea?
+
+If local material is insufficient, search recent top-venue/arXiv work online. Focus on **method sections, training setup, and failure modes**, not just abstracts.
+
+#### Step 1.2: Identify the Technical Gap
+
+Do not stop at generic research questions. Make the gap operational:
+
+1. **Current pipeline failure point**: where does the baseline break?
+2. **Why naive fixes are insufficient**: larger context, more data, prompting, memory bank, or stacking more modules.
+3. **Smallest adequate intervention**: what is the least additional mechanism that could plausibly fix the bottleneck?
+4. **Frontier-native alternative**: is there a more current route using foundation-model-era primitives that better matches the bottleneck?
+5. **Core technical claim**: what exact mechanism claim could survive top-venue scrutiny?
+6. **Required evidence**: what minimum proof is needed to defend that claim?
+
+#### Step 1.3: Choose the Sharpest Route
+
+Before locking the method, compare two candidate routes if both are plausible:
+
+- **Route A: Elegant minimal route** — the smallest mechanism that directly targets the bottleneck.
+- **Route B: Frontier-native route** — a more modern route that uses LLM / VLM / Diffusion / RL / distillation / inference-time scaling *only if* it gives a cleaner or stronger story.
+
+Then decide:
+
+- Which route is more likely to become a strong paper under the stated constraints?
+- Which route has the cleaner novelty story relative to the closest work?
+- Which route avoids contribution sprawl?
+
+If both routes are weak, rethink the framing instead of combining them into a larger system by default.
+
+#### Step 1.4: Concretize the Method First
+
+The proposal must answer "how would we actually build this?" Prefer method detail over broad experimentation and prefer reuse over invention.
+
+Cover:
+
+1. **One-sentence method thesis**: the single strongest mechanism claim.
+2. **Contribution focus**: one dominant contribution and at most one supporting contribution.
+3. **Complexity budget**: what is frozen or reused, what is new, and what tempting additions are intentionally excluded.
+4. **System graph**: modules, data flow, inputs, outputs.
+5. **Representation design**: what latent, embedding, plan token, reward signal, memory state, or alignment space is used?
+6. **Training recipe**: data source, supervision, pseudo-labeling, negatives, curriculum, losses, weighting, stagewise vs joint training.
+7. **Inference path**: how the trained components are used at test time and what signals flow where.
+8. **Why the mechanism stays small**: why a larger stack is unnecessary.
+9. **Exact role of any frontier primitive**: if you use an LLM / VLM / Diffusion / RL component, specify whether it acts as planner, teacher, critic, reward model, generator prior, search controller, or distillation source.
+10. **Failure handling**: what could go wrong and what fallback or diagnostic exists?
+11. **Novelty and elegance argument**: why this is more than naming a module and why the paper still looks focused.
+
+If the method is still only described as "add a module" or "use a planner," it is not concrete enough.
+
+#### Step 1.5: Design Minimal Claim-Driven Validation
+
+Experiments exist to validate the method, not to dominate the document.
+
+For each core claim, define the **smallest strong experiment** that can validate it:
+
+- the claim being tested
+- the necessary baseline or ablation
+- the decisive metric
+- the expected directional outcome
+
+Additional rules:
+
+- Ensure one experiment block directly supports the **Problem Anchor**.
+- If complexity risk exists, include one **simplification or deletion check**.
+- If a frontier primitive is central, include one **necessity check** showing why that choice matters.
+- Default to **1-3 core experiment blocks** and leave the full execution roadmap to `/experiment-plan`.
+
+#### Step 1.6: Write the Initial Proposal
+
+Save to `refine-logs/round-0-initial-proposal.md`.
+
+Use this structure:
+
+```markdown
+# Research Proposal: [Title]
+
+## Problem Anchor
+- Bottom-line problem:
+- Must-solve bottleneck:
+- Non-goals:
+- Constraints:
+- Success condition:
+
+## Technical Gap
+[Why current methods fail, why naive bigger systems are not enough, and what mechanism is missing]
+
+## Method Thesis
+- One-sentence thesis:
+- Why this is the smallest adequate intervention:
+- Why this route is timely in the foundation-model era:
+
+## Contribution Focus
+- Dominant contribution:
+- Optional supporting contribution:
+- Explicit non-contributions:
+
+## Proposed Method
+### Complexity Budget
+- Frozen / reused backbone:
+- New trainable components:
+- Tempting additions intentionally not used:
+
+### System Overview
+[Step-by-step pipeline or ASCII graph]
+
+### Core Mechanism
+- Input / output:
+- Architecture or policy:
+- Training signal / loss:
+- Why this is the main novelty:
+
+### Optional Supporting Component
+- Only include if truly necessary:
+- Input / output:
+- Training signal / loss:
+- Why it does not create contribution sprawl:
+
+### Modern Primitive Usage
+- Which LLM / VLM / Diffusion / RL-era primitive is used:
+- Exact role in the pipeline:
+- Why it is more natural than an old-school alternative:
+
+### Integration into Base Generator / Downstream Pipeline
+[Where the new method attaches, what is frozen, what is trainable, inference order]
+
+### Training Plan
+[Stagewise or joint training, losses, data construction, pseudo-labels, schedules]
+
+### Failure Modes and Diagnostics
+- [Failure mode]:
+- [How to detect]:
+- [Fallback or mitigation]:
+
+### Novelty and Elegance Argument
+[Closest work, exact difference, why this is a focused mechanism-level contribution rather than a module pile-up]
+
+## Claim-Driven Validation Sketch
+### Claim 1: [Main claim]
+- Minimal experiment:
+- Baselines / ablations:
+- Metric:
+- Expected evidence:
+
+### Claim 2: [Optional]
+- Minimal experiment:
+- Baselines / ablations:
+- Metric:
+- Expected evidence:
+
+## Experiment Handoff Inputs
+- Must-prove claims:
+- Must-run ablations:
+- Critical datasets / metrics:
+- Highest-risk assumptions:
+
+## Compute & Timeline Estimate
+- Estimated GPU-hours:
+- Data / annotation cost:
+- Timeline:
+```
+
+### Phase 2: External Method Review (Round 1)
+
+Send the full proposal to GPT-5.4 for an **elegance-first, frontier-aware, method-first** review. The reviewer should spend most of the critique budget on the method itself, not on expanding the experiment menu.
+
+```
+mcp__claude-review__review_start:
+  prompt: |
+    You are a senior ML reviewer for a top venue (NeurIPS/ICML/ICLR).
+    This is an early-stage, method-first research proposal.
+
+    Your job is NOT to reward extra modules, contribution sprawl, or a giant benchmark checklist.
+    Your job IS to stress-test whether the proposed method:
+    (1) still solves the original anchored problem,
+    (2) is concrete enough to implement,
+    (3) presents a focused, elegant contribution,
+    (4) uses foundation-model-era techniques appropriately when they are the natural fit.
+
+    Review principles:
+    - Prefer the smallest adequate mechanism over a larger system.
+    - Penalize parallel contributions that make the paper feel unfocused.
+    - If a modern LLM / VLM / Diffusion / RL route would clearly produce a better paper, say so concretely.
+    - If the proposal is already modern enough, do NOT force trendy components.
+    - Do not ask for extra experiments unless they are needed to prove the core claims.
+
+    Read the Problem Anchor first. If your suggested fix would change the problem being solved,
+    call that out explicitly as drift instead of treating it as a normal revision request.
+
+    === PROPOSAL ===
+    [Paste the FULL proposal from Phase 1]
+    === END PROPOSAL ===
+
+    Score these 7 dimensions from 1-10:
+
+    1. **Problem Fidelity**: Does the method still attack the original bottleneck, or has it drifted into solving something easier or different?
+
+    2. **Method Specificity**: Are the interfaces, representations, losses, training stages, and inference path concrete enough that an engineer could start implementing?
+
+    3. **Contribution Quality**: Is there one dominant mechanism-level contribution with real novelty, good parsimony, and no obvious contribution sprawl?
+
+    4. **Frontier Leverage**: Does the proposal use current foundation-model-era primitives appropriately when they are the right tool, instead of defaulting to old-school module stacking?
+
+    5. **Feasibility**: Can this method be trained and integrated with the stated resources and data assumptions?
+
+    6. **Validation Focus**: Are the proposed experiments minimal but sufficient to validate the core claims? Is there unnecessary experimental bloat?
+
+    7. **Venue Readiness**: If executed well, would the contribution feel sharp and timely enough for a top venue?
+
+    **OVERALL SCORE** (1-10): Weighted toward Problem Fidelity, Method Specificity, Contribution Quality, and Frontier Leverage.
+    Use this weighting: Problem Fidelity 15%, Method Specificity 25%, Contribution Quality 25%, Frontier Leverage 15%, Feasibility 10%, Validation Focus 5%, Venue Readiness 5%.
+
+    For each dimension scoring < 7, provide:
+    - The specific weakness
+    - A concrete fix at the method level (interface / loss / training recipe / integration point / deletion of unnecessary parts)
+    - Priority: CRITICAL / IMPORTANT / MINOR
+
+    Then add:
+    - **Simplification Opportunities**: 1-3 concrete ways to delete, merge, or reuse components while preserving the main claim. Write "NONE" if already tight.
+    - **Modernization Opportunities**: 1-3 concrete ways to replace old-school pieces with more natural foundation-model-era primitives if genuinely better. Write "NONE" if already modern enough.
+    - **Drift Warning**: "NONE" if the proposal still solves the anchored problem; otherwise explain the drift clearly.
+    - **Verdict**: READY / REVISE / RETHINK
+
+    Verdict rule:
+    - READY: overall score >= 9, no meaningful drift, one focused dominant contribution, and no obvious complexity bloat remains
+    - REVISE: the direction is promising but not yet at READY bar
+    - RETHINK: the core mechanism or framing is still fundamentally off
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+**CRITICAL: Save the returned `jobId`**, poll `mcp__claude-review__review_status` until `done=true`, then save the completed `threadId` from the status result for all later rounds.
+
+**CRITICAL: Save the FULL raw response** verbatim.
+
+Save review to `refine-logs/round-1-review.md` with the raw response in a `<details>` block.
+
+### Phase 3: Parse Feedback and Revise the Method
+
+#### Step 3.1: Parse the Review
+
+Extract:
+
+- **Problem Fidelity**
+- **Method Specificity**
+- **Contribution Quality**
+- **Frontier Leverage**
+- **Feasibility**
+- **Validation Focus**
+- **Venue Readiness**
+- **Overall score**
+- **Verdict**
+- **Drift Warning**
+- **Simplification Opportunities**
+- **Modernization Opportunities**
+- **Action items** ranked by priority
+
+Update `refine-logs/score-history.md`:
+
+```markdown
+# Score Evolution
+
+| Round | Problem Fidelity | Method Specificity | Contribution Quality | Frontier Leverage | Feasibility | Validation Focus | Venue Readiness | Overall | Verdict |
+|-------|------------------|--------------------|----------------------|-------------------|-------------|------------------|-----------------|---------|---------|
+| 1     | X                | X                  | X                    | X                 | X           | X                | X               | X       | REVISE  |
+```
+
+**STOP CONDITION**: If overall score >= SCORE_THRESHOLD, verdict is READY, and there is no unresolved drift warning, skip to Phase 5.
+
+#### Step 3.2: Revise With an Anchor Check and a Simplicity Check
+
+Before changing anything:
+
+1. Copy the **Problem Anchor verbatim**.
+2. Write an **Anchor Check**:
+   - What is the original bottleneck?
+   - Does the current method still solve it?
+   - Which reviewer suggestions would cause drift if followed blindly?
+3. Write a **Simplicity Check**:
+   - What is the dominant contribution now?
+   - What components can be removed, merged, or kept frozen?
+   - Which reviewer suggestions add unnecessary complexity?
+   - If a frontier primitive is central, is its role still crisp and justified?
+
+Then process reviewer feedback:
+
+- If **valid**: sharpen the mechanism, simplify if possible, or modernize if the paper really improves.
+- If **debatable**: revise, but explain your reasoning with evidence.
+- If **wrong, drifting, or over-complicating**: push back with evidence from local papers and the Problem Anchor.
+
+Bias the revisions toward:
+
+- a sharper central contribution
+- fewer moving parts
+- cleaner reuse of strong existing backbones
+- more natural foundation-model-era leverage when it improves the paper
+- leaner, claim-driven experiments
+
+Do **not** add multiple parallel contributions just to chase score. If the reviewer requests another module, first ask whether the same gain can come from a better interface, distillation signal, reward model, or inference policy on top of an existing backbone.
+
+Save to `refine-logs/round-N-refinement.md`:
+
+```markdown
+# Round N Refinement
+
+## Problem Anchor
+[Copy verbatim from round 0]
+
+## Anchor Check
+- Original bottleneck:
+- Why the revised method still addresses it:
+- Reviewer suggestions rejected as drift:
+
+## Simplicity Check
+- Dominant contribution after revision:
+- Components removed or merged:
+- Reviewer suggestions rejected as unnecessary complexity:
+- Why the remaining mechanism is still the smallest adequate route:
+
+## Changes Made
+
+### 1. [Method section changed]
+- Reviewer said:
+- Action:
+- Reasoning:
+- Impact on core method:
+
+### 2. [Novelty / modernity / feasibility / validation change]
+- Reviewer said:
+- Action:
+- Reasoning:
+- Impact on core method:
+
+## Revised Proposal
+[Full updated proposal from Problem Anchor through Claim-Driven Validation Sketch]
+```
+
+### Phase 4: Re-evaluation (Round 2+)
+
+Send the revised proposal back to GPT-5.4 in the **same agent**:
+
+```
+mcp__claude-review__review_reply_start:
+  threadId: [saved from Phase 2]
+  prompt: |
+    [Round N re-evaluation]
+
+    I revised the proposal based on your feedback.
+    First, check whether the original Problem Anchor is still preserved.
+    Second, judge whether the method is now more concrete, more focused, and more current.
+
+    Key changes:
+    1. [Method change 1]
+    2. [Method change 2]
+    3. [Simplification / modernization / pushback if any]
+
+    === REVISED PROPOSAL ===
+    [Paste the FULL revised proposal]
+    === END REVISED PROPOSAL ===
+
+    Please:
+    - Re-score the same 7 dimensions and overall
+    - State whether the Problem Anchor is preserved or drifted
+    - State whether the dominant contribution is now sharper or still too broad
+    - State whether the method is simpler or still overbuilt
+    - State whether the frontier leverage is now appropriate or still old-school / forced
+    - Focus new critiques on missing mechanism, weak training signal, weak integration point, pseudo-novelty, or unnecessary complexity
+    - Use the same verdict rule: READY only if overall score >= 9 and no blocking issue remains
+
+    Same output format: 7 scores, overall score, verdict, drift warning, simplification opportunities, modernization opportunities, remaining action items.
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+Save review to `refine-logs/round-N-review.md`.
+
+Then return to Phase 3 until:
+
+- **Overall score >= SCORE_THRESHOLD** and verdict is READY and no unresolved drift
+- or **MAX_ROUNDS reached**
+
+### Phase 5: Final Report and Logs
+
+#### Step 5.1: Write `refine-logs/REVIEW_SUMMARY.md`
+
+This file is the high-level round-by-round review record. It should answer: each round was trying to solve what, what changed, what got resolved, and what remained.
+
+```markdown
+# Review Summary
+
+**Problem**: [user's problem]
+**Initial Approach**: [user's vague approach]
+**Date**: [today]
+**Rounds**: N / MAX_ROUNDS
+**Final Score**: X / 10
+**Final Verdict**: [READY / REVISE / RETHINK]
+
+## Problem Anchor
+[Verbatim anchor used across all rounds]
+
+## Round-by-Round Resolution Log
+
+| Round | Main Reviewer Concerns | What This Round Simplified / Modernized | Solved? | Remaining Risk |
+|-------|-------------------------|------------------------------------------|---------|----------------|
+| 1     | [top issues from review] | [main method changes]                    | [yes / partial / no] | [if any] |
+| 2     | ...                     | ...                                      | ...     | ...            |
+
+## Overall Evolution
+- [How the method became more concrete]
+- [How the dominant contribution became more focused]
+- [How unnecessary complexity was removed]
+- [How modern technical leverage improved or stayed intentionally minimal]
+- [How drift was avoided or corrected]
+
+## Final Status
+- Anchor status: [preserved / corrected / unresolved]
+- Focus status: [tight / slightly broad / still diffuse]
+- Modernity status: [appropriately frontier-aware / intentionally conservative / still old-school]
+- Strongest parts of final method:
+- Remaining weaknesses:
+```
+
+#### Step 5.2: Write `refine-logs/FINAL_PROPOSAL.md`
+
+This file is the clean final version document. It should contain only the final proposal itself, without review chatter, round history, or raw reviewer output.
+
+```markdown
+# Research Proposal: [Title]
+
+[Paste the final refined proposal only]
+```
+
+If the final verdict is not READY, still write the best current final version here.
+
+#### Step 5.3: Write `refine-logs/REFINEMENT_REPORT.md`
+
+```markdown
+# Refinement Report
+
+**Problem**: [user's problem]
+**Initial Approach**: [user's vague approach]
+**Date**: [today]
+**Rounds**: N / MAX_ROUNDS
+**Final Score**: X / 10
+**Final Verdict**: [READY / REVISE / RETHINK]
+
+## Problem Anchor
+[Verbatim anchor used across all rounds]
+
+## Output Files
+- Review summary: `refine-logs/REVIEW_SUMMARY.md`
+- Final proposal: `refine-logs/FINAL_PROPOSAL.md`
+
+## Score Evolution
+
+| Round | Problem Fidelity | Method Specificity | Contribution Quality | Frontier Leverage | Feasibility | Validation Focus | Venue Readiness | Overall | Verdict |
+|-------|------------------|--------------------|----------------------|-------------------|-------------|------------------|-----------------|---------|---------|
+| 1     | ...              | ...                | ...                  | ...               | ...         | ...              | ...             | ...     | ...     |
+
+## Round-by-Round Review Record
+
+| Round | Main Reviewer Concerns | What Was Changed | Result |
+|-------|-------------------------|------------------|--------|
+| 1     | [top issues]            | [main fixes]     | [resolved / partial / unresolved] |
+| 2     | ...                     | ...              | ...    |
+
+## Final Proposal Snapshot
+- Canonical clean version lives in `refine-logs/FINAL_PROPOSAL.md`
+- Summarize the final thesis in 3-5 bullets here
+
+## Method Evolution Highlights
+1. [Most important simplification or focusing move]
+2. [Most important mechanism upgrade]
+3. [Most important modernization or justification for staying simple]
+
+## Pushback / Drift Log
+| Round | Reviewer Said | Author Response | Outcome |
+|-------|---------------|-----------------|---------|
+| 1     | [criticism]   | [pushback + anchor / evidence] | [accepted / rejected] |
+
+## Remaining Weaknesses
+[Honest unresolved issues]
+
+## Raw Reviewer Responses
+
+<details>
+<summary>Round 1 Review</summary>
+
+[Full verbatim response from GPT-5.4]
+
+</details>
+
+...
+
+## Next Steps
+- If READY: proceed to `/experiment-plan` for a full experiment roadmap, then `/run-experiment`
+- If REVISE: manually address the remaining mechanism weaknesses, then re-run `/research-refine`
+- If RETHINK: revisit the core mechanism, possibly with `/idea-creator`
+```
+
+#### Step 5.4: Finalize `score-history.md`
+
+Ensure it contains the complete score evolution table using the new dimensions.
+
+#### Step 5.5: Present a Brief Summary to the User
+
+```
+Refinement complete after N rounds.
+
+Final score: X/10 (Verdict: READY / REVISE / RETHINK)
+
+Anchor status:
+- [preserved / drift corrected / unresolved concern]
+
+Focus status:
+- [tight / slightly broad / still diffuse]
+
+Modernity status:
+- [appropriately frontier-aware / intentionally conservative / still old-school]
+
+Key method upgrades:
+- [method change 1]
+- [method change 2]
+
+Remaining concerns:
+- [if any]
+
+Review summary: refine-logs/REVIEW_SUMMARY.md
+Full report: refine-logs/REFINEMENT_REPORT.md
+Final proposal: refine-logs/FINAL_PROPOSAL.md
+Suggested next step: /experiment-plan
+```
+
+## Key Rules
+
+- **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
+
+- **Anchor first, every round.** Always carry forward the same Problem Anchor.
+- **One paper, one dominant contribution.** Avoid multiple parallel contributions unless the paper truly needs them.
+- **The smallest adequate mechanism wins.** Bigger is not automatically better.
+- **Prefer reuse over invention.** Start from strong existing backbones and add only what the bottleneck requires.
+- **Modern techniques are a prior, not a decoration.** Use LLM / VLM / Diffusion / RL-era components when they sharpen the method, not when they only make the proposal sound trendy.
+- **Minimal experiments.** Inside this skill, experiments only need to prove the core claims.
+- **Review the mechanism, not the parts count.** A long module list is not novelty.
+- **Pushback is encouraged.** If reviewer feedback causes drift or unnecessary complexity, argue back with evidence.
+- **Always ask the Claude reviewer for strict, high-rigor feedback** in every review round.
+- **Save the completed `threadId` from Phase 2** and use `mcp__claude-review__review_reply_start` plus `mcp__claude-review__review_status` for later rounds.
+- **Do not fabricate results.** Only describe expected evidence and planned experiments.
+- **Be specific about compute and data assumptions.** Vague "we'll train a model" is not enough.
+- **Document everything.** Save every raw review, every anchor check, every simplicity check, and every major method change.
+
+## Composing with Other Skills
+
+This skill sits between idea discovery and execution:
+
+```
+/research-refine-pipeline              -> one-shot refine + experiment planning
+/idea-creator "direction"       -> candidate ideas
+/research-refine "PROBLEM: ... | APPROACH: ..."  <- you are here
+/experiment-plan                -> detailed experiment roadmap
+/run-experiment                 -> execute the chosen method
+/auto-review-loop               -> iterate on results and paper
+```
+
+Typical flow:
+
+1. `/idea-creator` or local reading gives you a problem and a vague method direction
+2. `/research-refine` turns that into an anchored, elegant, frontier-aware method plan
+3. `/experiment-plan` turns the final proposal into a detailed claim-driven experiment roadmap
+4. `/research-refine-pipeline` is the one-shot wrapper when the user wants both stages in a single request
+5. `/run-experiment` executes the chosen runs
+6. Later loops operate on results, not just ideas
+
+This skill also works standalone if you already know the problem and just need the method to become concrete.

--- a/skills/skills-codex-claude-review/research-review/SKILL.md
+++ b/skills/skills-codex-claude-review/research-review/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: "research-review"
+description: "Get a deep critical review of research from Claude via claude-review MCP. Use when user says \"review my research\", \"help me review\", \"get external review\", or wants critical feedback on research ideas, papers, or experimental results."
+---
+
+> Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.
+
+# Research Review via `claude-review` MCP (high-rigor review)
+
+Get a multi-round critical review of research work from an external LLM with maximum reasoning depth.
+
+## Constants
+
+- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a specific Claude model override.
+
+## Context: $ARGUMENTS
+
+## Prerequisites
+
+- Install the base Codex-native skills first: copy `skills/skills-codex/*` into `~/.codex/skills/`.
+- Then install this overlay package: copy `skills/skills-codex-claude-review/*` into `~/.codex/skills/` and allow it to overwrite the same skill names.
+- Register the local reviewer bridge:
+  ```bash
+  codex mcp add claude-review -- python3 ~/.codex/mcp-servers/claude-review/server.py
+  ```
+- This gives Codex access to `mcp__claude-review__review_start`, `mcp__claude-review__review_reply_start`, and `mcp__claude-review__review_status`.
+
+
+## Workflow
+
+### Step 1: Gather Research Context
+Before calling the external reviewer, compile a comprehensive briefing:
+1. Read project narrative documents (e.g., STORY.md, README.md, paper drafts)
+2. Read any memory/notes files for key findings and experiment history
+3. Identify: core claims, methodology, key results, known weaknesses
+
+### Step 2: Initial Review (Round 1)
+Send a detailed prompt with high-rigor review:
+
+```
+mcp__claude-review__review_start:
+  prompt: |
+    [Full research context + specific questions]
+    Please act as a senior ML reviewer (NeurIPS/ICML level). Identify:
+    1. Logical gaps or unjustified claims
+    2. Missing experiments that would strengthen the story
+    3. Narrative weaknesses
+    4. Whether the contribution is sufficient for a top venue
+    Please be brutally honest.
+```
+
+After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+### Step 3: Iterative Dialogue (Rounds 2-N)
+Use `mcp__claude-review__review_reply_start` with the saved completed `threadId`, then poll `mcp__claude-review__review_status` with the returned `jobId` until `done=true` to continue the conversation:
+
+For each round:
+1. **Respond** to criticisms with evidence/counterarguments
+2. **Ask targeted follow-ups** on the most actionable points
+3. **Request specific deliverables**: experiment designs, paper outlines, claims matrices
+
+Key follow-up patterns:
+- "If we reframe X as Y, does that change your assessment?"
+- "What's the minimum experiment to satisfy concern Z?"
+- "Please design the minimal additional experiment package (highest acceptance lift per GPU week)"
+- "Please write a mock NeurIPS/ICML review with scores"
+- "Give me a results-to-claims matrix for possible experimental outcomes"
+
+### Step 4: Convergence
+Stop iterating when:
+- Both sides agree on the core claims and their evidence requirements
+- A concrete experiment plan is established
+- The narrative structure is settled
+
+### Step 5: Document Everything
+Save the full interaction and conclusions to a review document in the project root:
+- Round-by-round summary of criticisms and responses
+- Final consensus on claims, narrative, and experiments
+- Claims matrix (what claims are allowed under each possible outcome)
+- Prioritized TODO list with estimated compute costs
+- Paper outline if discussed
+
+Update project memory/notes with key review conclusions.
+
+## Key Rules
+
+- Always ask the Claude reviewer for strict, high-rigor feedback.
+- Send comprehensive context in Round 1 — the external model cannot read your files
+- Be honest about weaknesses — hiding them leads to worse feedback
+- Push back on criticisms you disagree with, but accept valid ones
+- Focus on ACTIONABLE feedback — "what experiment would fix this?"
+- Document the completed `threadId` for potential future resumption
+- The review document should be self-contained (readable without the conversation)
+
+## Prompt Templates
+
+### For initial review:
+"I'm going to present a complete ML research project for your critical review. Please act as a senior ML reviewer (NeurIPS/ICML level)..."
+
+### For experiment design:
+"Please design the minimal additional experiment package that gives the highest acceptance lift per GPU week. Our compute: [describe]. Be very specific about configurations."
+
+### For paper structure:
+"Please turn this into a concrete paper outline with section-by-section claims and figure plan."
+
+### For claims matrix:
+"Please give me a results-to-claims matrix: what claim is allowed under each possible outcome of experiments X and Y?"
+
+### For mock review:
+"Please write a mock NeurIPS review with: Summary, Strengths, Weaknesses, Questions for Authors, Score, Confidence, and What Would Move Toward Accept."

--- a/tools/generate_codex_claude_review_overrides.py
+++ b/tools/generate_codex_claude_review_overrides.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Generate Claude-review overrides for the upstream Codex-native skills."""
+
+from __future__ import annotations
+
+import ast
+import re
+import shutil
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "skills" / "skills-codex"
+DEST_ROOT = REPO_ROOT / "skills" / "skills-codex-claude-review"
+
+TARGET_SKILLS = [
+    "research-review",
+    "novelty-check",
+    "research-refine",
+    "auto-review-loop",
+    "paper-plan",
+    "paper-figure",
+    "paper-write",
+    "auto-paper-improvement-loop",
+]
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
+SPAWN_BLOCK_RE = re.compile(r"```(?:yaml|text)?\nspawn_agent:\n([\s\S]*?)```")
+SEND_BLOCK_RE = re.compile(r"```(?:yaml|text)?\nsend_input:\n([\s\S]*?)```")
+
+OVERRIDE_NOTE = (
+    "> Override for Codex users who want **Claude Code**, not a second Codex agent, "
+    "to act as the reviewer. Install this package **after** `skills/skills-codex/*`."
+)
+
+REVIEWER_LINE = (
+    "- **REVIEWER_MODEL = `claude-review`** — Claude reviewer invoked through the "
+    "local `claude-review` MCP bridge. Set `CLAUDE_REVIEW_MODEL` if you need a "
+    "specific Claude model override."
+)
+
+PREREQ_BLOCK = """## Prerequisites
+
+- Install the base Codex-native skills first: copy `skills/skills-codex/*` into `~/.codex/skills/`.
+- Then install this overlay package: copy `skills/skills-codex-claude-review/*` into `~/.codex/skills/` and allow it to overwrite the same skill names.
+- Register the local reviewer bridge:
+  ```bash
+  codex mcp add claude-review -- python3 ~/.codex/mcp-servers/claude-review/server.py
+  ```
+- This gives Codex access to `mcp__claude-review__review_start`, `mcp__claude-review__review_reply_start`, and `mcp__claude-review__review_status`.
+""".strip()
+
+
+def extract_field(frontmatter: str, field: str) -> str:
+    pattern = re.compile(rf"^{re.escape(field)}:\s*(.+)$", re.MULTILINE)
+    match = pattern.search(frontmatter)
+    if not match:
+        return ""
+    value = match.group(1).strip()
+    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+        try:
+            value = ast.literal_eval(value)
+        except (SyntaxError, ValueError):
+            value = value[1:-1]
+    return value
+
+
+def build_frontmatter(name: str, description: str) -> str:
+    safe_desc = description.replace('"', '\\"')
+    return f'---\nname: "{name}"\ndescription: "{safe_desc}"\n---\n\n'
+
+
+def normalize_description(text: str) -> str:
+    text = text or "Claude-review override for a Codex-native ARIS skill."
+    text = text.replace("GPT using a secondary Codex agent", "Claude via claude-review MCP")
+    text = text.replace("using a secondary Codex agent", "using Claude Code via claude-review MCP")
+    text = text.replace("via GPT-5.4 xhigh review", "via Claude review through claude-review MCP")
+    return text
+
+
+def rewrite_spawn_block(match: re.Match[str]) -> str:
+    lines = match.group(1).splitlines()
+    out = ["```", "mcp__claude-review__review_start:"]
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            out.append(line)
+            continue
+        if stripped.startswith("model:") or stripped.startswith("reasoning_effort:"):
+            continue
+        if stripped.startswith("message:"):
+            out.append(line.replace("message:", "prompt:", 1))
+            continue
+        out.append(line)
+    out.append("```")
+    return "\n".join(out)
+
+
+def rewrite_send_block(match: re.Match[str]) -> str:
+    lines = match.group(1).splitlines()
+    out = ["```", "mcp__claude-review__review_reply_start:"]
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            out.append(line)
+            continue
+        if stripped.startswith("model:") or stripped.startswith("reasoning_effort:"):
+            continue
+        if stripped.startswith("id:"):
+            out.append(line.replace("id:", "threadId:", 1))
+            continue
+        if stripped.startswith("message:"):
+            out.append(line.replace("message:", "prompt:", 1))
+            continue
+        out.append(line)
+    out.append("```")
+    return "\n".join(out)
+
+
+def append_async_notes(text: str) -> str:
+    note = (
+        "After this start call, immediately save the returned `jobId` and poll "
+        "`mcp__claude-review__review_status` with a bounded `waitSeconds` until "
+        "`done=true`. Treat the completed status payload's `response` as the "
+        "reviewer output, and save the completed `threadId` for any follow-up round."
+    )
+
+    def repl(match: re.Match[str]) -> str:
+        block = match.group(0)
+        if note in block:
+            return block
+        return f"{block}\n\n{note}"
+
+    return re.sub(
+        r"```(?:yaml|text)?\n(?:mcp__claude-review__review_start:|mcp__claude-review__review_reply_start:)[\s\S]*?```",
+        repl,
+        text,
+    )
+
+
+def transform_body(text: str) -> str:
+    text = text.replace("secondary Codex agent", "Claude reviewer via `claude-review` MCP")
+    text = text.replace("via a Claude reviewer via `claude-review` MCP (xhigh reasoning)", "via `claude-review` MCP (high-rigor review)")
+    text = text.replace("secondary Codex agent (xhigh reasoning)", "Claude reviewer via `claude-review` MCP")
+    text = text.replace("GPT-5.4 xhigh", "Claude review")
+    text = text.replace("Send the full paper text to GPT-5.4 xhigh:", "Send the full paper text to Claude through `claude-review`:")
+    text = text.replace("Send the complete outline to GPT-5.4 xhigh for feedback:", "Send the complete outline to Claude for feedback:")
+    text = text.replace("Call REVIEWER_MODEL via `spawn_agent` (`spawn_agent`) with xhigh reasoning:", "Call REVIEWER_MODEL via `mcp__claude-review__review_start` with high-rigor review:")
+    text = text.replace("Send a detailed prompt with xhigh reasoning:", "Send a detailed prompt with high-rigor review:")
+    text = text.replace("Use `send_input` with the returned agent id to continue the conversation:", "Use `mcp__claude-review__review_reply_start` with the saved completed `threadId`, then poll `mcp__claude-review__review_status` with the returned `jobId` until `done=true` to continue the conversation:")
+    text = text.replace("If this is round 2+, use `send_input` with the saved agent id to maintain continuity.", "If this is round 2+, use `mcp__claude-review__review_reply_start` with the saved completed `threadId`, then poll `mcp__claude-review__review_status` with the returned `jobId` until `done=true` to maintain continuity.")
+    text = text.replace("Save the agent id for Round 2.", "Save the returned `jobId`, poll `mcp__claude-review__review_status` until `done=true`, then save the completed `threadId` for Round 2.")
+    text = text.replace("Save agent id from first call, use `send_input` for subsequent rounds", "Save the completed `threadId` from the first `mcp__claude-review__review_status` result, then use `mcp__claude-review__review_reply_start` plus `mcp__claude-review__review_status` for subsequent rounds")
+    text = text.replace("Document the agent id for potential future resumption", "Document the completed `threadId` for potential future resumption")
+    text = text.replace("Use `send_input` with the saved agent id:", "Use `mcp__claude-review__review_reply_start` with the saved completed `threadId`:")
+    text = text.replace("use `send_input` for Round 2 to maintain conversation context", "use `mcp__claude-review__review_reply_start` plus `mcp__claude-review__review_status` for Round 2 to maintain conversation context")
+    text = text.replace("Save the agent id for Round 2.", "Save the completed `threadId` for Round 2.")
+    text = text.replace("**CRITICAL: Save the `agent_id`** from this call for all later rounds.", "**CRITICAL: Save the returned `jobId`**, poll `mcp__claude-review__review_status` until `done=true`, then save the completed `threadId` from the status result for all later rounds.")
+    text = text.replace("- **ALWAYS use `reasoning_effort: xhigh`** for all Codex review calls.", "- **Always ask the Claude reviewer for strict, high-rigor feedback** in every review round.")
+    text = text.replace("- **Save `agent_id` from Phase 2** and use `send_input` for later rounds.", "- **Save the completed `threadId` from Phase 2** and use `mcp__claude-review__review_reply_start` plus `mcp__claude-review__review_status` for later rounds.")
+    text = text.replace("- **Use `send_input`** for Round 2 to maintain conversation context", "- **Use `mcp__claude-review__review_reply_start` plus `mcp__claude-review__review_status`** for Round 2 to maintain conversation context")
+    text = text.replace("GPT-5.4 responses", "Claude reviewer responses")
+    text = text.replace("`agent_id`", "`thread_id`")
+    text = text.replace('"agent_id"', '"thread_id"')
+    text = text.replace("ALWAYS use `reasoning_effort: xhigh` for reviews", "Always ask the Claude reviewer for strict, high-rigor feedback.")
+    text = text.replace("ALWAYS use `reasoning_effort: xhigh` for maximum reasoning depth", "Always ask the Claude reviewer for strict, high-rigor feedback.")
+    text = text.replace("mcp__codex__codex", "mcp__claude-review__review_start")
+    text = text.replace("mcp__codex__codex-reply", "mcp__claude-review__review_reply_start")
+    text = re.sub(r"^-\s+\*{0,2}REVIEWER_MODEL.*$", REVIEWER_LINE, text, flags=re.MULTILINE)
+    text = re.sub(
+        r"## Prerequisites\n\n(?:- .*\n)+",
+        PREREQ_BLOCK + "\n\n",
+        text,
+        count=1,
+    )
+    text = SPAWN_BLOCK_RE.sub(rewrite_spawn_block, text)
+    text = SEND_BLOCK_RE.sub(rewrite_send_block, text)
+    text = text.replace(
+        "```\nreasoning_effort: xhigh\n```",
+        "```\nmcp__claude-review__review_start:\n  prompt: |\n    [Full novelty briefing + prior work list + specific novelty questions]\n```",
+    )
+    return append_async_notes(text)
+
+
+def generate_one(skill_name: str) -> None:
+    skill_path = SRC_ROOT / skill_name / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(content)
+    if not match:
+        raise ValueError(f"Missing frontmatter: {skill_path}")
+
+    frontmatter = match.group(1)
+    body = content[match.end():].lstrip("\n")
+    name = extract_field(frontmatter, "name") or skill_name
+    description = normalize_description(extract_field(frontmatter, "description"))
+
+    output = build_frontmatter(name, description)
+    output += OVERRIDE_NOTE + "\n\n"
+    output += transform_body(body).rstrip() + "\n"
+
+    target_dir = DEST_ROOT / skill_name
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "SKILL.md").write_text(output, encoding="utf-8")
+
+
+def main() -> None:
+    DEST_ROOT.mkdir(parents=True, exist_ok=True)
+    for skill_name in TARGET_SKILLS:
+        generate_one(skill_name)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

  This PR adds an alternative Codex-hosted path for ARIS:

  - executor: Codex CLI
  - reviewer: Claude Code CLI
  - bridge: local `claude-review` MCP server

  Unlike the existing `skills/skills-codex/` route, which uses a second Codex reviewer via `spawn_agent`, this PR keeps the upstream Codex-native skill set and adds a thin override layer for review-heavy
  skills.

  ## What this PR adds

  - add `mcp-servers/claude-review/` for local Claude reviewer bridging
  - add async reviewer job APIs:
    - `review_start`
    - `review_reply_start`
    - `review_status`
  - add `skills/skills-codex-claude-review/` as an overlay package on top of `skills/skills-codex/`
  - add `tools/generate_codex_claude_review_overrides.py` to regenerate the overlay package
  - add English and Chinese setup guides for the Codex + Claude reviewer path
  - update README / README_CN with a new alternative combination entry

  ## Design

  This PR intentionally does not replace the upstream Codex-native path.

  Instead, it keeps `skills/skills-codex/` as the base package and adds a thin override layer for review-heavy skills:

  - `research-review`
  - `novelty-check`
  - `research-refine`
  - `auto-review-loop`
  - `paper-plan`
  - `paper-figure`
  - `paper-write`
  - `auto-paper-improvement-loop`

  This keeps the change focused and avoids introducing a second full Codex skill mirror.

  ## Why async reviewer polling is needed

  In this host path the review hop is:

  `Codex -> claude-review MCP -> local Claude CLI -> Claude backend`

  Long paper or project reviews are more likely to hit the observed Codex-hosted MCP timeout if the reviewer call is synchronous. This PR switches the Claude reviewer path to async polling for long prompts.

  ## Local validation

  - `python3 -m py_compile mcp-servers/claude-review/server.py`
  - `bash -n mcp-servers/claude-review/run_with_claude_aws.sh`
  - `python3 -m py_compile tools/generate_codex_claude_review_overrides.py`
  - regenerated the overlay package successfully
  - local async smoke test for `start_async_review -> review_status`
  - verified that the bridge returns terminal failure state cleanly when local Claude CLI is not logged in

  ## Notes

  - this PR adds a new alternative path; it does not change the default Claude-hosted workflow
  - this PR also does not replace the existing Codex `spawn_agent` reviewer path