### PR TITLE
fix: increase llm-chat MCP timeout from 120s to 300s

### DIFF
--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -90,7 +90,7 @@ def call_llm(messages, model=None):
     debug_log(f"Calling LLM API: {url}")
 
     try:
-        with httpx.Client(timeout=120.0) as client:
+        with httpx.Client(timeout=300.0) as client:
             response = client.post(url, headers=headers, json=payload)
             if response.status_code != 200:
                 error_msg = f"API error {response.status_code}: {response.text[:500]}"


### PR DESCRIPTION
Third-party API proxies (e.g. boyuerichdata, Alibaba) often need more time for long prompts like research-refine reviews. 120s causes 504 Gateway Timeout on these providers. 300s is safer while still catching actual failures.

Relates to #38 (Alibaba model interruptions may be timeout-related)