### PR TITLE
feat: add watchdog.py — persistent server-side experiment monitoring

### DIFF
--- a/docs/WATCHDOG_GUIDE.md
+++ b/docs/WATCHDOG_GUIDE.md
@@ -1,0 +1,193 @@
+# Watchdog Monitoring Guide
+
+[中文版](WATCHDOG_GUIDE_CN.md) | English
+
+> Persistent server-side monitoring for ARIS experiments — catch dead sessions, stalled downloads, and idle GPUs without manual polling.
+
+## The Problem
+
+ARIS experiments run remotely in screen/tmux sessions. Current monitoring (`/monitor-experiment`) is **on-demand** — you have to actively ask "how are my experiments doing?". Between checks:
+
+- A training session can crash silently (screen dies, OOM kill)
+- A download can stall (network timeout, auth failure)
+- GPUs can go idle (training finished or crashed but session stays open)
+
+These go undetected until the next manual check, wasting hours of potential GPU time.
+
+## The Solution: watchdog.py
+
+A lightweight Python daemon that runs on each GPU server, continuously monitoring all registered tasks. Zero dependencies beyond Python 3 standard library + `nvidia-smi`.
+
+**What it monitors:**
+
+| Task Type | Checks | Anomalies |
+|-----------|--------|-----------|
+| `training` | Session alive + GPU utilization | `DEAD` (session gone), `IDLE` (GPU <5%) |
+| `download` | Session alive + file size growth + speed | `DEAD`, `STALLED` (no growth), `SLOW` (<1MB/s) |
+
+**What it outputs:**
+
+```
+/tmp/aris-watchdog/
+├── watchdog.pid              # daemon PID (for liveness checks)
+├── tasks.json                # registered tasks
+├── alerts.log                # anomaly log (for cross-session recovery)
+└── status/
+    ├── exp01.json            # per-task status
+    ├── dl01.json
+    └── summary.txt           # one-line-per-task summary
+```
+
+## Setup
+
+### 1. Copy to your server
+
+```bash
+# From your local machine (adjust paths)
+scp tools/watchdog.py your-server:/path/to/project/tools/
+```
+
+Or if using rsync for code sync (as in `/run-experiment`), just include `tools/` in the sync.
+
+### 2. Start the daemon
+
+```bash
+# In a screen/tmux session on the server (so it persists)
+screen -dmS watchdog python3 tools/watchdog.py
+# or
+tmux new-session -d -s watchdog "python3 tools/watchdog.py"
+```
+
+Optional flags:
+```bash
+python3 tools/watchdog.py --base-dir /tmp/my-monitor --interval 30
+```
+
+### 3. Register tasks
+
+After launching an experiment:
+
+```bash
+# Training task (screen session, specific GPUs)
+python3 tools/watchdog.py --register '{
+  "name": "exp01",
+  "type": "training",
+  "session": "exp01",
+  "session_type": "screen",
+  "gpus": [0, 1, 2, 3]
+}'
+
+# Download task (tmux session, with file to track)
+python3 tools/watchdog.py --register '{
+  "name": "dl-imagenet",
+  "type": "download",
+  "session": "dl01",
+  "session_type": "tmux",
+  "target_path": "/data/imagenet"
+}'
+```
+
+**Required fields:**
+- `name` — unique task identifier
+- `type` — `"training"` or `"download"`
+- `session` — screen/tmux session name
+
+**Optional fields:**
+- `session_type` — `"screen"` (default) or `"tmux"`
+- `gpus` — list of GPU indices to monitor (training only)
+- `target_path` — file/directory to track size growth (download only)
+
+### 4. Monitor from your local machine
+
+**One-shot check:**
+```bash
+ssh your-server "python3 /path/to/tools/watchdog.py --status"
+# or
+ssh your-server "cat /tmp/aris-watchdog/status/summary.txt"
+```
+
+**Example output:**
+```
+exp01(training): OK
+exp02(training): IDLE gpu={'0': 0, '1': 0, '2': 0, '3': 2}
+dl01(download): SLOW speed=0.45MB/s
+```
+
+**Automated polling with CronCreate (Claude Code):**
+```
+CronCreate: every 15 minutes
+  ssh your-server "cat /tmp/aris-watchdog/status/summary.txt"
+  → all OK → do nothing
+  → any DEAD/STALLED/SLOW/IDLE → investigate and fix
+```
+
+> **One cron job per server**, not per task — summary.txt aggregates everything.
+
+### 5. Unregister completed tasks
+
+```bash
+python3 tools/watchdog.py --unregister exp01
+```
+
+## Status Codes
+
+| Status | Meaning | Suggested Action |
+|--------|---------|-----------------|
+| `OK` | Task running normally | Nothing |
+| `DEAD` | Session no longer exists | Check if training finished or crashed; restart if needed |
+| `IDLE` | GPU utilization <5% | Training may have finished, crashed, or is stuck in data loading |
+| `STALLED` | Download file size not growing | Check network, disk space, auth tokens |
+| `SLOW` | Download speed <1 MB/s | May be throttled; check network or source |
+| `ERROR` | Watchdog encountered an error checking this task | Check watchdog logs |
+
+## Integration with ARIS Workflows
+
+### With `/run-experiment`
+
+After deploying an experiment with `/run-experiment`, register it with watchdog:
+
+```bash
+# /run-experiment launches screen session "exp01"
+# Then register it:
+python3 tools/watchdog.py --register '{"name":"exp01","type":"training","session":"exp01","gpus":[0,1]}'
+```
+
+### With `/monitor-experiment`
+
+`/monitor-experiment` does deep inspection (log parsing, W&B metrics, result collection). Watchdog does continuous surface-level health checks. They complement each other:
+
+- **Watchdog** — "is it alive and using GPU?" (runs 24/7, low overhead)
+- **`/monitor-experiment`** — "what are the actual results?" (on-demand, detailed)
+
+### With Session Recovery
+
+When starting a new session, check `alerts.log` for anomalies that happened while you were away:
+
+```bash
+ssh your-server "tail -20 /tmp/aris-watchdog/alerts.log"
+```
+
+This pairs well with the [Session Recovery Guide](SESSION_RECOVERY_GUIDE.md) — add watchdog alert checking to your recovery flow.
+
+## Customization
+
+| Parameter | Default | How to change |
+|-----------|---------|---------------|
+| Base directory | `/tmp/aris-watchdog` | `--base-dir /your/path` |
+| Check interval | 60 seconds | `--interval 30` |
+| GPU idle threshold | 5% | Edit `GPU_IDLE_THRESHOLD` in script |
+| Slow download threshold | 1 MB/s | Edit `SLOW_SPEED_THRESHOLD` in script |
+
+## FAQ
+
+**Q: Does it need root / sudo?**
+A: No. Just Python 3 and `nvidia-smi` (for training tasks).
+
+**Q: Can I run multiple watchdog instances on one server?**
+A: Yes, use different `--base-dir` for each. But normally one instance per server is sufficient — it handles multiple tasks.
+
+**Q: What if the watchdog itself crashes?**
+A: Check `watchdog.pid` — if the PID is stale, restart it. The daemon handles SIGTERM/SIGINT gracefully.
+
+**Q: Does it work without nvidia-smi?**
+A: Yes for download tasks. Training tasks will report OK (no GPU data) but won't detect IDLE GPUs.

--- a/docs/WATCHDOG_GUIDE_CN.md
+++ b/docs/WATCHDOG_GUIDE_CN.md
@@ -1,0 +1,192 @@
+# Watchdog 监控指南
+
+[English](WATCHDOG_GUIDE.md) | 中文版
+
+> 服务器端持续监控 ARIS 实验 — 自动检测死掉的 session、停滞的下载和空闲的 GPU，无需手动轮询。
+
+## 问题
+
+ARIS 实验在远程 screen/tmux session 中运行。当前的监控（`/monitor-experiment`）是**按需的** — 你必须主动问"实验怎么样了"。在两次检查之间：
+
+- 训练 session 可能静默崩溃（screen 死了、OOM kill）
+- 下载可能卡住（网络超时、认证失败）
+- GPU 可能空闲（训练结束或崩溃但 session 还在）
+
+这些问题直到下次手动检查才会被发现，浪费数小时 GPU 时间。
+
+## 方案：watchdog.py
+
+一个轻量级 Python 守护进程，运行在每台 GPU 服务器上，持续监控所有注册的任务。零依赖（只需 Python 3 标准库 + `nvidia-smi`）。
+
+**监控内容：**
+
+| 任务类型 | 检查项 | 异常状态 |
+|----------|--------|----------|
+| `training` | Session 存活 + GPU 利用率 | `DEAD`（session 没了）、`IDLE`（GPU <5%） |
+| `download` | Session 存活 + 文件大小增长 + 速度 | `DEAD`、`STALLED`（不增长）、`SLOW`（<1MB/s） |
+
+**输出结构：**
+
+```
+/tmp/aris-watchdog/
+├── watchdog.pid              # 守护进程 PID
+├── tasks.json                # 注册的任务
+├── alerts.log                # 异常日志（跨 session 恢复时读取）
+└── status/
+    ├── exp01.json            # 每个任务的状态
+    ├── dl01.json
+    └── summary.txt           # 每行一个任务的汇总
+```
+
+## 安装
+
+### 1. 复制到服务器
+
+```bash
+scp tools/watchdog.py your-server:/path/to/project/tools/
+```
+
+或者在用 rsync 同步代码时（如 `/run-experiment`），把 `tools/` 目录一起同步。
+
+### 2. 启动守护进程
+
+```bash
+# 在服务器上的 screen/tmux 中启动（持久化运行）
+screen -dmS watchdog python3 tools/watchdog.py
+# 或
+tmux new-session -d -s watchdog "python3 tools/watchdog.py"
+```
+
+可选参数：
+```bash
+python3 tools/watchdog.py --base-dir /tmp/my-monitor --interval 30
+```
+
+### 3. 注册任务
+
+启动实验后注册：
+
+```bash
+# 训练任务（screen session，指定 GPU）
+python3 tools/watchdog.py --register '{
+  "name": "exp01",
+  "type": "training",
+  "session": "exp01",
+  "session_type": "screen",
+  "gpus": [0, 1, 2, 3]
+}'
+
+# 下载任务（tmux session，追踪文件大小）
+python3 tools/watchdog.py --register '{
+  "name": "dl-imagenet",
+  "type": "download",
+  "session": "dl01",
+  "session_type": "tmux",
+  "target_path": "/data/imagenet"
+}'
+```
+
+**必填字段：**
+- `name` — 唯一任务标识
+- `type` — `"training"` 或 `"download"`
+- `session` — screen/tmux session 名
+
+**可选字段：**
+- `session_type` — `"screen"`（默认）或 `"tmux"`
+- `gpus` — 要监控的 GPU 编号列表（仅训练）
+- `target_path` — 追踪大小增长的文件/目录（仅下载）
+
+### 4. 从本地机器监控
+
+**一次性检查：**
+```bash
+ssh your-server "python3 /path/to/tools/watchdog.py --status"
+# 或
+ssh your-server "cat /tmp/aris-watchdog/status/summary.txt"
+```
+
+**示例输出：**
+```
+exp01(training): OK
+exp02(training): IDLE gpu={'0': 0, '1': 0, '2': 0, '3': 2}
+dl01(download): SLOW speed=0.45MB/s
+```
+
+**使用 CronCreate 自动轮询（Claude Code）：**
+```
+CronCreate: 每 15 分钟
+  ssh your-server "cat /tmp/aris-watchdog/status/summary.txt"
+  → 全部 OK → 不做任何事
+  → 有 DEAD/STALLED/SLOW/IDLE → 调查处理
+```
+
+> **每台服务器只设一个 cron**，不是每个任务一个 — summary.txt 已经汇总了所有任务。
+
+### 5. 注销已完成的任务
+
+```bash
+python3 tools/watchdog.py --unregister exp01
+```
+
+## 状态码
+
+| 状态 | 含义 | 建议操作 |
+|------|------|----------|
+| `OK` | 任务正常运行 | 无需操作 |
+| `DEAD` | Session 已不存在 | 检查训练是否完成或崩溃，必要时重启 |
+| `IDLE` | GPU 利用率 <5% | 训练可能已完成、崩溃或卡在数据加载 |
+| `STALLED` | 下载文件大小不增长 | 检查网络、磁盘空间、认证 token |
+| `SLOW` | 下载速度 <1 MB/s | 可能被限速，检查网络或下载源 |
+| `ERROR` | Watchdog 检查任务时出错 | 检查 watchdog 日志 |
+
+## 与 ARIS 工作流集成
+
+### 配合 `/run-experiment`
+
+用 `/run-experiment` 部署实验后，注册到 watchdog：
+
+```bash
+# /run-experiment 启动 screen session "exp01"
+# 然后注册：
+python3 tools/watchdog.py --register '{"name":"exp01","type":"training","session":"exp01","gpus":[0,1]}'
+```
+
+### 配合 `/monitor-experiment`
+
+`/monitor-experiment` 做深度检查（日志解析、W&B 指标、结果收集）。Watchdog 做持续的表面健康检查。互补关系：
+
+- **Watchdog** — "它活着吗？GPU 在用吗？"（7×24 运行，低开销）
+- **`/monitor-experiment`** — "实际结果怎么样？"（按需、详细）
+
+### 配合会话恢复
+
+开新 session 时，检查 `alerts.log` 查看你不在时发生的异常：
+
+```bash
+ssh your-server "tail -20 /tmp/aris-watchdog/alerts.log"
+```
+
+配合 [会话恢复指南](SESSION_RECOVERY_GUIDE_CN.md) 使用效果更佳 — 在恢复流程中加入 watchdog 告警检查。
+
+## 自定义
+
+| 参数 | 默认值 | 修改方式 |
+|------|--------|----------|
+| 工作目录 | `/tmp/aris-watchdog` | `--base-dir /your/path` |
+| 检查间隔 | 60 秒 | `--interval 30` |
+| GPU 空闲阈值 | 5% | 修改脚本中 `GPU_IDLE_THRESHOLD` |
+| 下载慢速阈值 | 1 MB/s | 修改脚本中 `SLOW_SPEED_THRESHOLD` |
+
+## 常见问题
+
+**Q：需要 root 权限吗？**
+A：不需要。只要 Python 3 和 `nvidia-smi`（仅训练任务需要）。
+
+**Q：一台服务器能跑多个 watchdog 吗？**
+A：可以，用不同的 `--base-dir`。但通常一台服务器一个实例就够了——它支持多任务。
+
+**Q：watchdog 自身崩溃了怎么办？**
+A：检查 `watchdog.pid` — 如果 PID 已失效，重启即可。守护进程能优雅处理 SIGTERM/SIGINT。
+
+**Q：没有 nvidia-smi 能用吗？**
+A：下载任务可以。训练任务会报 OK（无 GPU 数据）但无法检测 IDLE 状态。

--- a/tools/watchdog.py
+++ b/tools/watchdog.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+watchdog.py — Server-side unified monitoring daemon for ARIS.
+
+One process per server, monitors all registered tasks (training / download).
+Outputs per-task status JSON + aggregated summary.txt for low-frequency polling.
+
+Usage:
+    # Start the daemon (runs in foreground, use tmux/screen to persist)
+    python3 watchdog.py [--base-dir /tmp/aris-watchdog] [--interval 60]
+
+    # Register a training task
+    python3 watchdog.py --register '{"name":"exp01","type":"training","session":"exp01","session_type":"screen","gpus":[0,1,2,3]}'
+
+    # Register a download task
+    python3 watchdog.py --register '{"name":"dl01","type":"download","session":"dl01","session_type":"tmux","target_path":"/path/to/file"}'
+
+    # Unregister a task
+    python3 watchdog.py --unregister exp01
+
+    # Check current summary
+    python3 watchdog.py --status
+
+Directory structure:
+    /tmp/aris-watchdog/
+    ├── watchdog.pid
+    ├── tasks.json          # [{name, type, session, session_type, ...}, ...]
+    ├── alerts.log          # anomaly log (DEAD/STALLED/IDLE) for cross-session recovery
+    └── status/
+        ├── <task-name>.json   # per-task status
+        └── summary.txt        # one-line-per-task summary for CronCreate polling
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_BASE = "/tmp/aris-watchdog"
+DEFAULT_INTERVAL = 60
+SLOW_SPEED_THRESHOLD = 1 * 1024 * 1024  # 1 MB/s
+GPU_IDLE_THRESHOLD = 5  # percent
+
+
+def get_paths(base_dir):
+    base = Path(base_dir)
+    return {
+        "base": base,
+        "pid": base / "watchdog.pid",
+        "tasks": base / "tasks.json",
+        "status": base / "status",
+        "alerts": base / "alerts.log",
+    }
+
+
+# ── Task registration ────────────────────────────────────────────
+
+
+def register_task(base_dir, task_json):
+    paths = get_paths(base_dir)
+    paths["base"].mkdir(parents=True, exist_ok=True)
+    paths["status"].mkdir(parents=True, exist_ok=True)
+
+    task = json.loads(task_json)
+    required = {"name", "type", "session"}
+    missing = required - set(task.keys())
+    if missing:
+        print(f"error: missing required fields: {missing}", file=sys.stderr)
+        sys.exit(1)
+
+    if task["type"] not in ("training", "download"):
+        print(f"error: type must be 'training' or 'download', got '{task['type']}'", file=sys.stderr)
+        sys.exit(1)
+
+    # Default session_type: auto-detect or fallback to screen
+    if "session_type" not in task:
+        task["session_type"] = "screen"
+
+    tasks = []
+    if paths["tasks"].exists():
+        try:
+            tasks = json.loads(paths["tasks"].read_text())
+        except (json.JSONDecodeError, OSError):
+            tasks = []
+
+    # Deduplicate: replace existing task with same name
+    tasks = [t for t in tasks if t["name"] != task["name"]]
+    task["registered_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+    tasks.append(task)
+
+    paths["tasks"].write_text(json.dumps(tasks, indent=2))
+    print(f"registered: {task['name']} ({task['type']}, {task['session_type']})")
+
+
+def unregister_task(base_dir, name):
+    paths = get_paths(base_dir)
+    if not paths["tasks"].exists():
+        print(f"no tasks file found")
+        return
+    try:
+        tasks = json.loads(paths["tasks"].read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+    tasks = [t for t in tasks if t["name"] != name]
+    paths["tasks"].write_text(json.dumps(tasks, indent=2))
+    status_file = paths["status"] / f"{name}.json"
+    if status_file.exists():
+        status_file.unlink()
+    print(f"unregistered: {name}")
+
+
+# ── Session checks (tmux + screen) ──────────────────────────────
+
+
+def session_alive(session_name, session_type="screen"):
+    """Check if a tmux or screen session is alive."""
+    if session_type == "tmux":
+        r = subprocess.run(
+            ["tmux", "has-session", "-t", session_name],
+            capture_output=True,
+        )
+        return r.returncode == 0
+    else:  # screen
+        r = subprocess.run(
+            ["screen", "-list"], capture_output=True, text=True,
+        )
+        return session_name in r.stdout
+
+
+# ── GPU checks ───────────────────────────────────────────────────
+
+
+def get_gpu_util():
+    """Return list of GPU utilization percentages, e.g. [85, 92, 0, ...]"""
+    try:
+        r = subprocess.run(
+            ["nvidia-smi", "--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return [int(x.strip()) for x in r.stdout.strip().split("\n") if x.strip()]
+    except Exception:
+        return []
+
+
+# ── File size checks ─────────────────────────────────────────────
+
+
+def get_path_size(path):
+    """Get size of a file or directory in bytes."""
+    try:
+        r = subprocess.run(
+            ["du", "-sb", path], capture_output=True, text=True, timeout=30,
+        )
+        return int(r.stdout.split()[0])
+    except Exception:
+        return 0
+
+
+# ── Task checking logic ─────────────────────────────────────────
+
+
+def check_download(task, status_dir, interval):
+    name = task["name"]
+    session = task["session"]
+    session_type = task.get("session_type", "screen")
+    target = task.get("target_path", "")
+    status_file = status_dir / f"{name}.json"
+    now = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    if not session_alive(session, session_type):
+        return write_status(status_file, {
+            "status": "DEAD", "task": name, "type": "download",
+            "msg": f"{session_type} session gone", "ts": now,
+        })
+
+    if not target:
+        return write_status(status_file, {
+            "status": "OK", "task": name, "type": "download",
+            "msg": "alive, no target_path to check size", "ts": now,
+        })
+
+    current_size = get_path_size(target)
+
+    # Read previous size for delta
+    prev_size = 0
+    if status_file.exists():
+        try:
+            prev = json.loads(status_file.read_text())
+            prev_size = prev.get("size", 0)
+        except Exception:
+            pass
+
+    if current_size == prev_size and current_size > 0:
+        return write_status(status_file, {
+            "status": "STALLED", "task": name, "type": "download",
+            "size": current_size, "msg": "no size growth", "ts": now,
+        })
+
+    speed = (current_size - prev_size) / max(interval, 1)
+
+    if 0 < speed < SLOW_SPEED_THRESHOLD:
+        return write_status(status_file, {
+            "status": "SLOW", "task": name, "type": "download",
+            "size": current_size, "speed_mbps": round(speed / 1024 / 1024, 2),
+            "ts": now,
+        })
+
+    return write_status(status_file, {
+        "status": "OK", "task": name, "type": "download",
+        "size": current_size, "speed_mbps": round(speed / 1024 / 1024, 2),
+        "ts": now,
+    })
+
+
+def check_training(task, status_dir):
+    name = task["name"]
+    session = task["session"]
+    session_type = task.get("session_type", "screen")
+    status_file = status_dir / f"{name}.json"
+    now = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    if not session_alive(session, session_type):
+        return write_status(status_file, {
+            "status": "DEAD", "task": name, "type": "training",
+            "msg": f"{session_type} session gone", "ts": now,
+        })
+
+    gpu_utils = get_gpu_util()
+
+    # Check specified GPUs for activity
+    gpus = task.get("gpus", [])
+    if gpus and gpu_utils:
+        used_utils = [gpu_utils[i] for i in gpus if i < len(gpu_utils)]
+        if used_utils and all(u < GPU_IDLE_THRESHOLD for u in used_utils):
+            return write_status(status_file, {
+                "status": "IDLE", "task": name, "type": "training",
+                "gpu_util": {str(i): gpu_utils[i] for i in gpus if i < len(gpu_utils)},
+                "msg": f"GPUs idle (<{GPU_IDLE_THRESHOLD}%)", "ts": now,
+            })
+
+    return write_status(status_file, {
+        "status": "OK", "task": name, "type": "training",
+        "gpu_util": gpu_utils, "ts": now,
+    })
+
+
+# ── Status output ────────────────────────────────────────────────
+
+
+def write_status(path, data):
+    """Write per-task status and append to alerts.log on anomalies."""
+    path.write_text(json.dumps(data))
+
+    status = data.get("status", "OK")
+    if status in ("DEAD", "STALLED", "IDLE", "ERROR"):
+        alert_file = path.parent.parent / "alerts.log"
+        ts = data.get("ts", time.strftime("%Y-%m-%dT%H:%M:%S"))
+        task = data.get("task", "?")
+        msg = data.get("msg", "")
+        alert_line = f"[{ts}] {task}: {status} — {msg}\n"
+        with open(alert_file, "a") as f:
+            f.write(alert_line)
+
+    return data
+
+
+def write_summary(status_dir):
+    """Aggregate all task statuses into summary.txt (one line per task)."""
+    lines = []
+    for f in sorted(status_dir.glob("*.json")):
+        try:
+            d = json.loads(f.read_text())
+            name = d.get("task", f.stem)
+            status = d.get("status", "?")
+            typ = d.get("type", "?")
+            extra = ""
+            if status == "SLOW":
+                extra = f" speed={d.get('speed_mbps', '?')}MB/s"
+            elif status == "IDLE":
+                extra = f" gpu={d.get('gpu_util', '?')}"
+            elif status == "DEAD":
+                extra = f" {d.get('msg', '')}"
+            lines.append(f"{name}({typ}): {status}{extra}")
+        except Exception:
+            continue
+
+    summary = "\n".join(lines) if lines else "no tasks"
+    (status_dir / "summary.txt").write_text(summary)
+    return summary
+
+
+# ── Main loop ────────────────────────────────────────────────────
+
+
+def run_watchdog(base_dir, interval):
+    paths = get_paths(base_dir)
+    paths["base"].mkdir(parents=True, exist_ok=True)
+    paths["status"].mkdir(parents=True, exist_ok=True)
+
+    # Write PID for liveness checks
+    paths["pid"].write_text(str(os.getpid()))
+
+    def handle_signal(sig, frame):
+        paths["pid"].unlink(missing_ok=True)
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    print(f"watchdog started (pid={os.getpid()}, base={base_dir}, interval={interval}s)")
+
+    while True:
+        if not paths["tasks"].exists():
+            time.sleep(interval)
+            continue
+
+        try:
+            tasks = json.loads(paths["tasks"].read_text())
+        except (json.JSONDecodeError, OSError):
+            time.sleep(interval)
+            continue
+
+        for task in tasks:
+            try:
+                if task["type"] == "download":
+                    check_download(task, paths["status"], interval)
+                elif task["type"] == "training":
+                    check_training(task, paths["status"])
+            except Exception as e:
+                write_status(
+                    paths["status"] / f"{task['name']}.json",
+                    {"status": "ERROR", "task": task["name"], "msg": str(e),
+                     "ts": time.strftime("%Y-%m-%dT%H:%M:%S")},
+                )
+
+        write_summary(paths["status"])
+        time.sleep(interval)
+
+
+# ── CLI ──────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ARIS Watchdog — server-side task monitoring daemon",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Start daemon
+  python3 watchdog.py
+
+  # Register a training task (screen session)
+  python3 watchdog.py --register '{"name":"exp01","type":"training","session":"exp01","gpus":[0,1]}'
+
+  # Register a download task (tmux session)
+  python3 watchdog.py --register '{"name":"dl01","type":"download","session":"dl01","session_type":"tmux","target_path":"/data/imagenet"}'
+
+  # Check summary
+  python3 watchdog.py --status
+        """,
+    )
+    parser.add_argument("--base-dir", default=DEFAULT_BASE,
+                        help=f"Working directory (default: {DEFAULT_BASE})")
+    parser.add_argument("--interval", type=int, default=DEFAULT_INTERVAL,
+                        help=f"Check interval in seconds (default: {DEFAULT_INTERVAL})")
+    parser.add_argument("--register", metavar="JSON",
+                        help="Register a task (JSON with name, type, session)")
+    parser.add_argument("--unregister", metavar="NAME",
+                        help="Unregister a task by name")
+    parser.add_argument("--status", action="store_true",
+                        help="Print current summary and exit")
+    args = parser.parse_args()
+
+    if args.register:
+        register_task(args.base_dir, args.register)
+    elif args.unregister:
+        unregister_task(args.base_dir, args.unregister)
+    elif args.status:
+        paths = get_paths(args.base_dir)
+        summary = paths["status"] / "summary.txt"
+        print(summary.read_text() if summary.exists() else "no status")
+    else:
+        run_watchdog(args.base_dir, args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a persistent server-side monitoring daemon that complements `/monitor-experiment` with continuous health checks.

**The gap:** `/monitor-experiment` is on-demand — you have to actively ask how experiments are doing. Between checks, sessions can crash, downloads can stall, and GPUs can go idle undetected, wasting hours of compute.

**The fix:** `watchdog.py` runs 24/7 on each GPU server, checking all registered tasks every 60 seconds and writing a one-line-per-task summary. A single CronCreate job reads `summary.txt` to catch anomalies.

## What's Added

### `tools/watchdog.py`
- Zero dependencies (Python 3 stdlib + `nvidia-smi`)
- Supports both **screen** and **tmux** sessions (`session_type` field)
- Two task types: `training` (session alive + GPU utilization) and `download` (session alive + file size growth + speed)
- Status codes: `OK`, `DEAD`, `IDLE` (<5% GPU), `STALLED` (no growth), `SLOW` (<1MB/s)
- Per-task JSON status + aggregated `summary.txt` + `alerts.log` for cross-session recovery
- CLI for register/unregister/status check

### `docs/WATCHDOG_GUIDE.md` + `WATCHDOG_GUIDE_CN.md`
- Setup, task registration, CronCreate integration
- How it complements `/monitor-experiment` and `/run-experiment`
- Customization (thresholds, intervals)

## How It Fits

| Layer | Tool | What it checks | Frequency |
|-------|------|----------------|-----------|
| Process health | **watchdog.py** (new) | Session alive? GPU active? | Every 60s (continuous) |
| Deep inspection | `/monitor-experiment` (existing) | Actual results, W&B metrics | On-demand |

They complement each other — watchdog catches crashes fast, monitor-experiment does detailed analysis.

## Design Decisions

- Placed in `tools/` alongside existing `arxiv_fetch.py`
- Default `session_type: screen` (ARIS convention), tmux also supported
- One daemon per server, handles multiple tasks — summary.txt aggregates everything
- `alerts.log` enables cross-session recovery (check what went wrong while you were away)