### PR TITLE
feat: add Semantic Scholar tool and skill for venue paper search

### DIFF
--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -24,6 +24,7 @@ Research topic: $ARGUMENTS
 > - `/research-lit "topic" — sources: zotero, local` — only search Zotero + local PDFs
 > - `/research-lit "topic" — sources: zotero` — only search Zotero
 > - `/research-lit "topic" — sources: web` — only search the web (skip all local)
+> - `/research-lit "topic" — sources: web, semantic-scholar` — also search Semantic Scholar for published venue papers (IEEE, ACM, etc.)
 > - `/research-lit "topic" — arxiv download: true` — download top relevant arXiv PDFs
 > - `/research-lit "topic" — arxiv download: true, max download: 10` — download up to 10 PDFs
 
@@ -34,17 +35,19 @@ This skill checks multiple sources **in priority order**. All are optional — i
 ### Source Selection
 
 Parse `$ARGUMENTS` for a `— sources:` directive:
-- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `all`.
-- **If not specified**: Default to `all` — search every available source in priority order.
+- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `all`.
+- **If not specified**: Default to `all` — search every available source in priority order (`semantic-scholar` is **excluded** from `all`; it must be explicitly listed).
 
 Examples:
 ```
-/research-lit "diffusion models"                        → all (default)
-/research-lit "diffusion models" — sources: all         → all
-/research-lit "diffusion models" — sources: zotero      → Zotero only
-/research-lit "diffusion models" — sources: zotero, web → Zotero + web
-/research-lit "diffusion models" — sources: local       → local PDFs only
-/research-lit "topic" — sources: obsidian, local, web   → skip Zotero
+/research-lit "diffusion models"                                    → all (default, no S2)
+/research-lit "diffusion models" — sources: all                     → all (default, no S2)
+/research-lit "diffusion models" — sources: zotero                  → Zotero only
+/research-lit "diffusion models" — sources: zotero, web             → Zotero + web
+/research-lit "diffusion models" — sources: local                   → local PDFs only
+/research-lit "topic" — sources: obsidian, local, web               → skip Zotero
+/research-lit "topic" — sources: web, semantic-scholar              → web + S2 API (IEEE/ACM venue papers)
+/research-lit "topic" — sources: all, semantic-scholar              → all + S2 API
 ```
 
 ### Source Table
@@ -55,6 +58,7 @@ Examples:
 | 2 | **Obsidian** (via MCP) | `obsidian` | Try calling any `mcp__obsidian-vault__*` tool — if unavailable, skip | Research notes, paper summaries, tagged references, wikilinks |
 | 3 | **Local PDFs** | `local` | `Glob: papers/**/*.pdf, literature/**/*.pdf` | Raw PDF content (first 3 pages) |
 | 4 | **Web search** | `web` | Always available (WebSearch) | arXiv, Semantic Scholar, Google Scholar |
+| 5 | **Semantic Scholar API** | `semantic-scholar` | `tools/semantic_scholar_fetch.py` exists | Published venue papers (IEEE, ACM, Springer) with structured metadata: citation counts, venue info, TLDR. **Only runs when explicitly requested** via `— sources: semantic-scholar` or `— sources: web, semantic-scholar` |
 
 > **Graceful degradation**: If no MCP servers are configured, the skill works exactly as before (local PDFs + web search). Zotero and Obsidian are pure additions.
 
@@ -140,6 +144,29 @@ python3 "$SCRIPT" search "QUERY" --max 10
 If `arxiv_fetch.py` is not found, fall back to WebSearch for arXiv (same as before).
 
 The arXiv API returns structured metadata (title, abstract, full author list, categories, dates) — richer than WebSearch snippets. Merge these results with WebSearch findings and de-duplicate.
+
+**Semantic Scholar API search** (only when `semantic-scholar` is in sources):
+
+When the user explicitly requests `— sources: semantic-scholar` (or `— sources: web, semantic-scholar`), search for published venue papers beyond arXiv:
+
+```bash
+S2_SCRIPT=$(find tools/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+[ -z "$S2_SCRIPT" ] && S2_SCRIPT=$(find ~/.claude/skills/semantic-scholar/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+
+# Search for published CS/Engineering papers with quality filters
+python3 "$S2_SCRIPT" search "QUERY" --max 10 \
+  --fields-of-study "Computer Science,Engineering" \
+  --publication-types "JournalArticle,Conference"
+```
+
+If `semantic_scholar_fetch.py` is not found, skip silently.
+
+**Why use Semantic Scholar?** Many IEEE/ACM journal papers are NOT on arXiv. S2 fills the gap for published venue-only papers with citation counts and venue metadata.
+
+**De-duplication between arXiv and S2**: Match by arXiv ID (S2 returns `externalIds.ArXiv`):
+- If a paper appears in both: check S2's `venue`/`publicationVenue` — if it has been published in a journal/conference (e.g. IEEE TWC, JSAC), use S2's metadata (venue, citationCount, DOI) as the authoritative version, since the published version supersedes the preprint. Keep the arXiv PDF link for download.
+- If the S2 match has no venue (still just a preprint indexed by S2): keep the arXiv version as-is.
+- S2 results without `externalIds.ArXiv` are **venue-only papers** not on arXiv — these are the unique value of this source.
 
 **Optional PDF download** (only when `ARXIV_DOWNLOAD = true`):
 

--- a/skills/semantic-scholar/SKILL.md
+++ b/skills/semantic-scholar/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: semantic-scholar
+description: Search published venue papers (IEEE, ACM, Springer, etc.) via Semantic Scholar API. Complements /arxiv (preprints) with citation counts, venue metadata, and TLDR. Use when user says "search semantic scholar", "find IEEE papers", "find journal papers", "venue papers", "citation search", or wants published literature beyond arXiv preprints.
+argument-hint: query-or-paper-id
+allowed-tools: Bash(*), Read, Write
+---
+
+# Semantic Scholar Paper Search
+
+Search topic or paper ID: $ARGUMENTS
+
+## Role & Positioning
+
+This skill is the **published venue** counterpart to `/arxiv`:
+
+| Skill | Source | Best for |
+|-------|--------|----------|
+| `/arxiv` | arXiv API | Latest preprints, cutting-edge unrefereed work |
+| `/semantic-scholar` | Semantic Scholar API | **Published** journal/conference papers (IEEE, ACM, Springer, etc.) with citation counts, venue info, TLDR |
+
+**Do NOT duplicate arXiv's job.** If results contain an `externalIds.ArXiv` field, the paper is also on arXiv — note this but do not re-fetch from arXiv.
+
+## Constants
+
+- **MAX_RESULTS = 10** — Default number of search results.
+- **FETCH_SCRIPT** — `tools/semantic_scholar_fetch.py` relative to the project root. Fall back to inline Python if not found.
+- **DEFAULT_FILTERS** — For general research queries, apply these by default to reduce noise:
+  - `--fields-of-study "Computer Science,Engineering"`
+  - `--publication-types JournalArticle,Conference`
+
+> Overrides (append to arguments):
+> - `/semantic-scholar "topic" - max: 20` — return up to 20 results
+> - `/semantic-scholar "topic" - type: journal` — only journal articles
+> - `/semantic-scholar "topic" - type: conference` — only conference papers
+> - `/semantic-scholar "topic" - min-citations: 50` — only highly-cited papers
+> - `/semantic-scholar "topic" - year: 2022-` — papers from 2022 onward
+> - `/semantic-scholar "topic" - fields: all` — remove default field-of-study filter
+> - `/semantic-scholar "topic" - sort: citations` — bulk search sorted by citation count
+> - `/semantic-scholar "DOI:10.1109/..."` — fetch a single paper by DOI
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for directives:
+
+- **Query or ID**: main search term, or a paper identifier:
+  - DOI: `10.1109/TWC.2024.1234567`
+  - Semantic Scholar ID: `f9314fd99be5f2b1b3efcfab87197d578160d553`
+  - ArXiv: `ARXIV:2006.10685`
+  - Corpus: `CorpusId:219792180`
+- **`- max: N`**: override MAX_RESULTS
+- **`- type: journal|conference|review|all`**: map to `--publication-types`
+- **`- min-citations: N`**: map to `--min-citations`
+- **`- year: RANGE`**: map to `--year` (e.g. `2022-`, `2020-2024`)
+- **`- fields: FIELDS`**: override `--fields-of-study` (use `all` to remove filter)
+- **`- sort: citations|date`**: use `search-bulk` with `--sort citationCount:desc` or `publicationDate:desc`
+
+If the argument matches a DOI pattern (`10.XXXX/...`), a Semantic Scholar ID (40-char hex), or a prefixed ID (`ARXIV:...`, `CorpusId:...`), skip search and go directly to Step 3.
+
+### Step 2: Search Papers
+
+Locate the fetch script:
+
+```bash
+SCRIPT=$(find tools/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find ~/.claude/skills/semantic-scholar/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+```
+
+**Standard search** (default — relevance-ranked):
+
+```bash
+python3 "$SCRIPT" search "QUERY" --max MAX_RESULTS \
+  --fields-of-study "Computer Science,Engineering" \
+  --publication-types JournalArticle,Conference
+```
+
+**Bulk search** (when `- sort:` is specified, or MAX_RESULTS > 100):
+
+```bash
+python3 "$SCRIPT" search-bulk "QUERY" --max MAX_RESULTS \
+  --sort citationCount:desc \
+  --fields-of-study "Computer Science" \
+  --year "2020-"
+```
+
+If `semantic_scholar_fetch.py` is not found, fall back to inline Python using `urllib` against `https://api.semanticscholar.org/graph/v1/paper/search`.
+
+**Recommended filter combos** (from testing):
+
+| Goal | Flags |
+|------|-------|
+| High-quality journal papers | `--publication-types JournalArticle --min-citations 10` |
+| CS/EE papers, recent | `--fields-of-study "Computer Science,Engineering" --year "2022-"` |
+| Foundational / high-impact | `search-bulk --sort citationCount:desc --fields-of-study "Computer Science"` |
+| Conference papers only | `--publication-types Conference` |
+
+> **Note**: `--venue` requires exact venue names (e.g. "IEEE Transactions on Signal Processing"), not partial matches like "IEEE". Avoid using `--venue` in automated flows — prefer `--publication-types` + `--fields-of-study`.
+
+### Step 3: Fetch Details for a Specific Paper
+
+When a single paper ID is requested:
+
+```bash
+python3 "$SCRIPT" paper "PAPER_ID"
+```
+
+Where PAPER_ID can be:
+- DOI: `10.1109/TSP.2021.3071210`
+- ArXiv: `ARXIV:2006.10685`
+- CorpusId: `CorpusId:219792180`
+- S2 ID: `f9314fd99be5f2b1b3efcfab87197d578160d553`
+
+### Step 4: De-duplicate Against arXiv
+
+For each result, check `externalIds.ArXiv`:
+- If present → paper is also on arXiv. Note this in output but do NOT re-fetch via `/arxiv`.
+- If absent → paper is **venue-only** (e.g. IEEE without preprint). This is the unique value of this skill.
+
+### Step 5: Present Results
+
+Present results as a table:
+
+```text
+| # | Title | Venue | Year | Citations | Authors | Type |
+|---|-------|-------|------|-----------|---------|------|
+| 1 | Deep Learning Enabled... | IEEE Trans. Signal Process. | 2021 | 1364 | Xie et al. | Journal |
+```
+
+For each paper, also show:
+- **DOI link**: `https://doi.org/DOI` (for IEEE/ACM papers, this is the canonical link)
+- **Open Access PDF**: if `openAccessPdf.url` is non-empty, show it
+- **TLDR**: if available, show the one-line summary
+- **Also on arXiv**: if `externalIds.ArXiv` exists, note the arXiv ID
+
+### Step 6: Detailed Summary
+
+For each paper (or top 5 if many results):
+
+```markdown
+## [Title]
+
+- **Venue**: [venue name] ([publicationVenue.type]: journal/conference)
+- **Year**: [year] | **Citations**: [citationCount]
+- **Authors**: [full author list]
+- **DOI**: [doi link]
+- **Fields**: [fieldsOfStudy]
+- **TLDR**: [tldr.text if available]
+- **Abstract**: [abstract]
+- **Open Access**: [openAccessPdf.url or "Not available"]
+- **Also on arXiv**: [ArXiv ID if exists, else "No"]
+```
+
+### Step 7: Final Output
+
+Summarize what was done:
+
+- `Found N published papers for "query"`
+- `Filters applied: [publication types, fields, year range, etc.]`
+- `N papers are venue-only (not on arXiv)`
+
+Suggest follow-up skills:
+
+```text
+/arxiv "topic"           - search arXiv preprints (complements this search)
+/research-lit "topic"    - multi-source review: Zotero + local PDFs + arXiv + S2
+/novelty-check "idea"    - verify novelty against literature
+```
+
+## Key Rules
+
+- **Default to filtered search**: Always apply `--fields-of-study` and `--publication-types` unless user says `- fields: all`. Without filters, S2 returns cross-discipline noise (linguistics, psychology, etc.).
+- **Citation count is gold**: S2's citation data is its main advantage over arXiv. Always show `citationCount` prominently and use it to rank/prioritize results.
+- **Venue metadata matters**: Show `venue` and `publicationVenue.type` (journal vs conference) — this helps users assess paper quality.
+- **DOI is the canonical ID for published papers**: Always show DOI links for IEEE/ACM/Springer papers.
+- **Rate limiting**: S2 API without key is heavily rate-limited (~1 req/s, strict cooldown). If HTTP 429 occurs, wait and retry. Recommend users set `SEMANTIC_SCHOLAR_API_KEY` env var for higher limits (free at https://www.semanticscholar.org/product/api#api-key-form).
+- **TLDR may be null**: Some publishers (notably IEEE) elide the TLDR field. Fall back to showing the first sentence of the abstract.
+- **openAccessPdf may be empty**: Many IEEE papers are closed access. Always provide the DOI link as fallback.
+- If the S2 API is unreachable, suggest using `/arxiv` or `/research-lit "topic" - sources: web` as fallback.

--- a/tools/semantic_scholar_fetch.py
+++ b/tools/semantic_scholar_fetch.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""CLI helper for fetching Semantic Scholar papers.
+
+Designed to complement arxiv_fetch.py: arXiv handles preprints, this tool
+handles **published venue papers** (IEEE, ACM, Springer, etc.) with rich
+metadata (citations, venue, fieldsOfStudy, TLDR).
+
+Commands
+--------
+search       Relevance search for papers (offset pagination, max 100).
+search-bulk  Bulk search with token-based pagination (max 1000).
+paper        Fetch one paper by Semantic Scholar paper ID, DOI, CorpusId, ArXiv ID, etc.
+
+Filter flags (shared by search and search-bulk)
+-----------------------------------------------
+--fields-of-study   e.g. "Computer Science,Engineering"
+--publication-types  e.g. "JournalArticle", "Conference", "Review"
+--min-citations      e.g. 10
+--year               e.g. "2020-", "2020-2024"
+--venue              exact venue name, e.g. "IEEE Transactions on Signal Processing"
+--open-access        only papers with a public PDF
+
+Examples
+--------
+# Search for journal articles with >= 10 citations (best combo for quality filtering)
+python3 tools/semantic_scholar_fetch.py search "semantic communication" --max 10 \
+  --publication-types JournalArticle --min-citations 10
+
+# CS/Engineering papers from 2022 onward
+python3 tools/semantic_scholar_fetch.py search "semantic communication" --max 10 \
+  --fields-of-study "Computer Science,Engineering" --year "2022-"
+
+# Bulk search sorted by citation count, CS only
+python3 tools/semantic_scholar_fetch.py search-bulk "semantic communication" --max 50 \
+  --sort citationCount:desc --fields-of-study "Computer Science" --year "2020-"
+
+# Fetch a single paper by DOI or arXiv ID
+python3 tools/semantic_scholar_fetch.py paper "10.1109/JSAC.2021.3126077"
+python3 tools/semantic_scholar_fetch.py paper "ARXIV:2006.10685"
+
+# NOTE: --venue requires exact venue name (e.g. "IEEE Transactions on Signal Processing"),
+# not partial match like "IEEE". Prefer --publication-types + --fields-of-study instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_API_BASE = "https://api.semanticscholar.org/graph/v1"
+_USER_AGENT = "s2-fetch/1.1"
+_DEFAULT_TIMEOUT = 30
+
+# Good default for relevance search / single-paper fetch
+_DEFAULT_FIELDS = (
+    "paperId,title,abstract,year,venue,publicationVenue,publicationTypes,"
+    "publicationDate,url,openAccessPdf,authors,externalIds,citationCount,"
+    "referenceCount,fieldsOfStudy,s2FieldsOfStudy,tldr"
+)
+
+# Bulk search is intended for basic paper data; keep defaults conservative
+_DEFAULT_BULK_FIELDS = (
+    "paperId,title,abstract,year,venue,publicationDate,url,authors,"
+    "externalIds,citationCount,referenceCount,fieldsOfStudy"
+)
+
+
+def _headers() -> dict[str, str]:
+    headers = {
+        "User-Agent": _USER_AGENT,
+        "Accept": "application/json",
+    }
+    api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY", "").strip()
+    if api_key:
+        headers["x-api-key"] = api_key
+    return headers
+
+
+def _request_json(url: str, *, retries: int = 2, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any]:
+    req = urllib.request.Request(url, headers=_headers())
+    last_err: Exception | None = None
+
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8")
+            return json.loads(raw)
+        except urllib.error.HTTPError as exc:
+            body = ""
+            try:
+                body = exc.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+
+            if exc.code in (429, 500, 502, 503, 504) and attempt < retries:
+                time.sleep(1.5 * (attempt + 1))
+                last_err = exc
+                continue
+
+            message = f"HTTP {exc.code}"
+            if body:
+                message += f": {body}"
+            raise RuntimeError(message) from exc
+        except urllib.error.URLError as exc:
+            if attempt < retries:
+                time.sleep(1.5 * (attempt + 1))
+                last_err = exc
+                continue
+            raise RuntimeError(f"Network error: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Failed to parse JSON response from Semantic Scholar API") from exc
+
+    raise RuntimeError(f"Request failed after retries: {last_err}")
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip().replace("\n", " ")
+    return text or None
+
+
+def _parse_author(author: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "authorId": author.get("authorId"),
+        "name": _clean_text(author.get("name")),
+    }
+
+
+def _parse_publication_venue(pub_venue: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not pub_venue:
+        return None
+    return {
+        "id": pub_venue.get("id"),
+        "name": _clean_text(pub_venue.get("name")),
+        "type": _clean_text(pub_venue.get("type")),
+        "issn": _clean_text(pub_venue.get("issn")),
+        "url": _clean_text(pub_venue.get("url")),
+    }
+
+
+def _parse_paper(paper: dict[str, Any]) -> dict[str, Any]:
+    authors = paper.get("authors") or []
+    return {
+        "paperId": paper.get("paperId"),
+        "title": _clean_text(paper.get("title")),
+        "abstract": _clean_text(paper.get("abstract")),
+        "year": paper.get("year"),
+        "venue": _clean_text(paper.get("venue")),
+        "publicationVenue": _parse_publication_venue(paper.get("publicationVenue")),
+        "publicationTypes": paper.get("publicationTypes"),
+        "publicationDate": _clean_text(paper.get("publicationDate")),
+        "url": _clean_text(paper.get("url")),
+        "openAccessPdf": paper.get("openAccessPdf"),
+        "authors": [_parse_author(a) for a in authors],
+        "externalIds": paper.get("externalIds"),
+        "citationCount": paper.get("citationCount"),
+        "referenceCount": paper.get("referenceCount"),
+        "fieldsOfStudy": paper.get("fieldsOfStudy"),
+        "s2FieldsOfStudy": paper.get("s2FieldsOfStudy"),
+        "tldr": paper.get("tldr"),
+    }
+
+
+def search(
+    query: str,
+    max_results: int = 10,
+    offset: int = 0,
+    fields: str = _DEFAULT_FIELDS,
+    fields_of_study: str | None = None,
+    venue: str | None = None,
+    year: str | None = None,
+    min_citation_count: int | None = None,
+    publication_types: str | None = None,
+    open_access_pdf: bool = False,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "query": query,
+        "limit": max_results,
+        "offset": offset,
+        "fields": fields,
+    }
+    if fields_of_study:
+        params["fieldsOfStudy"] = fields_of_study
+    if venue:
+        params["venue"] = venue
+    if year:
+        params["year"] = year
+    if min_citation_count is not None:
+        params["minCitationCount"] = min_citation_count
+    if publication_types:
+        params["publicationTypes"] = publication_types
+    if open_access_pdf:
+        params["openAccessPdf"] = ""
+    url = f"{_API_BASE}/paper/search?{urllib.parse.urlencode(params)}"
+    payload = _request_json(url)
+
+    data = payload.get("data") or []
+    return {
+        "mode": "search",
+        "total": payload.get("total"),
+        "offset": offset,
+        "next_offset": offset + len(data),
+        "data": [_parse_paper(item) for item in data],
+    }
+
+
+def search_bulk(
+    query: str,
+    max_results: int = 100,
+    token: str | None = None,
+    fields: str = _DEFAULT_BULK_FIELDS,
+    sort: str | None = None,
+    fields_of_study: str | None = None,
+    venue: str | None = None,
+    year: str | None = None,
+    min_citation_count: int | None = None,
+    publication_types: str | None = None,
+    open_access_pdf: bool = False,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "query": query,
+        "limit": max_results,
+        "fields": fields,
+    }
+    if token:
+        params["token"] = token
+    if sort:
+        params["sort"] = sort
+    if fields_of_study:
+        params["fieldsOfStudy"] = fields_of_study
+    if venue:
+        params["venue"] = venue
+    if year:
+        params["year"] = year
+    if min_citation_count is not None:
+        params["minCitationCount"] = min_citation_count
+    if publication_types:
+        params["publicationTypes"] = publication_types
+    if open_access_pdf:
+        params["openAccessPdf"] = ""
+
+    url = f"{_API_BASE}/paper/search/bulk?{urllib.parse.urlencode(params)}"
+    payload = _request_json(url)
+
+    data = payload.get("data") or []
+    return {
+        "mode": "search-bulk",
+        "token": payload.get("token"),
+        "returned": len(data),
+        "sort": sort,
+        "data": [_parse_paper(item) for item in data],
+    }
+
+
+def get_paper(paper_id: str, fields: str = _DEFAULT_FIELDS) -> dict[str, Any]:
+    encoded_id = urllib.parse.quote(paper_id, safe="")
+    params = {"fields": fields}
+    url = f"{_API_BASE}/paper/{encoded_id}?{urllib.parse.urlencode(params)}"
+    payload = _request_json(url)
+    return _parse_paper(payload)
+
+
+def _add_filter_args(parser: argparse.ArgumentParser) -> None:
+    """Add shared filtering arguments to a search sub-parser."""
+    parser.add_argument(
+        "--fields-of-study",
+        default=None,
+        help="Comma-separated fields of study filter, e.g. 'Computer Science,Engineering'.",
+    )
+    parser.add_argument(
+        "--venue",
+        default=None,
+        help="Comma-separated venue filter, e.g. 'IEEE,ACM' or 'Nature'.",
+    )
+    parser.add_argument(
+        "--year",
+        default=None,
+        help="Year or range, e.g. '2023', '2020-2024', '2020-', '-2023'.",
+    )
+    parser.add_argument(
+        "--min-citations",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Minimum citation count filter.",
+    )
+    parser.add_argument(
+        "--publication-types",
+        default=None,
+        help="Comma-separated types: JournalArticle,Conference,Review,etc.",
+    )
+    parser.add_argument(
+        "--open-access",
+        action="store_true",
+        default=False,
+        help="Only return papers with a public PDF.",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Search and fetch papers from Semantic Scholar.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    search_parser = subparsers.add_parser("search", help="Relevance search for papers")
+    search_parser.add_argument("query", help="Keyword query")
+    search_parser.add_argument(
+        "--max",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Maximum number of results to return (default: 10).",
+    )
+    search_parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Offset for pagination (default: 0).",
+    )
+    search_parser.add_argument(
+        "--fields",
+        default=_DEFAULT_FIELDS,
+        help="Comma-separated response fields to request.",
+    )
+    _add_filter_args(search_parser)
+
+    bulk_parser = subparsers.add_parser(
+        "search-bulk",
+        help="Bulk search for papers with token-based pagination",
+    )
+    bulk_parser.add_argument("query", help="Keyword query")
+    bulk_parser.add_argument(
+        "--max",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Maximum number of results to return in this page (default: 100).",
+    )
+    bulk_parser.add_argument(
+        "--token",
+        default=None,
+        help="Continuation token returned by a previous bulk search page.",
+    )
+    bulk_parser.add_argument(
+        "--sort",
+        default=None,
+        help="Optional sort for bulk search, e.g. publicationDate:desc or citationCount:desc",
+    )
+    bulk_parser.add_argument(
+        "--fields",
+        default=_DEFAULT_BULK_FIELDS,
+        help="Comma-separated response fields to request.",
+    )
+    _add_filter_args(bulk_parser)
+
+    paper_parser = subparsers.add_parser("paper", help="Fetch one paper by ID")
+    paper_parser.add_argument(
+        "id",
+        help=(
+            "Semantic Scholar paper ID, DOI, CorpusId:..., ARXIV:..., PMID:..., MAG:..., ACL:..., etc."
+        ),
+    )
+    paper_parser.add_argument(
+        "--fields",
+        default=_DEFAULT_FIELDS,
+        help="Comma-separated response fields to request.",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    try:
+        if args.command == "search":
+            result = search(
+                query=args.query,
+                max_results=args.max,
+                offset=args.offset,
+                fields=args.fields,
+                fields_of_study=args.fields_of_study,
+                venue=args.venue,
+                year=args.year,
+                min_citation_count=args.min_citations,
+                publication_types=args.publication_types,
+                open_access_pdf=args.open_access,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+        if args.command == "search-bulk":
+            result = search_bulk(
+                query=args.query,
+                max_results=args.max,
+                token=args.token,
+                fields=args.fields,
+                sort=args.sort,
+                fields_of_study=args.fields_of_study,
+                venue=args.venue,
+                year=args.year,
+                min_citation_count=args.min_citations,
+                publication_types=args.publication_types,
+                open_access_pdf=args.open_access,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+        if args.command == "paper":
+            result = get_paper(
+                paper_id=args.id,
+                fields=args.fields,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+        raise ValueError(f"Unsupported command: {args.command}")
+
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        return 130
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add Semantic Scholar API integration for searching published venue papers (IEEE, ACM, Springer, etc.), complementing the existing `/arxiv` skill which handles preprints.

**Changed files:**
- `tools/semantic_scholar_fetch.py` — CLI tool wrapping the Semantic Scholar API
- `skills/semantic-scholar/SKILL.md` — standalone skill for venue paper search
- `skills/research-lit/SKILL.md` — integrate Semantic Scholar as opt-in source

## What changed

- Added `tools/semantic_scholar_fetch.py` with three commands (`search`, `search-bulk`, `paper`) and six filter flags (`--fields-of-study`, `--publication-types`, `--min-citations`, `--year`, `--venue`, `--open-access`)
- Added `skills/semantic-scholar/SKILL.md` as standalone skill for IEEE/ACM venue paper discovery
- Updated `skills/research-lit/SKILL.md` to support `semantic-scholar` as an opt-in data source (via `-- sources: semantic-scholar`)

## Why

In wireless communications, relevant literature often comes from IEEE journals such as TWC, JSAC, TCOM, and TSP. Many of these papers are not available on arXiv, so the existing /arxiv skill misses a substantial portion of venue-published work. This change adds Semantic Scholar as a metadata and abstract source for published papers across IEEE, ACM, Springer, and related venues.

## Design decisions

- Semantic Scholar is **opt-in** in `/research-lit` (not included in default `all` sources) to avoid rate-limit issues
- De-duplication: if a paper exists in both arXiv and Semantic Scholar, check whether it has been published in a venue — if yes, use Semantic Scholar metadata (venue, citationCount, DOI) as the authoritative version; otherwise keep the arXiv version as-is
- `--venue` requires exact match (not partial), so recommended filters are `--publication-types` + `--fields-of-study` instead
- Supports `SEMANTIC_SCHOLAR_API_KEY` env var for higher rate limits (free at semanticscholar.org)

## Test plan

Tested `/semantic-scholar "ISAC" - type: journal - min-citations: 50 - year: 2022-`:

| # | Title | Venue | Year | Citations |
|---|-------|-------|------|-----------|
| 1 | ISAC for Vehicular Communication Networks | IEEE Internet Things J. | 2022 | 250 |
| 2 | The ISAC Revolution for 6G | Proc. IEEE | 2024 | 247 |
| 3 | ISAC with Massive MIMO: A Unified Tensor Approach | IEEE Trans. Wireless Commun. | 2024 | 246 |
| 4 | Multi-Static Target Detection in Cell-Free Massive MIMO | IEEE Trans. Wireless Commun. | 2023 | 126 |
| 5 | Movable Antenna Enabled ISAC | IEEE Trans. Wireless Commun. | 2024 | 95 |

- 10/10 results are relevant IEEE journal papers, zero cross-discipline noise
- 3 papers are venue-only (not on arXiv) — confirming Semantic Scholar fills the gap that `/arxiv` cannot cover
- Key venues covered: IEEE TWC (4), IEEE TCOM (2), IEEE IoT-J, Proc. IEEE, IEEE Commun. Mag., IEEE TVT

### PR Checklist

- [x] Code follows the project style
- [x] Documentation is updated (SKILL.md created, research-lit SKILL.md updated)
- [x] Changes are tested locally
