### PR TITLE
feat: add Vast.ai on-demand GPU rental support (gpu: vast)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ See [full setup guide](#%EF%B8%8F-setup) for details and [alternative model comb
 - 📝 **Paper writing** — narrative → outline → figures → LaTeX → PDF → auto-review (4/10 → 8.5/10), one command. Anti-hallucination citations via [DBLP](https://dblp.org)/[CrossRef](https://www.crossref.org)
 - 🤖 **Cross-model collaboration** — Claude Code executes, GPT-5.4 xhigh reviews. Adversarial, not self-play
 - 📝 **Peer review** — review others' papers as a conference reviewer, with structured scoring and meta-review
-- 🖥️ **Review-driven experiments** — when GPT-5.4 says "run an ablation", Claude Code automatically writes the script, rsyncs to your GPU server, launches in screen, collects results, and folds them back into the paper. Just configure your server in `CLAUDE.md` ([setup guide](#%EF%B8%8F-gpu-server-setup-for-auto-experiments))
+- 🖥️ **Review-driven experiments** — when GPT-5.4 says "run an ablation", Claude Code automatically writes the script, rsyncs to your GPU server, launches in screen, collects results, and folds them back into the paper. Just configure your server in `CLAUDE.md` ([setup guide](#%EF%B8%8F-gpu-server-setup-for-auto-experiments)). **No GPU?** Use `gpu: vast` to rent one from [Vast.ai](https://vast.ai) on demand
 - 🔀 **Flexible models** — default Claude × GPT-5.4, also supports [GLM, MiniMax, Kimi, LongCat, DeepSeek, etc.](#-alternative-model-combinations) — no Claude or OpenAI API required
 - 🛑 **Human-in-the-loop** — configurable checkpoints at key decisions. `AUTO_PROCEED=true` for full autopilot, `false` to approve each step
 - 📱 **[Feishu/Lark notifications](#-feishulark-integration-optional)** — three modes: **off (default, strongly recommended for most users)**, push-only (webhook, mobile alerts), interactive (approve/reject from Feishu). Zero impact when unconfigured
@@ -458,7 +458,7 @@ Already have an experiment plan (from Workflow 1 or your own)? `/experiment-brid
 │   /novelty-check — verify idea isn't already published       │
 │                                                              │
 │   Supporting skills:                                         │
-│   /run-experiment    — deploy to local/remote GPU            │
+│   /run-experiment    — deploy to local/remote/vast.ai GPU     │
 │   /analyze-results   — interpret experiment outputs          │
 │   /monitor-experiment — check progress, collect results      │
 └─────────────────────────────────────────────────────────────┘
@@ -682,8 +682,9 @@ Got reviews back? `/rebuttal` parses them, builds a strategy, and drafts a venue
 | Skill | Description | Codex MCP? |
 |-------|-------------|:---:|
 | 🔗 **[`experiment-bridge`](skills/experiment-bridge/SKILL.md)** | Read experiment plan → implement code → sanity check → deploy to GPU → collect initial results | No |
-| ├ 🚀 [`run-experiment`](skills/run-experiment/SKILL.md) | Deploy experiments to local (MPS/CUDA) or remote GPU servers | No |
-| └ 👀 [`monitor-experiment`](skills/monitor-experiment/SKILL.md) | Monitor running experiments, check progress, collect results | No |
+| ├ 🚀 [`run-experiment`](skills/run-experiment/SKILL.md) | Deploy experiments to local, remote, or [Vast.ai](https://vast.ai) GPU (`gpu: local/remote/vast`) | No |
+| ├ 👀 [`monitor-experiment`](skills/monitor-experiment/SKILL.md) | Monitor running experiments, check progress, collect results | No |
+| └ ☁️ [`vast-gpu`](skills/vast-gpu/SKILL.md) | Rent, manage, and destroy on-demand GPU instances from [Vast.ai](https://vast.ai) | No |
 
 ### 🔁 Workflow 2: Auto Research Loop
 
@@ -692,7 +693,7 @@ Got reviews back? `/rebuttal` parses them, builds a strategy, and drafts a venue
 | 🔁 **[`auto-review-loop`](skills/auto-review-loop/SKILL.md)** | **Pipeline orchestrator** — autonomous review→fix→re-review (max 4 rounds) | Yes |
 | ├ 🔬 [`research-review`](skills/research-review/SKILL.md) | Deep review from external LLM (shared with Workflow 1) | Yes |
 | ├ 🔍 [`novelty-check`](skills/novelty-check/SKILL.md) | Verify novelty when reviewer suggests new directions | Yes |
-| ├ 🚀 [`run-experiment`](skills/run-experiment/SKILL.md) | Deploy experiments to local (MPS/CUDA) or remote GPU servers | No |
+| ├ 🚀 [`run-experiment`](skills/run-experiment/SKILL.md) | Deploy experiments to local, remote, or [Vast.ai](https://vast.ai) GPU (`gpu: local/remote/vast`) | No |
 | ├ 📊 [`analyze-results`](skills/analyze-results/SKILL.md) | Analyze experiment results, compute statistics, generate insights | No |
 | └ 👀 [`monitor-experiment`](skills/monitor-experiment/SKILL.md) | Monitor running experiments, check progress, collect results | No |
 | 🔁 [`auto-review-loop-llm`](skills/auto-review-loop-llm/SKILL.md) | Same as above, but uses any OpenAI-compatible API via [`llm-chat`](mcp-servers/llm-chat/) MCP server | No |
@@ -834,11 +835,13 @@ To run the auto-review loop without clicking permission prompts, add to `.claude
 
 When GPT-5.4 says "run an ablation study" or "add a baseline comparison", Claude Code automatically writes the experiment script and deploys it to your GPU server. For this to work, Claude Code needs to know your server environment.
 
-Add your server info to your project's `CLAUDE.md`:
+Three GPU modes are supported — pick one and add it to your project's `CLAUDE.md`:
+
+#### Option A: Remote SSH Server (`gpu: remote`)
 
 ```markdown
 ## Remote Server
-
+- gpu: remote
 - SSH: `ssh my-gpu-server` (key-based auth, no password)
 - GPU: 4x A100
 - Conda env: `research` (Python 3.10 + PyTorch)
@@ -849,10 +852,12 @@ Add your server info to your project's `CLAUDE.md`:
 
 Claude Code reads this and knows how to SSH in, activate the environment, and launch experiments. GPT-5.4 (the reviewer) only decides **what** experiments to run — Claude Code figures out **how** based on your `CLAUDE.md`.
 
+#### Option B: Local GPU (`gpu: local`)
+
 If you are already on the GPU server, you can add the following to your `CLAUDE.md`:
 ```markdown
 ## GPU Environment
-
+- gpu: local
 - This machine has direct GPU access (no SSH needed)
 - GPU: 4x A100 80GB
 - Experiment environment: `YOUR_CONDA_ENV` (Python 3.x + PyTorch)
@@ -860,7 +865,56 @@ If you are already on the GPU server, you can add the following to your `CLAUDE.
 - Code directory: `/home/YOUR_USERNAME/YOUR_CODE_DIRECTORY/`
 ```
 
-**No server?** The review and rewriting skills still work without GPU access. Only experiment-related fixes will be skipped (flagged for manual follow-up).
+#### Option C: Vast.ai On-Demand GPU (`gpu: vast`)
+
+No GPU? Rent one from [Vast.ai](https://vast.ai) on demand. ARIS **analyzes your training task** (model size, dataset, estimated time), searches for the cheapest GPU that fits, and presents options with **estimated total cost** — not just $/hr. After you pick, it handles everything: rent → setup → run → collect results → destroy.
+
+**Prerequisites:**
+
+1. **Create a Vast.ai account** at https://cloud.vast.ai/ and add billing (credit card or crypto)
+
+2. **Install the `vastai` CLI** (requires **Python ≥ 3.10**):
+   ```bash
+   pip install vastai
+   ```
+   If your Python is older (check with `python --version`), use a virtual environment with Python ≥ 3.10 (e.g., `conda create`, `pyenv`, `uv venv`, etc.).
+
+3. **Set your API key** — get it from https://cloud.vast.ai/cli/:
+   ```bash
+   vastai set api-key YOUR_API_KEY
+   ```
+
+4. **Upload your SSH public key** at https://cloud.vast.ai/manage-keys/ — this is **required before renting any instance** (keys are baked in at creation time). If you don't have one:
+   ```bash
+   ssh-keygen -t ed25519 -C "your_email@example.com"
+   cat ~/.ssh/id_ed25519.pub   # copy this to Vast.ai
+   ```
+
+5. **Verify setup** — test that search works:
+   ```bash
+   vastai search offers 'gpu_ram>=24 reliability>0.95' -o 'dph+' --limit 3
+   ```
+
+**Add to `CLAUDE.md`:**
+```markdown
+## Vast.ai
+- gpu: vast                  # rent on-demand GPU from vast.ai
+- auto_destroy: true         # auto-destroy after experiment completes (default)
+- max_budget: 5.00           # optional: warn if estimated cost exceeds this
+```
+
+That's it — no GPU model or hardware config needed. When you run `/run-experiment`, ARIS reads your experiment scripts/plan, estimates VRAM and training time, and presents options like:
+
+```
+| # | GPU       | VRAM  | $/hr  | Est. Hours | Est. Total | Offer ID |
+|---|-----------|-------|-------|------------|------------|----------|
+| 1 | RTX 4090  | 24 GB | $0.28 | ~4h        | ~$1.12     | 6995713  |  ← best value
+| 2 | A100 SXM  | 80 GB | $0.95 | ~2h        | ~$1.90     | 7023456  |  ← fastest
+```
+
+Pick a number and it handles the rest. Use `/vast-gpu` directly for manual control.
+
+**No server at all?** The review and rewriting skills still work without GPU access. Only experiment-related fixes will be skipped (flagged for manual follow-up).
 
 </details>
 
@@ -1127,6 +1181,7 @@ Now skills will:
 | `/auto-review-loop` | Review scored (each round), loop complete | Score + verdict | + wait for continue/stop |
 | `/auto-paper-improvement-loop` | Review scored, all rounds done | Score progression | Score progression |
 | `/run-experiment` | Experiments deployed | GPU assignment + ETA | GPU assignment + ETA |
+| `/vast-gpu` | Instance rented/destroyed | Instance ID + cost | Instance ID + cost |
 | `/monitor-experiment` | Results collected | Results table | Results table |
 | `/idea-discovery` | Phase transitions, final report | Summary at each phase | + approve/reject at checkpoints |
 | `/research-pipeline` | Stage transitions, pipeline done | Stage summary | + approve/reject |

--- a/skills/experiment-bridge/SKILL.md
+++ b/skills/experiment-bridge/SKILL.md
@@ -283,6 +283,7 @@ Ready for Workflow 2:
 - **Update the tracker.** `EXPERIMENT_TRACKER.md` should reflect real status after each run completes.
 - **Don't wait forever.** If an experiment exceeds 2x its estimated time, flag it and move on to the next milestone.
 - **Budget awareness.** Track GPU-hours against the plan's budget. Warn if approaching the limit.
+- **Vast.ai lifecycle.** If using vast.ai instances, destroy them after all experiments complete and results are downloaded. Running instances cost money every second — don't leave them idle. Use `/vast-gpu destroy` or `/vast-gpu destroy-all` when done.
 
 ## Composing with Other Skills
 

--- a/skills/monitor-experiment/SKILL.md
+++ b/skills/monitor-experiment/SKILL.md
@@ -12,8 +12,20 @@ Monitor: $ARGUMENTS
 ## Workflow
 
 ### Step 1: Check What's Running
+
+**SSH server:**
 ```bash
 ssh <server> "screen -ls"
+```
+
+**Vast.ai instance** (read `ssh_host`, `ssh_port` from `vast-instances.json`):
+```bash
+ssh -p <PORT> root@<HOST> "screen -ls"
+```
+
+Also check vast.ai instance status:
+```bash
+vastai show instances
 ```
 
 ### Step 2: Collect Output from Each Screen
@@ -108,3 +120,4 @@ After results are collected, check `~/.claude/feishu.json`:
 - Compare against the correct baseline (same config)
 - Note if experiments are still running (check progress bars, iteration counts)
 - If results look wrong, check training logs for errors before concluding
+- **Vast.ai cost awareness**: When monitoring vast.ai instances, report the running cost (hours * $/hr from `vast-instances.json`). If all experiments on an instance are done, remind the user to run `/vast-gpu destroy <instance_id>` to stop billing

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -15,19 +15,30 @@ Deploy and run ML experiment: $ARGUMENTS
 
 Read the project's `CLAUDE.md` to determine the experiment environment:
 
-- **Local GPU**: Look for local CUDA/MPS setup info
-- **Remote server**: Look for SSH alias, conda env, code directory
+- **Local GPU** (`gpu: local`): Look for local CUDA/MPS setup info
+- **Remote server** (`gpu: remote`): Look for SSH alias, conda env, code directory
+- **Vast.ai** (`gpu: vast`): Check for `vast-instances.json` at project root — if a running instance exists, use it. Also check `CLAUDE.md` for a `## Vast.ai` section.
 
-If no server info is found in `CLAUDE.md`, ask the user.
+**Vast.ai detection priority:**
+1. If `CLAUDE.md` has `gpu: vast` or a `## Vast.ai` section:
+   - If `vast-instances.json` exists and has a running instance → use that instance
+   - If no running instance → call `/vast-gpu provision` which analyzes the task, presents cost-optimized GPU options, and rents the user's choice
+2. If no server info is found in `CLAUDE.md`, ask the user.
 
 ### Step 2: Pre-flight Check
 
 Check GPU availability on the target machine:
 
-**Remote:**
+**Remote (SSH):**
 ```bash
 ssh <server> nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader
 ```
+
+**Remote (Vast.ai):**
+```bash
+ssh -p <PORT> root@<HOST> nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader
+```
+(Read `ssh_host` and `ssh_port` from `vast-instances.json`, or run `vastai ssh-url <INSTANCE_ID>` which returns `ssh://root@HOST:PORT`)
 
 **Local:**
 ```bash
@@ -61,6 +72,25 @@ ssh <server> "cd <remote_dst> && git pull"
 ```
 
 Benefits: version-tracked, multi-server sync with one push, no rsync include/exclude rules needed.
+
+#### Option C: Vast.ai instance
+
+Sync code to the vast.ai instance (always rsync, code dir is `/workspace/project/`):
+```bash
+rsync -avz -e "ssh -p <PORT>" \
+  --include='*.py' --include='*.yaml' --include='*.yml' --include='*.json' \
+  --include='*.txt' --include='*.sh' --include='*/' \
+  --exclude='*.pt' --exclude='*.pth' --exclude='*.ckpt' \
+  --exclude='__pycache__' --exclude='.git' --exclude='data/' \
+  --exclude='wandb/' --exclude='outputs/' \
+  ./ root@<HOST>:/workspace/project/
+```
+
+If `requirements.txt` exists, install dependencies:
+```bash
+scp -P <PORT> requirements.txt root@<HOST>:/workspace/
+ssh -p <PORT> root@<HOST> "pip install -q -r /workspace/requirements.txt"
+```
 
 ### Step 3.5: W&B Integration (when `wandb: true` in CLAUDE.md)
 
@@ -114,6 +144,17 @@ ssh <server> "screen -dmS <exp_name> bash -c '\
   CUDA_VISIBLE_DEVICES=<gpu_id> python <script> <args> 2>&1 | tee <log_file>'"
 ```
 
+#### Vast.ai instance
+
+No conda needed — the Docker image has the environment. Use `/workspace/project/` as working dir:
+```bash
+ssh -p <PORT> root@<HOST> "screen -dmS <exp_name> bash -c '\
+  cd /workspace/project && \
+  CUDA_VISIBLE_DEVICES=<gpu_id> python <script> <args> 2>&1 | tee /workspace/<log_file>'"
+```
+
+After launching, update the `experiment` field in `vast-instances.json` for this instance.
+
 #### Local
 
 ```bash
@@ -128,9 +169,14 @@ For local long-running jobs, use `run_in_background: true` to keep the conversat
 
 ### Step 5: Verify Launch
 
-**Remote:**
+**Remote (SSH):**
 ```bash
 ssh <server> "screen -ls"
+```
+
+**Remote (Vast.ai):**
+```bash
+ssh -p <PORT> root@<HOST> "screen -ls"
 ```
 
 **Local:**
@@ -142,6 +188,39 @@ After deployment is verified, check `~/.claude/feishu.json`:
 - Send `experiment_done` notification: which experiments launched, which GPUs, estimated time
 - If config absent or mode `"off"`: skip entirely (no-op)
 
+### Step 7: Auto-Destroy Vast.ai Instance (when `gpu: vast` and `auto_destroy: true`)
+
+**Skip this step if not using vast.ai or `auto_destroy` is `false`.**
+
+After the experiment completes (detected via `/monitor-experiment` or screen session ending):
+
+1. **Download results** from the instance:
+   ```bash
+   rsync -avz -e "ssh -p <PORT>" root@<HOST>:/workspace/project/results/ ./results/
+   ```
+
+2. **Download logs**:
+   ```bash
+   scp -P <PORT> root@<HOST>:/workspace/*.log ./logs/
+   ```
+
+3. **Destroy the instance** to stop billing:
+   ```bash
+   vastai destroy instance <INSTANCE_ID>
+   ```
+
+4. **Update `vast-instances.json`** — mark status as `destroyed`.
+
+5. **Report cost**:
+   ```
+   Vast.ai instance <ID> auto-destroyed.
+   - Duration: ~X.X hours
+   - Estimated cost: ~$X.XX
+   - Results saved to: ./results/
+   ```
+
+> This ensures users are never billed for idle instances. When `auto_destroy: true` (the default), the full lifecycle is automatic: rent → setup → run → collect → destroy.
+
 ## Key Rules
 
 - ALWAYS check GPU availability first — never blindly assign GPUs
@@ -150,6 +229,7 @@ After deployment is verified, check `~/.claude/feishu.json`:
 - Run deployment commands with `run_in_background: true` to keep conversation responsive
 - Report back: which GPU, which screen/process, what command, estimated time
 - If multiple experiments, launch them in parallel on different GPUs
+- **Vast.ai cost awareness**: When using `gpu: vast`, always report the running cost. If `auto_destroy: true`, destroy the instance as soon as all experiments on it complete
 
 ## CLAUDE.md Example
 
@@ -157,6 +237,7 @@ Users should add their server info to their project's `CLAUDE.md`:
 
 ```markdown
 ## Remote Server
+- gpu: remote               # use pre-configured SSH server
 - SSH: `ssh my-gpu-server`
 - GPU: 4x A100 (80GB each)
 - Conda: `eval "$(/opt/conda/bin/conda shell.bash hook)" && conda activate research`
@@ -166,9 +247,17 @@ Users should add their server info to their project's `CLAUDE.md`:
 - wandb_project: my-project # W&B project name (required if wandb: true)
 - wandb_entity: my-team     # W&B team/user (optional, uses default if omitted)
 
+## Vast.ai
+- gpu: vast                  # rent on-demand GPU from vast.ai
+- auto_destroy: true         # auto-destroy after experiment completes (default: true)
+- max_budget: 5.00           # optional: max total $ to spend per experiment
+
 ## Local Environment
+- gpu: local                 # use local GPU
 - Mac MPS / Linux CUDA
 - Conda env: `ml` (Python 3.10 + PyTorch)
 ```
+
+> **Vast.ai setup**: Run `pip install vastai && vastai set api-key YOUR_KEY`. Upload your SSH public key at https://cloud.vast.ai/manage-keys/. Set `gpu: vast` in your `CLAUDE.md` — `/run-experiment` will automatically rent an instance, run the experiment, and destroy it when done.
 
 > **W&B setup**: Run `wandb login` on your server once (or set `WANDB_API_KEY` env var). The skill reads project/entity from CLAUDE.md and adds `wandb.init()` + `wandb.log()` to your training scripts automatically. Dashboard: `https://wandb.ai/<entity>/<project>`.

--- a/skills/vast-gpu/SKILL.md
+++ b/skills/vast-gpu/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: vast-gpu
+description: "Rent, manage, and destroy GPU instances on vast.ai. Use when user says \"rent gpu\", \"vast.ai\", \"rent a server\", \"cloud gpu\", or needs on-demand GPU without owning hardware."
+argument-hint: [task-description or action]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
+---
+
+# Vast.ai GPU Management
+
+Manage vast.ai GPU instance: $ARGUMENTS
+
+## Overview
+
+Rent cheap, capable GPUs from vast.ai on demand. This skill **analyzes the training task** to determine GPU requirements, searches for the best-value offers, presents options with estimated total cost, and handles the full lifecycle: rent → setup → run → destroy.
+
+Users do NOT specify GPU models or hardware. They describe the task — the skill figures out what to rent.
+
+**Prerequisites:** The `vastai` CLI must be installed (requires **Python ≥ 3.10**) and authenticated:
+```bash
+pip install vastai
+vastai set api-key YOUR_API_KEY
+```
+
+> If your system Python is < 3.10, create a virtual environment with Python ≥ 3.10 (e.g., `conda create`, `pyenv`, `uv venv`, etc.) and install `vastai` there.
+
+SSH public key **must be uploaded at https://cloud.vast.ai/manage-keys/ BEFORE creating any instance**. Keys are baked into instances at creation time — if you add a key after renting, you must destroy and re-create the instance.
+
+## State File
+
+All active vast.ai instances are tracked in `vast-instances.json` at the project root:
+```json
+[
+  {
+    "instance_id": 33799165,
+    "offer_id": 25831376,
+    "gpu_name": "RTX_3060",
+    "num_gpus": 1,
+    "dph": 0.0414,
+    "ssh_url": "ssh://root@1.208.108.242:58955",
+    "ssh_host": "1.208.108.242",
+    "ssh_port": 58955,
+    "created_at": "2026-03-29T21:12:00Z",
+    "status": "running",
+    "experiment": "exp01_baseline",
+    "estimated_hours": 4.0,
+    "estimated_cost": 0.17
+  }
+]
+```
+
+This file is the source of truth for `/run-experiment` and `/monitor-experiment` to connect to vast.ai instances.
+
+## Workflow
+
+### Action: Provision (default)
+
+Analyze the task, find the best GPU, and present cost-optimized options. This is the main entry point — called directly or automatically by `/run-experiment` when `gpu: vast` is set.
+
+**Step 1: Analyze Task Requirements**
+
+Read available context to determine what the task needs:
+
+1. **From the experiment plan** (`refine-logs/EXPERIMENT_PLAN.md`):
+   - Compute budget (total GPU-hours)
+   - Hardware hints (e.g., "4x RTX 3090")
+   - Model architecture and dataset size
+   - Run order and per-milestone cost estimates
+
+2. **From experiment scripts** (if already written):
+   - Model size — scan for model class, `num_parameters`, config files
+   - Batch size, sequence length — estimate VRAM from these
+   - Dataset — estimate training time from dataset size + epochs
+   - Multi-GPU — check for `DataParallel`, `DistributedDataParallel`, `accelerate`, `deepspeed`
+
+3. **From user description** (if no plan/scripts exist):
+   - Model name/size (e.g., "fine-tune LLaMA-7B", "train ResNet-50")
+   - Dataset scale (e.g., "ImageNet", "10k samples")
+   - Estimated duration (e.g., "about 2 hours")
+
+**Step 2: Determine GPU Requirements**
+
+Based on the task analysis, determine:
+
+| Factor | How to estimate |
+|--------|----------------|
+| **Min VRAM** | Model params × 4 bytes (fp32) or × 2 (fp16/bf16) + optimizer states + activations. Rules of thumb: 7B model ≈ 16 GB (fp16), 13B ≈ 28 GB, 70B ≈ 140 GB (needs multi-GPU). ResNet/ViT ≈ 4-8 GB. Add 20% headroom. |
+| **Num GPUs** | 1 unless: model doesn't fit in single GPU VRAM, or scripts use DDP/FSDP/DeepSpeed, or plan specifies multi-GPU |
+| **Est. hours** | From experiment plan's cost column, or: (dataset_size × epochs) / (throughput × batch_size). Default to user estimate if available. Add 30% buffer for setup + unexpected slowdowns |
+| **Min disk** | 20 GB base + model checkpoint size + dataset size. Default: 50 GB |
+| **CUDA version** | Match PyTorch version. PyTorch 2.x needs CUDA ≥ 11.8. Default: 12.1 |
+
+**Step 3: Search Offers**
+
+Search across multiple GPU tiers to find the best value. Always search broadly — do NOT limit to one GPU model:
+
+```bash
+# Tier 1: Budget GPUs (good for small models, fine-tuning, ablations)
+vastai search offers "gpu_ram>=<MIN_VRAM> num_gpus>=<N> reliability>0.95 inet_down>100" -o 'dph+' --storage <DISK> --limit 10
+
+# Tier 2: If VRAM > 24 GB, also search high-VRAM cards specifically
+vastai search offers "gpu_ram>=48 num_gpus>=<N> reliability>0.95" -o 'dph+' --storage <DISK> --limit 5
+```
+
+The output is a table with columns: `ID`, `CUDA`, `N` (GPU count), `Model`, `PCIE`, `cpu_ghz`, `vCPUs`, `RAM`, `Disk`, `$/hr`, `DLP` (deep learning perf), `score`, `NV Driver`, `Net_up`, `Net_down`, `R` (reliability %), `Max_Days`, `mach_id`, `status`, `host_id`, `ports`, `country`.
+
+The **first column (`ID`)** is the offer ID needed for `vastai create instance`.
+
+**Step 4: Present Cost-Optimized Options**
+
+Present **3 options** to the user, ranked by estimated total cost:
+
+```
+Task analysis:
+- Model: [model name/size] → estimated VRAM: ~[X] GB
+- Training: ~[Y] hours estimated
+- Requirements: [N] GPU(s), ≥[X] GB VRAM, ~[Z] GB disk
+
+Recommended options (sorted by estimated total cost):
+
+| # | GPU          | VRAM  | $/hr   | Est. Hours | Est. Total | Reliability | Offer ID  |
+|---|-------------|-------|--------|------------|------------|-------------|-----------|
+| 1 | RTX 3060    | 12 GB | $0.04  | ~6h        | ~$0.25     | 99.4%       | 25831376  |  ← cheapest
+| 2 | RTX 4090    | 24 GB | $0.28  | ~4h        | ~$1.12     | 99.2%       | 6995713   |  ← best value
+| 3 | A100 SXM    | 80 GB | $0.95  | ~2h        | ~$1.90     | 99.5%       | 7023456   |  ← fastest
+
+Option 1 is cheapest overall. Option 3 finishes fastest.
+Pick a number (or type a different offer ID):
+```
+
+**Key presentation rules:**
+- Always show **estimated total cost** ($/hr × estimated hours), not just $/hr
+- Faster GPUs have shorter estimated hours (scale by relative FLOPS)
+- Flag if a cheap option has reliability < 0.97 ("budget pick — 3% chance of interruption")
+- If task is small (<1 hour), recommend interruptible pricing for even lower cost
+- If no offers meet VRAM requirements, explain why and suggest alternatives (e.g., multi-GPU, quantization)
+
+**Relative speed scaling (approximate, for estimating hours across GPU tiers):**
+
+| GPU | Relative Speed (FP16) |
+|-----|-----------------------:|
+| RTX 3060 | 0.5× |
+| RTX 3090 | 1.0× |
+| RTX 4090 | 1.6× |
+| A5000 | 0.9× |
+| A6000 | 1.1× |
+| L40S | 1.5× |
+| A100 SXM | 2.0× |
+| H100 SXM | 3.3× |
+
+Use these to scale the base estimated hours across offers.
+
+### Action: Rent
+
+Create an instance from a user-selected offer.
+
+**Step 1: Create Instance**
+
+```bash
+vastai create instance <OFFER_ID> \
+  --image <DOCKER_IMAGE> \
+  --disk <DISK_GB> \
+  --ssh \
+  --direct \
+  --onstart-cmd "apt-get update && apt-get install -y git screen rsync"
+```
+
+Default Docker image: `pytorch/pytorch:2.1.0-cuda12.1-cudnn8-devel` (override via `CLAUDE.md` `image:` field if set).
+
+The output looks like:
+```
+Started. {'success': True, 'new_contract': 33799165, 'instance_api_key': '...'}
+```
+
+The **`new_contract` value is the instance ID** — save this for all subsequent commands.
+
+**Step 2: Wait for Instance Ready**
+
+Poll instance status every 20 seconds until it's running (typically takes 30-60 seconds, max ~5 minutes):
+```bash
+vastai show instances --raw | python3 -c "
+import sys, json
+instances = json.load(sys.stdin)
+for inst in instances:
+    if inst['id'] == <INSTANCE_ID>:
+        print(inst['actual_status'])
+"
+```
+
+Wait states: `loading` → `running`. If stuck in `loading` for >5 minutes, warn the user — the host may be slow or the image may be large.
+
+**Step 3: Get SSH Connection Details**
+
+```bash
+vastai ssh-url <INSTANCE_ID>
+```
+
+This returns a URL in the format: `ssh://root@<HOST>:<PORT>`
+
+Parse out host and port from this URL. Example:
+- Input: `ssh://root@1.208.108.242:58955`
+- Host: `1.208.108.242`, Port: `58955`
+
+> **Important:** Always use `vastai ssh-url` to get connection details — do NOT rely on `ssh_host`/`ssh_port` from `vastai show instances`, as those may point to proxy servers that differ from the direct connection endpoint.
+
+**Step 4: Verify SSH Connectivity**
+
+```bash
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=15 -p <PORT> root@<HOST> "nvidia-smi && echo 'CONNECTION_OK'"
+```
+
+If SSH fails with "Permission denied (publickey)":
+- The user's SSH key was not uploaded to https://cloud.vast.ai/manage-keys/ **before** the instance was created
+- **Fix:** Destroy this instance, have user upload their key, then create a new instance. Keys are baked in at creation time — there is no way to add keys to a running instance.
+
+If SSH fails with "Connection refused":
+- The instance may still be initializing. Retry up to 3 times with 15-second intervals.
+
+**Step 5: Update State File**
+
+Write/update `vast-instances.json` with the new instance details including the `ssh_url` from Step 3, estimated hours and cost.
+
+**Step 6: Report**
+
+```
+Vast.ai instance ready:
+- Instance ID: <ID>
+- GPU: <GPU_NAME> x <NUM_GPUS>
+- Cost: $<DPH>/hr (estimated total: ~$<TOTAL>)
+- SSH: ssh -p <PORT> root@<HOST>
+- Docker: <IMAGE>
+
+To deploy: /run-experiment (will auto-detect this instance)
+To destroy when done: /vast-gpu destroy <ID>
+```
+
+### Action: Setup
+
+Set up the rented instance for a specific experiment. Called automatically by `/run-experiment` when targeting a vast.ai instance.
+
+**Step 1: Install Dependencies**
+
+```bash
+ssh -p <PORT> root@<HOST> "pip install -q wandb tensorboard scipy scikit-learn pandas"
+```
+
+If a `requirements.txt` exists in the project, install that instead:
+```bash
+scp -P <PORT> requirements.txt root@<HOST>:/workspace/
+ssh -p <PORT> root@<HOST> "pip install -q -r /workspace/requirements.txt"
+```
+
+> Note: `scp` uses uppercase `-P` for port, while `ssh` uses lowercase `-p`.
+
+**Step 2: Sync Code**
+
+```bash
+rsync -avz -e "ssh -p <PORT>" \
+  --include='*.py' --include='*.yaml' --include='*.yml' --include='*.json' \
+  --include='*.txt' --include='*.sh' --include='*/' \
+  --exclude='*.pt' --exclude='*.pth' --exclude='*.ckpt' \
+  --exclude='__pycache__' --exclude='.git' --exclude='data/' \
+  --exclude='wandb/' --exclude='outputs/' \
+  ./ root@<HOST>:/workspace/project/
+```
+
+**Step 3: Verify Setup**
+
+```bash
+ssh -p <PORT> root@<HOST> "cd /workspace/project && python -c 'import torch; print(f\"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}, GPUs: {torch.cuda.device_count()}\")'"
+```
+
+Expected output: `PyTorch 2.1.0, CUDA: True, GPUs: 1` (or more GPUs if multi-GPU instance).
+
+### Action: Destroy
+
+Tear down a vast.ai instance to stop billing.
+
+**Step 1: Confirm Results Collected**
+
+Before destroying, check if there are experiment results to download:
+```bash
+ssh -p <PORT> root@<HOST> "ls /workspace/project/results/ 2>/dev/null || echo 'NO_RESULTS_DIR'"
+```
+
+If results exist, download them first:
+```bash
+rsync -avz -e "ssh -p <PORT>" root@<HOST>:/workspace/project/results/ ./results/
+```
+
+Also download logs:
+```bash
+scp -P <PORT> root@<HOST>:/workspace/*.log ./logs/ 2>/dev/null
+```
+
+**Step 2: Destroy Instance**
+
+```bash
+vastai destroy instance <INSTANCE_ID>
+```
+
+Output: `destroying instance <INSTANCE_ID>.`
+
+> Destruction is **irreversible** — all data on the instance is permanently deleted.
+
+**Step 3: Update State File**
+
+Remove the instance from `vast-instances.json` or mark its status as `destroyed`.
+
+**Step 4: Report Cost**
+
+Calculate actual cost based on creation time and $/hr:
+```
+Instance <ID> destroyed.
+- Duration: ~X.X hours
+- Actual cost: ~$X.XX (estimated was $Y.YY)
+- Results downloaded to: ./results/
+```
+
+### Action: List
+
+Show all active vast.ai instances:
+```bash
+vastai show instances
+```
+
+Cross-reference with `vast-instances.json` for experiment associations.
+
+### Action: Destroy All
+
+Tear down all active instances (use after all experiments complete):
+
+1. Download results from each instance
+2. Destroy all instances
+3. Clear `vast-instances.json`
+4. Report total cost
+
+## Key Rules
+
+- **Task-driven selection** — NEVER ask users to pick GPU models. Analyze the task, estimate requirements, present cost-optimized options with total price
+- **ALWAYS destroy instances when experiments are done** — vast.ai bills per second, leaving instances running wastes money
+- **Download results before destroying** — data is lost permanently on destroy
+- **Prefer on-demand pricing** for short experiments (<2 hours). Suggest interruptible/bid pricing for long runs (>4 hours) with checkpointing
+- **Check reliability > 0.95** — unreliable hosts may crash mid-training
+- **Use `--direct` SSH** when creating instances — faster than proxy SSH
+- **Always use `vastai ssh-url <ID>`** to get connection details — the host/port from `show instances` may differ
+- **SSH keys must be uploaded BEFORE creating instances** — keys are baked in at creation time. If SSH fails with "Permission denied", destroy and recreate after adding the key
+- **Default Docker image**: `pytorch/pytorch:2.1.0-cuda12.1-cudnn8-devel` unless user specifies otherwise
+- **Working directory on instance**: `/workspace/` (Docker default). Code syncs to `/workspace/project/`
+- **State file `vast-instances.json` must stay up to date** — other skills depend on it
+- **Show estimated total cost, not just $/hr** — a $0.90/hr GPU that finishes in 2h ($1.80) beats a $0.30/hr GPU that takes 8h ($2.40)
+- **`vastai` CLI requires Python ≥ 3.10** — if system Python is older, use a conda env
+
+## CLAUDE.md Example
+
+Users only need to set `gpu: vast` — no hardware preferences required:
+
+```markdown
+## Vast.ai
+- gpu: vast                  # tells run-experiment to use vast.ai
+- auto_destroy: true         # auto-destroy after experiment completes (default: true)
+- max_budget: 5.00           # optional: max total $ to spend (skill warns if estimate exceeds this)
+- image: pytorch/pytorch:2.1.0-cuda12.1-cudnn8-devel  # optional: override Docker image
+```
+
+The skill analyzes experiment scripts and plans to determine what GPU to rent. No need to specify GPU model, VRAM, or instance count.
+
+## Composing with Other Skills
+
+```
+/run-experiment "train model"       ← detects gpu: vast, calls /vast-gpu provision
+  ↳ /vast-gpu provision             ← analyzes task, presents options with cost
+  ↳ user picks option               ← rent + setup + deploy
+  ↳ /vast-gpu destroy               ← auto-destroy when done (if auto_destroy: true)
+
+/vast-gpu provision                 ← manual: analyze task + show options
+/vast-gpu rent <offer_id>           ← manual: rent a specific offer
+/vast-gpu list                      ← show active instances
+/vast-gpu destroy <instance_id>     ← tear down, stop billing
+/vast-gpu destroy-all               ← tear down everything
+```


### PR DESCRIPTION
## Summary

- Adds a new `vast-gpu` skill that manages the full Vast.ai GPU lifecycle: analyze task → search offers → present cost-optimized options → rent → setup → destroy
- Integrates `gpu: vast` as a third GPU mode in `run-experiment` alongside `gpu: local` and `gpu: remote`
- **Task-driven GPU selection** — users don't pick hardware. The skill analyzes experiment scripts/plans (model size, VRAM needs, estimated hours) and presents 3 options ranked by estimated **total cost**, not just $/hr
- Auto-destroy instances after experiments complete to prevent idle billing
- Updates `monitor-experiment` and `experiment-bridge` for Vast.ai awareness (cost reporting, lifecycle cleanup)
- Adds full Vast.ai prerequisites and setup guide to README

### Files changed

| File | Change |
|------|--------|
| `skills/vast-gpu/SKILL.md` | **New** — full Vast.ai lifecycle skill (provision, rent, setup, destroy) |
| `skills/run-experiment/SKILL.md` | `gpu: vast` detection, code sync, deploy, auto-destroy step |
| `skills/monitor-experiment/SKILL.md` | Vast.ai instance monitoring, cost awareness |
| `skills/experiment-bridge/SKILL.md` | Vast.ai lifecycle cleanup rule |
| `README.md` | GPU setup section with 3 options (local/remote/vast.ai), skill table, prerequisites |

### Tested end-to-end

Verified the full lifecycle on a real Vast.ai instance:
1. `vastai search offers` — found RTX 3060 at $0.04/hr
2. `vastai create instance` — rented instance, waited ~40s for loading → running
3. `vastai ssh-url` → parsed `ssh://root@HOST:PORT` → SSH'd in
4. Ran PyTorch GPU training script — confirmed CUDA working, model trained to 100% acc
5. `vastai destroy instance` — torn down, billing stopped

Total test cost: ~$0.01

Closes #89

## Test plan

- [x] `vastai` CLI install + auth
- [x] Search offers with filters (`gpu_ram>=`, `reliability>`, sorted by `dph+`)
- [x] Rent instance, wait for ready, get SSH URL
- [x] SSH into instance, verify `nvidia-smi` and PyTorch CUDA
- [x] Run GPU training script end-to-end
- [x] Destroy instance, confirm billing stops
- [x] Test `/run-experiment` auto-detection of `vast-instances.json`
- [x] Test auto-destroy flow after experiment completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)