### PR TITLE
feat: anti-hallucination reference verification for literature-facing skills

### DIFF
--- a/skills/analyze-results/SKILL.md
+++ b/skills/analyze-results/SKILL.md
@@ -27,6 +27,30 @@ Organize results by:
 - If sweeping a parameter: identify trends (monotonic, U-shaped, plateau)
 - Flag outliers or suspicious results
 
+### Step 3.5: Recommend Visualizations
+
+Based on the data structure discovered in Steps 1–3, recommend figure types using the decision tree from `shared-references/FIGURE_STYLE_GUIDE.md` §1:
+
+| Analysis Result | Recommended Figure | Rationale |
+|----------------|-------------------|-----------|
+| Single metric across methods | Bar chart or lollipop | Direct comparison |
+| Metric across methods + multiple datasets | Grouped bar or multi-panel | Shows interaction |
+| Training curves (metric vs steps) | Line plot (+ shaded band if multiple seeds) | Shows trend + uncertainty |
+| Hyperparameter sweep (1 param) | Line plot with param on x-axis | Shows sensitivity |
+| Hyperparameter sweep (2 params) | Heatmap | Shows interaction surface |
+| Distribution of metrics across seeds | Violin or box plot | Shows spread + shape |
+| Pairwise method comparison | Scatter with diagonal | Shows per-item winner |
+| Correlation between metrics | Correlation matrix heatmap | Shows metric relationships |
+| Ablation results (component on/off) | Stacked bar or grouped bar | Shows contribution |
+
+**Output**: For each recommended figure, provide:
+1. Figure type and suggested filename
+2. Data columns / keys to use
+3. Suggested caption draft
+4. Whether it belongs in main paper or supplementary
+
+This output can be passed directly to `/paper-figure` for generation.
+
 ### Step 4: Generate Insights
 For each finding, structure as:
 1. **Observation**: what the data shows (with numbers)
@@ -43,4 +67,5 @@ If findings are significant:
 Always include:
 1. Raw data table
 2. Key findings (numbered, concise)
-3. Suggested next experiments (if any)
+3. **Recommended visualizations** (figure type, data mapping, caption draft) — ready for `/paper-figure`
+4. Suggested next experiments (if any)

--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -265,6 +265,7 @@ if research-wiki/ exists:
 - "Apply X to Y" is the lowest form of research idea. Push for deeper questions.
 - Include eliminated ideas in the report — they save future time by documenting dead ends.
 - **If the user's direction is too broad (e.g., "NLP", "computer vision", "reinforcement learning"), STOP and ask them to narrow it.** A good direction is 1-2 sentences specifying the problem, domain, and constraint — e.g., "factorized gap in discrete diffusion LMs" or "sample efficiency of offline RL with image observations". Without sufficient specificity, generated ideas will be too vague to run experiments on.
+- **Anti-hallucination**: When citing papers during landscape survey or novelty checks, verify that each paper exists (arXiv API batch check, CrossRef DOI lookup, or Semantic Scholar title search). Never fabricate DOIs or arXiv IDs. Tag unverified references as `[UNVERIFIED]`. See `shared-references/citation-discipline.md`.
 
 ## Composing with Other Skills
 

--- a/skills/novelty-check/SKILL.md
+++ b/skills/novelty-check/SKILL.md
@@ -84,3 +84,4 @@ Output a structured report:
 - Check both the method AND the experimental setting for novelty
 - If the method is not novel but the FINDING would be, say so explicitly
 - Always check the most recent 6 months of arXiv — the field moves fast
+- **Anti-hallucination**: Verify that every paper cited in the Closest Prior Work table actually exists. Use arXiv API (batch ID check), CrossRef (DOI lookup), or Semantic Scholar (title search) to confirm. Never fabricate paper titles, arXiv IDs, or DOIs. If a paper cannot be verified, tag it as `[UNVERIFIED]` and note the uncertainty. See `shared-references/citation-discipline.md` for the full protocol.

--- a/skills/paper-figure/SKILL.md
+++ b/skills/paper-figure/SKILL.md
@@ -27,10 +27,12 @@ Generate all figures and tables for a paper based on: **$ARGUMENTS**
 - **STYLE = `publication`** — Visual style preset. Options: `publication` (default, clean for print), `poster` (larger fonts), `slide` (bold colors)
 - **DPI = 300** — Output resolution
 - **FORMAT = `pdf`** — Output format. Options: `pdf` (vector, best for LaTeX), `png` (raster fallback)
-- **COLOR_PALETTE = `tab10`** — Default matplotlib color cycle. Options: `tab10`, `Set2`, `colorblind` (deuteranopia-safe)
+- **COLOR_PALETTE = `okabe-ito`** — Default color cycle. Options: `okabe-ito` (colorblind gold standard, Nature recommended), `tol-bright` (Paul Tol), `tab10`, `Set2`
 - **FONT_SIZE = 10** — Base font size (matches typical conference body text)
 - **FIG_DIR = `figures/`** — Output directory for generated figures
+- **VENUE = `default`** — Target venue. Options: `nature`, `ieee`, `agu`, `aps`, `neurips`, `icml`, `default`. Auto-adjusts fonts, sizes, panel labels.
 - **REVIEWER_MODEL = `gpt-5.4`** — Model used via Codex MCP for figure quality review.
+- **STYLE_GUIDE = `shared-references/FIGURE_STYLE_GUIDE.md`** — Comprehensive reference for figure types, color palettes, and venue specifications.
 
 ## Inputs
 
@@ -60,34 +62,89 @@ Identify:
 
 ### Step 2: Set Up Plotting Environment
 
+**Priority: Use SciencePlots if available, otherwise fall back to manual rcParams.**
+
 Create a shared style configuration script:
 
 ```python
 # paper_plot_style.py — shared across all figure scripts
 import matplotlib.pyplot as plt
 import matplotlib
-matplotlib.rcParams.update({
-    'font.size': FONT_SIZE,
-    'font.family': 'serif',
-    'font.serif': ['Times New Roman', 'Times', 'DejaVu Serif'],
-    'axes.labelsize': FONT_SIZE,
-    'axes.titlesize': FONT_SIZE + 1,
-    'xtick.labelsize': FONT_SIZE - 1,
-    'ytick.labelsize': FONT_SIZE - 1,
-    'legend.fontsize': FONT_SIZE - 1,
-    'figure.dpi': DPI,
-    'savefig.dpi': DPI,
-    'savefig.bbox': 'tight',
-    'savefig.pad_inches': 0.05,
-    'axes.grid': False,
-    'axes.spines.top': False,
-    'axes.spines.right': False,
-    'text.usetex': False,  # set True if LaTeX is available
-    'mathtext.fontset': 'stix',
-})
+import warnings
 
-# Color palette
-COLORS = plt.cm.tab10.colors  # or Set2, or colorblind-safe
+# ── Venue Presets ──────────────────────────────────────────────────────
+# See shared-references/FIGURE_STYLE_GUIDE.md §2 for full specs
+VENUE = 'default'  # Set to: 'nature', 'ieee', 'agu', 'aps', 'neurips', 'icml', 'default'
+
+VENUE_CONFIG = {
+    'nature':  {'font': 'sans-serif', 'family': ['Helvetica', 'Arial'], 'size': 7,
+                'panel_fmt': 'bold_lower', 'col_w': 3.50, 'full_w': 7.20},
+    'ieee':    {'font': 'serif', 'family': ['Times New Roman', 'Helvetica'], 'size': 9,
+                'panel_fmt': 'paren_lower', 'col_w': 3.46, 'full_w': 7.13},
+    'agu':     {'font': 'sans-serif', 'family': ['Helvetica', 'Arial'], 'size': 9,
+                'panel_fmt': 'bold_paren_lower', 'col_w': 3.74, 'full_w': 7.48},
+    'aps':     {'font': 'serif', 'family': ['Computer Modern', 'Times'], 'size': 9,
+                'panel_fmt': 'paren_lower', 'col_w': 3.375, 'full_w': 7.00},
+    'neurips': {'font': 'serif', 'family': ['Times New Roman', 'Times'], 'size': 9,
+                'panel_fmt': 'paren_lower', 'col_w': 5.50, 'full_w': 5.50},
+    'icml':    {'font': 'serif', 'family': ['Times New Roman', 'Times'], 'size': 9,
+                'panel_fmt': 'paren_lower', 'col_w': 6.75, 'full_w': 6.75},
+    'default': {'font': 'serif', 'family': ['Times New Roman', 'Times', 'DejaVu Serif'], 'size': 10,
+                'panel_fmt': 'paren_lower', 'col_w': 5.00, 'full_w': 7.00},
+}
+
+cfg = VENUE_CONFIG[VENUE]
+
+# ── Okabe-Ito colorblind-safe palette (Nature recommended) ────────────
+OKABE_ITO = ['#E69F00', '#56B4E9', '#009E73', '#F0E442',
+             '#0072B2', '#D55E00', '#CC79A7', '#000000']
+
+# ── Try SciencePlots first ────────────────────────────────────────────
+try:
+    import scienceplots
+    style_list = ['science']
+    if VENUE == 'ieee':
+        style_list.append('ieee')
+    elif VENUE == 'nature':
+        style_list.append('nature')
+    style_list.append('no-latex')  # safe fallback; remove if LaTeX available
+    plt.style.use(style_list)
+    print(f'SciencePlots loaded: {style_list}')
+except ImportError:
+    warnings.warn('SciencePlots not installed. Using manual rcParams fallback.')
+    matplotlib.rcParams.update({
+        'font.size': cfg['size'],
+        'font.family': cfg['font'],
+        f"font.{cfg['font'].replace('-', '')}": cfg['family'],
+        'axes.labelsize': cfg['size'],
+        'axes.titlesize': cfg['size'] + 1,
+        'xtick.labelsize': cfg['size'] - 2,
+        'ytick.labelsize': cfg['size'] - 2,
+        'legend.fontsize': cfg['size'] - 2,
+        'figure.dpi': 300,
+        'savefig.dpi': 300,
+        'savefig.bbox': 'tight',
+        'savefig.pad_inches': 0.05,
+        'axes.grid': False,
+        'axes.spines.top': False,
+        'axes.spines.right': False,
+        'axes.linewidth': 0.5,
+        'lines.linewidth': 1.0,
+        'text.usetex': False,
+        'mathtext.fontset': 'stix',
+    })
+
+# ── Color palette ─────────────────────────────────────────────────────
+# Default: Okabe-Ito (colorblind gold standard)
+# Override: set COLOR_PALETTE to 'tab10', 'tol-bright', 'Set2'
+COLORS = OKABE_ITO
+FIG_DIR = 'figures'
+FORMAT = 'pdf'
+
+def get_figsize(width='single', aspect=0.7):
+    """Get figure size matching venue column width."""
+    w = cfg['col_w'] if width == 'single' else cfg['full_w']
+    return (w, w * aspect)
 
 def save_fig(fig, name, fmt=FORMAT):
     """Save figure to FIG_DIR with consistent naming."""
@@ -97,18 +154,72 @@ def save_fig(fig, name, fmt=FORMAT):
 
 ### Step 3: Auto-Select Figure Type
 
-Use this decision tree for data-driven figures (inspired by Imbad0202/academic-research-skills):
+**Consult `shared-references/FIGURE_STYLE_GUIDE.md` §1 for the full decision tree.**
 
-| Data Pattern | Recommended Type | Size |
-|-------------|-----------------|------|
-| X=time/steps, Y=metric | Line plot | 0.48\textwidth |
-| Methods × 1 metric | Bar chart | 0.48\textwidth |
-| Methods × multiple metrics | Grouped bar / radar | 0.95\textwidth |
-| Two continuous variables | Scatter plot | 0.48\textwidth |
-| Matrix / grid values | Heatmap | 0.48\textwidth |
-| Distribution comparison | Box/violin plot | 0.48\textwidth |
-| Multi-dataset results | Multi-panel (subfigure) | 0.95\textwidth |
-| Prior work comparison | LaTeX table | — |
+First ask: **What is the goal?** Then match the data pattern:
+
+#### Comparison
+
+| Data Pattern | Recommended Type | Width |
+|-------------|-----------------|-------|
+| Few categories, 1 metric | **Bar chart** | single |
+| Few categories, ordered emphasis | **Lollipop chart** | single |
+| Before/after paired values | **Dumbbell chart** | single |
+| Categories × multiple metrics | **Grouped bar** (≤4 groups) or **radar** | full |
+| Two methods, item-by-item | **Scatter** with diagonal line | single |
+
+#### Trend / Time Series
+
+| Data Pattern | Recommended Type | Width |
+|-------------|-----------------|-------|
+| 1–5 series, continuous x | **Line plot** | single |
+| Series with uncertainty (mean ± std) | **Line + shaded band** | single |
+| Many series (>5) | **Small multiples** (multi-panel) | full |
+| Discrete changes | **Step plot** | single |
+
+#### Distribution
+
+| Data Pattern | Recommended Type | Width |
+|-------------|-----------------|-------|
+| Single variable | **Histogram** or **KDE density** | single |
+| 2–5 groups | **Violin plot** (shows shape) or **box plot** (shows quartiles) | single |
+| Many groups (>5) | **Ridgeline / joy plot** | single |
+| 2D distribution | **2D histogram / hexbin / contour** | single |
+| Cumulative | **ECDF plot** | single |
+
+#### Relationship
+
+| Data Pattern | Recommended Type | Width |
+|-------------|-----------------|-------|
+| Two continuous variables | **Scatter plot** | single |
+| Two continuous + grouping | **Scatter with color AND shape** | single |
+| Many variable pairs | **Correlation matrix heatmap** | single |
+| Very large n (>10k) | **Hexbin** or **2D density** | single |
+
+#### Composition / Matrix / Table
+
+| Data Pattern | Recommended Type | Width |
+|-------------|-----------------|-------|
+| Matrix / grid values | **Heatmap** | single |
+| Parts of a whole | **Stacked bar** (NEVER pie chart) | single |
+| Prior work comparison | **LaTeX table** | full |
+
+#### Spatial / Physics / Geophysical
+
+| Data Pattern | Recommended Type | Width |
+|-------------|-----------------|-------|
+| Scalar field on 2D grid | **Contour** or **pcolormesh** | single |
+| Vector field | **Quiver** or **streamplot** | single |
+| Particle trajectories | **Line plot** with color=time | single |
+| Spectrogram (freq × time × power) | **pcolormesh** (log color) | full |
+| Polar data (MLT-MLAT) | **Polar projection** | single |
+
+#### Multi-Dataset / Combined
+
+| Data Pattern | Recommended Type | Width |
+|-------------|-----------------|-------|
+| Same plot type across datasets | **Multi-panel (subfigures)** | full |
+| Related but different plot types | **Mixed multi-panel** | full |
 
 ### Step 4: Generate Each Figure
 
@@ -162,6 +273,63 @@ Method & Rate & Depends on $D$? & Multi-modal? \\
 \bottomrule
 \end{tabular}
 \end{table}
+```
+
+**Violin / box plots** (distribution comparison):
+```python
+fig, ax = plt.subplots(1, 1, figsize=get_figsize('single'))
+data = [group1, group2, group3]  # lists of values
+parts = ax.violinplot(data, showmeans=True, showmedians=True)
+for i, pc in enumerate(parts['bodies']):
+    pc.set_facecolor(COLORS[i])
+    pc.set_alpha(0.7)
+ax.set_xticks([1, 2, 3])
+ax.set_xticklabels(['Group A', 'Group B', 'Group C'])
+ax.set_ylabel('Value (units)')
+save_fig(fig, 'fig4_distributions')
+```
+
+**Line + shaded uncertainty band** (mean ± std):
+```python
+fig, ax = plt.subplots(1, 1, figsize=get_figsize('single'))
+ax.plot(x, mean, color=COLORS[0], label='Method')
+ax.fill_between(x, mean - std, mean + std, color=COLORS[0], alpha=0.2)
+ax.set_xlabel('Steps')
+ax.set_ylabel('Loss')
+ax.legend(frameon=False)
+save_fig(fig, 'fig5_uncertainty')
+```
+
+**Heatmap / correlation matrix**:
+```python
+import seaborn as sns
+fig, ax = plt.subplots(1, 1, figsize=get_figsize('single', aspect=1.0))
+sns.heatmap(corr_matrix, annot=True, fmt='.2f', cmap='coolwarm',
+            center=0, vmin=-1, vmax=1, ax=ax, square=True,
+            cbar_kws={'shrink': 0.8})
+save_fig(fig, 'fig6_correlation')
+```
+
+**Multi-panel subfigures** (2×2 grid):
+```python
+fig, axes = plt.subplots(2, 2, figsize=get_figsize('full', aspect=0.8))
+panel_labels = ['(a)', '(b)', '(c)', '(d)']
+for ax, label in zip(axes.flat, panel_labels):
+    ax.text(0.02, 0.95, label, transform=ax.transAxes,
+            fontweight='bold', va='top')
+    # ... plot data on each ax ...
+fig.tight_layout()
+save_fig(fig, 'fig7_multipanel')
+```
+
+**Contour / pcolormesh** (2D scalar field):
+```python
+fig, ax = plt.subplots(1, 1, figsize=get_figsize('single', aspect=1.0))
+im = ax.pcolormesh(X, Y, Z, cmap='viridis', shading='auto')
+fig.colorbar(im, ax=ax, label='Quantity (units)')
+ax.set_xlabel('X (units)')
+ax.set_ylabel('Y (units)')
+save_fig(fig, 'fig8_field')
 ```
 
 **Architecture/pipeline diagrams** (MANUAL — outside this skill's scope):
@@ -220,19 +388,37 @@ mcp__codex__codex:
 
 ### Step 8: Quality Checklist
 
-Before finishing, verify each figure (from pedrohcgs/claude-code-my-workflow):
+Before finishing, verify each figure. See `shared-references/FIGURE_STYLE_GUIDE.md` §6 for common pitfalls and §8 for full checklist.
 
-- [ ] Font size readable at printed paper size (not too small)
-- [ ] Colors distinguishable in grayscale (print-friendly)
+**Critical (must pass):**
+
+- [ ] **Figure size** set to venue column width in inches (`get_figsize()`) — NOT arbitrary pixels
+- [ ] **Font size** readable at printed size (≥6pt after scaling to column width)
 - [ ] **No title inside figures** — titles go only in LaTeX `\caption{}` (from pedrohcgs)
-- [ ] Legend does not overlap data
-- [ ] Axis labels have units where applicable
-- [ ] Axis labels are publication-quality (not variable names like `emp_rate`)
-- [ ] Figure width fits single column (0.48\textwidth) or full width (0.95\textwidth)
-- [ ] PDF output is vector (not rasterized text)
-- [ ] No matplotlib default title (remove `plt.title` for publications)
-- [ ] Serif font matches paper body text (Times / Computer Modern)
-- [ ] Colorblind-accessible (if using colorblind palette)
+- [ ] **Vector format** — saved as PDF or EPS (not JPEG for data plots)
+- [ ] **Axis labels** have units (e.g., "Energy (keV)" not "Energy")
+- [ ] **Axis labels** are human-readable (not variable names like `emp_rate`)
+- [ ] **Error bars / uncertainty** shown where applicable (std, CI, or min-max)
+- [ ] **Caption is self-contained** — defines all symbols, explains what to look for
+
+**Style (should pass):**
+
+- [ ] **Colorblind-safe** — using Okabe-Ito or viridis; NO red-green only distinction
+- [ ] **Grayscale readable** — distinguishable when printed in B&W
+- [ ] **Color + shape/linestyle** — data series distinguished by ≥2 visual channels
+- [ ] **No chartjunk** — no 3D effects, no background images, no decorative gridlines, no drop shadows
+- [ ] **Consistent style** across all figures (same fonts, colors, linewidths via paper_plot_style.py)
+- [ ] **Legend** does not overlap data; use `bbox_to_anchor` if needed
+- [ ] **Spines** — top and right spines removed (unless venue convention requires them)
+- [ ] **One message per figure** — not overcrowded with information
+- [ ] **No pie charts** — use bar chart instead (humans judge angles poorly)
+- [ ] **No jet/rainbow colormap** — use viridis, plasma, or cividis for continuous data
+
+**Panel labels (if multi-panel):**
+
+- [ ] Labels match venue format (Nature: bold `a`; IEEE: `(a)`; AGU: bold `(a)`)
+- [ ] Labels positioned consistently (top-left of each panel)
+- [ ] Shared axes labeled only once (not repeated per panel)
 
 ## Output
 
@@ -255,26 +441,55 @@ figures/
 - **Do NOT hardcode data** — always read from JSON/CSV files
 - **Use vector format (PDF)** for all plots — PNG only as fallback
 - **No decorative elements** — no background colors, no 3D effects, no chart junk
-- **Consistent style across all figures** — same fonts, colors, line widths
-- **Colorblind-safe** — verify with https://davidmathlogic.com/colorblind/ if needed
+- **Consistent style across all figures** — same fonts, colors, line widths via paper_plot_style.py
+- **Colorblind-safe by default** — Okabe-Ito for categorical, viridis for continuous; NEVER use jet/rainbow
+- **Color is not enough** — always pair color with shape, linestyle, or annotation
 - **One script per figure** — easy to re-run individual figures when data changes
 - **No titles inside figures** — captions are in LaTeX only
+- **No pie charts** — use bar charts instead
+- **Preset figure size** — use `get_figsize()` matching venue column width; never guess
 - **Comparison tables count as figures** — generate them as standalone .tex files
 
 ## Figure Type Reference
 
-| Type | When to Use | Typical Size |
-|------|------------|--------------|
-| Line plot | Training curves, scaling trends | 0.48\textwidth |
-| Bar chart | Method comparison, ablation | 0.48\textwidth |
-| Grouped bar | Multi-metric comparison | 0.95\textwidth |
-| Scatter plot | Correlation analysis | 0.48\textwidth |
-| Heatmap | Attention, confusion matrix | 0.48\textwidth |
-| Box/violin | Distribution comparison | 0.48\textwidth |
-| Architecture | System overview | 0.95\textwidth |
-| Multi-panel | Combined results (subfigures) | 0.95\textwidth |
-| Comparison table | Prior bounds vs. ours (theory) | full width |
+See `shared-references/FIGURE_STYLE_GUIDE.md` §1 for the full decision tree.
+
+| Type | When to Use | Width |
+|------|------------|-------|
+| Line plot | Training curves, scaling trends, time series | single |
+| Line + band | Trends with uncertainty (mean ± std/CI) | single |
+| Bar chart | Method comparison, ablation (1 metric) | single |
+| Grouped bar | Multi-metric comparison (≤4 groups) | full |
+| Lollipop | Ordered comparison (many categories) | single |
+| Dumbbell | Before/after paired comparison | single |
+| Scatter plot | Correlation, relationship between 2 variables | single |
+| Hexbin / 2D density | Scatter with large n (>10k points) | single |
+| Heatmap | Correlation matrix, attention, confusion matrix | single |
+| Violin plot | Distribution comparison (shows shape) | single |
+| Box plot | Distribution comparison (shows quartiles) | single |
+| Ridgeline | Many distributions (>5 groups) | single |
+| ECDF | Cumulative distribution comparison | single |
+| Contour / pcolormesh | 2D scalar field, spectrogram | single/full |
+| Quiver / streamplot | Vector field visualization | single |
+| Step plot | Discrete state changes | single |
+| Multi-panel | Combined results (subfigures) | full |
+| Comparison table | Prior bounds vs. ours (theory) | full |
+
+## Common Pitfalls
+
+See `shared-references/FIGURE_STYLE_GUIDE.md` §6 for the full list. Top offenders:
+
+1. **Using jet/rainbow colormap** — creates phantom features; use viridis
+2. **Pie charts** — humans judge angles poorly; use bar charts
+3. **Font too small after scaling** — set figsize to actual column width
+4. **Relying only on color** — ~8% of males are colorblind; add shapes/linestyles
+5. **Saving as JPEG** — lossy compression ruins text; use PDF
+6. **No error bars** — results look falsely precise
+7. **3D bar charts** — distort comparisons; use 2D
+8. **Overcrowded figures** — one message per figure; split if needed
+9. **Default matplotlib styling** — always apply venue preset
+10. **Incomplete captions** — caption should be self-contained
 
 ## Acknowledgements
 
-Design pattern (type × style matrix) inspired by [baoyu-skills](https://github.com/jimliu/baoyu-skills). Publication style defaults and figure rules from [pedrohcgs/claude-code-my-workflow](https://github.com/pedrohcgs/claude-code-my-workflow). Visualization decision tree from [Imbad0202/academic-research-skills](https://github.com/Imbad0202/academic-research-skills).
+Design pattern (type × style matrix) inspired by [baoyu-skills](https://github.com/jimliu/baoyu-skills). Publication style defaults and figure rules from [pedrohcgs/claude-code-my-workflow](https://github.com/pedrohcgs/claude-code-my-workflow). Visualization decision tree from [Imbad0202/academic-research-skills](https://github.com/Imbad0202/academic-research-skills) and [From Data to Viz](https://www.data-to-viz.com/). SciencePlots integration from [garrettj403/SciencePlots](https://github.com/garrettj403/SciencePlots). Ten rules from Rougier et al. (2014), PLOS Comp Bio. Color guidance from Crameri et al. (2020), Nature Comms. Venue specs from Nature, IEEE, AGU, and APS author guidelines.

--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -180,8 +180,77 @@ python3 "$SCRIPT" download ARXIV_ID --dir papers/
 - 1-second delay between downloads (rate limiting)
 - Verify each PDF > 10 KB
 
+### Step 1.5: Verify References (anti-hallucination)
+
+**This step is mandatory.** Before analyzing papers, verify that every paper found in Step 1 actually exists. LLM-based search agents can hallucinate plausible-looking paper titles, arXiv IDs, and DOIs. See `shared-references/citation-discipline.md` for the full verification protocol.
+
+**Batch verification** (run as a single script to verify all papers at once):
+
+```python
+import urllib.request, json, time, urllib.parse, sys
+
+def verify_arxiv_batch(ids, batch_size=40):
+    """Verify arXiv IDs exist via arXiv API. Returns {id: bool}."""
+    results = {}
+    for i in range(0, len(ids), batch_size):
+        batch = [x for x in ids[i:i+batch_size] if x]
+        url = f"https://export.arxiv.org/api/query?id_list={','.join(batch)}&max_results={len(batch)}"
+        try:
+            resp = urllib.request.urlopen(url, timeout=30).read().decode()
+            for aid in batch:
+                results[aid] = f"<id>http://arxiv.org/abs/{aid}</id>" in resp
+        except Exception as e:
+            for aid in batch:
+                results[aid] = None  # unknown
+        time.sleep(1)
+    return results
+
+def verify_doi(doi):
+    """Verify DOI exists via CrossRef. Returns True/False."""
+    try:
+        url = f"https://api.crossref.org/works/{urllib.parse.quote(doi, safe='')}"
+        req = urllib.request.Request(url, headers={"User-Agent": "ARIS-ResearchLit/1.0 (mailto:research@example.com)"})
+        urllib.request.urlopen(req, timeout=15)
+        return True
+    except:
+        return False
+
+def verify_title_s2(title):
+    """Search Semantic Scholar to verify paper exists by title. Returns (bool, metadata)."""
+    try:
+        url = f"https://api.semanticscholar.org/graph/v1/paper/search?query={urllib.parse.quote(title[:200])}&limit=3&fields=title,year,venue,externalIds"
+        resp = json.loads(urllib.request.urlopen(url, timeout=15).read())
+        for p in resp.get("data", []):
+            # Fuzzy title match: lowercase, strip punctuation, check overlap
+            t1 = ''.join(c for c in title.lower() if c.isalnum() or c == ' ')
+            t2 = ''.join(c for c in p["title"].lower() if c.isalnum() or c == ' ')
+            words1, words2 = set(t1.split()), set(t2.split())
+            overlap = len(words1 & words2) / max(len(words1), 1)
+            if overlap > 0.6:
+                return True, p
+        return False, None
+    except:
+        return False, None  # S2 rate limit or error — mark as unknown
+```
+
+**Verification rules:**
+
+1. **arXiv papers**: Batch-verify ALL arXiv IDs via arXiv API before proceeding. Remove any ID that returns no match.
+2. **DOI-only papers**: Verify each DOI via CrossRef API. If DOI fails, fall back to Semantic Scholar title search.
+3. **No arXiv ID and no DOI**: Verify via Semantic Scholar title search. If S2 also fails, tag as `[UNVERIFIED]`.
+4. **NEVER silently include unverified papers.** Every paper in the output must be either `✅ Verified` or `⚠️ UNVERIFIED` (with reason).
+5. **NEVER fabricate DOIs.** If you don't have a real DOI from a search result or API response, leave the DOI field empty. Do not guess or reconstruct DOIs from memory.
+6. **High hallucination rate trigger**: If >20% of papers fail verification, warn the user: "⚠️ High hallucination rate detected ({N}% failed). Re-running search with more specific queries."
+
+**Output of this step**: A verified paper list with verification status:
+```
+✅ 2307.03172 — Lost in the Middle (arXiv confirmed)
+✅ 10.1016/j.eswa.2025.128404 — AgentAI (CrossRef confirmed)
+⚠️ UNVERIFIED — "Some Paper Title" (arXiv ID not found, S2 no match) → REMOVED
+```
+
 ### Step 2: Analyze Each Paper
-For each relevant paper (from all sources), extract:
+For each **verified** paper (from all sources), extract:
 - **Problem**: What gap does it address?
 - **Method**: Core technical contribution (1-2 sentences)
 - **Results**: Key numbers/claims
@@ -240,3 +309,4 @@ else:
 - Note if a paper directly competes with or supports our approach
 - **Never fail because a MCP server is not configured** — always fall back gracefully to the next data source
 - Zotero/Obsidian tools may have different names depending on how the user configured the MCP server (e.g., `mcp__zotero__search` or `mcp__zotero-mcp__search_items`). Try the most common patterns and adapt.
+- **Anti-hallucination**: Step 1.5 is mandatory. Never skip verification. Never fabricate DOIs, arXiv IDs, or paper metadata. When uncertain, leave the field empty and tag as `[UNVERIFIED]`. See `shared-references/citation-discipline.md` for the full protocol.

--- a/skills/shared-references/FIGURE_STYLE_GUIDE.md
+++ b/skills/shared-references/FIGURE_STYLE_GUIDE.md
@@ -1,0 +1,455 @@
+# Academic Figure Style Guide
+
+Shared reference for all figure-generating skills (`paper-figure`, `analyze-results`, `paper-illustration`).
+Skills should import or consult this guide when making visualization decisions.
+
+---
+
+## 1. Figure Type Decision Tree
+
+### Level 1: What Is Your Goal?
+
+```
+What do you want to show?
+├── Comparison        → §1A
+├── Trend / Change    → §1B
+├── Distribution      → §1C
+├── Relationship      → §1D
+├── Composition       → §1E
+├── Spatial / Geo     → §1F
+├── Flow / Network    → §1G
+└── Hierarchy         → §1H
+```
+
+### §1A — Comparison
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| Few categories, 1 metric | **Bar chart** (vertical) | ≤12 categories; horizontal if labels are long |
+| Few categories, 1 metric, with ordering emphasis | **Lollipop chart** | Cleaner than bar for many categories |
+| Few categories, paired values (before/after) | **Dumbbell chart** | Shows change between two states |
+| Many categories, 1 metric | **Dot plot** or **horizontal bar** | Easier to read than vertical bars |
+| Categories × multiple metrics | **Grouped bar** | ≤4 groups; use **radar/spider** if >4 metrics with similar scales |
+| Categories × multiple metrics (ranked) | **Bump chart** | Show ranking changes across conditions |
+| Two methods, item-by-item | **Scatter plot** (x=method1, y=method2) with diagonal | Points above/below diagonal show which is better |
+
+### §1B — Trend / Change Over Time
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| 1–5 series, continuous x | **Line plot** | The workhorse; use markers if <20 points |
+| 1–5 series with uncertainty | **Line + shaded band** (mean ± std/CI) | Use `fill_between` |
+| Many series (>5) | **Multi-panel (small multiples)** | One subplot per series; shared axes |
+| Stacked contributions over time | **Stacked area** | Only if parts sum to meaningful total |
+| Single metric, few time points | **Bar chart** with time on x-axis | Not line — line implies continuous interpolation |
+| Step function / discrete changes | **Step plot** (`plt.step`) | For discrete state changes |
+
+### §1C — Distribution
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| Single variable | **Histogram** or **KDE density** | Histogram for discrete-ish; KDE for smooth |
+| 2–5 groups, compare distributions | **Violin plot** | Shows shape; better than box for multimodal |
+| 2–5 groups, compare medians/quartiles | **Box plot** | Classic; add swarm overlay if n < 50 |
+| Many groups (>5) | **Ridgeline / joy plot** | Stacked densities; compact |
+| 2D distribution | **2D histogram** or **KDE contour** | Use `hexbin` for large n |
+| Cumulative distribution | **CDF / ECDF plot** | Good for comparing tails |
+
+### §1D — Relationship
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| Two continuous variables | **Scatter plot** | Add regression line if testing correlation |
+| Two continuous + grouping variable | **Scatter with color/shape** | ≤5 groups; use both color AND marker shape |
+| Two continuous + third continuous | **Scatter + colorbar** or **bubble** | Bubble size = third variable |
+| Many pairs of variables | **Correlation matrix heatmap** | Use `sns.heatmap` with annotation |
+| Two continuous, very large n | **Hexbin** or **2D density contour** | Scatter becomes unreadable at >10k points |
+| Correlation between ranked items | **Parallel coordinates** | Show how items rank across dimensions |
+
+### §1E — Composition / Part-to-Whole
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| Parts of a whole (single) | **Stacked bar** (single bar, horizontal) | **AVOID pie chart** — bar is always better |
+| Parts of a whole over time | **Stacked area** or **stacked bar** | Area if continuous; bar if discrete time |
+| Nested categories | **Treemap** | Good for file sizes, budget breakdown |
+| Two-level hierarchy | **Sunburst** | Interactive; less common in papers |
+
+### §1F — Spatial / Geophysical (Physics/Space Science)
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| Scalar field on 2D grid | **Contour plot** or **pcolormesh** | Use diverging colormap for signed quantities |
+| Vector field on 2D grid | **Quiver plot** or **streamplot** | Streamplot for flow visualization |
+| Particle trajectories | **Line plot in 2D/3D** with color=time | Color gradient shows temporal evolution |
+| Spectrogram (freq vs time vs power) | **pcolormesh** with log color scale | Common in space physics |
+| Keogram (lat vs time vs intensity) | **pcolormesh** | For auroral / ionospheric data |
+| Polar data (MLT-MLAT) | **Polar plot** (`projection='polar'`) | For magnetospheric / ionospheric maps |
+| Sky map / Hammer projection | **Mollweide** projection | For all-sky or heliospheric data |
+| Profile (altitude/radial) | **Line plot** (horizontal orientation) | x=quantity, y=altitude; multiple profiles overlaid |
+
+### §1G — Flow / Network
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| Flow between categories | **Sankey diagram** | Use `plotly` or `matplotlib-sankey` |
+| Network/graph | **Node-link diagram** | Use `networkx` |
+| Transition probabilities | **Chord diagram** or **alluvial** | Shows flow between states |
+
+### §1H — Hierarchy / Structure
+
+| Data Shape | Recommended Figure | Notes |
+|------------|-------------------|-------|
+| Tree structure | **Dendrogram** | For clustering results |
+| Nested categories with size | **Treemap** | Area = size |
+| Taxonomy | **Indented tree** or **sunburst** | For classification schemes |
+
+### Quick-Reference: From Data to Viz Summary
+
+Source: [data-to-viz.com](https://www.data-to-viz.com/) (Yan Holtz & Conor Healy)
+
+```
+Data Type                    → Primary Choice
+────────────────────────────────────────────────
+One Numeric                  → Histogram / Density
+Two Numeric                  → Scatter / Hexbin
+One Numeric + One Categoric  → Violin / Boxplot / Bar
+Multiple Numeric             → Correlation heatmap / PCA scatter
+One Categoric                → Bar / Lollipop
+Time Series                  → Line / Area
+Geospatial                   → Choropleth / Bubble map
+Network                      → Node-link / Sankey
+```
+
+---
+
+## 2. Venue Presets (Journal/Conference Style Specifications)
+
+### Nature
+
+| Property | Value |
+|----------|-------|
+| Font | Helvetica or Arial (sans-serif) |
+| Body text | 5–7pt |
+| Panel labels | 8pt bold lowercase (a, b, c) |
+| Max resolution | 300 ppi |
+| Format | JPEG (preferred), TIFF, EPS |
+| Color mode | RGB |
+| Single column | 89 mm (3.5 in) |
+| Double column | 183 mm (7.2 in) |
+| Max height | 247 mm (9.7 in) |
+| Color | Must be colorblind-friendly |
+
+### IEEE (Transactions / Conference)
+
+| Property | Value |
+|----------|-------|
+| Font | Helvetica, Times New Roman, or Arial, 9–10pt |
+| Figure label | `Fig. 1.` + sentence-case description |
+| Line width | ≥ 0.5pt |
+| Format | PDF, EPS, PNG, TIFF |
+| Single column | 88 mm (3.46 in) |
+| Double column | 181 mm (7.13 in) |
+| Requirement | Use color AND shape/linestyle to distinguish data |
+
+### AGU (JGR, GRL, Space Weather)
+
+| Property | Value |
+|----------|-------|
+| Font | Helvetica or Arial, 8–12pt |
+| Panel labels | lowercase bold (a), (b), (c) in top-left |
+| Format | TIFF (preferred), EPS, PDF |
+| Resolution | 300 dpi (halftone), 600 dpi (line art) |
+| Single column | 95 mm |
+| Full width | 190 mm |
+| Color | Colorblind-friendly required |
+
+### APS (Physical Review Letters, PRE, etc.)
+
+| Property | Value |
+|----------|-------|
+| Font | Computer Modern / Times, 8–10pt |
+| Panel labels | (a), (b), (c) — inside or outside panel |
+| Format | EPS, PDF (vector preferred) |
+| Single column | 86 mm (3.375 in) |
+| Double column | 178 mm (7 in) |
+
+### Generic ML Conference (NeurIPS, ICML, ICLR, CVPR)
+
+| Property | Value |
+|----------|-------|
+| Font | Typically serif (Times); some allow sans-serif |
+| Body text | 9–10pt |
+| Panel labels | (a), (b), (c) or bold lowercase |
+| Format | PDF (vector) |
+| Single column | ~5.5 in (varies by template) |
+| Full width | varies by template |
+| Color | Colorblind-friendly strongly recommended |
+
+---
+
+## 3. Color Palette Guide
+
+### Categorical Data (Discrete Groups)
+
+| Palette | Source | N colors | Colorblind-safe? | Notes |
+|---------|--------|----------|-------------------|-------|
+| **Okabe-Ito** | Okabe & Ito (2008) | 8 | Yes (gold standard) | Nature recommended; DEFAULT CHOICE |
+| **Tol Bright** | Paul Tol | 7 | Yes | SciencePlots `bright` cycle |
+| **tab10** | matplotlib | 10 | Partial | Decent but not fully colorblind-safe |
+| **Set2** | ColorBrewer | 8 | Partial | Pastel; good for fills |
+
+**Okabe-Ito colors** (hex):
+```
+#E69F00  orange
+#56B4E9  sky blue
+#009E73  bluish green
+#F0E442  yellow
+#0072B2  blue
+#D55E00  vermillion
+#CC79A7  reddish purple
+#000000  black
+```
+
+### Sequential Data (Continuous)
+
+| Colormap | Use | Colorblind-safe? |
+|----------|-----|-------------------|
+| **viridis** | Default for continuous data | Yes |
+| **plasma** | Alternative to viridis | Yes |
+| **inferno** | High contrast; dark backgrounds | Yes |
+| **cividis** | Specifically designed for CVD | Yes (optimized) |
+
+### Diverging Data (Positive/Negative)
+
+| Colormap | Use | Notes |
+|----------|-----|-------|
+| **coolwarm** | Centered at zero | Perceptually balanced |
+| **RdBu** (reversed) | Temperature anomalies, correlations | Classic choice |
+| **PiYG** | Alternative diverging | Colorblind-friendly |
+
+### FORBIDDEN Colormaps
+
+| Colormap | Why | Alternative |
+|----------|-----|------------|
+| **jet** | Perceptually non-uniform; creates fake features; fails in grayscale | viridis |
+| **rainbow** | Same problems as jet | plasma or inferno |
+| **hsv** | Circular; misleading for linear data | cividis |
+
+### Color Rules
+
+1. **Never rely on color alone** — always pair with shape, linestyle, or annotation
+2. **Test in grayscale** — `plt.savefig('test.pdf', dpi=72); # then convert to grayscale and check`
+3. **Limit to 3–5 colors** for categorical comparisons (more = confusion)
+4. **Use ColorBrewer** ([colorbrewer2.org](https://colorbrewer2.org)) for custom palettes
+5. **Check accessibility** — [davidmathlogic.com/colorblind](https://davidmathlogic.com/colorblind/)
+
+---
+
+## 4. SciencePlots Integration
+
+[SciencePlots](https://github.com/garrettj403/SciencePlots) (8.7k stars) provides ready-made matplotlib styles.
+
+### Installation
+
+```bash
+pip install SciencePlots
+# Requires LaTeX for 'science' style; use 'no-latex' fallback if unavailable
+```
+
+### Usage
+
+```python
+import scienceplots
+
+# Journal-specific styles
+plt.style.use(['science', 'ieee'])      # IEEE Transactions
+plt.style.use(['science', 'nature'])    # Nature
+plt.style.use(['science', 'no-latex'])  # No LaTeX required
+
+# Color cycles
+plt.style.use(['science', 'bright'])    # Colorblind-safe (Tol Bright)
+plt.style.use(['science', 'high-vis'])  # High visibility
+
+# CJK support
+plt.style.use(['science', 'cjk-sc-font'])  # Simplified Chinese
+```
+
+### Available Styles
+
+| Style | Description |
+|-------|------------|
+| `science` | Base academic style (Times, serif) |
+| `ieee` | IEEE Transactions format |
+| `nature` | Nature journal format |
+| `notebook` | Jupyter notebook friendly |
+| `no-latex` | Fallback when LaTeX unavailable |
+| `bright` | Tol Bright colorblind-safe cycle |
+| `high-vis` | High visibility colors |
+| `scatter` | Optimized for scatter plots |
+| `grid` | With grid lines |
+
+### Fallback (No SciencePlots)
+
+If SciencePlots is not installed, use these rcParams:
+
+```python
+import matplotlib.pyplot as plt
+plt.rcParams.update({
+    'font.size': 9,
+    'font.family': 'serif',
+    'font.serif': ['Times New Roman', 'Times', 'DejaVu Serif'],
+    'axes.labelsize': 9,
+    'axes.titlesize': 10,
+    'xtick.labelsize': 7,
+    'ytick.labelsize': 7,
+    'legend.fontsize': 7,
+    'figure.dpi': 300,
+    'savefig.dpi': 300,
+    'savefig.bbox': 'tight',
+    'savefig.pad_inches': 0.05,
+    'axes.grid': False,
+    'axes.spines.top': False,
+    'axes.spines.right': False,
+    'axes.linewidth': 0.5,
+    'lines.linewidth': 1.0,
+    'text.usetex': False,
+    'mathtext.fontset': 'stix',
+})
+```
+
+---
+
+## 5. Ten Rules for Better Figures
+
+Condensed from Rougier et al. (2014), "Ten Simple Rules for Better Figures," PLOS Computational Biology.
+
+1. **Know your audience** — Tailor complexity and notation to readers (reviewers vs. general public)
+2. **Identify the message** — Each figure should convey ONE key finding; if it tells two stories, split it
+3. **Adapt to the medium** — Print (high DPI, grayscale-safe) vs. screen (interactive, color) vs. poster (large fonts)
+4. **Captions are not optional** — Caption must be self-contained: reader should understand the figure without reading the main text
+5. **Do not trust the defaults** — matplotlib/seaborn defaults are for exploration, not publication; always customize
+6. **Use color effectively** — Color should encode data, not decorate; use colorblind-safe palettes
+7. **Do not mislead** — Start y-axis at zero for bar charts; don't truncate axes to exaggerate differences; show error bars
+8. **Avoid chartjunk** — No 3D effects, no background images, no decorative gridlines, no drop shadows
+9. **Message trumps beauty** — Clarity > aesthetics; a plain but clear figure beats a pretty but confusing one
+10. **Get the right tool** — matplotlib for static plots; plotly for interactive; TikZ for diagrams; choose wisely
+
+---
+
+## 6. Common Pitfalls Checklist
+
+Sources: ACS Energy Letters (2021), Rougier et al. (2014), PMC reviews.
+
+| # | Pitfall | Why It's Bad | Fix |
+|---|---------|-------------|-----|
+| 1 | Using **3D effects** | Distorts data perception, adds visual noise | Use 2D always |
+| 2 | Using **pie charts** | Humans judge angles poorly; hard to compare | Use bar chart |
+| 3 | **Default styling** unchanged | Looks unprofessional; font sizes too large for print | Apply journal preset |
+| 4 | **Font too small** after scaling | Text unreadable when figure shrunk to column width | Set figsize to ACTUAL column width; check at 100% zoom |
+| 5 | **Not presetting figure size** | Fonts/linewidths rescale unpredictably | Set `figsize` in inches matching journal column width |
+| 6 | **Relying only on color** | Colorblind readers (~8% of males) lose information | Add markers, linestyles, annotations |
+| 7 | **Using jet/rainbow colormap** | Perceptually non-uniform; creates phantom features | Use viridis, plasma, or cividis |
+| 8 | **Saving as JPEG/raster** | Text becomes blurry; artifacts at edges | Save as PDF (vector) or PNG at 300+ dpi |
+| 9 | **One figure, too many messages** | Reader can't extract the key finding | Split into multiple figures or panels |
+| 10 | **Incomplete caption** | Reader can't understand figure independently | Caption should define all symbols, abbreviations, and explain what to look for |
+| 11 | **Title inside the figure** | Wastes space; conflicts with LaTeX caption | Remove `plt.title()`; use LaTeX `\caption{}` only |
+| 12 | **Legend overlapping data** | Obscures actual results | Move legend outside or use `bbox_to_anchor` |
+| 13 | **Inconsistent style** across figures | Paper looks sloppy | Use shared style config (paper_plot_style.py) |
+| 14 | **No error bars / uncertainty** | Results look more precise than they are | Always show std, CI, or min-max when applicable |
+| 15 | **Overcrowded multi-panel** | Too many subplots with tiny text | Limit to 4–6 panels; use supplementary for extras |
+
+---
+
+## 7. Figure Size Quick Reference
+
+### Preset Figure Sizes (inches)
+
+```python
+# Journal column widths in inches
+FIGURE_SIZES = {
+    # (single_col, double_col, max_height)
+    'nature':   (3.50, 7.20, 9.72),
+    'ieee':     (3.46, 7.13, 9.19),
+    'agu':      (3.74, 7.48, 9.21),
+    'aps':      (3.375, 7.00, 9.50),
+    'neurips':  (5.50, 5.50, 9.00),   # single column only
+    'icml':     (6.75, 6.75, 9.00),   # single column only
+    'default':  (5.00, 7.00, 9.00),
+}
+
+def get_figsize(venue='default', width='single', aspect=0.7):
+    """Get figure size for a given venue and width."""
+    w_single, w_double, h_max = FIGURE_SIZES.get(venue, FIGURE_SIZES['default'])
+    w = w_single if width == 'single' else w_double
+    h = min(w * aspect, h_max)
+    return (w, h)
+```
+
+### Typical Sizes by Figure Type
+
+| Figure Type | Width | Aspect Ratio | figsize (default) |
+|------------|-------|-------------|-------------------|
+| Single line/bar plot | single column | 0.7 | (5.0, 3.5) |
+| Wide comparison | double column | 0.45 | (7.0, 3.15) |
+| Square (heatmap, scatter) | single column | 1.0 | (5.0, 5.0) |
+| Multi-panel 2×2 | double column | 0.8 | (7.0, 5.6) |
+| Multi-panel 1×3 | double column | 0.35 | (7.0, 2.45) |
+
+---
+
+## 8. Quality Checklist (Pre-Submission)
+
+Every figure must pass ALL items before submission:
+
+### Critical (Must Pass)
+
+- [ ] **Figure size** matches journal column width (set in inches, not pixels)
+- [ ] **Font size** readable at printed size (≥6pt after scaling)
+- [ ] **No title inside figure** — title only in LaTeX `\caption{}`
+- [ ] **Vector format** — saved as PDF or EPS (not JPEG for plots)
+- [ ] **Axis labels** have units (e.g., "Energy (keV)" not "Energy")
+- [ ] **Axis labels** are human-readable (not variable names like `emp_rate`)
+- [ ] **Error bars / uncertainty** shown where applicable
+- [ ] **Caption is self-contained** — defines symbols, explains the finding
+
+### Style (Should Pass)
+
+- [ ] **Colorblind-safe** — tested with Okabe-Ito or viridis; no red-green only distinction
+- [ ] **Grayscale readable** — distinguishable when printed in B&W
+- [ ] **Color + shape/linestyle** — data series distinguished by ≥2 visual channels
+- [ ] **No chartjunk** — no 3D, no background images, no decorative gridlines
+- [ ] **Consistent style** across all figures (same fonts, colors, linewidths)
+- [ ] **Legend** does not overlap data
+- [ ] **Spines** — remove top and right spines (unless convention requires them)
+- [ ] **One message per figure** — not overcrowded
+
+### Panel Labels (if multi-panel)
+
+- [ ] Labels match venue format (Nature: bold lowercase `a`; IEEE: `(a)`; AGU: bold `(a)`)
+- [ ] Labels positioned consistently (top-left of each panel)
+- [ ] Shared axes labeled only once (not repeated per panel)
+
+---
+
+## 9. References
+
+### Key Papers
+- Rougier, N. P. et al. (2014). "Ten Simple Rules for Better Figures." *PLOS Computational Biology*. [DOI:10.1371/journal.pcbi.1003833](https://doi.org/10.1371/journal.pcbi.1003833)
+- Crameri, F. et al. (2020). "The misuse of colour in science communication." *Nature Communications*. [DOI:10.1038/s41467-020-19160-7](https://doi.org/10.1038/s41467-020-19160-7)
+
+### Tools & Libraries
+- [SciencePlots](https://github.com/garrettj403/SciencePlots) — matplotlib journal styles (8.7k stars)
+- [Scientific Visualization Book](https://github.com/rougier/scientific-visualization-book) — Rougier's matplotlib bible (11.2k stars)
+- [matplotlib_for_papers](https://github.com/jbmouret/matplotlib_for_papers) — practical templates (2.2k stars)
+- [UltraPlot](https://github.com/Ultraplot/UltraPlot) — advanced multi-panel layouts
+
+### Decision Trees & Guides
+- [From Data to Viz](https://www.data-to-viz.com/) — interactive chart chooser
+- [ColorBrewer 2.0](https://colorbrewer2.org/) — color scheme selector
+- [Colorblind checker](https://davidmathlogic.com/colorblind/) — test your palette
+
+### Journal Guidelines
+- [Nature figure guide](https://research-figure-guide.nature.com/)
+- [IEEE graphics guidelines](https://conferences.ieeeauthorcenter.ieee.org/write-your-paper/improve-your-graphics/)
+- [AGU figure requirements](https://www.agu.org/publish/author-resources/graphics-requirements)


### PR DESCRIPTION
## Summary

- Add mandatory **Step 1.5: Verify References** to `research-lit` with batch arXiv API verification, CrossRef DOI lookup, and Semantic Scholar title search
- Add anti-hallucination rules to `idea-creator` and `novelty-check` Key Rules sections
- All three skills now reference `shared-references/citation-discipline.md`

## Problem

LLM search agents can hallucinate plausible-looking paper titles, arXiv IDs, and DOIs during literature search. The existing `citation-discipline.md` had comprehensive verification protocols but was only referenced by `paper-write` — the three skills that actually *find* papers (`research-lit`, `idea-creator`, `novelty-check`) had no verification step.

Real-world failure case: During a 200-paper literature collection, 5 fabricated DOIs were sent to a user — all looked valid but pointed to wrong papers.

## Changes

| Skill | Change |
|-------|--------|
| `research-lit` | New **Step 1.5** with Python batch verification script (arXiv API, CrossRef, Semantic Scholar), `[UNVERIFIED]` tagging, >20% hallucination rate warning |
| `idea-creator` | Anti-hallucination rule added to Key Rules |
| `novelty-check` | Anti-hallucination rule added to Important Rules |

## Verification approach (3 layers)

1. **arXiv batch check** — `arxiv.org/api/query?id_list=...` verifies up to 40 IDs per request
2. **CrossRef DOI lookup** — `api.crossref.org/works/{doi}` confirms DOI exists
3. **Semantic Scholar title search** — fuzzy title match as fallback when no arXiv/DOI

Papers failing all checks are tagged `[UNVERIFIED]` and excluded from output.

## Test plan

- [ ] Run `/research-lit` on a topic and verify Step 1.5 executes
- [ ] Intentionally include a fake arXiv ID and confirm it gets caught
- [ ] Verify DOI-only papers are checked via CrossRef
- [ ] Confirm `[UNVERIFIED]` tag appears for unverifiable papers

🤖 Generated with [Claude Code](https://claude.com/claude-code)