### PR TITLE
feat(config): add custom OpenAI-compatible provider [PR A of 3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ARIS-Code Changelog
 
+## Unreleased
+
+- **Custom OpenAI-compatible provider**: Added a single `custom` provider for both Executor and Reviewer.
+- **Dynamic model discovery**: Custom setup, `/model`, and `/reviewer` now fetch model ids from `/models` instead of asking users to type them manually.
+- **Custom reviewer routing**: `LlmReview` now respects `ARIS_REVIEWER_PROVIDER=custom` and sends requests directly to the configured endpoint.
+
 ## v0.3.5 (2026-04-08)
 
 - **New**: **Research Wiki** — persistent research knowledge base with papers, ideas, experiments, claims, and typed relationship graph. Python helper with auto-fallback to direct LLM execution.

--- a/README.md
+++ b/README.md
@@ -88,14 +88,16 @@ The first time you run `aris`, an interactive setup wizard launches automaticall
     Google Gemini
     Zhipu GLM
     MiniMax
-Enter API Key: sk-...
+    Custom OpenAI-compatible
+Enter API Key / Base URL, then choose a model from /models
 
 [2/3] Choose Reviewer provider (adversarial LLM)
   > OpenAI GPT
     Google Gemini
     Zhipu GLM
     MiniMax
-Enter API Key: sk-...
+    Custom OpenAI-compatible
+Enter API Key / Base URL, then choose a model from /models
 
 [3/3] Choose language preference
     中文 (CN)
@@ -117,8 +119,9 @@ After setup you drop straight into the REPL. Run `/setup` at any time to reconfi
 | 🔵 Google Gemini | ✅ | ✅ | gemini-2.5-pro, gemini-2.5-flash |
 | 🔶 Zhipu GLM | ✅ | ✅ | GLM-5, GLM-5-Turbo |
 | 🔷 MiniMax | ✅ | ✅ | MiniMax-M2.7, MiniMax-M2.7-highspeed |
+| ⚪ Custom OpenAI-compatible | ✅ | ✅ | fetched dynamically from `/models` |
 
-> **Design note**: Anthropic Claude is Executor-only; all other providers can serve as both Executor and Reviewer. The classic pairing is **Claude Executor + GPT/GLM Reviewer** for true adversarial multi-agent research.
+> **Design note**: Anthropic Claude is Executor-only; all other providers can serve as both Executor and Reviewer. For the `custom` provider, ARIS fetches the model list from your endpoint's `/models` API during `/setup`, `/model`, and `/reviewer`, so users never type custom model ids manually.
 
 ---
 
@@ -256,19 +259,18 @@ The system prompt explicitly informs the model of its exact identity (ARIS-Code)
 **Example config.json**:
 ```json
 {
-  "executor": {
-    "provider": "anthropic",
-    "model": "claude-sonnet-4-5",
-    "api_key": "sk-ant-..."
-  },
-  "reviewer": {
-    "provider": "openai",
-    "model": "gpt-5.4",
-    "api_key": "sk-..."
-  },
-  "language": "EN"
+  "executor_provider": "custom",
+  "executor_api_key": "sk-custom-...",
+  "executor_base_url": "https://your-provider.example/v1",
+  "executor_model": "model-picked-from-models",
+  "reviewer_provider": "openai",
+  "reviewer_api_key": "sk-openai-...",
+  "reviewer_model": "gpt-5.4",
+  "language": "en"
 }
 ```
+
+If the reviewer also uses `custom`, add `reviewer_base_url` and the selected `reviewer_model`.
 
 ---
 
@@ -306,4 +308,3 @@ MIT License © 2025 ARIS-Code Contributors
 <div align="center">
   <sub>🌙 Let AI do research while you sleep · Built with ❤️ and Rust</sub>
 </div>
-

--- a/README_CN.md
+++ b/README_CN.md
@@ -88,14 +88,16 @@ aris
     Google Gemini
     Zhipu GLM
     MiniMax
-请输入 API Key: sk-...
+    Custom OpenAI-compatible
+输入 API Key / Base URL 后，从 /models 返回列表中选择模型
 
 [2/3] 选择 Reviewer 提供商（对抗审查 LLM）
   > OpenAI GPT
     Google Gemini
     Zhipu GLM
     MiniMax
-请输入 API Key: sk-...
+    Custom OpenAI-compatible
+输入 API Key / Base URL 后，从 /models 返回列表中选择模型
 
 [3/3] 选择语言偏好
   > 中文 (CN)
@@ -117,8 +119,9 @@ aris
 | 🔵 Google Gemini | ✅ | ✅ | gemini-2.5-pro, gemini-2.5-flash |
 | 🔶 Zhipu GLM | ✅ | ✅ | GLM-5, GLM-5-Turbo |
 | 🔷 MiniMax | ✅ | ✅ | MiniMax-M2.7, MiniMax-M2.7-highspeed |
+| ⚪ Custom OpenAI-compatible | ✅ | ✅ | 通过 `/models` 动态获取 |
 
-> **设计说明**：Anthropic Claude 仅作 Executor，其他四家可同时作 Executor 和 Reviewer。推荐经典搭配：**Claude Executor + GPT/GLM Reviewer**，构成真正的对抗多智能体。
+> **设计说明**：Anthropic Claude 仅作 Executor，其他提供商均可同时作 Executor 和 Reviewer。对于 `custom`，ARIS 会在 `/setup`、`/model`、`/reviewer` 中实时请求你的 `/models` 接口，因此用户不需要手输自定义模型名。
 
 ---
 
@@ -249,19 +252,18 @@ aris
 **config.json 示例**：
 ```json
 {
-  "executor": {
-    "provider": "anthropic",
-    "model": "claude-sonnet-4-5",
-    "api_key": "sk-ant-..."
-  },
-  "reviewer": {
-    "provider": "openai",
-    "model": "gpt-5.4",
-    "api_key": "sk-..."
-  },
-  "language": "CN"
+  "executor_provider": "custom",
+  "executor_api_key": "sk-custom-...",
+  "executor_base_url": "https://your-provider.example/v1",
+  "executor_model": "从-models-选择的模型",
+  "reviewer_provider": "openai",
+  "reviewer_api_key": "sk-openai-...",
+  "reviewer_model": "gpt-5.4",
+  "language": "cn"
 }
 ```
+
+如果 Reviewer 也使用 `custom`，再补充 `reviewer_base_url` 和选择后的 `reviewer_model`。
 
 ---
 
@@ -299,4 +301,3 @@ MIT License © 2025 ARIS-Code Contributors
 <div align="center">
   <sub>🌙 让 AI 在你睡觉时帮你做研究 · Built with ❤️ and Rust</sub>
 </div>
-

--- a/README_EN.md
+++ b/README_EN.md
@@ -62,14 +62,16 @@ The first time you run `aris`, an interactive setup wizard launches automaticall
     Google Gemini
     Zhipu GLM
     MiniMax
-Enter API Key: sk-...
+    Custom OpenAI-compatible
+Enter API Key / Base URL, then choose a model from /models
 
 [2/3] Choose Reviewer provider (adversarial LLM)
   > OpenAI GPT
     Google Gemini
     Zhipu GLM
     MiniMax
-Enter API Key: sk-...
+    Custom OpenAI-compatible
+Enter API Key / Base URL, then choose a model from /models
 
 [3/3] Choose language preference
     中文 (CN)
@@ -91,8 +93,9 @@ After setup you drop straight into the REPL. Run `/setup` at any time to reconfi
 | 🔵 Google Gemini | ✅ | ✅ | gemini-2.5-pro, gemini-2.5-flash |
 | 🔶 Zhipu GLM | ✅ | ✅ | GLM-5, GLM-5-Turbo |
 | 🔷 MiniMax | ✅ | ✅ | MiniMax-M2.7, MiniMax-M2.7-highspeed |
+| ⚪ Custom OpenAI-compatible | ✅ | ✅ | fetched dynamically from `/models` |
 
-> **Design note**: Anthropic Claude is Executor-only; all other providers can serve as both Executor and Reviewer. The classic pairing is **Claude Executor + GPT/GLM Reviewer** for true adversarial multi-agent research.
+> **Design note**: Anthropic Claude is Executor-only; all other providers can serve as both Executor and Reviewer. For the `custom` provider, ARIS fetches the model list from your endpoint's `/models` API during `/setup`, `/model`, and `/reviewer`, so users never type custom model ids manually.
 
 ---
 
@@ -230,19 +233,18 @@ The system prompt explicitly informs the model of its exact identity (ARIS-Code)
 **Example config.json**:
 ```json
 {
-  "executor": {
-    "provider": "anthropic",
-    "model": "claude-sonnet-4-5",
-    "api_key": "sk-ant-..."
-  },
-  "reviewer": {
-    "provider": "openai",
-    "model": "gpt-5.4",
-    "api_key": "sk-..."
-  },
-  "language": "EN"
+  "executor_provider": "custom",
+  "executor_api_key": "sk-custom-...",
+  "executor_base_url": "https://your-provider.example/v1",
+  "executor_model": "model-picked-from-models",
+  "reviewer_provider": "openai",
+  "reviewer_api_key": "sk-openai-...",
+  "reviewer_model": "gpt-5.4",
+  "language": "en"
 }
 ```
+
+If the reviewer also uses `custom`, add `reviewer_base_url` and the selected `reviewer_model`.
 
 ---
 

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -9,12 +9,17 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::input;
+use crate::openai_compat::{
+    fetch_openai_models, is_openai_compat_provider, model_select_items, normalize_openai_base_url,
+};
+
 const CONFIG_DIR: &str = ".config/aris";
 const CONFIG_FILE: &str = "config.json";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ArisConfig {
-    /// "anthropic" or "openai"
+    /// "anthropic", "openai", or "custom"
     #[serde(default)]
     pub executor_provider: Option<String>,
     #[serde(default)]
@@ -23,11 +28,13 @@ pub struct ArisConfig {
     pub executor_base_url: Option<String>,
     #[serde(default)]
     pub executor_model: Option<String>,
-    /// "gemini" or "openai"
+    /// "gemini", "openai", "glm", "minimax", "kimi", "custom", or "none"
     #[serde(default)]
     pub reviewer_provider: Option<String>,
     #[serde(default)]
     pub reviewer_api_key: Option<String>,
+    #[serde(default)]
+    pub reviewer_base_url: Option<String>,
     #[serde(default)]
     pub reviewer_model: Option<String>,
     /// "cn" or "en"
@@ -60,9 +67,8 @@ impl ArisConfig {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let json = serde_json::to_string_pretty(self).map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, e)
-        })?;
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         fs::write(&path, json)
     }
 
@@ -77,17 +83,29 @@ impl ArisConfig {
     }
 
     fn apply_to_env_inner(&self, force: bool) {
+        if force {
+            std::env::remove_var("EXECUTOR_PROVIDER");
+            std::env::remove_var("EXECUTOR_API_KEY");
+            std::env::remove_var("EXECUTOR_BASE_URL");
+            std::env::remove_var("ARIS_REVIEWER_PROVIDER");
+            std::env::remove_var("ARIS_REVIEWER_API_KEY");
+            std::env::remove_var("ARIS_REVIEWER_BASE_URL");
+            std::env::remove_var("ARIS_REVIEWER_MODEL");
+            std::env::remove_var("ARIS_REVIEWER_DISABLED");
+        }
+
         // Executor provider
-        if force || std::env::var("EXECUTOR_PROVIDER").is_err() {
-            if let Some(provider) = &self.executor_provider {
-                if provider == "openai" {
-                    std::env::set_var("EXECUTOR_PROVIDER", provider);
-                }
+        let provider = self.executor_provider.as_deref().unwrap_or("anthropic");
+        if is_openai_compat_provider(provider) {
+            if force || std::env::var("EXECUTOR_PROVIDER").is_err() {
+                std::env::set_var("EXECUTOR_PROVIDER", provider);
             }
+        } else if force {
+            std::env::remove_var("EXECUTOR_PROVIDER");
+            std::env::remove_var("EXECUTOR_BASE_URL");
         }
 
         // Executor API key + base URL
-        let provider = self.executor_provider.as_deref().unwrap_or("anthropic");
         if let Some(key) = &self.executor_api_key {
             match provider {
                 "anthropic" => {
@@ -111,15 +129,20 @@ impl ArisConfig {
                         std::env::set_var("EXECUTOR_API_KEY", key);
                     }
                 }
+                "custom" => {
+                    if force || std::env::var("EXECUTOR_API_KEY").is_err() {
+                        std::env::set_var("EXECUTOR_API_KEY", key);
+                    }
+                }
                 _ => {}
             }
         }
 
         // Executor base URL (for openai-compat providers)
-        if provider == "openai" {
+        if is_openai_compat_provider(provider) {
             if force || std::env::var("EXECUTOR_BASE_URL").is_err() {
                 if let Some(url) = &self.executor_base_url {
-                    std::env::set_var("EXECUTOR_BASE_URL", url);
+                    std::env::set_var("EXECUTOR_BASE_URL", normalize_openai_base_url(url));
                 }
             }
         }
@@ -153,7 +176,33 @@ impl ArisConfig {
                             std::env::set_var("KIMI_API_KEY", key);
                         }
                     }
+                    "custom" => {
+                        if force || std::env::var("ARIS_REVIEWER_API_KEY").is_err() {
+                            std::env::set_var("ARIS_REVIEWER_API_KEY", key);
+                        }
+                    }
                     _ => {}
+                }
+            }
+        }
+
+        let should_disable_reviewer = self.reviewer_provider.as_deref() == Some("none")
+            && (force || !reviewer_env_present());
+        if should_disable_reviewer
+            && (force || std::env::var("ARIS_REVIEWER_DISABLED").is_err())
+        {
+            std::env::set_var("ARIS_REVIEWER_DISABLED", "1");
+        }
+
+        if let Some(reviewer_provider) = &self.reviewer_provider {
+            if reviewer_provider == "custom" {
+                if force || std::env::var("ARIS_REVIEWER_PROVIDER").is_err() {
+                    std::env::set_var("ARIS_REVIEWER_PROVIDER", reviewer_provider);
+                }
+                if force || std::env::var("ARIS_REVIEWER_BASE_URL").is_err() {
+                    if let Some(url) = &self.reviewer_base_url {
+                        std::env::set_var("ARIS_REVIEWER_BASE_URL", normalize_openai_base_url(url));
+                    }
                 }
             }
         }
@@ -187,7 +236,9 @@ impl ArisConfig {
 
     /// Check if we have minimum viable config (at least an executor API key).
     pub fn has_executor_key(&self) -> bool {
-        self.executor_api_key.as_ref().is_some_and(|k| !k.is_empty())
+        self.executor_api_key
+            .as_ref()
+            .is_some_and(|k| !k.is_empty())
     }
 }
 
@@ -206,6 +257,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     println!("  4. GLM         (GLM-5)");
     println!("  5. MiniMax     (MiniMax-M2.7)");
     println!("  6. Kimi        (kimi-k2.5)");
+    println!("  7. Custom OpenAI-compatible");
 
     let default_executor = match config.executor_provider.as_deref() {
         Some("openai") => match config.executor_base_url.as_deref() {
@@ -213,47 +265,61 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             Some(u) if u.contains("bigmodel") => "4",
             Some(u) if u.contains("minimax") => "5",
             Some(u) if u.contains("moonshot") => "6",
+            Some(u) if u.contains("api.openai.com") => "2",
+            Some(_) => "7",
             _ => "2",
         },
+        Some("custom") => "7",
         _ => "1",
     };
-    let exec_choice = prompt_with_default("  Choose [1-6]", default_executor)?;
+    let exec_choice = prompt_with_default("  Choose [1-7]", default_executor)?;
 
     // (provider, key_env, key_label, base_url, default_model)
-    let exec_info: (&str, &str, &str, Option<&str>, &str) = match exec_choice.trim() {
-        "2" => ("openai", "EXECUTOR_API_KEY", "OpenAI API key", Some("https://api.openai.com/v1"), "gpt-5.4"),
-        "3" => ("openai", "EXECUTOR_API_KEY", "Gemini API key", Some("https://generativelanguage.googleapis.com/v1beta/openai"), "gemini-2.5-pro"),
-        "4" => ("openai", "EXECUTOR_API_KEY", "GLM API key", Some("https://open.bigmodel.cn/api/paas/v4"), "GLM-5"),
-        "5" => ("openai", "EXECUTOR_API_KEY", "MiniMax API key", Some("https://api.minimax.chat/v1"), "MiniMax-M2.7"),
-        "6" => ("openai", "EXECUTOR_API_KEY", "Kimi API key", Some("https://api.moonshot.cn/v1"), "kimi-k2.5"),
-        _ => ("anthropic", "ANTHROPIC_API_KEY", "Anthropic API key", None, "claude-opus-4-6"),
-    };
-
-    config.executor_provider = Some(exec_info.0.into());
-    if let Some(url) = exec_info.3 {
-        config.executor_base_url = Some(url.into());
-    } else {
-        config.executor_base_url = None;
+    match exec_choice.trim() {
+        "2" => configure_builtin_executor(
+            &mut config,
+            "openai",
+            "OpenAI API key",
+            Some("https://api.openai.com/v1"),
+            "gpt-5.4",
+        )?,
+        "3" => configure_builtin_executor(
+            &mut config,
+            "openai",
+            "Gemini API key",
+            Some("https://generativelanguage.googleapis.com/v1beta/openai"),
+            "gemini-2.5-pro",
+        )?,
+        "4" => configure_builtin_executor(
+            &mut config,
+            "openai",
+            "GLM API key",
+            Some("https://open.bigmodel.cn/api/paas/v4"),
+            "GLM-5",
+        )?,
+        "5" => configure_builtin_executor(
+            &mut config,
+            "openai",
+            "MiniMax API key",
+            Some("https://api.minimax.chat/v1"),
+            "MiniMax-M2.7",
+        )?,
+        "6" => configure_builtin_executor(
+            &mut config,
+            "openai",
+            "Kimi API key",
+            Some("https://api.moonshot.cn/v1"),
+            "kimi-k2.5",
+        )?,
+        "7" => configure_custom_executor(&mut config)?,
+        _ => configure_builtin_executor(
+            &mut config,
+            "anthropic",
+            "Anthropic API key",
+            None,
+            "claude-opus-4-6",
+        )?,
     }
-
-    // Ask for API key
-    let current_key_masked = config
-        .executor_api_key
-        .as_deref()
-        .filter(|k| k.len() > 8)
-        .map(|k| format!("{}...{}", &k[..4], &k[k.len() - 4..]))
-        .unwrap_or_else(|| "(not set)".into());
-    let new_key = prompt_with_default(
-        &format!("  {} [{current_key_masked}]", exec_info.2),
-        "",
-    )?;
-    if !new_key.is_empty() {
-        config.executor_api_key = Some(new_key);
-    }
-
-    // Auto-set best model for the chosen provider
-    config.executor_model = Some(exec_info.4.to_string());
-    println!("  \x1b[2mModel: {}\x1b[0m", exec_info.4);
 
     // ── Step 4: Reviewer ──
     println!("\n\x1b[1m[2/3] Reviewer (for LlmReview tool)\x1b[0m");
@@ -262,57 +328,61 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     println!("  3. GLM       (GLM-5)");
     println!("  4. MiniMax   (MiniMax-M2.7)");
     println!("  5. Kimi      (kimi-k2.5)");
-    println!("  6. Skip (no reviewer)");
+    println!("  6. Custom OpenAI-compatible");
+    println!("  7. Skip (no reviewer)");
     let reviewer_choice = prompt_with_default(
-        "  Choose [1-6]",
+        "  Choose [1-7]",
         match config.reviewer_provider.as_deref() {
             Some("openai") => "1",
             Some("gemini") => "2",
             Some("glm") => "3",
             Some("minimax") => "4",
             Some("kimi") => "5",
+            Some("custom") => "6",
             None => "1",
-            _ => "6",
+            _ => "7",
         },
     )?;
 
-    // (provider_name, key_env_var, key_label, default_model)
-    let reviewer_info: Option<(&str, &str, &str, &str)> = match reviewer_choice.trim() {
-        "1" => Some(("openai", "OPENAI_API_KEY", "OpenAI API key", "gpt-5.4")),
-        "2" => Some(("gemini", "GEMINI_API_KEY", "Gemini API key", "gemini-2.5-pro")),
-        "3" => Some(("glm", "GLM_API_KEY", "GLM API key", "GLM-5")),
-        "4" => Some(("minimax", "MINIMAX_API_KEY", "MiniMax API key", "MiniMax-M2.7")),
-        "5" => Some(("kimi", "KIMI_API_KEY", "Kimi API key", "kimi-k2.5")),
-        _ => None,
-    };
-
-    if let Some((provider, key_env, key_label, default_model)) = reviewer_info {
-        config.reviewer_provider = Some(provider.into());
-
-        // Ask for API key
-        let current_masked = std::env::var(key_env)
-            .ok()
-            .or_else(|| config.reviewer_api_key.clone())
-            .filter(|k| k.len() > 8)
-            .map(|k| format!("{}...{}", &k[..4], &k[k.len() - 4..]))
-            .unwrap_or_else(|| "(not set)".into());
-        let new_key = prompt_with_default(
-            &format!("  {key_label} [{current_masked}]"),
-            "",
-        )?;
-        if !new_key.is_empty() {
-            config.reviewer_api_key = Some(new_key.clone());
-            std::env::set_var(key_env, &new_key);
-        } else if let Some(existing) = &config.reviewer_api_key {
-            std::env::set_var(key_env, existing);
+    match reviewer_choice.trim() {
+        "1" => configure_builtin_reviewer(
+            &mut config,
+            "openai",
+            "OPENAI_API_KEY",
+            "OpenAI API key",
+            "gpt-5.4",
+        )?,
+        "2" => configure_builtin_reviewer(
+            &mut config,
+            "gemini",
+            "GEMINI_API_KEY",
+            "Gemini API key",
+            "gemini-2.5-pro",
+        )?,
+        "3" => {
+            configure_builtin_reviewer(&mut config, "glm", "GLM_API_KEY", "GLM API key", "GLM-5")?
         }
-
-        // Auto-set best model for the chosen reviewer provider
-        config.reviewer_model = Some(default_model.to_string());
-        println!("  \x1b[2mModel: {default_model}\x1b[0m");
-    } else {
-        config.reviewer_provider = None;
-        config.reviewer_api_key = None;
+        "4" => configure_builtin_reviewer(
+            &mut config,
+            "minimax",
+            "MINIMAX_API_KEY",
+            "MiniMax API key",
+            "MiniMax-M2.7",
+        )?,
+        "5" => configure_builtin_reviewer(
+            &mut config,
+            "kimi",
+            "KIMI_API_KEY",
+            "Kimi API key",
+            "kimi-k2.5",
+        )?,
+        "6" => configure_custom_reviewer(&mut config)?,
+        _ => {
+            config.reviewer_provider = Some("none".to_string());
+            config.reviewer_api_key = None;
+            config.reviewer_base_url = None;
+            config.reviewer_model = None;
+        }
     }
 
     // ── Step 5: Language ──
@@ -326,7 +396,14 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             _ => "1",
         },
     )?;
-    config.language = Some(if lang_choice.trim() == "2" { "en" } else { "cn" }.into());
+    config.language = Some(
+        if lang_choice.trim() == "2" {
+            "en"
+        } else {
+            "cn"
+        }
+        .into(),
+    );
 
     // ── Save ──
     println!("\n\x1b[1mSaving configuration\x1b[0m");
@@ -349,5 +426,490 @@ fn prompt_with_default(prompt: &str, default: &str) -> io::Result<String> {
         Ok(default.to_string())
     } else {
         Ok(trimmed)
+    }
+}
+
+fn configure_builtin_executor(
+    config: &mut ArisConfig,
+    provider: &str,
+    key_label: &str,
+    base_url: Option<&str>,
+    default_model: &str,
+) -> io::Result<()> {
+    let preserve_existing = same_executor_slot(config, provider, base_url);
+    config.executor_provider = Some(provider.to_string());
+    config.executor_base_url = base_url.map(normalize_openai_base_url);
+
+    let current_key_masked = if preserve_existing {
+        mask_secret(config.executor_api_key.as_deref())
+    } else {
+        "(not set)".to_string()
+    };
+    let key_prompt = if current_key_masked == "(not set)" {
+        format!("  {key_label}")
+    } else {
+        format!("  {key_label} [{current_key_masked}]")
+    };
+    let new_key = prompt_with_default(&key_prompt, "")?;
+    apply_prompted_secret(&mut config.executor_api_key, preserve_existing, new_key);
+
+    config.executor_model = Some(default_model.to_string());
+    println!("  \x1b[2mModel: {default_model}\x1b[0m");
+    Ok(())
+}
+
+fn configure_builtin_reviewer(
+    config: &mut ArisConfig,
+    provider: &str,
+    key_env: &str,
+    key_label: &str,
+    default_model: &str,
+) -> io::Result<()> {
+    let preserve_existing = same_reviewer_slot(config, provider);
+    config.reviewer_provider = Some(provider.to_string());
+    config.reviewer_base_url = None;
+
+    let current_secret = if preserve_existing {
+        std::env::var(key_env)
+            .ok()
+            .or_else(|| config.reviewer_api_key.clone())
+    } else {
+        None
+    };
+    let current_masked = mask_secret(current_secret.as_deref());
+    let key_prompt = if current_masked == "(not set)" {
+        format!("  {key_label}")
+    } else {
+        format!("  {key_label} [{current_masked}]")
+    };
+    let new_key = prompt_with_default(&key_prompt, "")?;
+    apply_prompted_secret(&mut config.reviewer_api_key, preserve_existing, new_key);
+    if let Some(existing) = &config.reviewer_api_key {
+        std::env::set_var(key_env, existing);
+    }
+
+    config.reviewer_model = Some(default_model.to_string());
+    println!("  \x1b[2mModel: {default_model}\x1b[0m");
+    Ok(())
+}
+
+fn configure_custom_executor(config: &mut ArisConfig) -> io::Result<()> {
+    let preserve_existing = config.executor_provider.as_deref() == Some("custom");
+    loop {
+        config.executor_provider = Some("custom".to_string());
+
+        let current_key_masked = if preserve_existing {
+            mask_secret(config.executor_api_key.as_deref())
+        } else {
+            "(not set)".to_string()
+        };
+        let key_prompt = if current_key_masked == "(not set)" {
+            "  Custom API key".to_string()
+        } else {
+            format!("  Custom API key [{current_key_masked}]")
+        };
+        let new_key = prompt_with_default(&key_prompt, "")?;
+        apply_prompted_secret(&mut config.executor_api_key, preserve_existing, new_key);
+
+        let current_base_url = if preserve_existing {
+            config.executor_base_url.as_deref()
+        } else {
+            None
+        };
+        let base_prompt = match current_base_url {
+            Some(url) => format!("  Custom base URL [{url}]"),
+            None => "  Custom base URL".to_string(),
+        };
+        let base_default = current_base_url.unwrap_or("");
+        let new_base_url = prompt_with_default(&base_prompt, base_default)?;
+        apply_prompted_base_url(&mut config.executor_base_url, preserve_existing, new_base_url);
+
+        let Some(api_key) = config
+            .executor_api_key
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        else {
+            println!("  Error: Custom API key is required.");
+            continue;
+        };
+        let Some(base_url) = config
+            .executor_base_url
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        else {
+            println!("  Error: Custom base URL is required.");
+            continue;
+        };
+
+        match fetch_openai_models(base_url, api_key) {
+            Ok(models) => {
+                let current_model = config.executor_model.as_deref().unwrap_or("");
+                match select_model_from_list(
+                    "Select executor model",
+                    "Models fetched from the custom /models endpoint.",
+                    &models,
+                    current_model,
+                )? {
+                    Some(model) => {
+                        config.executor_model = Some(model.clone());
+                        println!("  \x1b[2mModel: {model}\x1b[0m");
+                        return Ok(());
+                    }
+                    None => println!(
+                        "  Model selection cancelled. Fetching the custom model list again."
+                    ),
+                }
+            }
+            Err(error) => {
+                println!("  Error fetching custom models: {error}");
+                println!("  Re-enter the custom API key or base URL and try again.");
+            }
+        }
+    }
+}
+
+fn configure_custom_reviewer(config: &mut ArisConfig) -> io::Result<()> {
+    let preserve_existing = config.reviewer_provider.as_deref() == Some("custom");
+    loop {
+        config.reviewer_provider = Some("custom".to_string());
+
+        let current_key_masked = if preserve_existing {
+            mask_secret(config.reviewer_api_key.as_deref())
+        } else {
+            "(not set)".to_string()
+        };
+        let key_prompt = if current_key_masked == "(not set)" {
+            "  Custom reviewer API key".to_string()
+        } else {
+            format!("  Custom reviewer API key [{current_key_masked}]")
+        };
+        let new_key = prompt_with_default(&key_prompt, "")?;
+        apply_prompted_secret(&mut config.reviewer_api_key, preserve_existing, new_key);
+
+        let current_base_url = if preserve_existing {
+            config.reviewer_base_url.as_deref()
+        } else {
+            None
+        };
+        let base_prompt = match current_base_url {
+            Some(url) => format!("  Custom reviewer base URL [{url}]"),
+            None => "  Custom reviewer base URL".to_string(),
+        };
+        let base_default = current_base_url.unwrap_or("");
+        let new_base_url = prompt_with_default(&base_prompt, base_default)?;
+        apply_prompted_base_url(&mut config.reviewer_base_url, preserve_existing, new_base_url);
+
+        let Some(api_key) = config
+            .reviewer_api_key
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        else {
+            println!("  Error: Custom reviewer API key is required.");
+            continue;
+        };
+        let Some(base_url) = config
+            .reviewer_base_url
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        else {
+            println!("  Error: Custom reviewer base URL is required.");
+            continue;
+        };
+
+        match fetch_openai_models(base_url, api_key) {
+            Ok(models) => {
+                let current_model = config.reviewer_model.as_deref().unwrap_or("");
+                match select_model_from_list(
+                    "Select reviewer model",
+                    "Models fetched from the custom reviewer /models endpoint.",
+                    &models,
+                    current_model,
+                )? {
+                    Some(model) => {
+                        config.reviewer_model = Some(model.clone());
+                        println!("  \x1b[2mModel: {model}\x1b[0m");
+                        return Ok(());
+                    }
+                    None => println!(
+                        "  Model selection cancelled. Fetching the custom model list again."
+                    ),
+                }
+            }
+            Err(error) => {
+                println!("  Error fetching custom reviewer models: {error}");
+                println!("  Re-enter the custom reviewer API key or base URL and try again.");
+            }
+        }
+    }
+}
+
+fn select_model_from_list(
+    title: &str,
+    subtitle: &str,
+    models: &[crate::openai_compat::OpenAIModelInfo],
+    current_model: &str,
+) -> io::Result<Option<String>> {
+    let items = model_select_items(models, current_model);
+    match input::select_menu(title, subtitle, &items)? {
+        Some(index) => Ok(Some(items[index].label.clone())),
+        None => Ok(None),
+    }
+}
+
+fn mask_secret(value: Option<&str>) -> String {
+    value
+        .filter(|secret| secret.len() > 8)
+        .map(|secret| format!("{}...{}", &secret[..4], &secret[secret.len() - 4..]))
+        .unwrap_or_else(|| "(not set)".to_string())
+}
+
+fn apply_prompted_secret(existing: &mut Option<String>, preserve_existing: bool, new_value: String) {
+    if new_value.is_empty() {
+        if !preserve_existing {
+            *existing = None;
+        }
+    } else {
+        *existing = Some(new_value);
+    }
+}
+
+fn apply_prompted_base_url(existing: &mut Option<String>, preserve_existing: bool, new_value: String) {
+    if new_value.is_empty() {
+        if !preserve_existing {
+            *existing = None;
+        }
+    } else {
+        *existing = Some(normalize_openai_base_url(&new_value));
+    }
+}
+
+fn same_executor_slot(config: &ArisConfig, provider: &str, base_url: Option<&str>) -> bool {
+    match (config.executor_provider.as_deref(), provider) {
+        (Some("anthropic"), "anthropic") => true,
+        (Some("custom"), "custom") => true,
+        (Some("openai"), "openai") => config.executor_base_url.as_deref().map(normalize_openai_base_url)
+            == base_url.map(normalize_openai_base_url),
+        _ => false,
+    }
+}
+
+fn same_reviewer_slot(config: &ArisConfig, provider: &str) -> bool {
+    config.reviewer_provider.as_deref() == Some(provider)
+}
+
+fn reviewer_env_present() -> bool {
+    [
+        "ARIS_REVIEWER_DISABLED",
+        "ARIS_REVIEWER_PROVIDER",
+        "ARIS_REVIEWER_API_KEY",
+        "ARIS_REVIEWER_BASE_URL",
+        "ARIS_REVIEWER_MODEL",
+    ]
+    .into_iter()
+    .any(|name| std::env::var(name).ok().is_some_and(|value| !value.is_empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, OnceLock};
+
+    use super::{
+        apply_prompted_secret, same_executor_slot, same_reviewer_slot, ArisConfig,
+    };
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn config_round_trip_preserves_reviewer_base_url() {
+        let config = ArisConfig {
+            reviewer_provider: Some("custom".to_string()),
+            reviewer_api_key: Some("rk-test-123456789".to_string()),
+            reviewer_base_url: Some("https://example.com/v1".to_string()),
+            reviewer_model: Some("custom-model".to_string()),
+            ..ArisConfig::default()
+        };
+
+        let json = serde_json::to_string(&config).expect("serialize config");
+        let decoded: ArisConfig = serde_json::from_str(&json).expect("deserialize config");
+        assert_eq!(
+            decoded.reviewer_base_url.as_deref(),
+            Some("https://example.com/v1")
+        );
+    }
+
+    #[test]
+    fn force_apply_to_env_sets_custom_reviewer_envs() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::remove_var("ARIS_REVIEWER_PROVIDER");
+        std::env::remove_var("ARIS_REVIEWER_API_KEY");
+        std::env::remove_var("ARIS_REVIEWER_BASE_URL");
+        std::env::remove_var("ARIS_REVIEWER_DISABLED");
+
+        let config = ArisConfig {
+            reviewer_provider: Some("custom".to_string()),
+            reviewer_api_key: Some("rk-test-123456789".to_string()),
+            reviewer_base_url: Some("https://example.com/v1/chat/completions".to_string()),
+            reviewer_model: Some("custom-reviewer".to_string()),
+            ..ArisConfig::default()
+        };
+
+        config.force_apply_to_env();
+
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_PROVIDER").as_deref(),
+            Ok("custom")
+        );
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_API_KEY").as_deref(),
+            Ok("rk-test-123456789")
+        );
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_BASE_URL").as_deref(),
+            Ok("https://example.com/v1")
+        );
+    }
+
+    #[test]
+    fn force_apply_to_env_clears_custom_reviewer_envs_for_builtin_provider() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::set_var("ARIS_REVIEWER_PROVIDER", "custom");
+        std::env::set_var("ARIS_REVIEWER_API_KEY", "stale-key");
+        std::env::set_var("ARIS_REVIEWER_BASE_URL", "https://stale.example/v1");
+        std::env::set_var("ARIS_REVIEWER_DISABLED", "1");
+
+        let config = ArisConfig {
+            reviewer_provider: Some("openai".to_string()),
+            reviewer_api_key: Some("rk-openai-123456789".to_string()),
+            reviewer_model: Some("gpt-5.4".to_string()),
+            ..ArisConfig::default()
+        };
+
+        config.force_apply_to_env();
+
+        assert!(std::env::var("ARIS_REVIEWER_PROVIDER").is_err());
+        assert!(std::env::var("ARIS_REVIEWER_API_KEY").is_err());
+        assert!(std::env::var("ARIS_REVIEWER_BASE_URL").is_err());
+        assert!(std::env::var("ARIS_REVIEWER_DISABLED").is_err());
+    }
+
+    #[test]
+    fn force_apply_to_env_clears_executor_provider_when_switching_to_anthropic() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::set_var("EXECUTOR_PROVIDER", "custom");
+        std::env::set_var("EXECUTOR_API_KEY", "stale-executor-key");
+        std::env::set_var("EXECUTOR_BASE_URL", "https://old.example/v1");
+
+        let config = ArisConfig {
+            executor_provider: Some("anthropic".to_string()),
+            executor_api_key: Some("sk-ant-test".to_string()),
+            ..ArisConfig::default()
+        };
+
+        config.force_apply_to_env();
+
+        assert!(std::env::var("EXECUTOR_PROVIDER").is_err());
+        assert!(std::env::var("EXECUTOR_API_KEY").is_err());
+        assert!(std::env::var("EXECUTOR_BASE_URL").is_err());
+    }
+
+    #[test]
+    fn force_apply_to_env_marks_reviewer_as_disabled_for_skip() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::remove_var("ARIS_REVIEWER_DISABLED");
+        std::env::remove_var("ARIS_REVIEWER_MODEL");
+
+        let config = ArisConfig {
+            reviewer_provider: Some("none".to_string()),
+            ..ArisConfig::default()
+        };
+
+        config.force_apply_to_env();
+
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_DISABLED").as_deref(),
+            Ok("1")
+        );
+        assert!(std::env::var("ARIS_REVIEWER_MODEL").is_err());
+    }
+
+    #[test]
+    fn force_apply_to_env_clears_stale_executor_key_when_config_key_is_missing() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::set_var("EXECUTOR_API_KEY", "stale-executor-key");
+
+        let config = ArisConfig {
+            executor_provider: Some("custom".to_string()),
+            executor_base_url: Some("https://custom.example/v1".to_string()),
+            executor_api_key: None,
+            ..ArisConfig::default()
+        };
+
+        config.force_apply_to_env();
+
+        assert_eq!(std::env::var("EXECUTOR_PROVIDER").as_deref(), Ok("custom"));
+        assert_eq!(
+            std::env::var("EXECUTOR_BASE_URL").as_deref(),
+            Ok("https://custom.example/v1")
+        );
+        assert!(std::env::var("EXECUTOR_API_KEY").is_err());
+    }
+
+    #[test]
+    fn apply_to_env_marks_reviewer_as_disabled_even_with_openai_key_present() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::remove_var("ARIS_REVIEWER_DISABLED");
+        std::env::remove_var("ARIS_REVIEWER_PROVIDER");
+        std::env::remove_var("ARIS_REVIEWER_API_KEY");
+        std::env::remove_var("ARIS_REVIEWER_BASE_URL");
+        std::env::remove_var("ARIS_REVIEWER_MODEL");
+        std::env::set_var("OPENAI_API_KEY", "sk-openai-test");
+
+        let config = ArisConfig {
+            reviewer_provider: Some("none".to_string()),
+            ..ArisConfig::default()
+        };
+
+        config.apply_to_env();
+
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_DISABLED").as_deref(),
+            Ok("1")
+        );
+
+        std::env::remove_var("OPENAI_API_KEY");
+        std::env::remove_var("ARIS_REVIEWER_DISABLED");
+    }
+
+    #[test]
+    fn prompted_secret_clears_when_switching_provider_and_pressing_enter() {
+        let mut secret = Some("stale-key".to_string());
+        apply_prompted_secret(&mut secret, false, String::new());
+        assert_eq!(secret, None);
+    }
+
+    #[test]
+    fn same_slot_helpers_only_preserve_matching_provider_configuration() {
+        let config = ArisConfig {
+            executor_provider: Some("openai".to_string()),
+            executor_base_url: Some("https://api.moonshot.cn/v1".to_string()),
+            reviewer_provider: Some("gemini".to_string()),
+            ..ArisConfig::default()
+        };
+
+        assert!(same_executor_slot(
+            &config,
+            "openai",
+            Some("https://api.moonshot.cn/v1/")
+        ));
+        assert!(!same_executor_slot(
+            &config,
+            "openai",
+            Some("https://api.openai.com/v1")
+        ));
+        assert!(same_reviewer_slot(&config, "gemini"));
+        assert!(!same_reviewer_slot(&config, "openai"));
     }
 }

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -3,6 +3,7 @@ mod init;
 mod input;
 mod memories;
 mod meta_optimize;
+mod openai_compat;
 mod openai_executor;
 mod render;
 
@@ -26,6 +27,9 @@ use commands::{
 };
 use compat_harness::{extract_manifest, UpstreamPaths};
 use init::initialize_repo;
+use openai_compat::{
+    fetch_openai_models, is_openai_compat_provider, model_select_items, openai_provider_label,
+};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
     clear_oauth_credentials, generate_pkce_pair, generate_state, load_system_prompt,
@@ -79,11 +83,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // For REPL and Prompt modes: if no executor API key is available, run setup first
     let needs_api_key = matches!(action, CliAction::Repl { .. } | CliAction::Prompt { .. });
-    if needs_api_key
-        && std::env::var("ANTHROPIC_API_KEY").is_err()
-        && std::env::var("EXECUTOR_API_KEY").is_err()
-        && std::env::var("ANTHROPIC_AUTH_TOKEN").is_err()
-    {
+    if needs_api_key && !has_executor_credentials() {
         println!("\x1b[1;33mNo API key found.\x1b[0m Let's set up ARIS first.\n");
         let new_config = config::run_interactive_setup()?;
         new_config.apply_to_env();
@@ -337,7 +337,7 @@ fn resolve_model_alias(model: &str) -> &str {
     // When using OpenAI-compat executor, don't map to Claude model IDs
     if std::env::var("EXECUTOR_PROVIDER")
         .ok()
-        .is_some_and(|p| p == "openai")
+        .is_some_and(|p| is_openai_compat_provider(&p))
     {
         return model;
     }
@@ -346,6 +346,94 @@ fn resolve_model_alias(model: &str) -> &str {
         "sonnet" => "claude-sonnet-4-6",
         "haiku" => "claude-haiku-4-5-20251001",
         _ => model,
+    }
+}
+
+fn current_custom_executor_config() -> Option<(String, String)> {
+    if std::env::var("EXECUTOR_PROVIDER").ok().as_deref() != Some("custom") {
+        return None;
+    }
+
+    let api_key = std::env::var("EXECUTOR_API_KEY")
+        .or_else(|_| std::env::var("OPENAI_API_KEY"))
+        .ok()
+        .filter(|value| !value.is_empty())?;
+    let base_url = std::env::var("EXECUTOR_BASE_URL")
+        .ok()
+        .filter(|value| !value.is_empty())?;
+    Some((api_key, base_url))
+}
+
+fn current_custom_reviewer_config() -> Option<(String, String)> {
+    if std::env::var("ARIS_REVIEWER_PROVIDER").ok().as_deref() != Some("custom") {
+        return None;
+    }
+
+    let api_key = std::env::var("ARIS_REVIEWER_API_KEY")
+        .ok()
+        .filter(|value| !value.is_empty())?;
+    let base_url = std::env::var("ARIS_REVIEWER_BASE_URL")
+        .ok()
+        .filter(|value| !value.is_empty())?;
+    Some((api_key, base_url))
+}
+
+fn reviewer_is_disabled() -> bool {
+    std::env::var("ARIS_REVIEWER_DISABLED").ok().as_deref() == Some("1")
+}
+
+fn env_var_present(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .is_some_and(|value| !value.is_empty())
+}
+
+fn executor_uses_openai_compat() -> bool {
+    std::env::var("EXECUTOR_PROVIDER")
+        .ok()
+        .as_deref()
+        .is_some_and(is_openai_compat_provider)
+}
+
+fn reviewer_provider_label(model: &str) -> &'static str {
+    if reviewer_is_disabled() {
+        return "Disabled";
+    }
+    if std::env::var("ARIS_REVIEWER_PROVIDER").ok().as_deref() == Some("custom") {
+        return "Custom OpenAI-compatible";
+    }
+    if model.contains("gemini") {
+        "Gemini"
+    } else if model.contains("glm") || model.contains("GLM") {
+        "GLM"
+    } else if model.starts_with("MiniMax") || model.starts_with("minimax") {
+        "MiniMax"
+    } else if model.contains("kimi") || model.contains("moonshot") {
+        "Kimi"
+    } else {
+        "OpenAI"
+    }
+}
+
+fn select_model_from_custom_endpoint(
+    title: &str,
+    subtitle: &str,
+    api_key: &str,
+    base_url: &str,
+    current_model: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let models = fetch_openai_models(base_url, api_key).map_err(io::Error::other)?;
+    let items = model_select_items(&models, current_model);
+    Ok(input::select_menu(title, subtitle, &items)?.map(|index| items[index].label.clone()))
+}
+
+fn has_executor_credentials() -> bool {
+    if executor_uses_openai_compat() {
+        openai_executor::resolve_openai_executor_config().is_some()
+    } else {
+        env_var_present("ANTHROPIC_API_KEY")
+            || env_var_present("ANTHROPIC_AUTH_TOKEN")
+            || openai_executor::resolve_openai_executor_config().is_some()
     }
 }
 
@@ -996,7 +1084,10 @@ fn run_repl(
     permission_mode: PermissionMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode)?;
-    let mut editor = input::LineEditor::new("\x1b[38;5;74m❯\x1b[0m ", slash_command_completion_candidates());
+    let mut editor = input::LineEditor::new(
+        "\x1b[38;5;74m❯\x1b[0m ",
+        slash_command_completion_candidates(),
+    );
     println!("{}", cli.startup_banner());
 
     loop {
@@ -1018,7 +1109,9 @@ fn run_repl(
                 }
                 editor.push_history(input);
                 // Visual separator before assistant response
-                let term_w = crossterm::terminal::size().map(|(w, _)| w as usize).unwrap_or(80);
+                let term_w = crossterm::terminal::size()
+                    .map(|(w, _)| w as usize)
+                    .unwrap_or(80);
                 let sep = "─".repeat(term_w.min(80));
                 println!("\x1b[38;5;240m{sep}\x1b[0m");
                 cli.run_turn(&trimmed)?;
@@ -1081,13 +1174,21 @@ impl LiveCli {
             .ok()
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| {
-                if std::env::var("GEMINI_API_KEY").is_ok() {
+                if reviewer_is_disabled() {
+                    "disabled".to_string()
+                } else if std::env::var("ARIS_REVIEWER_PROVIDER").ok().as_deref() == Some("custom") {
+                    "custom-reviewer".to_string()
+                } else if env_var_present("GEMINI_API_KEY") {
                     "gemini-2.5-pro".to_string()
                 } else {
                     "gpt-5.4".to_string()
                 }
             });
-        std::env::set_var("ARIS_REVIEWER_MODEL", &reviewer_model);
+        if reviewer_is_disabled() {
+            std::env::remove_var("ARIS_REVIEWER_MODEL");
+        } else {
+            std::env::set_var("ARIS_REVIEWER_MODEL", &reviewer_model);
+        }
         let cli = Self {
             model,
             reviewer_model,
@@ -1211,36 +1312,35 @@ impl LiveCli {
         }
 
         let executor_label = if openai_executor::resolve_openai_executor_config().is_some() {
+            let provider = std::env::var("EXECUTOR_PROVIDER").ok();
             let base = std::env::var("EXECUTOR_BASE_URL").unwrap_or_default();
-            if base.contains("deepseek") {
-                "DeepSeek"
-            } else if base.contains("bigmodel") {
-                "GLM"
-            } else if base.contains("minimax") {
-                "MiniMax"
-            } else if base.contains("moonshot") {
-                "Moonshot"
-            } else if base.contains("dashscope") || base.contains("qwen") {
-                "Qwen"
-            } else if base.contains("generativelanguage.googleapis") {
-                "Gemini"
-            } else {
-                "OpenAI"
-            }
+            openai_provider_label(provider.as_deref(), &base)
         } else {
             "Anthropic"
         };
+        let reviewer_label = reviewer_provider_label(&self.reviewer_model);
 
         let info_lines = [
-            format!("\x1b[2mExecutor\x1b[0m     {executor_label} · {}", self.model),
-            format!("\x1b[2mReviewer\x1b[0m     {}", self.reviewer_model),
-            format!("\x1b[2mPermissions\x1b[0m  {}", self.permission_mode.as_str()),
+            format!(
+                "\x1b[2mExecutor\x1b[0m     {executor_label} · {}",
+                self.model
+            ),
+            format!(
+                "\x1b[2mReviewer\x1b[0m     {reviewer_label} · {}",
+                self.reviewer_model
+            ),
+            format!(
+                "\x1b[2mPermissions\x1b[0m  {}",
+                self.permission_mode.as_str()
+            ),
             format!("\x1b[2mDirectory\x1b[0m    {cwd}"),
             format!("\x1b[2mSession\x1b[0m      {}", self.session.id),
         ];
 
         // Box drawing
-        let term_w = crossterm::terminal::size().map(|(w, _)| w as usize).unwrap_or(80);
+        let term_w = crossterm::terminal::size()
+            .map(|(w, _)| w as usize)
+            .unwrap_or(80);
         let box_w = term_w.min(76);
         let hr = "─".repeat(box_w.saturating_sub(2));
         let dim = "\x1b[38;5;240m";
@@ -1248,7 +1348,10 @@ impl LiveCli {
 
         let mut banner = String::new();
         // Top border with title
-        banner.push_str(&format!("{dim}╭─ {reset}ARIS-Code v{VERSION}{dim} {hr}{reset}\n", hr = "─".repeat(box_w.saturating_sub(18 + VERSION.len()))));
+        banner.push_str(&format!(
+            "{dim}╭─ {reset}ARIS-Code v{VERSION}{dim} {hr}{reset}\n",
+            hr = "─".repeat(box_w.saturating_sub(18 + VERSION.len()))
+        ));
         // Sprite lines
         for line in &sprite_lines {
             banner.push_str(&format!("{dim}│{reset} {line}\n"));
@@ -1513,45 +1616,72 @@ impl LiveCli {
             Some(m) => resolve_model_alias(&m).to_string(),
             None => {
                 // Show interactive menu
-                let is_openai = openai_executor::resolve_openai_executor_config().is_some();
-                let items: Vec<input::SelectItem> = if is_openai {
-                    // OpenAI-compat mode: show common models
-                    vec![
-                        ("gpt-5.4", "OpenAI · Best intelligence at scale"),
-                        ("gpt-5.4-mini", "OpenAI · Strong mini model"),
-                        ("gpt-5.4-nano", "OpenAI · Cheapest, high-volume"),
-                        ("gemini-2.5-pro", "Google · Most capable Gemini"),
-                        ("gemini-2.5-flash", "Google · Fast Gemini"),
-                        ("GLM-5", "Zhipu · GLM 5 latest"),
-                        ("MiniMax-M2.7", "MiniMax · M2.7 latest"),
-                        ("kimi-k2.5", "Kimi · K2.5 reasoning"),
-                    ]
-                    .into_iter()
-                    .map(|(name, desc)| input::SelectItem {
-                        label: name.to_string(),
-                        description: desc.to_string(),
-                        is_current: self.model == name,
-                    })
-                    .collect()
+                if let Some((api_key, base_url)) = current_custom_executor_config() {
+                    match select_model_from_custom_endpoint(
+                        "Select executor model",
+                        "Switch the model used for the main conversation. Models are fetched from the custom /models endpoint.",
+                        &api_key,
+                        &base_url,
+                        &self.model,
+                    ) {
+                        Ok(Some(model)) => model,
+                        Ok(None) => return Ok(false),
+                        Err(error) => {
+                            println!("Failed to fetch custom executor models: {error}");
+                            return Ok(false);
+                        }
+                    }
                 } else {
-                    // Anthropic mode
-                    vec![
-                        ("claude-opus-4-6", "Opus 4.6 · Most capable for complex work"),
-                        ("claude-sonnet-4-6", "Sonnet 4.6 · Best for everyday tasks"),
-                        ("claude-haiku-4-5-20251001", "Haiku 4.5 · Fastest for quick answers"),
-                    ]
-                    .into_iter()
-                    .map(|(name, desc)| input::SelectItem {
-                        label: name.to_string(),
-                        description: desc.to_string(),
-                        is_current: self.model == name,
-                    })
-                    .collect()
-                };
+                    let is_openai = openai_executor::resolve_openai_executor_config().is_some();
+                    let items: Vec<input::SelectItem> = if is_openai {
+                        // OpenAI-compat mode: show common models
+                        vec![
+                            ("gpt-5.4", "OpenAI · Best intelligence at scale"),
+                            ("gpt-5.4-mini", "OpenAI · Strong mini model"),
+                            ("gpt-5.4-nano", "OpenAI · Cheapest, high-volume"),
+                            ("gemini-2.5-pro", "Google · Most capable Gemini"),
+                            ("gemini-2.5-flash", "Google · Fast Gemini"),
+                            ("GLM-5", "Zhipu · GLM 5 latest"),
+                            ("MiniMax-M2.7", "MiniMax · M2.7 latest"),
+                            ("kimi-k2.5", "Kimi · K2.5 reasoning"),
+                        ]
+                        .into_iter()
+                        .map(|(name, desc)| input::SelectItem {
+                            label: name.to_string(),
+                            description: desc.to_string(),
+                            is_current: self.model == name,
+                        })
+                        .collect()
+                    } else {
+                        // Anthropic mode
+                        vec![
+                            (
+                                "claude-opus-4-6",
+                                "Opus 4.6 · Most capable for complex work",
+                            ),
+                            ("claude-sonnet-4-6", "Sonnet 4.6 · Best for everyday tasks"),
+                            (
+                                "claude-haiku-4-5-20251001",
+                                "Haiku 4.5 · Fastest for quick answers",
+                            ),
+                        ]
+                        .into_iter()
+                        .map(|(name, desc)| input::SelectItem {
+                            label: name.to_string(),
+                            description: desc.to_string(),
+                            is_current: self.model == name,
+                        })
+                        .collect()
+                    };
 
-                match input::select_menu("Select executor model", "Switch the model used for the main conversation.", &items)? {
-                    Some(idx) => items[idx].label.clone(),
-                    None => return Ok(false),
+                    match input::select_menu(
+                        "Select executor model",
+                        "Switch the model used for the main conversation.",
+                        &items,
+                    )? {
+                        Some(idx) => items[idx].label.clone(),
+                        None => return Ok(false),
+                    }
                 }
             }
         };
@@ -1592,86 +1722,108 @@ impl LiveCli {
         let model = match model {
             Some(m) => m,
             None => {
-                let has_gemini = std::env::var("GEMINI_API_KEY").is_ok();
-                let has_openai = std::env::var("OPENAI_API_KEY").is_ok();
+                if let Some((api_key, base_url)) = current_custom_reviewer_config() {
+                    match select_model_from_custom_endpoint(
+                        "Select reviewer model",
+                        "Switch the model used by LlmReview. Models are fetched from the custom reviewer /models endpoint.",
+                        &api_key,
+                        &base_url,
+                        &self.reviewer_model,
+                    ) {
+                        Ok(Some(model)) => model,
+                        Ok(None) => return Ok(false),
+                        Err(error) => {
+                            println!("Failed to fetch custom reviewer models: {error}");
+                            return Ok(false);
+                        }
+                    }
+                } else {
+                    let has_gemini = env_var_present("GEMINI_API_KEY");
+                    let has_openai = env_var_present("OPENAI_API_KEY");
 
-                let mut items: Vec<input::SelectItem> = Vec::new();
-                if has_gemini {
-                    for (name, desc) in [
-                        ("gemini-2.5-pro", "Google · Most capable, deep reasoning"),
-                        ("gemini-2.5-flash", "Google · Fast and efficient"),
-                        ("gemini-2.0-flash-001", "Google · Previous gen fast model"),
-                    ] {
-                        items.push(input::SelectItem {
-                            label: name.to_string(),
-                            description: desc.to_string(),
-                            is_current: self.reviewer_model == name,
-                        });
+                    let mut items: Vec<input::SelectItem> = Vec::new();
+                    if has_gemini {
+                        for (name, desc) in [
+                            ("gemini-2.5-pro", "Google · Most capable, deep reasoning"),
+                            ("gemini-2.5-flash", "Google · Fast and efficient"),
+                            ("gemini-2.0-flash-001", "Google · Previous gen fast model"),
+                        ] {
+                            items.push(input::SelectItem {
+                                label: name.to_string(),
+                                description: desc.to_string(),
+                                is_current: self.reviewer_model == name,
+                            });
+                        }
                     }
-                }
-                // GLM models
-                if std::env::var("GLM_API_KEY").is_ok() {
-                    for (name, desc) in [
-                        ("GLM-5", "Zhipu · Most capable"),
-                        ("GLM-5-Turbo", "Zhipu · Fast"),
-                        ("GLM-4.7", "Zhipu · Previous gen"),
-                    ] {
-                        items.push(input::SelectItem {
-                            label: name.to_string(),
-                            description: desc.to_string(),
-                            is_current: self.reviewer_model == name,
-                        });
+                    // GLM models
+                    if env_var_present("GLM_API_KEY") {
+                        for (name, desc) in [
+                            ("GLM-5", "Zhipu · Most capable"),
+                            ("GLM-5-Turbo", "Zhipu · Fast"),
+                            ("GLM-4.7", "Zhipu · Previous gen"),
+                        ] {
+                            items.push(input::SelectItem {
+                                label: name.to_string(),
+                                description: desc.to_string(),
+                                is_current: self.reviewer_model == name,
+                            });
+                        }
                     }
-                }
-                // MiniMax models
-                if std::env::var("MINIMAX_API_KEY").is_ok() {
-                    for (name, desc) in [
-                        ("MiniMax-M2.7", "MiniMax · Latest, recursive self-improvement"),
-                        ("MiniMax-M2.7-highspeed", "MiniMax · Fast inference"),
-                        ("MiniMax-M2.5", "MiniMax · Code generation"),
-                    ] {
-                        items.push(input::SelectItem {
-                            label: name.to_string(),
-                            description: desc.to_string(),
-                            is_current: self.reviewer_model == name,
-                        });
+                    // MiniMax models
+                    if env_var_present("MINIMAX_API_KEY") {
+                        for (name, desc) in [
+                            (
+                                "MiniMax-M2.7",
+                                "MiniMax · Latest, recursive self-improvement",
+                            ),
+                            ("MiniMax-M2.7-highspeed", "MiniMax · Fast inference"),
+                            ("MiniMax-M2.5", "MiniMax · Code generation"),
+                        ] {
+                            items.push(input::SelectItem {
+                                label: name.to_string(),
+                                description: desc.to_string(),
+                                is_current: self.reviewer_model == name,
+                            });
+                        }
                     }
-                }
-                // Kimi models
-                if std::env::var("KIMI_API_KEY").is_ok() {
-                    for (name, desc) in [
-                        ("kimi-k2.5", "Kimi · K2.5 reasoning"),
-                    ] {
-                        items.push(input::SelectItem {
-                            label: name.to_string(),
-                            description: desc.to_string(),
-                            is_current: self.reviewer_model == name,
-                        });
+                    // Kimi models
+                    if env_var_present("KIMI_API_KEY") {
+                        for (name, desc) in [("kimi-k2.5", "Kimi · K2.5 reasoning")] {
+                            items.push(input::SelectItem {
+                                label: name.to_string(),
+                                description: desc.to_string(),
+                                is_current: self.reviewer_model == name,
+                            });
+                        }
                     }
-                }
-                if has_openai {
-                    for (name, desc) in [
-                        ("gpt-5.4", "OpenAI · Best intelligence for reviews"),
-                        ("gpt-5.4-mini", "OpenAI · Strong and affordable"),
-                        ("gpt-5.4-nano", "OpenAI · Cheapest, high-volume"),
-                        ("gpt-4o", "OpenAI · Previous gen, stable"),
-                    ] {
-                        items.push(input::SelectItem {
-                            label: name.to_string(),
-                            description: desc.to_string(),
-                            is_current: self.reviewer_model == name,
-                        });
+                    if has_openai {
+                        for (name, desc) in [
+                            ("gpt-5.4", "OpenAI · Best intelligence for reviews"),
+                            ("gpt-5.4-mini", "OpenAI · Strong and affordable"),
+                            ("gpt-5.4-nano", "OpenAI · Cheapest, high-volume"),
+                            ("gpt-4o", "OpenAI · Previous gen, stable"),
+                        ] {
+                            items.push(input::SelectItem {
+                                label: name.to_string(),
+                                description: desc.to_string(),
+                                is_current: self.reviewer_model == name,
+                            });
+                        }
                     }
-                }
 
-                if items.is_empty() {
-                    println!("No reviewer API key found. Set GEMINI_API_KEY or OPENAI_API_KEY.");
-                    return Ok(false);
-                }
+                    if items.is_empty() {
+                        println!("No reviewer configuration found. Run /setup or set a reviewer API key.");
+                        return Ok(false);
+                    }
 
-                match input::select_menu("Select reviewer model", "Switch the model used by LlmReview for external reviews.", &items)? {
-                    Some(idx) => items[idx].label.clone(),
-                    None => return Ok(false),
+                    match input::select_menu(
+                        "Select reviewer model",
+                        "Switch the model used by LlmReview for external reviews.",
+                        &items,
+                    )? {
+                        Some(idx) => items[idx].label.clone(),
+                        None => return Ok(false),
+                    }
                 }
             }
         };
@@ -1679,7 +1831,8 @@ impl LiveCli {
         let previous = self.reviewer_model.clone();
         self.reviewer_model.clone_from(&model);
 
-        // Update the REVIEWER_MODEL env var so LlmReview picks it up
+        // Update the reviewer env var so LlmReview picks it up
+        std::env::remove_var("ARIS_REVIEWER_DISABLED");
         std::env::set_var("ARIS_REVIEWER_MODEL", &model);
 
         println!(
@@ -1692,29 +1845,34 @@ impl LiveCli {
         let new_config = config::run_interactive_setup()?;
         new_config.force_apply_to_env();
 
-        // Update model if config changed it
-        if let Some(new_model) = new_config.executor_model() {
-            let new_model = resolve_model_alias(new_model).to_string();
-            if new_model != self.model {
-                let previous = self.model.clone();
-                let session = self.runtime.session().clone();
-                self.runtime = build_runtime(
-                    session,
-                    new_model.clone(),
-                    self.system_prompt.clone(),
-                    true,
-                    true,
-                    self.allowed_tools.clone(),
-                    self.permission_mode,
-                )?;
-                self.model.clone_from(&new_model);
-                println!("  Executor model: {previous} → \x1b[1;32m{new_model}\x1b[0m");
-            }
+        let previous = self.model.clone();
+        let new_model = new_config
+            .executor_model()
+            .map(resolve_model_alias)
+            .unwrap_or(previous.as_str())
+            .to_string();
+        let session = self.runtime.session().clone();
+        self.runtime = build_runtime(
+            session,
+            new_model.clone(),
+            self.system_prompt.clone(),
+            true,
+            true,
+            self.allowed_tools.clone(),
+            self.permission_mode,
+        )?;
+        self.model.clone_from(&new_model);
+        if new_model != previous {
+            println!("  Executor model: {previous} → \x1b[1;32m{new_model}\x1b[0m");
+        } else {
+            println!("  Executor configuration refreshed for the current session.");
         }
 
         // Update reviewer model
         if let Some(new_reviewer) = &new_config.reviewer_model {
             self.reviewer_model.clone_from(new_reviewer);
+        } else if reviewer_is_disabled() {
+            self.reviewer_model = "disabled".to_string();
         }
 
         Ok(true)
@@ -1740,8 +1898,12 @@ impl LiveCli {
                         } else {
                             println!("\x1b[1mTasks\x1b[0m\n");
                             for todo in &todos {
-                                let status = todo.get("status").and_then(|s| s.as_str()).unwrap_or("pending");
-                                let content_text = todo.get("content").and_then(|c| c.as_str()).unwrap_or("?");
+                                let status = todo
+                                    .get("status")
+                                    .and_then(|s| s.as_str())
+                                    .unwrap_or("pending");
+                                let content_text =
+                                    todo.get("content").and_then(|c| c.as_str()).unwrap_or("?");
                                 let icon = match status {
                                     "completed" => "\x1b[1;32m✓\x1b[0m",
                                     "in_progress" => "\x1b[1;33m●\x1b[0m",
@@ -1846,7 +2008,10 @@ impl LiveCli {
             None => {
                 let items: Vec<input::SelectItem> = vec![
                     ("read-only", "Safe · Read files only, no writes or commands"),
-                    ("workspace-write", "Normal · Read + write files in workspace"),
+                    (
+                        "workspace-write",
+                        "Normal · Read + write files in workspace",
+                    ),
                     ("danger-full-access", "Full · All tools, no restrictions"),
                 ]
                 .into_iter()
@@ -2943,7 +3108,8 @@ fn build_system_prompt(model_id: Option<&str>) -> Result<Vec<String>, Box<dyn st
     prompt.push(
         "IMPORTANT: When a skill instructs you to use `mcp__codex__codex` or `mcp__codex__codex-reply` \
          for external LLM review, use the `LlmReview` tool instead. The LlmReview tool calls \
-         Gemini or OpenAI directly (via GEMINI_API_KEY or OPENAI_API_KEY) without needing MCP. \
+         the configured reviewer directly, including Gemini, OpenAI, GLM, MiniMax, Kimi, \
+         or a custom OpenAI-compatible endpoint, without needing MCP. \
          Pass the full review prompt as the `prompt` parameter to LlmReview."
             .to_string(),
     );
@@ -2988,11 +3154,17 @@ fn build_system_prompt(model_id: Option<&str>) -> Result<Vec<String>, Box<dyn st
         if let Ok(content) = fs::read_to_string(&tasks_path) {
             if let Ok(todos) = serde_json::from_str::<Vec<serde_json::Value>>(&content) {
                 if !todos.is_empty() {
-                    let summary: Vec<String> = todos.iter().map(|t| {
-                        let status = t.get("status").and_then(|s| s.as_str()).unwrap_or("pending");
-                        let text = t.get("content").and_then(|c| c.as_str()).unwrap_or("?");
-                        format!("- [{status}] {text}")
-                    }).collect();
+                    let summary: Vec<String> = todos
+                        .iter()
+                        .map(|t| {
+                            let status = t
+                                .get("status")
+                                .and_then(|s| s.as_str())
+                                .unwrap_or("pending");
+                            let text = t.get("content").and_then(|c| c.as_str()).unwrap_or("?");
+                            format!("- [{status}] {text}")
+                        })
+                        .collect();
                     prompt.push(format!(
                         "# ARIS Task List\n\
                          Current tasks:\n{}\n\n\
@@ -3025,10 +3197,12 @@ fn aris_tasks_path() -> PathBuf {
 /// Ensure TodoWrite uses ARIS tasks path.
 fn init_aris_tasks_env() {
     if env::var("CLAWD_TODO_STORE").is_err() {
-        env::set_var("CLAWD_TODO_STORE", aris_tasks_path().to_string_lossy().as_ref());
+        env::set_var(
+            "CLAWD_TODO_STORE",
+            aris_tasks_path().to_string_lossy().as_ref(),
+        );
     }
 }
-
 
 fn build_runtime_feature_config(
 ) -> Result<runtime::RuntimeFeatureConfig, Box<dyn std::error::Error>> {
@@ -3064,6 +3238,12 @@ fn build_runtime(
                 emit_output,
                 allowed_tools.clone(),
             )?)
+        } else if executor_uses_openai_compat() {
+            let provider = std::env::var("EXECUTOR_PROVIDER").unwrap_or_else(|_| "openai".into());
+            return Err(io::Error::other(format!(
+                "executor provider '{provider}' requires EXECUTOR_API_KEY or OPENAI_API_KEY"
+            ))
+            .into());
         } else {
             ExecutorClient::Anthropic(AnthropicRuntimeClient::new(
                 model,
@@ -3327,7 +3507,12 @@ impl ApiClient for AnthropicRuntimeClient {
                         events.push(AssistantEvent::MessageStop);
                     }
                     ApiStreamEvent::Error(e) => {
-                        let msg = e.error.get("message").and_then(|v| v.as_str()).unwrap_or("stream error").to_string();
+                        let msg = e
+                            .error
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("stream error")
+                            .to_string();
                         return Err(RuntimeError::new(msg));
                     }
                 }
@@ -3507,9 +3692,7 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
         _ => summarize_tool_payload(input),
     };
 
-    format!(
-        "\x1b[38;5;74m●\x1b[0m \x1b[1m{name}\x1b[0m\x1b[38;5;245m({detail})\x1b[0m"
-    )
+    format!("\x1b[38;5;74m●\x1b[0m \x1b[1m{name}\x1b[0m\x1b[38;5;245m({detail})\x1b[0m")
 }
 
 fn format_tool_result(name: &str, output: &str, is_error: bool) -> String {
@@ -3995,7 +4178,10 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         "      Inspect or maintain a saved session without entering the REPL"
     )?;
     writeln!(out, "  aris setup                                          Initialize ARIS (install skills, configure MCP)")?;
-    writeln!(out, "  aris doctor                                         Health check")?;
+    writeln!(
+        out,
+        "  aris doctor                                         Health check"
+    )?;
     writeln!(out, "  aris dump-manifests")?;
     writeln!(out, "  aris bootstrap-plan")?;
     writeln!(out, "  aris system-prompt [--cwd PATH] [--date YYYY-MM-DD]")?;
@@ -4027,10 +4213,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(out)?;
     writeln!(out, "Executor providers:")?;
-    writeln!(
-        out,
-        "  Default:   Anthropic Claude (ANTHROPIC_API_KEY)"
-    )?;
+    writeln!(out, "  Default:   Anthropic Claude (ANTHROPIC_API_KEY)")?;
     writeln!(
         out,
         "  OpenAI:    EXECUTOR_PROVIDER=openai EXECUTOR_API_KEY=xxx aris --model gpt-4o"
@@ -4046,6 +4229,10 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(
         out,
         "  Gemini:    EXECUTOR_PROVIDER=openai EXECUTOR_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai EXECUTOR_API_KEY=xxx aris --model gemini-2.5-pro"
+    )?;
+    writeln!(
+        out,
+        "  Custom:    EXECUTOR_PROVIDER=custom EXECUTOR_BASE_URL=https://your-provider.example/v1 EXECUTOR_API_KEY=xxx aris"
     )?;
     writeln!(out)?;
     writeln!(out, "Interactive slash commands:")?;
@@ -4093,13 +4280,20 @@ fn check_auth_status() -> &'static str {
         return "OK (bearer token)";
     }
     let home = env::var("HOME").unwrap_or_default();
-    let creds_path = PathBuf::from(&home).join(".claude").join("credentials.json");
+    let creds_path = PathBuf::from(&home)
+        .join(".claude")
+        .join("credentials.json");
     if creds_path.exists() {
         return "OK (OAuth saved)";
     }
     // Check macOS Keychain for Claude Code's OAuth token
     if let Ok(output) = Command::new("security")
-        .args(["find-generic-password", "-s", "Claude Code-credentials", "-w"])
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
         .output()
     {
         if output.status.success() {
@@ -4212,17 +4406,18 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
     let mut all_ok = true;
 
     // Check 0: Executor provider
-    let executor_provider = std::env::var("EXECUTOR_PROVIDER").unwrap_or_else(|_| "anthropic".into());
+    let executor_provider =
+        std::env::var("EXECUTOR_PROVIDER").unwrap_or_else(|_| "anthropic".into());
     print!("  Executor:     ");
-    if executor_provider == "openai" {
-        let base = std::env::var("EXECUTOR_BASE_URL").unwrap_or_else(|_| "https://api.openai.com/v1".into());
-        let has_key = std::env::var("EXECUTOR_API_KEY")
-            .or_else(|_| std::env::var("OPENAI_API_KEY"))
-            .is_ok();
+    if is_openai_compat_provider(&executor_provider) {
+        let base = std::env::var("EXECUTOR_BASE_URL")
+            .unwrap_or_else(|_| "https://api.openai.com/v1".into());
+        let has_key = openai_executor::resolve_openai_executor_config().is_some();
+        let label = openai_provider_label(Some(executor_provider.as_str()), &base);
         if has_key {
-            println!("OpenAI-compat ({base})");
+            println!("{label} ({base})");
         } else {
-            println!("OpenAI-compat (NO API KEY!)");
+            println!("{label} (NO API KEY!)");
             all_ok = false;
         }
     } else {
@@ -4232,7 +4427,9 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
     // Check 1: API auth
     let auth_status = check_auth_status();
     println!("  API auth:     {auth_status}");
-    if auth_status == "NOT FOUND" && executor_provider != "openai" { all_ok = false; }
+    if auth_status == "NOT FOUND" && !is_openai_compat_provider(&executor_provider) {
+        all_ok = false;
+    }
 
     // Check 2: Skills directory + discovered skills
     let skills_dir = dirs_claude_skills();
@@ -4255,19 +4452,36 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check 2b: Reviewer API (LlmReview)
     print!("  Reviewer API: ");
-    if std::env::var("GEMINI_API_KEY").is_ok() {
+    if reviewer_is_disabled() {
+        println!("DISABLED");
+    } else if std::env::var("ARIS_REVIEWER_PROVIDER").ok().as_deref() == Some("custom") {
+        let base = std::env::var("ARIS_REVIEWER_BASE_URL").unwrap_or_default();
+        if env_var_present("ARIS_REVIEWER_API_KEY") {
+            println!("OK (Custom OpenAI-compatible: {base})");
+        } else {
+            println!("NOT FOUND (set ARIS_REVIEWER_API_KEY for custom reviewer)");
+        }
+    } else if env_var_present("GEMINI_API_KEY") {
         println!("OK (Gemini)");
-    } else if std::env::var("OPENAI_API_KEY").is_ok() {
+    } else if env_var_present("GLM_API_KEY") {
+        println!("OK (GLM)");
+    } else if env_var_present("MINIMAX_API_KEY") {
+        println!("OK (MiniMax)");
+    } else if env_var_present("KIMI_API_KEY") {
+        println!("OK (Kimi)");
+    } else if env_var_present("OPENAI_API_KEY") {
         println!("OK (OpenAI)");
     } else {
-        println!("NOT FOUND (set GEMINI_API_KEY or OPENAI_API_KEY for LlmReview)");
+        println!("NOT FOUND (run `aris setup` or set reviewer API credentials)");
     }
 
     // Check 3: Codex CLI
     print!("  Codex CLI:    ");
     match which_codex() {
         Some(path) => println!("OK ({})", path.display()),
-        None => { println!("NOT FOUND (optional)"); }
+        None => {
+            println!("NOT FOUND (optional)");
+        }
     }
 
     // Check 4: Codex MCP in config
@@ -4277,7 +4491,8 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
     if config_path.exists() {
         if let Ok(content) = fs::read_to_string(&config_path) {
             if let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) {
-                if config.get("mcpServers")
+                if config
+                    .get("mcpServers")
                     .and_then(|s| s.as_object())
                     .map_or(false, |s| s.contains_key("codex"))
                 {
@@ -4307,7 +4522,10 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
 /// ARIS-specific skills directory (highest priority).
 fn dirs_aris_skills() -> PathBuf {
     let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".config").join("aris").join("skills")
+    PathBuf::from(home)
+        .join(".config")
+        .join("aris")
+        .join("skills")
 }
 
 /// Claude Code user skills directory.
@@ -4345,7 +4563,11 @@ fn which_codex() -> Option<PathBuf> {
     let output = Command::new("which").arg("codex").output().ok()?;
     if output.status.success() {
         let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if path.is_empty() { None } else { Some(PathBuf::from(path)) }
+        if path.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(path))
+        }
     } else {
         None
     }
@@ -4420,18 +4642,28 @@ fn discover_all_skills() -> Vec<(String, String, &'static str)> {
 #[cfg(test)]
 mod tests {
     use super::{
-        filter_tool_specs, format_compact_report, format_cost_report, format_model_report,
-        format_model_switch_report, format_permissions_report, format_permissions_switch_report,
-        format_resume_report, format_status_report, format_tool_call_start, format_tool_result,
+        build_runtime, filter_tool_specs, format_compact_report, format_cost_report,
+        format_model_report, format_model_switch_report, format_permissions_report,
+        format_permissions_switch_report, format_resume_report, format_status_report,
+        format_tool_call_start, format_tool_result, has_executor_credentials,
         normalize_permission_mode, parse_args, parse_git_status_metadata, print_help_to,
         push_output_block, render_config_report, render_memory_report, render_repl_help,
-        resolve_model_alias, response_to_events, resume_supported_slash_commands, status_context,
-        CliAction, CliOutputFormat, SlashCommand, StatusUsage, DEFAULT_MODEL,
+        resolve_model_alias, response_to_events, resume_supported_slash_commands,
+        reviewer_provider_label, status_context, CliAction, CliOutputFormat, SlashCommand,
+        StatusUsage, DEFAULT_MODEL,
     };
     use api::{MessageResponse, OutputContentBlock, Usage};
-    use runtime::{AssistantEvent, ContentBlock, ConversationMessage, MessageRole, PermissionMode};
+    use runtime::{
+        AssistantEvent, ContentBlock, ConversationMessage, MessageRole, PermissionMode, Session,
+    };
     use serde_json::json;
     use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn defaults_to_repl_when_no_args() {
@@ -4822,6 +5054,99 @@ mod tests {
         assert!(status.contains("Session          session.json"));
         assert!(status.contains("Config files     loaded 2/3"));
         assert!(status.contains("Memory files     4"));
+    }
+
+    #[test]
+    fn has_executor_credentials_accepts_openai_fallback_key_when_provider_is_set() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("EXECUTOR_API_KEY");
+        std::env::set_var("EXECUTOR_PROVIDER", "openai");
+        std::env::set_var("EXECUTOR_BASE_URL", "https://api.openai.com/v1");
+        std::env::set_var("OPENAI_API_KEY", "sk-openai-test");
+
+        assert!(has_executor_credentials());
+
+        std::env::remove_var("EXECUTOR_PROVIDER");
+        std::env::remove_var("EXECUTOR_BASE_URL");
+        std::env::remove_var("OPENAI_API_KEY");
+    }
+
+    #[test]
+    fn has_executor_credentials_rejects_empty_env_values() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::set_var("ANTHROPIC_API_KEY", "");
+        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "");
+        std::env::set_var("EXECUTOR_PROVIDER", "openai");
+        std::env::set_var("EXECUTOR_BASE_URL", "https://api.openai.com/v1");
+        std::env::set_var("EXECUTOR_API_KEY", "");
+        std::env::set_var("OPENAI_API_KEY", "");
+
+        assert!(!has_executor_credentials());
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("EXECUTOR_PROVIDER");
+        std::env::remove_var("EXECUTOR_BASE_URL");
+        std::env::remove_var("EXECUTOR_API_KEY");
+        std::env::remove_var("OPENAI_API_KEY");
+    }
+
+    #[test]
+    fn has_executor_credentials_rejects_anthropic_fallback_when_openai_provider_is_selected() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::set_var("EXECUTOR_PROVIDER", "openai");
+        std::env::set_var("EXECUTOR_BASE_URL", "https://api.openai.com/v1");
+        std::env::remove_var("EXECUTOR_API_KEY");
+        std::env::remove_var("OPENAI_API_KEY");
+
+        assert!(!has_executor_credentials());
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("EXECUTOR_PROVIDER");
+        std::env::remove_var("EXECUTOR_BASE_URL");
+    }
+
+    #[test]
+    fn build_runtime_rejects_anthropic_fallback_when_openai_provider_is_selected() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::set_var("EXECUTOR_PROVIDER", "openai");
+        std::env::set_var("EXECUTOR_BASE_URL", "https://api.openai.com/v1");
+        std::env::remove_var("EXECUTOR_API_KEY");
+        std::env::remove_var("OPENAI_API_KEY");
+
+        let error = match build_runtime(
+            Session::new(),
+            "gpt-5.4".to_string(),
+            Vec::new(),
+            false,
+            false,
+            None,
+            PermissionMode::WorkspaceWrite,
+        ) {
+            Ok(_) => panic!("missing openai-compatible key should fail"),
+            Err(error) => error,
+        };
+        assert!(error
+            .to_string()
+            .contains("requires EXECUTOR_API_KEY or OPENAI_API_KEY"));
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("EXECUTOR_PROVIDER");
+        std::env::remove_var("EXECUTOR_BASE_URL");
+    }
+
+    #[test]
+    fn reviewer_provider_label_reports_disabled_state() {
+        let _guard = env_lock().lock().expect("lock env");
+        std::env::set_var("ARIS_REVIEWER_DISABLED", "1");
+        assert_eq!(reviewer_provider_label("gpt-5.4"), "Disabled");
+        std::env::remove_var("ARIS_REVIEWER_DISABLED");
     }
 
     #[test]

--- a/crates/aris-cli/src/openai_compat.rs
+++ b/crates/aris-cli/src/openai_compat.rs
@@ -1,0 +1,230 @@
+use std::collections::HashSet;
+
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::input::SelectItem;
+
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenAIModelInfo {
+    pub id: String,
+    pub owned_by: Option<String>,
+}
+
+pub fn is_openai_compat_provider(provider: &str) -> bool {
+    matches!(provider, "openai" | "custom")
+}
+
+pub fn normalize_openai_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return DEFAULT_OPENAI_BASE_URL.to_string();
+    }
+
+    let without_chat = trimmed.strip_suffix("/chat/completions").unwrap_or(trimmed);
+    let without_models = without_chat.strip_suffix("/models").unwrap_or(without_chat);
+    without_models.trim_end_matches('/').to_string()
+}
+
+pub fn chat_completions_url(base_url: &str) -> String {
+    format!("{}/chat/completions", normalize_openai_base_url(base_url))
+}
+
+pub fn models_url(base_url: &str) -> String {
+    format!("{}/models", normalize_openai_base_url(base_url))
+}
+
+pub fn openai_provider_label(provider: Option<&str>, base_url: &str) -> &'static str {
+    if provider == Some("custom") {
+        return "Custom OpenAI-compatible";
+    }
+
+    let normalized = normalize_openai_base_url(base_url);
+    if normalized.contains("deepseek") {
+        "DeepSeek"
+    } else if normalized.contains("bigmodel") {
+        "GLM"
+    } else if normalized.contains("minimax") {
+        "MiniMax"
+    } else if normalized.contains("moonshot") {
+        "Moonshot"
+    } else if normalized.contains("dashscope") || normalized.contains("qwen") {
+        "Qwen"
+    } else if normalized.contains("generativelanguage.googleapis") {
+        "Gemini"
+    } else {
+        "OpenAI"
+    }
+}
+
+pub fn model_select_items(models: &[OpenAIModelInfo], current_model: &str) -> Vec<SelectItem> {
+    models
+        .iter()
+        .map(|model| SelectItem {
+            label: model.id.clone(),
+            description: model.owned_by.clone().unwrap_or_default(),
+            is_current: model.id == current_model,
+        })
+        .collect()
+}
+
+pub fn fetch_openai_models(base_url: &str, api_key: &str) -> Result<Vec<OpenAIModelInfo>, String> {
+    let base_url = normalize_openai_base_url(base_url);
+    let api_key = api_key.trim();
+    if api_key.is_empty() {
+        return Err("API key is required".to_string());
+    }
+
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|error| format!("Failed to start async runtime: {error}"))?;
+    runtime.block_on(async move {
+        let response = Client::new()
+            .get(models_url(&base_url))
+            .bearer_auth(api_key)
+            .send()
+            .await
+            .map_err(|error| format!("Failed to fetch /models: {error}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to fetch /models ({status}): {body}"));
+        }
+
+        let payload = response
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("Failed to parse /models response: {error}"))?;
+        parse_openai_models(payload)
+    })
+}
+
+fn parse_openai_models(payload: Value) -> Result<Vec<OpenAIModelInfo>, String> {
+    let items = payload
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("Unexpected /models response: {payload}"))?;
+
+    let mut seen = HashSet::new();
+    let mut models = Vec::new();
+    for item in items {
+        let Some(id) = item.get("id").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        if id.is_empty() || !seen.insert(id.to_string()) {
+            continue;
+        }
+        let owned_by = item
+            .get("owned_by")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        models.push(OpenAIModelInfo {
+            id: id.to_string(),
+            owned_by,
+        });
+    }
+
+    if models.is_empty() {
+        return Err("The /models endpoint returned no usable model ids".to_string());
+    }
+
+    Ok(models)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    use super::{fetch_openai_models, model_select_items, normalize_openai_base_url};
+
+    #[test]
+    fn normalize_openai_base_url_strips_known_suffixes() {
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/v1/chat/completions"),
+            "https://example.com/v1"
+        );
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/v1/models"),
+            "https://example.com/v1"
+        );
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/v1/"),
+            "https://example.com/v1"
+        );
+    }
+
+    #[test]
+    fn fetch_openai_models_uses_models_endpoint_and_deduplicates_ids() {
+        let request_capture = Arc::new(Mutex::new(String::new()));
+        let request_capture_for_thread = Arc::clone(&request_capture);
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            let mut buffer = [0_u8; 4096];
+            let bytes = stream.read(&mut buffer).expect("read request");
+            *request_capture_for_thread.lock().expect("lock capture") =
+                String::from_utf8_lossy(&buffer[..bytes]).into_owned();
+
+            let body = serde_json::json!({
+                "data": [
+                    {"id": "alpha", "owned_by": "vendor-a"},
+                    {"id": "alpha", "owned_by": "vendor-a"},
+                    {"id": "beta"}
+                ]
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        let models =
+            fetch_openai_models(&format!("http://{addr}/v1"), "test-key").expect("fetch models");
+        handle.join().expect("server thread");
+
+        let request = request_capture.lock().expect("lock capture").clone();
+        assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-key"));
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "alpha");
+        assert_eq!(models[0].owned_by.as_deref(), Some("vendor-a"));
+        assert_eq!(models[1].id, "beta");
+        assert_eq!(models[1].owned_by, None);
+    }
+
+    #[test]
+    fn model_select_items_marks_current_model() {
+        let items = model_select_items(
+            &[
+                super::OpenAIModelInfo {
+                    id: "alpha".to_string(),
+                    owned_by: Some("vendor-a".to_string()),
+                },
+                super::OpenAIModelInfo {
+                    id: "beta".to_string(),
+                    owned_by: None,
+                },
+            ],
+            "beta",
+        );
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].description, "vendor-a");
+        assert!(!items[0].is_current);
+        assert!(items[1].is_current);
+    }
+}

--- a/crates/aris-cli/src/openai_executor.rs
+++ b/crates/aris-cli/src/openai_executor.rs
@@ -13,16 +13,18 @@ use runtime::{
 use serde_json::{json, Value};
 use tools::ToolSpec;
 
+use crate::openai_compat::{chat_completions_url, is_openai_compat_provider};
 use crate::{filter_tool_specs, format_tool_call_start, AllowedToolSet};
 
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 
 /// Resolve executor configuration from environment variables.
 ///
-/// Returns `(api_key, base_url, model)` or `None` if `EXECUTOR_PROVIDER` is not set to `openai`.
+/// Returns `(api_key, base_url, model)` or `None` if `EXECUTOR_PROVIDER` is not set to
+/// an OpenAI-compatible provider.
 pub fn resolve_openai_executor_config() -> Option<OpenAIExecutorConfig> {
     let provider = std::env::var("EXECUTOR_PROVIDER").ok()?;
-    if provider != "openai" {
+    if !is_openai_compat_provider(&provider) {
         return None;
     }
 
@@ -31,8 +33,8 @@ pub fn resolve_openai_executor_config() -> Option<OpenAIExecutorConfig> {
         .ok()
         .filter(|s| !s.is_empty())?;
 
-    let base_url = std::env::var("EXECUTOR_BASE_URL")
-        .unwrap_or_else(|_| DEFAULT_OPENAI_BASE_URL.to_string());
+    let base_url =
+        std::env::var("EXECUTOR_BASE_URL").unwrap_or_else(|_| DEFAULT_OPENAI_BASE_URL.to_string());
 
     Some(OpenAIExecutorConfig { api_key, base_url })
 }
@@ -115,10 +117,7 @@ impl ApiClient for OpenAIRuntimeClient {
             body["tool_choice"] = json!("auto");
         }
 
-        let url = format!(
-            "{}/chat/completions",
-            self.base_url.trim_end_matches('/')
-        );
+        let url = chat_completions_url(&self.base_url);
 
         self.runtime.block_on(async {
             let mut response = self
@@ -133,10 +132,7 @@ impl ApiClient for OpenAIRuntimeClient {
 
             if !response.status().is_success() {
                 let status = response.status();
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|_| String::new());
+                let body = response.text().await.unwrap_or_else(|_| String::new());
                 return Err(RuntimeError::new(format!(
                     "OpenAI API error {status}: {body}"
                 )));
@@ -188,11 +184,7 @@ impl ApiClient for OpenAIRuntimeClient {
                     };
 
                     if data == "[DONE]" {
-                        flush_pending_tools(
-                            &mut pending_tools,
-                            out,
-                            &mut events,
-                        )?;
+                        flush_pending_tools(&mut pending_tools, out, &mut events)?;
                         if let Some(rendered) = markdown_stream.flush(&renderer) {
                             write!(out, "{rendered}")
                                 .and_then(|()| out.flush())
@@ -210,8 +202,10 @@ impl ApiClient for OpenAIRuntimeClient {
 
                     // Extract usage if present (some providers send it)
                     if let Some(usage) = parsed.get("usage") {
-                        let input_tokens =
-                            usage.get("prompt_tokens").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+                        let input_tokens = usage
+                            .get("prompt_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0) as u32;
                         let output_tokens = usage
                             .get("completion_tokens")
                             .and_then(|v| v.as_u64())
@@ -235,7 +229,9 @@ impl ApiClient for OpenAIRuntimeClient {
 
                         // Kimi: capture reasoning_content from delta
                         if is_kimi {
-                            if let Some(rc) = delta.get("reasoning_content").and_then(|r| r.as_str()) {
+                            if let Some(rc) =
+                                delta.get("reasoning_content").and_then(|r| r.as_str())
+                            {
                                 current_reasoning.push_str(rc);
                             }
                         }
@@ -257,12 +253,16 @@ impl ApiClient for OpenAIRuntimeClient {
                             delta.get("tool_calls").and_then(|tc| tc.as_array())
                         {
                             for tc in tool_calls {
-                                let idx = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0)
-                                    as usize;
+                                let idx =
+                                    tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
 
                                 // Ensure vector is long enough
                                 while pending_tools.len() <= idx {
-                                    pending_tools.push((String::new(), String::new(), String::new()));
+                                    pending_tools.push((
+                                        String::new(),
+                                        String::new(),
+                                        String::new(),
+                                    ));
                                 }
 
                                 if let Some(id) = tc.get("id").and_then(|i| i.as_str()) {
@@ -282,14 +282,9 @@ impl ApiClient for OpenAIRuntimeClient {
                         }
 
                         // Check finish_reason
-                        if let Some(reason) = choice.get("finish_reason").and_then(|r| r.as_str())
-                        {
+                        if let Some(reason) = choice.get("finish_reason").and_then(|r| r.as_str()) {
                             if reason == "tool_calls" || reason == "stop" {
-                                flush_pending_tools(
-                                    &mut pending_tools,
-                                    out,
-                                    &mut events,
-                                )?;
+                                flush_pending_tools(&mut pending_tools, out, &mut events)?;
                             }
                         }
                     }
@@ -321,7 +316,8 @@ impl ApiClient for OpenAIRuntimeClient {
 
             // Kimi: save reasoning_content for this turn so we can replay it
             if is_kimi && !current_reasoning.is_empty() {
-                self.kimi_reasoning_cache.insert(current_msg_index, current_reasoning);
+                self.kimi_reasoning_cache
+                    .insert(current_msg_index, current_reasoning);
             }
 
             Ok(events)

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1292,7 +1292,11 @@ fn execute_todo_write(input: TodoWriteInput) -> Result<TodoWriteOutput, String> 
 }
 
 fn execute_skill(input: SkillInput) -> Result<SkillOutput, String> {
-    let requested = input.skill.trim().trim_start_matches('/').trim_start_matches('$');
+    let requested = input
+        .skill
+        .trim()
+        .trim_start_matches('/')
+        .trim_start_matches('$');
 
     // Try filesystem search roots first (user overrides take priority)
     if let Ok(skill_path) = resolve_skill_path(requested) {
@@ -1377,7 +1381,11 @@ fn skill_search_roots() -> Vec<std::path::PathBuf> {
 
     // 2. ~/.claude/skills/ (Claude Code compat, user-level)
     if let Ok(home) = std::env::var("HOME") {
-        roots.push(std::path::PathBuf::from(&home).join(".claude").join("skills"));
+        roots.push(
+            std::path::PathBuf::from(&home)
+                .join(".claude")
+                .join("skills"),
+        );
     }
 
     // 3. Project-level .claude/skills/
@@ -1393,7 +1401,8 @@ fn skill_search_roots() -> Vec<std::path::PathBuf> {
     // 4. ARIS bundled share/skills/ (next to binary)
     if let Ok(exe) = std::env::current_exe() {
         if let Some(bin_dir) = exe.parent() {
-            let share_skills = bin_dir.parent()
+            let share_skills = bin_dir
+                .parent()
                 .map(|p| p.join("share").join("aris").join("skills"))
                 .unwrap_or_else(|| bin_dir.join("share").join("aris").join("skills"));
             roots.push(share_skills);
@@ -1493,7 +1502,11 @@ pub fn discover_skills() -> Vec<SkillMeta> {
             continue;
         }
         seen.insert(name.to_string());
-        let meta = parse_skill_frontmatter(name, content, std::path::PathBuf::from(format!("<bundled:{name}>")));
+        let meta = parse_skill_frontmatter(
+            name,
+            content,
+            std::path::PathBuf::from(format!("<bundled:{name}>")),
+        );
         skills.push(meta);
     }
 
@@ -1504,11 +1517,7 @@ pub fn discover_skills() -> Vec<SkillMeta> {
 /// Parse YAML frontmatter from a SKILL.md file.
 /// Expects `---` delimited YAML block at the top with fields like
 /// name, description, argument-hint, allowed-tools.
-fn parse_skill_frontmatter(
-    dir_name: &str,
-    content: &str,
-    path: std::path::PathBuf,
-) -> SkillMeta {
+fn parse_skill_frontmatter(dir_name: &str, content: &str, path: std::path::PathBuf) -> SkillMeta {
     let mut name = dir_name.to_string();
     let mut description = None;
     let mut argument_hint = None;
@@ -1578,7 +1587,10 @@ pub fn render_skill_discovery_section() -> Option<String> {
         let desc = skill.description.as_deref().unwrap_or("No description");
         // Truncate description to 200 chars (char-safe for CJK)
         let desc_short: String = desc.chars().take(200).collect();
-        let hint = skill.argument_hint.as_deref().map_or(String::new(), |h| format!(" {h}"));
+        let hint = skill
+            .argument_hint
+            .as_deref()
+            .map_or(String::new(), |h| format!(" {h}"));
         lines.push(format!("- `/{}{hint}` — {}", skill.name, desc_short));
     }
 
@@ -1989,7 +2001,12 @@ impl ApiClient for AnthropicRuntimeClient {
                         events.push(AssistantEvent::MessageStop);
                     }
                     ApiStreamEvent::Error(e) => {
-                        let msg = e.error.get("message").and_then(|v| v.as_str()).unwrap_or("stream error").to_string();
+                        let msg = e
+                            .error
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("stream error")
+                            .to_string();
                         return Err(RuntimeError::new(msg));
                     }
                 }
@@ -3158,27 +3175,66 @@ struct LlmReviewInput {
 }
 
 fn run_llm_review(input: LlmReviewInput) -> Result<String, String> {
+    if std::env::var("ARIS_REVIEWER_DISABLED").ok().as_deref() == Some("1") {
+        return Err(String::from(
+            "LlmReview: reviewer is disabled in the current ARIS configuration",
+        ));
+    }
+
     // Resolve which model to use
-    let env_reviewer_model = std::env::var("ARIS_REVIEWER_MODEL").ok().filter(|s| !s.is_empty());
+    let env_reviewer_model = std::env::var("ARIS_REVIEWER_MODEL")
+        .ok()
+        .filter(|s| !s.is_empty());
     let model = input
         .model
         .as_deref()
         .or(env_reviewer_model.as_deref())
         .unwrap_or("gpt-5.4");
 
+    if std::env::var("ARIS_REVIEWER_PROVIDER").ok().as_deref() == Some("custom") {
+        let key = std::env::var("ARIS_REVIEWER_API_KEY")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                String::from("LlmReview: ARIS_REVIEWER_API_KEY not set for custom reviewer")
+            })?;
+        let base_url = std::env::var("ARIS_REVIEWER_BASE_URL")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                String::from("LlmReview: ARIS_REVIEWER_BASE_URL not set for custom reviewer")
+            })?;
+        return call_openai_compat_reviewer(&key, &base_url, model, &input.prompt);
+    }
+
     // Route by model name: gemini models → Gemini API, everything else → OpenAI API
     // Route by model name to the correct API endpoint and key
     let (key_env, base_url) = if model.contains("gemini") {
-        ("GEMINI_API_KEY", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")
+        (
+            "GEMINI_API_KEY",
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+        )
     } else if model.contains("glm") || model.contains("GLM") {
-        ("GLM_API_KEY", "https://open.bigmodel.cn/api/paas/v4/chat/completions")
+        (
+            "GLM_API_KEY",
+            "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+        )
     } else if model.starts_with("MiniMax") || model.starts_with("minimax") {
-        ("MINIMAX_API_KEY", "https://api.minimax.chat/v1/chat/completions")
+        (
+            "MINIMAX_API_KEY",
+            "https://api.minimax.chat/v1/chat/completions",
+        )
     } else if model.contains("kimi") || model.contains("moonshot") {
-        ("KIMI_API_KEY", "https://api.moonshot.cn/v1/chat/completions")
+        (
+            "KIMI_API_KEY",
+            "https://api.moonshot.cn/v1/chat/completions",
+        )
     } else {
         // Default: OpenAI (also covers gpt, o3, o4, deepseek via OPENAI_API_KEY)
-        ("OPENAI_API_KEY", "https://api.openai.com/v1/chat/completions")
+        (
+            "OPENAI_API_KEY",
+            "https://api.openai.com/v1/chat/completions",
+        )
     };
 
     let key = std::env::var(key_env)
@@ -3230,6 +3286,7 @@ fn call_openai_compat_reviewer(
     model: &str,
     prompt: &str,
 ) -> Result<String, String> {
+    let endpoint = openai_chat_completions_endpoint(base_url);
     let body = serde_json::json!({
         "model": model,
         "messages": [{"role": "user", "content": prompt}]
@@ -3237,7 +3294,7 @@ fn call_openai_compat_reviewer(
 
     let client = reqwest::blocking::Client::new();
     let response = client
-        .post(base_url)
+        .post(endpoint)
         .bearer_auth(api_key)
         .json(&body)
         .send()
@@ -3256,6 +3313,13 @@ fn call_openai_compat_reviewer(
         .ok_or_else(|| format!("LlmReview: unexpected response format: {json}"))
 }
 
+fn openai_chat_completions_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    let without_chat = trimmed.strip_suffix("/chat/completions").unwrap_or(trimmed);
+    let without_models = without_chat.strip_suffix("/models").unwrap_or(without_chat);
+    format!("{}/chat/completions", without_models.trim_end_matches('/'))
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
@@ -3270,7 +3334,7 @@ mod tests {
     use super::{
         agent_permission_policy, allowed_tools_for_subagent, execute_agent_with_spawn,
         execute_tool, final_assistant_text, mvp_tool_specs, persist_agent_terminal_state,
-        AgentInput, AgentJob, SubagentToolExecutor,
+        run_llm_review, AgentInput, AgentJob, LlmReviewInput, SubagentToolExecutor,
     };
     use runtime::{ApiRequest, AssistantEvent, ConversationRuntime, RuntimeError, Session};
     use serde_json::json;
@@ -3487,6 +3551,57 @@ mod tests {
     }
 
     #[test]
+    fn llm_review_custom_provider_ignores_model_name_routing() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::env::remove_var("OPENAI_API_KEY");
+        std::env::set_var("ARIS_REVIEWER_PROVIDER", "custom");
+        std::env::set_var("ARIS_REVIEWER_API_KEY", "custom-key");
+
+        let server = TestServer::spawn(Arc::new(|request_line: &str| {
+            assert!(request_line.starts_with("POST /v1/chat/completions "));
+            HttpResponse::json(
+                200,
+                "OK",
+                r#"{"choices":[{"message":{"content":"custom-ok"}}]}"#,
+            )
+        }));
+        std::env::set_var(
+            "ARIS_REVIEWER_BASE_URL",
+            format!("http://{}/v1", server.addr()),
+        );
+
+        let result = run_llm_review(LlmReviewInput {
+            prompt: "hello".to_string(),
+            model: Some("gpt-5.4".to_string()),
+        })
+        .expect("custom reviewer should succeed");
+
+        assert_eq!(result, "custom-ok");
+
+        std::env::remove_var("ARIS_REVIEWER_PROVIDER");
+        std::env::remove_var("ARIS_REVIEWER_API_KEY");
+        std::env::remove_var("ARIS_REVIEWER_BASE_URL");
+    }
+
+    #[test]
+    fn openai_chat_completions_endpoint_normalizes_base_url() {
+        assert_eq!(
+            super::openai_chat_completions_endpoint("https://example.com/v1"),
+            "https://example.com/v1/chat/completions"
+        );
+        assert_eq!(
+            super::openai_chat_completions_endpoint("https://example.com/v1/"),
+            "https://example.com/v1/chat/completions"
+        );
+        assert_eq!(
+            super::openai_chat_completions_endpoint("https://example.com/v1/chat/completions"),
+            "https://example.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
     fn todo_write_persists_and_returns_previous_state() {
         let _guard = env_lock()
             .lock()
@@ -3601,7 +3716,12 @@ mod tests {
         // Point HOME to temp dir so ~/.claude/skills/ resolves there
         let _guard = env_lock();
         let original_home = std::env::var("HOME").ok();
-        let claude_skills = tmp.parent().unwrap().join("claude-home").join(".claude").join("skills");
+        let claude_skills = tmp
+            .parent()
+            .unwrap()
+            .join("claude-home")
+            .join(".claude")
+            .join("skills");
         fs::create_dir_all(&claude_skills).expect("create claude skills dir");
         // Copy the skill into the claude skills dir
         let target_skill = claude_skills.join("test-skill");
@@ -4615,6 +4735,15 @@ printf 'pwsh:%s' "$1"
                 status,
                 reason,
                 content_type: "text/plain; charset=utf-8",
+                body: body.to_string(),
+            }
+        }
+
+        fn json(status: u16, reason: &'static str, body: &str) -> Self {
+            Self {
+                status,
+                reason,
+                content_type: "application/json; charset=utf-8",
                 body: body.to_string(),
             }
         }


### PR DESCRIPTION
## Summary
  - add a single custom OpenAI-compatible provider for executor and reviewer
  - fetch custom model choices dynamically from /models during setup, /model, and /reviewer
  - fix reviewer disable state and executor credential/runtime refresh logic for provider switches