### PR TITLE
fix: improve code quality in MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__/
 
 # Environment
 .env
+
+# Local utility scripts
+update_mcp.js

--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -15,6 +15,7 @@ Supported Providers (examples):
     MiniMax:     LLM_BASE_URL=https://api.minimax.io/v1 LLM_MODEL=MiniMax-M2.7
 """
 
+import datetime
 import json
 import os
 import sys
@@ -38,18 +39,16 @@ DEBUG_LOG = os.path.join(tempfile.gettempdir(), f"{SERVER_NAME}-mcp-debug.log")
 def debug_log(msg):
     try:
         with open(DEBUG_LOG, "a") as f:
-            import datetime
             f.write(f"{datetime.datetime.now()}: {msg}\n")
             f.flush()
-    except:
+    except Exception:
         pass
 
 def log_error(msg):
     try:
         with open(DEBUG_LOG, "a") as f:
-            import datetime
             f.write(f"{datetime.datetime.now()}: ERROR: {msg}\n")
-    except:
+    except Exception:
         pass
 
 debug_log(f"=== {SERVER_NAME} MCP Server Starting (v2.1) ===")
@@ -112,7 +111,10 @@ def call_llm(messages, model=None):
                     return None, error_msg
 
                 data = response.json()
-                content = data["choices"][0]["message"]["content"]
+                try:
+                    content = data["choices"][0]["message"]["content"]
+                except (KeyError, IndexError) as e:
+                    return None, f"Unexpected API response structure: {e}"
                 if current_model != use_model:
                     fallback_note = f"\n\n[Note: Used fallback model {current_model} after 504 timeout with {use_model}]"
                     content = fallback_note + "\n" + content
@@ -267,14 +269,14 @@ def read_message():
         body = sys.stdin.read(content_length)
         try:
             return json.loads(body.decode('utf-8'))
-        except:
+        except json.JSONDecodeError:
             return None
 
     elif line.startswith("{") or line.startswith("["):
         _use_ndjson = True
         try:
             return json.loads(line)
-        except:
+        except json.JSONDecodeError:
             return None
 
     return None

--- a/mcp-servers/minimax-chat/server.py
+++ b/mcp-servers/minimax-chat/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """MiniMax Chat MCP Server - A robust MCP server that calls MiniMax Chat Completions API"""
 
+import datetime
 import json
 import os
 import sys
@@ -18,10 +19,9 @@ def debug_log(msg):
     """Write debug message to log file"""
     try:
         with open(DEBUG_LOG, "a") as f:
-            import datetime
             f.write(f"{datetime.datetime.now()}: {msg}\n")
             f.flush()
-    except:
+    except Exception:
         pass
 
 debug_log("=== MCP Server Starting (v2.1) ===")
@@ -48,9 +48,8 @@ def clamp_temperature(temp):
 def log_error(msg):
     try:
         with open(DEBUG_LOG, "a") as f:
-            import datetime
             f.write(f"{datetime.datetime.now()}: ERROR: {msg}\n")
-    except:
+    except Exception:
         pass
 
 # Global flag for output format
@@ -112,7 +111,10 @@ def call_minimax(messages, model=None, temperature=0.7):
                 debug_log(f"API error: {error_msg}")
                 return None, error_msg
             data = response.json()
-            content = data["choices"][0]["message"]["content"]
+            try:
+                content = data["choices"][0]["message"]["content"]
+            except (KeyError, IndexError) as e:
+                return None, f"Unexpected API response structure: {e}"
             debug_log(f"API success, response length: {len(content)}")
             return content, None
     except Exception as e:
@@ -344,7 +346,7 @@ def main():
                     "id": None,
                     "error": {"code": -32603, "message": f"Internal error: {e}"}
                 })
-            except:
+            except Exception:
                 pass
 
     debug_log("=== MCP Server Exiting ===")


### PR DESCRIPTION
## Summary

- Move `import datetime` to module level in `llm-chat` and `minimax-chat` servers (was re-imported on every log call)
- Replace bare `except:` clauses with `except Exception:` or `except json.JSONDecodeError:` — bare `except` catches `KeyboardInterrupt` and `SystemExit`, masking real errors (PEP 8 E722)
- Guard `data["choices"][0]["message"]["content"]` with `try/except (KeyError, IndexError)` in both servers to return a clear error message on unexpected API response structure instead of crashing
- Add `update_mcp.js` to `.gitignore` (local one-off utility script)

## Test plan

- [ ] Start `llm-chat` MCP server and verify normal chat completions still work
- [ ] Start `minimax-chat` MCP server and verify normal chat completions still work
- [ ] Confirm debug log file is still written on startup (datetime import still works)
- [ ] Simulate a malformed API response (empty `choices` array) — server should now return an error string instead of raising an uncaught exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)