### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Exa Search
+EXA_API_KEY=
+
 # Semantic Scholar
 SEMANTIC_SCHOLAR_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ claude
 > ```
 > Then use [`/deepxiv`](skills/deepxiv/SKILL.md) directly or opt into it from `/research-lit` with `— sources: deepxiv` or `— sources: all, deepxiv`.
 >
+> 🔎 **Optional: Exa AI-powered web search**
+> ```bash
+> pip install exa-py
+> export EXA_API_KEY=your-key-here
+> ```
+> Then use [`/exa-search`](skills/exa-search/SKILL.md) directly or opt into it from `/research-lit` with `— sources: exa` or `— sources: all, exa`. Covers blogs, docs, news, and research papers with built-in content extraction.
+>
 > 🗑️ **Uninstall:** To remove ARIS skills without affecting your own personal skills:
 > ```bash
 > cd Auto-claude-code-research-in-sleep && ls skills/ | xargs -I{} rm -rf ~/.claude/skills/{}
@@ -226,7 +233,7 @@ claude
 > |-----------|---------|-------------|
 > | `AUTO_PROCEED` | `true` | Auto-continue at idea selection gate. Set `false` to manually pick which idea to pursue before committing GPU time |
 > | `human checkpoint` | `false` | Pause after each review round so you can read the score, give custom modification instructions, skip specific fixes, or stop early |
-> | `sources` | `all` | Which literature sources to search: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, or `all`. Note: `semantic-scholar` and `deepxiv` must be explicitly listed — not included in `all` |
+> | `sources` | `all` | Which literature sources to search: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, or `all`. Note: `semantic-scholar`, `deepxiv`, and `exa` must be explicitly listed — not included in `all` |
 > | `arxiv download` | `false` | Download top relevant arXiv PDFs during literature survey. When `false`, only fetches metadata (title, abstract, authors) |
 > | `DBLP_BIBTEX` | `true` | Fetch real BibTeX from [DBLP](https://dblp.org)/[CrossRef](https://www.crossref.org) instead of LLM-generated entries. Eliminates hallucinated citations. Zero install |
 > | `code review` | `true` | GPT-5.4 xhigh reviews experiment code before GPU deployment. Set `false` to skip |
@@ -245,6 +252,7 @@ claude
 > /research-pipeline "your topic" — human checkpoint: true                       # pause after each review round to give feedback
 > /research-pipeline "your topic" — sources: zotero, web                         # only search Zotero + web (skip local PDFs)
 > /research-pipeline "your topic" — sources: all, deepxiv                        # default sources plus DeepXiv progressive retrieval
+> /research-pipeline "your topic" — sources: all, exa                            # default sources plus Exa AI-powered web search
 > /research-pipeline "your topic" — arxiv download: true                         # download top arXiv PDFs during literature survey
 > /research-pipeline "your topic" — difficulty: nightmare                        # maximum adversarial review before submission
 > /research-pipeline "your topic" — effort: beast                               # all knobs to maximum — top-venue sprint
@@ -1036,6 +1044,7 @@ claude   # hooks active immediately
 | 📄 [`arxiv`](skills/arxiv/SKILL.md) | Search, download, and summarize arXiv papers. Standalone or `/research-lit` supplement | No |
 | 🔎 [`semantic-scholar`](skills/semantic-scholar/SKILL.md) | Search published venue papers (IEEE, ACM, Springer) via Semantic Scholar API. Citation counts, venue metadata, TLDR | No |
 | 📚 [`deepxiv`](skills/deepxiv/SKILL.md) | Progressive paper retrieval via DeepXiv CLI: search, brief, section map, section reads, trending, web search | Yes (`pip install deepxiv-sdk`) |
+| 🔎 [`exa-search`](skills/exa-search/SKILL.md) | AI-powered broad web search via Exa: blogs, docs, news, companies, research papers with content extraction (highlights, text, summaries) | Yes (`pip install exa-py`) |
 | 🎨 [`pixel-art`](skills/pixel-art/SKILL.md) | Generate pixel art SVG illustrations for READMEs, docs, or slides | No |
 | 📱 [`feishu-notify`](skills/feishu-notify/SKILL.md) | [Feishu/Lark](#-feishulark-integration-optional) push (webhook) or interactive (bidirectional). Off by default | No |
 
@@ -1137,6 +1146,7 @@ bash tools/smart_update.sh --apply  # apply: adds new + updates safe ones
 > /research-lit "topic"                              # just literature survey (all sources)
 > /research-lit "topic" — sources: zotero, web        # mix and match sources
 > /research-lit "topic" — sources: deepxiv            # DeepXiv-only progressive retrieval
+> /research-lit "topic" — sources: exa                # Exa AI-powered web search with content extraction
 > /research-lit "topic" — arxiv download: true         # also download top arXiv PDFs
 > /arxiv "discrete diffusion" — download               # standalone arXiv search + download
 > /idea-creator "topic"                              # just brainstorm
@@ -1545,7 +1555,7 @@ Now skills will:
 
 Skills are plain Markdown files. Fork and customize:
 
-> 💡 **Parameter pass-through**: Parameters flow down the call chain automatically. For example, `/research-pipeline "topic" — sources: zotero, arxiv download: true` passes `sources` and `arxiv download` through `idea-discovery` all the way down to `research-lit`. This also works for optional sources such as `deepxiv`: `/research-pipeline "topic" — sources: all, deepxiv`. You can set any downstream parameter at any level — just add `— key: value` to your command.
+> 💡 **Parameter pass-through**: Parameters flow down the call chain automatically. For example, `/research-pipeline "topic" — sources: zotero, arxiv download: true` passes `sources` and `arxiv download` through `idea-discovery` all the way down to `research-lit`. This also works for optional sources such as `deepxiv` and `exa`: `/research-pipeline "topic" — sources: all, deepxiv, exa`. You can set any downstream parameter at any level — just add `— key: value` to your command.
 >
 > ```
 > research-pipeline  ──→  idea-discovery      ──→  research-lit
@@ -1613,11 +1623,11 @@ Override inline: `/experiment-bridge — base repo: https://github.com/org/proje
 |----------|---------|-------------|
 | `PAPER_LIBRARY` | `papers/`, `literature/` | Local directories to scan for PDFs before searching online |
 | `MAX_LOCAL_PAPERS` | 20 | Max local PDFs to scan (first 3 pages each) |
-| `SOURCES` | `all` | Which sources to search: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, or `all`. `semantic-scholar` and `deepxiv` must be explicitly listed |
+| `SOURCES` | `all` | Which sources to search: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, or `all`. `semantic-scholar`, `deepxiv`, and `exa` must be explicitly listed |
 | `ARXIV_DOWNLOAD` | false | When `true`, download top relevant arXiv PDFs to PAPER_LIBRARY after search |
 | `ARXIV_MAX_DOWNLOAD` | 5 | Maximum number of PDFs to download when `ARXIV_DOWNLOAD = true` |
 
-Override inline: `/research-lit "topic" — sources: zotero, web`, `/research-lit "topic" — sources: all, deepxiv`, `/research-lit "topic" — arxiv download: true, max download: 10`
+Override inline: `/research-lit "topic" — sources: zotero, web`, `/research-lit "topic" — sources: all, deepxiv`, `/research-lit "topic" — sources: all, exa`, `/research-lit "topic" — arxiv download: true, max download: 10`
 
 ### Paper Writing (`paper-write`)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -182,6 +182,13 @@ claude
 > ```
 > 安装后可直接使用 [`/deepxiv`](skills/deepxiv/SKILL.md)，或在 `/research-lit` 中通过 `— sources: deepxiv` / `— sources: all, deepxiv` 显式启用。
 >
+> 🔎 **可选：Exa AI 智能网页搜索**
+> ```bash
+> pip install exa-py
+> export EXA_API_KEY=your-key-here
+> ```
+> 安装后可直接使用 [`/exa-search`](skills/exa-search/SKILL.md)，或在 `/research-lit` 中通过 `— sources: exa` / `— sources: all, exa` 显式启用。覆盖博客、文档、新闻和研究论文，并内置内容提取。
+>
 > 🗑️ **卸载：** 仅删除 ARIS skills，不影响你自己的 skills：
 > ```bash
 > cd Auto-claude-code-research-in-sleep && ls skills/ | xargs -I{} rm -rf ~/.claude/skills/{}
@@ -193,7 +200,7 @@ claude
 > |------|------|------|
 > | `AUTO_PROCEED` | `true` | 在 idea 选择关卡自动继续。设为 `false` 可在花 GPU 前手动挑选 idea |
 > | `human checkpoint` | `false` | 每轮 review 后暂停，让你查看分数、给出修改意见、跳过特定修复或提前终止 |
-> | `sources` | `all` | 搜索哪些文献源：`zotero`、`obsidian`、`local`、`web`、`semantic-scholar`、`deepxiv`、`all`。`semantic-scholar` 和 `deepxiv` 都需显式指定 |
+> | `sources` | `all` | 搜索哪些文献源：`zotero`、`obsidian`、`local`、`web`、`semantic-scholar`、`deepxiv`、`exa`、`all`。`semantic-scholar`、`deepxiv` 和 `exa` 都需显式指定 |
 > | `arxiv download` | `false` | 文献调研时下载最相关的 arXiv PDF。为 `false` 时仅获取元数据（标题、摘要、作者） |
 > | `DBLP_BIBTEX` | `true` | 从 [DBLP](https://dblp.org)/[CrossRef](https://www.crossref.org) 获取真实 BibTeX，替代 LLM 生成。杜绝幻觉引用。零安装 |
 > | `code review` | `true` | GPT-5.4 xhigh 部署前审查实验代码。设 `false` 跳过 |
@@ -210,6 +217,7 @@ claude
 > /research-pipeline "你的课题" — human checkpoint: true                       # 每轮 review 后暂停，可给修改意见
 > /research-pipeline "你的课题" — sources: zotero, web                         # 只搜 Zotero + 网络（跳过本地 PDF）
 > /research-pipeline "你的课题" — sources: all, deepxiv                        # 默认源 + DeepXiv 渐进式检索
+> /research-pipeline "你的课题" — sources: all, exa                            # 默认源 + Exa AI 智能网页搜索
 > /research-pipeline "你的课题" — arxiv download: true                         # 文献调研时下载最相关的 arXiv PDF
 > /research-pipeline "你的课题" — difficulty: nightmare                        # 投顶会前极限压测
 > /research-pipeline "你的课题" — AUTO_PROCEED: false, human checkpoint: true  # 组合使用
@@ -1141,7 +1149,7 @@ EOF
 
 Skills 就是普通的 Markdown 文件，fork 后随意改：
 
-> 💡 **参数自动透传**：参数沿调用链自动向下传递。例如 `/research-pipeline "方向" — sources: zotero, arxiv download: true` 会将 `sources` 和 `arxiv download` 经 `idea-discovery` 一路传到 `research-lit`。这同样适用于 `deepxiv` 这类可选源：`/research-pipeline "方向" — sources: all, deepxiv`。你可以在任何层级设置下游参数——只需加 `— key: value`。
+> 💡 **参数自动透传**：参数沿调用链自动向下传递。例如 `/research-pipeline "方向" — sources: zotero, arxiv download: true` 会将 `sources` 和 `arxiv download` 经 `idea-discovery` 一路传到 `research-lit`。这同样适用于 `deepxiv` 和 `exa` 这类可选源：`/research-pipeline "方向" — sources: all, deepxiv, exa`。你可以在任何层级设置下游参数——只需加 `— key: value`。
 >
 > ```
 > research-pipeline  ──→  idea-discovery      ──→  research-lit
@@ -1208,11 +1216,11 @@ Skills 就是普通的 Markdown 文件，fork 后随意改：
 |------|--------|------|
 | `PAPER_LIBRARY` | `papers/`, `literature/` | 本地论文目录，搜外部之前先扫这里的 PDF |
 | `MAX_LOCAL_PAPERS` | 20 | 最多扫描多少本地 PDF（每篇读前 3 页） |
-| `SOURCES` | `all` | 搜索哪些源：`zotero`、`obsidian`、`local`、`web`、`semantic-scholar`、`deepxiv`、`all`（逗号分隔）。`semantic-scholar` 和 `deepxiv` 需显式指定 |
+| `SOURCES` | `all` | 搜索哪些源：`zotero`、`obsidian`、`local`、`web`、`semantic-scholar`、`deepxiv`、`exa`、`all`（逗号分隔）。`semantic-scholar`、`deepxiv` 和 `exa` 需显式指定 |
 | `ARXIV_DOWNLOAD` | false | 设为 `true` 时，搜索后自动下载最相关的 arXiv PDF 到 PAPER_LIBRARY |
 | `ARXIV_MAX_DOWNLOAD` | 5 | `ARXIV_DOWNLOAD = true` 时最多下载的 PDF 数量 |
 
-行内覆盖：`/research-lit "方向" — sources: zotero, web`、`/research-lit "方向" — sources: all, deepxiv`、`/research-lit "方向" — arxiv download: true, max download: 10`
+行内覆盖：`/research-lit "方向" — sources: zotero, web`、`/research-lit "方向" — sources: all, deepxiv`、`/research-lit "方向" — sources: all, exa`、`/research-lit "方向" — arxiv download: true, max download: 10`
 
 ### 论文写作（`paper-write`）
 

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: exa-search
+description: AI-powered web search via Exa with content extraction. Use when user says "exa search", "web search with content", "find similar pages", or needs broad web results beyond academic databases (arXiv, Semantic Scholar).
+argument-hint: [search-query-or-url]
+allowed-tools: Bash(*), Read, Write
+---
+
+# Exa AI-Powered Web Search
+
+Search query: $ARGUMENTS
+
+## Role & Positioning
+
+Exa is the **broad web search** source with built-in content extraction:
+
+| Skill | Best for |
+|------|----------|
+| `/arxiv` | Direct preprint search and PDF download |
+| `/semantic-scholar` | Published venue papers (IEEE, ACM, Springer), citation counts |
+| `/deepxiv` | Layered reading: search, brief, section map, section reads |
+| `/exa-search` | Broad web search: blogs, docs, news, companies, research papers — with content extraction |
+
+Use Exa when you need results beyond academic databases, or when you want content (highlights, full text, summaries) extracted alongside search results.
+
+## Constants
+
+- **FETCH_SCRIPT** — `tools/exa_search.py` relative to the current project.
+- **MAX_RESULTS = 10** — Default number of results to return.
+
+> Overrides (append to arguments):
+> - `/exa-search "RAG pipelines" — max: 5` — top 5 results
+> - `/exa-search "diffusion models" — category: research paper` — research papers only
+> - `/exa-search "startup funding" — category: news, start date: 2025-01-01` — recent news
+> - `/exa-search "transformer" — content: text, max chars: 8000` — full text mode
+> - `/exa-search "transformer" — content: summary` — LLM-generated summaries
+> - `/exa-search "transformer" — domains: arxiv.org,huggingface.co` — domain filter
+> - `/exa-search "https://arxiv.org/abs/2301.07041" — similar` — find similar pages
+
+## Setup
+
+Exa requires the `exa-py` SDK and an API key:
+
+```bash
+pip install exa-py
+```
+
+Set your API key:
+```bash
+export EXA_API_KEY=your-key-here
+```
+
+Get a key from [exa.ai](https://exa.ai).
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **query**: The search query (required) or a URL (for `find-similar` mode)
+- **similar**: If present, use `find-similar` mode instead of search
+- **max**: Override MAX_RESULTS
+- **category**: `research paper`, `news`, `company`, `personal site`, `financial report`, `people`
+- **content**: `highlights` (default), `text`, `summary`, `none`
+- **max chars**: Max characters for content extraction
+- **type**: Search type — `auto` (default), `neural`, `fast`, `instant`
+- **domains**: Comma-separated include domains
+- **exclude domains**: Comma-separated exclude domains
+- **include text**: Phrase that must appear in results
+- **exclude text**: Phrase to exclude from results
+- **start date**: ISO 8601 date — only results after this
+- **end date**: ISO 8601 date — only results before this
+- **location**: Two-letter ISO country code
+
+### Step 2: Locate Script
+
+```bash
+SCRIPT=$(find tools/ -name "exa_search.py" 2>/dev/null | head -1)
+```
+
+If not found, tell the user:
+```
+exa_search.py not found. Make sure tools/exa_search.py exists and exa-py is installed:
+pip install exa-py
+```
+
+### Step 3: Execute Search
+
+**Standard search:**
+```bash
+python3 "$SCRIPT" search "QUERY" --max 10 --content highlights
+```
+
+**With filters:**
+```bash
+python3 "$SCRIPT" search "QUERY" --max 10 \
+  --category "research paper" \
+  --start-date 2025-01-01 \
+  --content text --max-chars 8000
+```
+
+**Find similar pages:**
+```bash
+python3 "$SCRIPT" find-similar "URL" --max 5 --content highlights
+```
+
+**Get content for known URLs:**
+```bash
+python3 "$SCRIPT" get-contents "URL1" "URL2" --content text
+```
+
+### Step 4: Present Results
+
+Format results as a structured table:
+
+```
+| # | Title | URL | Date | Key Content |
+|---|-------|-----|------|-------------|
+```
+
+For each result:
+- Show title and URL
+- Show published date if available
+- Show highlights, text excerpt, or summary depending on content mode
+- Flag particularly relevant results
+
+### Step 5: Offer Follow-up
+
+After presenting results, suggest:
+- **Deepen**: "I can fetch full text for any of these results"
+- **Find similar**: "I can find pages similar to any result"
+- **Narrow**: "I can re-search with domain/date/text filters"
+
+## Key Rules
+- Always check that `EXA_API_KEY` is set before searching
+- Default to `highlights` content mode for a good balance of speed and context
+- Use `category: "research paper"` when the user is clearly looking for academic content
+- Use `text` content mode when the user needs full page content
+- Combine with `/arxiv` or `/semantic-scholar` for comprehensive literature coverage

--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -37,8 +37,8 @@ This skill checks multiple sources **in priority order**. All are optional — i
 ### Source Selection
 
 Parse `$ARGUMENTS` for a `— sources:` directive:
-- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `all`.
-- **If not specified**: Default to `all` — search every available source in priority order (`semantic-scholar` and `deepxiv` are **excluded** from `all`; they must be explicitly listed).
+- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, `all`.
+- **If not specified**: Default to `all` — search every available source in priority order (`semantic-scholar`, `deepxiv`, and `exa` are **excluded** from `all`; they must be explicitly listed).
 
 Examples:
 ```
@@ -52,6 +52,8 @@ Examples:
 /research-lit "topic" — sources: deepxiv                            → DeepXiv only
 /research-lit "topic" — sources: all, deepxiv                       → default sources + DeepXiv
 /research-lit "topic" — sources: all, semantic-scholar              → all + S2 API
+/research-lit "topic" — sources: exa                               → Exa only (broad web + content extraction)
+/research-lit "topic" — sources: all, exa                          → default sources + Exa web search
 ```
 
 ### Source Table
@@ -64,6 +66,7 @@ Examples:
 | 4 | **Web search** | `web` | Always available (WebSearch) | arXiv, Semantic Scholar, Google Scholar |
 | 5 | **Semantic Scholar API** | `semantic-scholar` | `tools/semantic_scholar_fetch.py` exists | Published venue papers (IEEE, ACM, Springer) with structured metadata: citation counts, venue info, TLDR. **Only runs when explicitly requested** via `— sources: semantic-scholar` or `— sources: web, semantic-scholar` |
 | 6 | **DeepXiv CLI** | `deepxiv` | `tools/deepxiv_fetch.py` and installed `deepxiv` CLI | Progressive paper retrieval: search, brief, head, section, trending, web search. **Only runs when explicitly requested** via `— sources: deepxiv` or `— sources: all, deepxiv` |
+| 7 | **Exa Search** | `exa` | `tools/exa_search.py` and installed `exa-py` SDK | AI-powered broad web search with content extraction (highlights, text, summaries). Covers blogs, docs, news, companies, and research papers beyond arXiv/S2. **Only runs when explicitly requested** via `— sources: exa` or `— sources: all, exa` |
 
 > **Graceful degradation**: If no MCP servers are configured, the skill works exactly as before (local PDFs + web search). Zotero and Obsidian are pure additions.
 
@@ -197,6 +200,29 @@ If `tools/deepxiv_fetch.py` or the `deepxiv` CLI is unavailable, skip this sourc
 - Match by arXiv ID first, DOI second, normalized title third
 - If DeepXiv and arXiv refer to the same preprint, keep one canonical paper row and record `deepxiv` as an additional source
 - If DeepXiv overlaps with S2 on a published paper, prefer S2 venue/citation metadata in the final table, but keep DeepXiv-derived section notes when they add value
+
+**Exa search** (only when `exa` is in sources):
+
+When the user explicitly requests `— sources: exa` (or includes `exa` in a combined source list), use the Exa tool for broad AI-powered web search with content extraction:
+
+```bash
+EXA_SCRIPT=$(find tools/ -name "exa_search.py" 2>/dev/null | head -1)
+
+# Search for research papers with highlights
+python3 "$EXA_SCRIPT" search "QUERY" --max 10 --category "research paper" --content highlights
+
+# Search for broader web content (blogs, docs, news)
+python3 "$EXA_SCRIPT" search "QUERY" --max 10 --content highlights
+```
+
+If `tools/exa_search.py` or the `exa-py` SDK is unavailable, skip this source gracefully and continue with the remaining requested sources.
+
+**Why use Exa?** Exa provides AI-powered search across the broader web (blogs, documentation, news, company pages) with built-in content extraction. It fills a gap between academic databases (arXiv, S2) and generic WebSearch by returning richer content with each result.
+
+**De-duplication against arXiv, S2, and DeepXiv**:
+- Match by URL first, then normalized title
+- If Exa returns an arXiv paper already found by arXiv/S2, prefer the structured metadata from those sources
+- Exa results from non-academic domains (blogs, docs, news) are unique value not covered by other sources
 
 **Optional PDF download** (only when `ARXIV_DOWNLOAD = true`):
 

--- a/skills/skills-codex/research-lit/SKILL.md
+++ b/skills/skills-codex/research-lit/SKILL.md
@@ -34,8 +34,8 @@ This skill checks multiple sources **in priority order**. All are optional — i
 ### Source Selection
 
 Parse `$ARGUMENTS` for a `— sources:` directive:
-- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `deepxiv`, `all`.
-- **If not specified**: Default to `all` — search every available source in priority order (`deepxiv` is excluded from `all`; it must be explicitly listed).
+- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `deepxiv`, `exa`, `all`.
+- **If not specified**: Default to `all` — search every available source in priority order (`deepxiv` and `exa` are excluded from `all`; they must be explicitly listed).
 
 Examples:
 ```
@@ -47,6 +47,8 @@ Examples:
 /research-lit "topic" — sources: obsidian, local, web   → skip Zotero
 /research-lit "topic" — sources: deepxiv                → DeepXiv only
 /research-lit "topic" — sources: all, deepxiv           → default sources + DeepXiv
+/research-lit "topic" — sources: exa                    → Exa only (broad web + content extraction)
+/research-lit "topic" — sources: all, exa               → default sources + Exa web search
 ```
 
 ### Source Table
@@ -58,6 +60,7 @@ Examples:
 | 3 | **Local PDFs** | `local` | `Glob: papers/**/*.pdf, literature/**/*.pdf` | Raw PDF content (first 3 pages) |
 | 4 | **Web search** | `web` | Always available (WebSearch) | arXiv, Semantic Scholar, Google Scholar |
 | 5 | **DeepXiv CLI** | `deepxiv` | `tools/deepxiv_fetch.py` and installed `deepxiv` CLI | Progressive paper retrieval: search, brief, head, section, trending, web search. **Only runs when explicitly requested** |
+| 6 | **Exa Search** | `exa` | `tools/exa_search.py` and installed `exa-py` SDK | AI-powered broad web search with content extraction (highlights, text, summaries). Covers blogs, docs, news, companies, and research papers beyond arXiv/S2. **Only runs when explicitly requested** |
 
 > **Graceful degradation**: If no MCP servers are configured, the skill works exactly as before (local PDFs + web search). Zotero and Obsidian are pure additions.
 
@@ -161,6 +164,27 @@ If `tools/deepxiv_fetch.py` or the `deepxiv` CLI is unavailable, skip this sourc
 - Match by arXiv ID first
 - Fall back to normalized title when needed
 - Keep one canonical paper entry and record `deepxiv` as an additional source when it overlaps with web/arXiv findings
+
+**Exa search** (only when `exa` is in sources):
+
+When the user explicitly requests `— sources: exa` (or includes `exa` in a combined source list), use the Exa tool for broad AI-powered web search with content extraction:
+
+```bash
+EXA_SCRIPT=$(find tools/ -name "exa_search.py" 2>/dev/null | head -1)
+
+# Search for research papers with highlights
+python3 "$EXA_SCRIPT" search "QUERY" --max 10 --category "research paper" --content highlights
+
+# Search for broader web content (blogs, docs, news)
+python3 "$EXA_SCRIPT" search "QUERY" --max 10 --content highlights
+```
+
+If `tools/exa_search.py` or the `exa-py` SDK is unavailable, skip this source gracefully and continue with the remaining requested sources.
+
+**De-duplication against other sources**:
+- Match by URL first, then normalized title
+- If Exa returns an arXiv paper already found by other sources, prefer structured metadata from arXiv/S2
+- Exa results from non-academic domains (blogs, docs, news) are unique value not covered by other sources
 
 **Optional PDF download** (only when `ARXIV_DOWNLOAD = true`):
 

--- a/tests/test_exa_search.py
+++ b/tests/test_exa_search.py
@@ -1,0 +1,220 @@
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "exa_search.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("exa_search", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_client_raises_when_exa_py_not_installed(monkeypatch):
+    exa_search = load_module()
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+    import builtins
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "exa_py":
+            raise ImportError("No module named 'exa_py'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    with pytest.raises(RuntimeError, match="exa-py not found"):
+        exa_search._get_client()
+
+
+def test_get_client_raises_when_api_key_missing(monkeypatch):
+    exa_search = load_module()
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="EXA_API_KEY"):
+        exa_search._get_client()
+
+
+def test_parse_list_returns_none_for_empty():
+    exa_search = load_module()
+    assert exa_search._parse_list(None) is None
+    assert exa_search._parse_list("") is None
+
+
+def test_parse_list_splits_comma_separated():
+    exa_search = load_module()
+    result = exa_search._parse_list("arxiv.org, huggingface.co, github.com")
+    assert result == ["arxiv.org", "huggingface.co", "github.com"]
+
+
+def test_build_content_kwargs_highlights():
+    exa_search = load_module()
+    result = exa_search._build_content_kwargs("highlights", 4000)
+    assert result == {"highlights": {"max_characters": 4000}}
+
+
+def test_build_content_kwargs_text():
+    exa_search = load_module()
+    result = exa_search._build_content_kwargs("text", 8000)
+    assert result == {"text": {"max_characters": 8000}}
+
+
+def test_build_content_kwargs_summary():
+    exa_search = load_module()
+    result = exa_search._build_content_kwargs("summary", 4000)
+    assert result == {"summary": True}
+
+
+def test_build_content_kwargs_none():
+    exa_search = load_module()
+    result = exa_search._build_content_kwargs("none", 4000)
+    assert result == {}
+
+
+def test_process_result_highlights():
+    exa_search = load_module()
+    mock_result = SimpleNamespace(
+        title="Test Paper",
+        url="https://example.com/paper",
+        published_date="2025-01-15",
+        author="John Doe",
+        highlights=["Key finding 1", "Key finding 2"],
+    )
+    entry = exa_search._process_result(mock_result, "highlights")
+
+    assert entry["title"] == "Test Paper"
+    assert entry["url"] == "https://example.com/paper"
+    assert entry["published_date"] == "2025-01-15"
+    assert entry["author"] == "John Doe"
+    assert entry["highlights"] == ["Key finding 1", "Key finding 2"]
+
+
+def test_process_result_text():
+    exa_search = load_module()
+    mock_result = SimpleNamespace(
+        title="Test Page",
+        url="https://example.com",
+        text="Full page text content here.",
+    )
+    entry = exa_search._process_result(mock_result, "text")
+
+    assert entry["title"] == "Test Page"
+    assert entry["text"] == "Full page text content here."
+
+
+def test_process_result_summary():
+    exa_search = load_module()
+    mock_result = SimpleNamespace(
+        title="Test Page",
+        url="https://example.com",
+        summary="A concise summary of the page.",
+    )
+    entry = exa_search._process_result(mock_result, "summary")
+
+    assert entry["summary"] == "A concise summary of the page."
+
+
+def test_process_result_missing_optional_fields():
+    exa_search = load_module()
+    mock_result = SimpleNamespace(
+        title=None,
+        url=None,
+    )
+    entry = exa_search._process_result(mock_result, "none")
+
+    assert entry["title"] == "No Title"
+    assert entry["url"] == ""
+    assert "published_date" not in entry
+    assert "author" not in entry
+
+
+def test_cli_parser_builds_help_without_traceback():
+    exa_search = load_module()
+    parser = exa_search._build_parser()
+    help_text = parser.format_help()
+
+    assert "search" in help_text
+    assert "find-similar" in help_text
+    assert "get-contents" in help_text
+
+
+def test_search_calls_client_with_correct_kwargs(monkeypatch):
+    exa_search = load_module()
+
+    captured = {}
+    mock_results = [
+        SimpleNamespace(
+            title="Result 1",
+            url="https://example.com/1",
+            highlights=["highlight 1"],
+        ),
+    ]
+
+    class MockResponse:
+        results = mock_results
+
+    class MockClient:
+        headers = {}
+
+        def search_and_contents(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return MockResponse()
+
+    monkeypatch.setattr(exa_search, "_get_client", MockClient)
+
+    result = exa_search.search(
+        query="test query",
+        max_results=5,
+        search_type="auto",
+        content_mode="highlights",
+        max_chars=4000,
+        category="research paper",
+        include_domains=["arxiv.org"],
+    )
+
+    assert captured["kwargs"]["query"] == "test query"
+    assert captured["kwargs"]["num_results"] == 5
+    assert captured["kwargs"]["type"] == "auto"
+    assert captured["kwargs"]["category"] == "research paper"
+    assert captured["kwargs"]["include_domains"] == ["arxiv.org"]
+    assert result["mode"] == "search"
+    assert result["returned"] == 1
+
+
+def test_main_search_outputs_json(monkeypatch, capsys):
+    exa_search = load_module()
+
+    mock_results = [
+        SimpleNamespace(
+            title="Result 1",
+            url="https://example.com/1",
+            highlights=["highlight 1"],
+        ),
+    ]
+
+    class MockResponse:
+        results = mock_results
+
+    class MockClient:
+        headers = {}
+
+        def search_and_contents(self, **kwargs):
+            return MockResponse()
+
+    monkeypatch.setattr(exa_search, "_get_client", MockClient)
+
+    exit_code = exa_search.main(["search", "test query", "--max", "5"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["mode"] == "search"
+    assert len(output["data"]) == 1

--- a/tools/exa_search.py
+++ b/tools/exa_search.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""CLI helper for AI-powered web search via Exa.
+
+Designed to complement arXiv (preprints) and Semantic Scholar (published venues)
+with **broad web search**: blog posts, documentation, company pages, news, and
+research papers — all with built-in content extraction.
+
+Requires
+--------
+pip install exa-py
+
+Commands
+--------
+search          Search the web and optionally retrieve content.
+find-similar    Find pages similar to a given URL.
+get-contents    Retrieve content for specific URLs.
+
+Filter flags (search)
+---------------------
+--type           Search type: auto (default), neural, fast, instant
+--category       Focus area: "company", "research paper", "news",
+                 "personal site", "financial report", "people"
+--include-domains  Only include results from these domains (comma-separated)
+--exclude-domains  Exclude results from these domains (comma-separated)
+--include-text   Required text in page (comma-separated phrases)
+--exclude-text   Prohibited text in page (comma-separated phrases)
+--start-date     Only results published after this ISO 8601 date
+--end-date       Only results published before this ISO 8601 date
+--location       Two-letter ISO country code for localized results
+
+Content flags (shared)
+----------------------
+--content        Content mode: highlights (default), text, summary, none
+--max-chars      Max characters for content extraction (default: 4000)
+
+Examples
+--------
+# Basic search with highlights
+python3 tools/exa_search.py search "transformer attention mechanisms" --max 10
+
+# Research papers with full text
+python3 tools/exa_search.py search "semantic communication" --category "research paper" \
+  --content text --max-chars 8000
+
+# Recent news about a topic
+python3 tools/exa_search.py search "foundation models" --category news \
+  --start-date 2025-01-01
+
+# Domain-restricted search
+python3 tools/exa_search.py search "RAG pipeline" --include-domains "arxiv.org,huggingface.co"
+
+# Find similar pages to a URL
+python3 tools/exa_search.py find-similar "https://arxiv.org/abs/2301.07041" --max 5
+
+# Get content for specific URLs
+python3 tools/exa_search.py get-contents "https://example.com/page1" "https://example.com/page2"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+_INSTALL_MESSAGE = "exa-py not found. Install it with: pip install exa-py"
+
+
+def _get_client() -> Any:
+    """Create and return an Exa client with the integration tracking header."""
+    try:
+        from exa_py import Exa
+    except ImportError:
+        raise RuntimeError(_INSTALL_MESSAGE)
+
+    api_key = os.getenv("EXA_API_KEY", "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "EXA_API_KEY environment variable is required. "
+            "Get your key from: https://exa.ai"
+        )
+
+    client = Exa(api_key=api_key)
+    client.headers["x-exa-integration"] = "auto-claude-code-research-in-sleep"
+    return client
+
+
+def _parse_list(value: str | None) -> list[str] | None:
+    """Split a comma-separated string into a list, or return None."""
+    if not value:
+        return None
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _build_content_kwargs(content_mode: str, max_chars: int) -> dict[str, Any]:
+    """Build content retrieval kwargs for Exa search_and_contents."""
+    if content_mode == "none":
+        return {}
+    if content_mode == "highlights":
+        return {"highlights": {"max_characters": max_chars}}
+    if content_mode == "text":
+        return {"text": {"max_characters": max_chars}}
+    if content_mode == "summary":
+        return {"summary": True}
+    return {"highlights": {"max_characters": max_chars}}
+
+
+def _process_result(result: Any, content_mode: str) -> dict[str, Any]:
+    """Extract structured fields from a single Exa result object."""
+    entry: dict[str, Any] = {
+        "title": getattr(result, "title", None) or "No Title",
+        "url": getattr(result, "url", None) or "",
+    }
+
+    published_date = getattr(result, "published_date", None)
+    if published_date:
+        entry["published_date"] = published_date
+
+    author = getattr(result, "author", None)
+    if author:
+        entry["author"] = author
+
+    if content_mode == "highlights":
+        highlights = getattr(result, "highlights", None)
+        if highlights:
+            entry["highlights"] = highlights
+    elif content_mode == "text":
+        text = getattr(result, "text", None)
+        if text:
+            entry["text"] = text
+    elif content_mode == "summary":
+        summary = getattr(result, "summary", None)
+        if summary:
+            entry["summary"] = summary
+
+    return entry
+
+
+def search(
+    query: str,
+    max_results: int = 10,
+    search_type: str = "auto",
+    content_mode: str = "highlights",
+    max_chars: int = 4000,
+    category: str | None = None,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    include_text: list[str] | None = None,
+    exclude_text: list[str] | None = None,
+    start_published_date: str | None = None,
+    end_published_date: str | None = None,
+    user_location: str | None = None,
+) -> dict[str, Any]:
+    """Search the web via Exa and return structured results."""
+    client = _get_client()
+
+    kwargs: dict[str, Any] = {
+        "query": query,
+        "num_results": max_results,
+        "type": search_type,
+    }
+
+    kwargs.update(_build_content_kwargs(content_mode, max_chars))
+
+    if category:
+        kwargs["category"] = category
+    if include_domains:
+        kwargs["include_domains"] = include_domains
+    if exclude_domains:
+        kwargs["exclude_domains"] = exclude_domains
+    if include_text:
+        kwargs["include_text"] = include_text
+    if exclude_text:
+        kwargs["exclude_text"] = exclude_text
+    if start_published_date:
+        kwargs["start_published_date"] = start_published_date
+    if end_published_date:
+        kwargs["end_published_date"] = end_published_date
+    if user_location:
+        kwargs["user_location"] = user_location
+
+    response = client.search_and_contents(**kwargs)
+
+    return {
+        "mode": "search",
+        "query": query,
+        "type": search_type,
+        "returned": len(response.results),
+        "data": [_process_result(r, content_mode) for r in response.results],
+    }
+
+
+def find_similar(
+    url: str,
+    max_results: int = 10,
+    content_mode: str = "highlights",
+    max_chars: int = 4000,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    start_published_date: str | None = None,
+    end_published_date: str | None = None,
+) -> dict[str, Any]:
+    """Find pages similar to a given URL."""
+    client = _get_client()
+
+    kwargs: dict[str, Any] = {
+        "url": url,
+        "num_results": max_results,
+    }
+
+    kwargs.update(_build_content_kwargs(content_mode, max_chars))
+
+    if include_domains:
+        kwargs["include_domains"] = include_domains
+    if exclude_domains:
+        kwargs["exclude_domains"] = exclude_domains
+    if start_published_date:
+        kwargs["start_published_date"] = start_published_date
+    if end_published_date:
+        kwargs["end_published_date"] = end_published_date
+
+    response = client.find_similar_and_contents(**kwargs)
+
+    return {
+        "mode": "find-similar",
+        "url": url,
+        "returned": len(response.results),
+        "data": [_process_result(r, content_mode) for r in response.results],
+    }
+
+
+def get_contents(
+    urls: list[str],
+    content_mode: str = "text",
+    max_chars: int = 10000,
+) -> dict[str, Any]:
+    """Retrieve content for specific URLs."""
+    client = _get_client()
+
+    kwargs: dict[str, Any] = {"ids": urls}
+    kwargs.update(_build_content_kwargs(content_mode, max_chars))
+
+    response = client.get_contents(**kwargs)
+
+    return {
+        "mode": "get-contents",
+        "returned": len(response.results),
+        "data": [_process_result(r, content_mode) for r in response.results],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="AI-powered web search via Exa.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # --- search ---
+    search_parser = subparsers.add_parser("search", help="Search the web via Exa")
+    search_parser.add_argument("query", help="Search query")
+    search_parser.add_argument(
+        "--max", type=int, default=10, metavar="N",
+        help="Maximum number of results (default: 10).",
+    )
+    search_parser.add_argument(
+        "--type", default="auto", dest="search_type",
+        choices=("auto", "neural", "fast", "instant"),
+        help="Search type (default: auto).",
+    )
+    search_parser.add_argument(
+        "--content", default="highlights", dest="content_mode",
+        choices=("highlights", "text", "summary", "none"),
+        help="Content retrieval mode (default: highlights).",
+    )
+    search_parser.add_argument(
+        "--max-chars", type=int, default=4000, metavar="N",
+        help="Max characters for content extraction (default: 4000).",
+    )
+    search_parser.add_argument(
+        "--category", default=None,
+        help='Category filter: "company", "research paper", "news", '
+             '"personal site", "financial report", "people".',
+    )
+    search_parser.add_argument(
+        "--include-domains", default=None,
+        help="Comma-separated domains to include.",
+    )
+    search_parser.add_argument(
+        "--exclude-domains", default=None,
+        help="Comma-separated domains to exclude.",
+    )
+    search_parser.add_argument(
+        "--include-text", default=None,
+        help="Comma-separated phrases that must appear in page.",
+    )
+    search_parser.add_argument(
+        "--exclude-text", default=None,
+        help="Comma-separated phrases to exclude from results.",
+    )
+    search_parser.add_argument(
+        "--start-date", default=None,
+        help="Only results published after this date (ISO 8601).",
+    )
+    search_parser.add_argument(
+        "--end-date", default=None,
+        help="Only results published before this date (ISO 8601).",
+    )
+    search_parser.add_argument(
+        "--location", default=None,
+        help="Two-letter ISO country code for localized results.",
+    )
+
+    # --- find-similar ---
+    similar_parser = subparsers.add_parser(
+        "find-similar", help="Find pages similar to a URL",
+    )
+    similar_parser.add_argument("url", help="URL to find similar pages for")
+    similar_parser.add_argument(
+        "--max", type=int, default=10, metavar="N",
+        help="Maximum number of results (default: 10).",
+    )
+    similar_parser.add_argument(
+        "--content", default="highlights", dest="content_mode",
+        choices=("highlights", "text", "summary", "none"),
+        help="Content retrieval mode (default: highlights).",
+    )
+    similar_parser.add_argument(
+        "--max-chars", type=int, default=4000, metavar="N",
+        help="Max characters for content extraction (default: 4000).",
+    )
+    similar_parser.add_argument(
+        "--include-domains", default=None,
+        help="Comma-separated domains to include.",
+    )
+    similar_parser.add_argument(
+        "--exclude-domains", default=None,
+        help="Comma-separated domains to exclude.",
+    )
+    similar_parser.add_argument(
+        "--start-date", default=None,
+        help="Only results published after this date (ISO 8601).",
+    )
+    similar_parser.add_argument(
+        "--end-date", default=None,
+        help="Only results published before this date (ISO 8601).",
+    )
+
+    # --- get-contents ---
+    contents_parser = subparsers.add_parser(
+        "get-contents", help="Retrieve content for specific URLs",
+    )
+    contents_parser.add_argument("urls", nargs="+", help="URLs to fetch content for")
+    contents_parser.add_argument(
+        "--content", default="text", dest="content_mode",
+        choices=("highlights", "text", "summary", "none"),
+        help="Content retrieval mode (default: text).",
+    )
+    contents_parser.add_argument(
+        "--max-chars", type=int, default=10000, metavar="N",
+        help="Max characters for content extraction (default: 10000).",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    try:
+        if args.command == "search":
+            result = search(
+                query=args.query,
+                max_results=args.max,
+                search_type=args.search_type,
+                content_mode=args.content_mode,
+                max_chars=args.max_chars,
+                category=args.category,
+                include_domains=_parse_list(args.include_domains),
+                exclude_domains=_parse_list(args.exclude_domains),
+                include_text=_parse_list(args.include_text),
+                exclude_text=_parse_list(args.exclude_text),
+                start_published_date=args.start_date,
+                end_published_date=args.end_date,
+                user_location=args.location,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+        if args.command == "find-similar":
+            result = find_similar(
+                url=args.url,
+                max_results=args.max,
+                content_mode=args.content_mode,
+                max_chars=args.max_chars,
+                include_domains=_parse_list(args.include_domains),
+                exclude_domains=_parse_list(args.exclude_domains),
+                start_published_date=args.start_date,
+                end_published_date=args.end_date,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+        if args.command == "get-contents":
+            result = get_contents(
+                urls=args.urls,
+                content_mode=args.content_mode,
+                max_chars=args.max_chars,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+        raise ValueError(f"Unsupported command: {args.command}")
+
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        return 130
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **New tool**: `tools/exa_search.py` — CLI helper for AI-powered web search via [Exa](https://exa.ai), with three commands: `search`, `find-similar`, `get-contents`
- **New skill**: `skills/exa-search/SKILL.md` — standalone `/exa-search` skill for direct use
- **Integrated into `/research-lit`** as an opt-in source (`— sources: exa` or `— sources: all, exa`), complementing arXiv (preprints), Semantic Scholar (published venues), and DeepXiv (progressive reading) with broad web search and built-in content extraction
- **Key features**: multiple search types (auto, neural, fast, instant), content modes (highlights, text, summary), category filtering (research paper, news, company, etc.), domain/text/date filtering
- **Updated**: `.env.example`, `README.md`, `README_CN.md`, `skills/research-lit/SKILL.md`, `skills/skills-codex/research-lit/SKILL.md`

## Usage

```bash
# Install
pip install exa-py
export EXA_API_KEY=your-key-here

# Standalone search
python3 tools/exa_search.py search "transformer attention mechanisms" --max 10

# Research papers with full text extraction
python3 tools/exa_search.py search "semantic communication" --category "research paper" --content text

# Find similar pages
python3 tools/exa_search.py find-similar "https://arxiv.org/abs/2301.07041" --max 5

# As a research-lit source
/research-lit "diffusion models" — sources: all, exa
```

## Files changed

| File | Change |
|------|--------|
| `tools/exa_search.py` | New CLI tool (search, find-similar, get-contents) |
| `skills/exa-search/SKILL.md` | New standalone skill |
| `skills/research-lit/SKILL.md` | Added Exa as source #7 with workflow instructions |
| `skills/skills-codex/research-lit/SKILL.md` | Added Exa as source #6 with workflow instructions |
| `.env.example` | Added `EXA_API_KEY` |
| `README.md` | Added Exa to skill table, source options, quick-start examples |
| `README_CN.md` | Added Exa to skill table, source options, quick-start examples |
| `tests/test_exa_search.py` | Unit tests for the CLI tool |

## Test plan

- [ ] `pip install exa-py` and set `EXA_API_KEY`
- [ ] Run `python3 tools/exa_search.py search "test query" --max 3` and verify JSON output
- [ ] Run `python3 tools/exa_search.py search "transformers" --category "research paper" --content text` and verify content extraction
- [ ] Run `python3 tools/exa_search.py find-similar "https://arxiv.org/abs/2301.07041"` and verify similar results
- [ ] Run `pytest tests/test_exa_search.py -v` and verify all unit tests pass
- [ ] Test `/exa-search "test query"` as a skill in Claude Code
- [ ] Test `/research-lit "topic" — sources: exa` integration