### PR TITLE
fix: replace assert with explicit error handling in review servers

### DIFF
--- a/mcp-servers/claude-review/server.py
+++ b/mcp-servers/claude-review/server.py
@@ -240,7 +240,8 @@ def run_claude_review(
         message = parse_error if not stderr else f"{parse_error}. stderr: {stderr}"
         return None, message
 
-    assert payload is not None
+    if payload is None:
+        return None, "Failed to parse Claude CLI output"
     if result.returncode != 0 or payload.get("is_error"):
         message = str(payload.get("result") or payload.get("error") or result.stderr.strip() or "Claude review failed")
         return None, message

--- a/mcp-servers/gemini-review/server.py
+++ b/mcp-servers/gemini-review/server.py
@@ -427,7 +427,8 @@ def run_gemini_cli_review(
         message = parse_error if not stderr else f"{parse_error}. stderr: {stderr}"
         return None, message
 
-    assert payload is not None
+    if payload is None:
+        return None, "Failed to parse Gemini CLI output"
     if result.returncode != 0:
         return None, f"Gemini review failed: {extract_cli_error_message(result.stdout, result.stderr)}"
 
@@ -577,7 +578,8 @@ def run_gemini_review(
     if error:
         return None, error
 
-    assert payload is not None
+    if payload is None:
+        return None, "Failed to parse Gemini CLI output"
     updated_history = list(history)
     updated_history.append({"role": "user", "text": prompt})
     updated_history.append({"role": "model", "text": str(payload["response"])})


### PR DESCRIPTION
## Summary

- Replace `assert payload is not None` with explicit `if payload is None: return None, "..."` guards in `gemini-review/server.py` (2 sites) and `claude-review/server.py` (1 site)

## Why

`assert` statements are disabled when Python runs with the `-O` (optimize) flag, which is common in production deployments. When disabled, a `None` payload would propagate silently and cause an unhelpful `AttributeError` or `TypeError` downstream. The explicit `if`-guard returns a descriptive error string immediately, consistent with the pattern used everywhere else in these servers.

## Test plan

- [ ] Run `gemini-review` server with a prompt that triggers a parse failure — should now return a clear error instead of `AssertionError`
- [ ] Run `claude-review` server similarly — same behavior
- [ ] Normal review flows should be unaffected (the guards only trigger on `None` payload, which was already an error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)