### PR TITLE
fix: clean up feishu-bridge dependency docs and pin lark-oapi version

### DIFF
--- a/mcp-servers/feishu-bridge/requirements.txt
+++ b/mcp-servers/feishu-bridge/requirements.txt
@@ -1,1 +1,1 @@
-lark-oapi
+lark-oapi>=1.0,<2.0

--- a/mcp-servers/feishu-bridge/server.py
+++ b/mcp-servers/feishu-bridge/server.py
@@ -9,7 +9,7 @@ Endpoints:
   GET  /health  — health check
 
 Requires:
-  pip install lark-oapi httpx
+  pip install lark-oapi
 
 Environment variables:
   FEISHU_APP_ID      — Feishu app ID


### PR DESCRIPTION
## Summary

- Remove `httpx` from the `pip install` line in the module docstring — `httpx` is not imported or used anywhere in `feishu-bridge/server.py`, so including it misleads users into installing an unnecessary package
- Pin `lark-oapi>=1.0,<2.0` in `requirements.txt` for reproducible installs, consistent with how other MCP servers pin their dependencies (e.g. `httpx>=0.27,<1.0` in llm-chat and minimax-chat)

## Test plan

- [ ] `pip install -r mcp-servers/feishu-bridge/requirements.txt` succeeds cleanly
- [ ] Feishu bridge server starts and sends/receives messages normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)