### PR TITLE
feat: add patent drafting pipeline (CN/US/EP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,28 @@ __pycache__/
 
 # Environment
 .env
+
+# Claude Code local config — contains API keys and personal settings
+.claude/
+
+# Patent output — contains confidential invention details, do not commit
+patent/
+# Allow patent framework files (skills, templates, shared references)
+!skills/patent-pipeline/
+!skills/prior-art-search/
+!skills/patent-novelty-check/
+!skills/invention-structuring/
+!skills/claims-drafting/
+!skills/embodiment-description/
+!skills/figure-description/
+!skills/specification-writing/
+!skills/patent-review/
+!skills/jurisdiction-format/
+!skills/shared-references/patent-format-cn.md
+!skills/shared-references/patent-format-ep.md
+!skills/shared-references/patent-format-us.md
+!skills/shared-references/patent-writing-principles.md
+!skills/shared-references/prior-art-databases.md
+!templates/INVENTION_BRIEF_TEMPLATE.md
+!templates/PATENT_CLAIMS_TEMPLATE.md
+!templates/PATENT_SPECIFICATION_TEMPLATE.md

--- a/skills/claims-drafting/SKILL.md
+++ b/skills/claims-drafting/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: claims-drafting
+description: "Draft patent claims for an invention. Use when user says \"撰写权利要求\", \"draft claims\", \"写权利要求书\", \"claim drafting\", or wants to create patent claims. The core skill of the patent pipeline."
+argument-hint: [invention-disclosure-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
+---
+
+# Claims Drafting: The Core Patent Skill
+
+Draft patent claims based on: **$ARGUMENTS**
+
+This is the most critical skill in the patent pipeline. Claims define the legal scope of protection -- everything else (specification, figures, abstract) exists to support and enable the claims.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — External examiner for claim quality review
+- `MAX_CLAIM_REVISION_ROUNDS = 3` — Maximum revision iterations
+- `CLAIM_STYLE = "auto"` — `US` (Jepson or open), `EP` (two-part mandatory), `CN` (two-part), `auto` (detect from jurisdiction)
+- `MIN_INDEPENDENT_CLAIMS = 2` — Typically method + system. For utility model (实用新型): apparatus/device only, NO method claims.
+- `MAX_TOTAL_CLAIMS = 20` — Practical limit (USPTO includes 20 in base fee)
+- `PATENT_TYPE = "invention"` — `invention` (发明专利) or `utility_model` (实用新型, apparatus claims only)
+
+## Inputs
+
+1. `patent/INVENTION_DISCLOSURE.md` — structured invention with core/supporting/optional features
+2. `patent/PRIOR_ART_REPORT.md` — prior art to avoid
+3. `patent/NOVELTY_ASSESSMENT.md` — novelty analysis with suggested amendments
+4. Target jurisdiction from invention disclosure or `$ARGUMENTS`
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for claim drafting principles, antecedent basis rules, and common pitfalls.
+Load `../shared-references/patent-format-cn.md` for CN claim format (其特征在于).
+Load `../shared-references/patent-format-us.md` for US claim format (comprising, means-plus-function).
+Load `../shared-references/patent-format-ep.md` for EP two-part form (characterised in that).
+
+## Workflow
+
+### Step 1: Determine Claim Style and Patent Type
+
+Based on patent type and jurisdiction:
+
+**If `PATENT_TYPE = utility_model` (实用新型)**:
+- CN jurisdiction ONLY
+- Apparatus/device claims ONLY — no method, no product-by-process
+- `MIN_INDEPENDENT_CLAIMS = 1` (single apparatus claim is sufficient)
+- Claim format: "1. 一种[主题]，其特征在于，包括：[组件描述]。"
+
+Based on target jurisdiction:
+
+| Jurisdiction | Claim Style | Characterising Phrase | Preamble Format |
+|-------------|------------|----------------------|-----------------|
+| CN | Two-part (两部式) | 其特征在于 | 一种...的方法/装置，包括： |
+| US | Open (preferred) | comprising | A method for..., comprising: |
+| EP | Two-part (mandatory) | characterised in that | A method for..., comprising [known], characterised in that [inventive] |
+| ALL | Draft CN + US + EP | All of the above | All of the above |
+
+### Step 2: Draft Independent Claims
+
+**CRITICAL — Claims numbering (CN format):**
+- Claims must be numbered 1, 2, 3, ... continuously without gaps
+- Independent and dependent claims are INTERMIXED in final numbering
+- Do NOT group independent claims separately from dependent claims
+- Example correct: Claim 1 (independent, product), Claim 2 (depends on 1), Claim 3 (depends on 1), Claim 4 (independent, method), Claim 5 (depends on 4)...
+- Example WRONG: Claim 1 (independent), Claim 5 (independent), Claim 8 (independent), then Claim 2, 3, 4, 6, 7, 9, 10 as dependents
+
+**CRITICAL — No empirical content in claims:**
+- Claims describe ONLY structural features or method steps
+- Do NOT include signal characteristics, detection principles, measurement results
+- WRONG: "产生负脉冲信号" / "谐振频率下降" — these are results, not features
+- RIGHT: "所述开口谐振环的开口处形成用于检测通过流体中颗粒物的间隙传感区域"
+
+For each claim category identified in INVENTION_DISCLOSURE.md:
+
+**Method Claim (broadest)**:
+1. Start with preamble identifying the category and purpose
+2. List the core inventive features (from the "Core Inventive Concept" section)
+3. Include enough known features for context (but not more than necessary)
+4. Use open transition ("comprising" / "包括")
+5. Each element should be separated by semicolons or on separate lines
+6. Apply jurisdiction-specific format:
+   - CN: 前序部分 + "其特征在于" + 特征部分
+   - US: Preamble + "comprising:" + elements
+   - EP: Preamble + known features + "characterised in that" + inventive features
+
+**System/Apparatus Claim**:
+1. Mirror the method claim in structural form
+2. Each method step becomes a "module configured to..." or "component for..."
+3. Same hierarchy of known vs. inventive features
+
+**Quality checks for each independent claim**:
+- [ ] Single sentence (US/EP) or properly structured (CN)
+- [ ] Antecedent basis: "a" first, "the" thereafter for each element
+- [ ] No relative terms without definition
+- [ ] No result-to-be-achieved limitations
+- [ ] Transitional phrase is appropriate (open preferred)
+- [ ] Preamble does not import unnecessary limitations
+- [ ] Each element is necessary for patentability
+- [ ] Claim scope is broadest defensible over prior art
+
+### Step 3: Draft Dependent Claims
+
+For each independent claim, draft 5-10 dependent claims that:
+
+1. **Narrow the core inventive features**: Specific implementations, parameters, ranges
+2. **Cover preferred embodiments**: Features from the specification's detailed description
+3. **Provide fallback positions**: If the independent claim is rejected, these narrower claims may survive
+4. **Cover alternatives**: Different ways to achieve the same inventive result
+
+**Dependent claim format**:
+- CN: "根据权利要求X所述的[主题]，其特征在于，所述[特征]具体为..."
+- US: "The [method/system] of claim X, wherein the [element] comprises [limitation]."
+- EP: "The [method/system] according to claim X, characterised in that [limitation]."
+
+**Rules for dependent claims**:
+- Each must add at least one meaningful limitation
+- Must reference a prior claim by number
+- Must not merely repeat the parent claim
+- Should not be cumulative (each claim should be independently useful as a fallback)
+- Multiple dependent claims (US: only "or" references, not "and")
+
+### Step 4: Claim-to-Specification Mapping
+
+Create a preliminary mapping to verify enablement:
+
+| Claim Element | Must be described in specification | Reference numeral |
+|---------------|-----------------------------------|-------------------|
+| [element 1] | Yes/No | [numeral] |
+| [element 2] | Yes/No | [numeral] |
+
+If any element lacks specification support, add it to the specification requirements.
+
+### Step 5: Cross-Model Examiner Review
+
+Call `REVIEWER_MODEL` via `mcp__codex__codex` with xhigh reasoning:
+
+```
+mcp__codex__codex:
+  config: {"model_reasoning_effort": "xhigh"}
+  prompt: |
+    You are a senior patent examiner at the [USPTO/CNIPA/EPO].
+    Review the following patent claims for quality and patentability.
+
+    CLAIMS: [all claims]
+
+    PRIOR ART: [prior art references from PRIOR_ART_REPORT.md]
+
+    INVENTION: [summary from INVENTION_DISCLOSURE.md]
+
+    Analyze each claim for:
+    1. Clarity (35 USC 112(b) / Art 84 EPC): Are terms definite?
+    2. Written description support: Does the spec support all claim scope?
+    3. Anticipation (102/Art 54): Would any single reference anticipate?
+    4. Obviousness (103/Art 56): Would any combination render obvious?
+    5. Claim scope: Are independent claims broad enough to be valuable?
+    6. Dependent claims: Do they provide meaningful fallback positions?
+    7. Antecedent basis: Any issues with "a"/"the" usage?
+    8. Indefinite terms: Any functional/result language issues?
+
+    For each issue found, provide:
+    - The specific claim number and element
+    - The problem (cite statute/rule)
+    - A suggested fix
+
+    Provide an overall PATENTABILITY SCORE: 1-10.
+```
+
+### Step 6: Revision Loop
+
+If the examiner review identifies issues:
+
+1. Address all CRITICAL issues (anticipation, obviousness, indefiniteness)
+2. Address MAJOR issues (scope too narrow, missing support, weak fallbacks)
+3. Consider MINOR issues (antecedent basis, formatting)
+4. Re-submit to examiner for round 2 (use `mcp__codex__codex` with threadId)
+5. Repeat up to `MAX_CLAIM_REVISION_ROUNDS` times
+
+### Step 7: Output
+
+Write `patent/CLAIMS.md`:
+
+```markdown
+## Patent Claims
+
+### Independent Claims
+
+#### Claim 1 — Method
+[formatted claim text]
+
+#### Claim X — System/Apparatus
+[formatted claim text]
+
+### Dependent Claims
+
+#### Claim 2 (depends on 1)
+[formatted claim text]
+
+#### Claim 3 (depends on 1)
+[formatted claim text]
+...
+
+### Claims Summary Table
+
+| Claim | Type | Depends On | Key Limitation | Prior Art Avoidance |
+|-------|------|-----------|----------------|---------------------|
+| 1 | Method | — | [core inventive features] | [what makes it novel over prior art] |
+| 2 | Method | 1 | [narrowing] | [additional distinguishing] |
+| X | System | — | [mirrors claim 1] | [same as claim 1] |
+...
+
+### Examiner Review Summary
+[Key findings and how they were addressed]
+```
+
+## Key Rules
+
+- Claims are the single most important part of the patent. Everything else supports them.
+- Draft independent claims first, then dependent claims.
+- Independent claims must be broadest defensible scope over prior art -- not broader, not narrower.
+- Each dependent claim should be independently useful as a fallback position.
+- Antecedent basis is mandatory: "a processor" first, "the processor" thereafter.
+- Use "comprising" (open) unless there is a specific reason for "consisting of" (closed).
+- Never include result-to-be-achieved language in claims ("configured to achieve high accuracy").
+- Never fabricate claim language -- every element must come from the actual invention.
+- If drafting for ALL jurisdictions, produce separate claim sets for CN, US, and EP.
+- If `mcp__codex__codex` is not available, skip cross-model examiner review and note it in the output.

--- a/skills/embodiment-description/SKILL.md
+++ b/skills/embodiment-description/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: embodiment-description
+description: "Write detailed embodiment descriptions for patent specifications. Use when user says \"撰写实施例\", \"write embodiment\", \"实施例描述\", \"detailed description\", or wants to describe how to practice an invention."
+argument-hint: [claims-path-or-embodiment-details]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
+---
+
+# Embodiment Description
+
+Write detailed embodiments for: **$ARGUMENTS**
+
+Embodiments describe HOW to make and use the invention -- they are the patent equivalent of experiment sections, but describe the invention rather than evaluating it empirically.
+
+## Constants
+
+- `MIN_EMBODIMENTS = 1` — At least one complete embodiment required
+- `MAX_EMBODIMENTS = 3` — Practical limit; more embodiments strengthen enablement
+- `EMBODIMENT_STYLE = detailed` — `detailed` (full working example) or `outline` (sketch)
+- `REFERENCE_NUMERAL_PREFIX = 100` — Starting reference numeral for first figure's components
+
+## Inputs
+
+1. `patent/INVENTION_DISCLOSURE.md` — invention decomposition (core/supporting/optional features)
+2. `patent/CLAIMS.md` — drafted claims that the embodiments must support
+3. User-provided figures (if any) in any directory
+4. `patent/figures/numeral_index.md` if it exists (from `/figure-description`)
+
+## Workflow
+
+### Step 1: Plan Embodiments
+
+For each claim category (method, system, etc.), plan at least one embodiment:
+
+| Embodiment | Covers Claims | Type | Key Variations |
+|-----------|--------------|------|----------------|
+| 1 | Claims 1, X | Best mode / preferred | [primary implementation] |
+| 2 | Claims 2, 3 | Alternative | [different parameters/materials] |
+| 3 | Claims 4, 5 | Additional alternative | [different configuration] |
+
+### Step 2: Write Each Embodiment
+
+For each embodiment, write a detailed description following this structure:
+
+**Opening paragraph**:
+"In one embodiment, [invention summary with reference to what is being described]."
+
+**Component/step-by-step description**:
+
+For method embodiments:
+- Describe each step in order
+- Reference figure numerals: "As shown in FIG. 1, at step 202, the processor 102 receives the input data 104..."
+- Include specific parameters, ranges, and conditions
+- Describe what happens at each decision point
+
+For system/apparatus embodiments:
+- Describe each component
+- Reference figure numerals: "Referring to FIG. 1, the system 100 comprises a processor 102, a memory 104, and a communication interface 106..."
+- Describe interconnections between components
+- Describe operation of the system step-by-step
+
+**Variations and alternatives**:
+- "In some embodiments, the processor 102 may be a GPU, an FPGA, or an ASIC."
+- "In another embodiment, the memory 104 may be replaced with a distributed storage system."
+- "The parameters described above are exemplary; other values within the range [X, Y] are also contemplated."
+
+These variations are critical -- they support broader claim interpretation.
+
+### Step 3: Reference Numeral Integration
+
+Ensure consistent reference numeral usage:
+
+1. Every component mentioned must have a numeral
+2. Numeral must appear first in parentheses after the component name: "the processor (102)"
+3. Subsequent references: "the processor 102" (no parentheses)
+4. Numbering follows figure series: 100-series for FIG. 1, 200-series for FIG. 2
+
+**Format**:
+- First mention: "the processor (102)"
+- Later in same embodiment: "the processor 102"
+- Cross-figure: "the processor 102 (shown in both FIG. 1 and FIG. 2)"
+
+### Step 4: Claim Support Verification
+
+For each claim element, verify it appears in at least one embodiment:
+
+| Claim Element | Embodiment | Reference Numeral | Description Paragraph |
+|---------------|-----------|-------------------|----------------------|
+| [element] | [which] | [numeral] | [paragraph reference] |
+
+If any claim element lacks embodiment support, add the necessary description.
+
+### Step 5: Software/Algorithm Embodiments (if applicable)
+
+For method/software inventions, include:
+- Pseudocode or algorithmic description (NOT actual code)
+- Flowchart description tied to figures
+- Data structure descriptions
+- Interface specifications
+
+Example:
+```
+In one embodiment, the method comprises the following steps:
+At step 202, the processor 102 receives input data from the input device 108.
+At step 204, the processor 102 extracts feature vectors from the input data using a convolutional neural network.
+At step 206, the processor 102 applies the attention mechanism 110 to the feature vectors...
+```
+
+### Step 6: Output
+
+Embodiment sections are written to `patent/specification/detailed_description.md` (or appended to the specification structure).
+
+Each embodiment section should be self-contained but cross-reference other embodiments when describing alternatives.
+
+## Key Rules
+
+- Embodiments must teach a POSITA to make and use the invention without undue experimentation.
+- Include at least one "best mode" embodiment (US requirement).
+- Multiple embodiments strengthen the specification against enablement challenges.
+- Describe the invention, do NOT evaluate it empirically ("The embodiment achieves 95% accuracy" is wrong; "The processor classifies the input data" is correct).
+- **CRITICAL — NO experimental data, test results, accuracy percentages, detection rates, precision values, or comparative performance data.** These belong in papers, not patents. The embodiment teaches HOW to make and use, not HOW WELL it performs.
+- WRONG: "传感器对直径超过150μm的金属颗粒实现了100%的检测精度，即使在检测限处仍保持94%的高精度。"
+- RIGHT: "当不锈钢颗粒通过间隙传感区域时，谐振频率下降。颗粒直径越大，频率偏移幅度越大。"
+- Do NOT include tables of experimental results, graphs of measurement data, or comparisons with prior art performance.
+- **CRITICAL — An embodiment is NOT an experiment.** Do NOT describe "repeated experiments", "accuracy evaluation", "precision testing", "calibration experiments", or "comparison with reference methods". An embodiment describes ONE way to make and use the invention — it is a recipe, not a test report.
+- Do NOT copy experimental sections from source papers verbatim. Transform the experimental setup into a manufacturing/operation description.
+- If the source material is a paper, extract ONLY: (1) what was built, (2) what materials/parameters were used, (3) how it operates. Ignore all test methodology, results, and performance metrics.
+- Include specific parameters where possible, but frame them as exemplary, not limiting.
+- Reference numerals must be consistent with the figures.
+- Do NOT use subjective language ("excellent", "surprising", "superior").

--- a/skills/figure-description/SKILL.md
+++ b/skills/figure-description/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: figure-description
+description: "Process user-provided patent figures and generate formal drawing descriptions. Use when user says \"附图处理\", \"figure description\", \"附图说明\", \"drawings description\", or wants to describe patent figures with reference numerals."
+argument-hint: [figure-directory-or-figure-list]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
+---
+
+# Figure Description for Patents
+
+Process patent figures and generate drawing descriptions based on: **$ARGUMENTS**
+
+Unlike `/paper-figure` which generates data plots, this skill processes user-provided technical diagrams and assigns reference numerals.
+
+## Constants
+
+- `FIGURE_DIR = "patent/figures/"` — Output directory for figure descriptions
+- `REFERENCE_NUMERAL_PREFIX = 100` — Starting numeral for first figure's components
+- `NUMERAL_SERIES = 100` — Each figure uses a separate 100-series (Fig 1: 100-199, Fig 2: 200-299, etc.)
+
+## Inputs
+
+1. User-provided figures (PNG, JPG, SVG, PDF) — search for them in the project directory
+2. `patent/INVENTION_DISCLOSURE.md` — for understanding what components to identify
+3. `patent/CLAIMS.md` — for mapping numerals to claim elements
+
+## Workflow
+
+### Step 1: Discover Figures
+
+1. Search the project directory for figure files:
+   - Check `patent/figures/`, `figures/`, root directory
+   - Look for PNG, JPG, SVG, PDF files
+   - Check INVENTION_BRIEF.md or INVENTION_DISCLOSURE.md for figure references
+2. List all discovered figures with their paths
+3. If figures are missing that claims require, note them as `[MISSING: description needed]`
+
+### Step 2: Analyze Each Figure
+
+For each figure found:
+
+1. **Read the image** using the Read tool (supports image files)
+2. **Identify components**: What labeled or visually distinct components are shown?
+3. **Identify connections**: How do components relate to each other?
+4. **Identify flow**: If it's a flowchart or sequence, what is the step order?
+
+### Step 3: Assign Reference Numerals
+
+For each figure, assign numerals using the series convention:
+
+| Figure | Numeral Range |
+|--------|-------------|
+| FIG. 1 | 100-199 |
+| FIG. 2 | 200-299 |
+| FIG. 3 | 300-399 |
+
+For each identified component:
+- Assign the next available numeral in the series
+- Cross-reference to the claim elements it supports
+- Note if a component appears in multiple figures (use same numeral across figures)
+
+### Step 4: Generate Drawing Descriptions
+
+Write formal drawing descriptions (附图说明):
+
+**For CN jurisdiction (Chinese)**:
+```
+图1是[发明名称]的系统结构示意图；
+图2是[发明名称]的方法流程图；
+图3是[具体组件]的详细结构示意图；
+```
+
+**For US/EP jurisdiction (English)**:
+```
+FIG. 1 is a block diagram illustrating the system architecture according to one embodiment;
+FIG. 2 is a flowchart illustrating the method steps according to one embodiment;
+FIG. 3 is a detailed view of the processing module of FIG. 1;
+```
+
+### Step 5: Generate Reference Numeral Index
+
+Create a complete mapping:
+
+```markdown
+## Reference Numeral Index
+
+| Numeral | Component Name | Figure(s) | Claim Element |
+|---------|---------------|-----------|---------------|
+| 100 | System | FIG. 1 | Claim X preamble |
+| 102 | Processor | FIG. 1 | Claim X, element 1 |
+| 104 | Memory | FIG. 1 | Claim X, element 2 |
+| 106 | Communication bus | FIG. 1 | Claim X, element 3 |
+| 200 | Method | FIG. 2 | Claim 1 preamble |
+| 202 | Receiving step | FIG. 2 | Claim 1, step 1 |
+| 204 | Processing step | FIG. 2 | Claim 1, step 2 |
+```
+
+### Step 6: Cross-Reference to Claims
+
+Verify that every claim element has at least one reference numeral:
+
+| Claim Element | Figure | Numeral | Status |
+|---------------|--------|---------|--------|
+| [element] | [which fig] | [numeral] | Covered / [MISSING] |
+
+If any claim element has no corresponding figure or numeral, flag it:
+- `[MISSING FIGURE: Need a diagram showing {element description}]`
+- `[MISSING NUMERAL: Component {name} in figure {X} needs a numeral]`
+
+### Step 7: Output
+
+Write `patent/figures/figure_descriptions.md`:
+```markdown
+## Figure Descriptions
+
+### FIG. 1 — [Description]
+[Formal one-paragraph description with all reference numerals]
+
+### FIG. 2 — [Description]
+[Formal one-paragraph description with all reference numerals]
+...
+```
+
+Write `patent/figures/numeral_index.md`:
+```markdown
+## Reference Numeral Index
+
+[Complete table of all numerals, components, figures, and claim mappings]
+```
+
+## Key Rules
+
+- Every component in every figure must have a reference numeral.
+- Every reference numeral must be explained in the specification.
+- Numeral series must be consistent: 100-series for FIG. 1, 200-series for FIG. 2.
+- If the same component appears in multiple figures, use the SAME numeral.
+- Do NOT modify user-provided figures -- only describe them.
+- Flag missing figures that the claims require but the user has not provided.
+- Drawing descriptions are one sentence each, in a consistent format.

--- a/skills/invention-structuring/SKILL.md
+++ b/skills/invention-structuring/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: invention-structuring
+description: "Structure a raw invention idea into a formal invention disclosure. Use when user says \"构建发明\", \"structure invention\", \"发明构建\", \"invention disclosure\", or wants to formalize a rough idea into a patent-ready structure."
+argument-hint: [invention-description-or-brief-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex
+---
+
+# Invention Structuring
+
+Structure the invention into a formal disclosure based on: **$ARGUMENTS**
+
+Adapted from the refinement pattern in `/research-refine` for patent invention decomposition.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — External reviewer for invention decomposition validation
+- `MAX_REFINEMENT_ROUNDS = 3` — Maximum structuring iterations
+
+## Inputs
+
+1. Invention description from `$ARGUMENTS`
+2. `patent/INVENTION_BRIEF.md` if exists
+3. `patent/PRIOR_ART_REPORT.md` — prior art landscape
+4. `patent/NOVELTY_ASSESSMENT.md` — novelty analysis
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for the Problem-Solution-Advantage framework and claimable subject matter guidelines.
+
+## Workflow
+
+### Step 1: Problem-Solution-Advantage Framework
+
+Structure the invention using the universal patent framework:
+
+**Technical Problem (要解决的技术问题)**:
+- Derived from prior art deficiencies identified in NOVELTY_ASSESSMENT.md
+- Must be a specific, technical problem (not a commercial or social problem)
+- Statement format: "The technical problem to be solved is how to [specific technical objective] given [specific technical constraint]."
+
+**Technical Solution (技术方案)**:
+- The invention's specific technical contribution
+- Focus on the mechanism, not the result
+- Must be described at a level that matches the intended claim scope
+- Identify which features are known vs. inventive
+
+**Advantages (有益效果)**:
+- Measurable or quantifiable improvements over prior art
+- Must result from the inventive features, not just good engineering
+- Include specific technical effects if known (e.g., "reduces processing time by 40%")
+
+### Step 2: Invention Decomposition
+
+Break the invention into three layers:
+
+**Core Inventive Concept (核心发明构思)**:
+- The minimal set of features that make the invention patentable
+- This maps to the independent claim scope
+- Test: if you remove this feature, the invention is no longer novel
+
+**Supporting Features (支撑性特征)**:
+- Features that make the invention work well in practice
+- These become dependent claim material
+- They narrow the scope but add practical value
+
+**Optional Features (可选特征)**:
+- Implementation details, preferred parameters, alternatives
+- These become embodiment material
+- They support broader claim interpretation
+
+### Step 3: Claimable Subject Matter Identification
+
+For the core inventive concept, determine what categories of claims to draft:
+
+| Category | Applicability | Content |
+|----------|-------------|---------|
+| Method/process | If invention involves steps | Process flow, algorithm, workflow |
+| System/apparatus | If invention involves components | Hardware structure, modules, connections |
+| Product | If invention is a physical device | Shape, structure, composition |
+| Computer-readable medium | If software invention (US) | Stored instructions, non-transitory medium |
+| Product-by-process | If structure is hard to define | Product defined by how it is made |
+
+### Step 4: Drawing Plan
+
+Plan what figures are needed to support the claims and specification:
+
+| Figure | Type | Shows | Supports Claim Elements |
+|--------|------|-------|------------------------|
+| FIG. 1 | Block diagram | System architecture | System claim components |
+| FIG. 2 | Flowchart | Method steps | Method claim steps |
+| FIG. 3 | Sequence diagram | Interaction between components | Specific implementation details |
+
+If user has provided figures, reference them here. If figures are missing, note what is needed.
+
+### Step 5: Dependency Mapping
+
+Map feature dependencies to plan the claim hierarchy:
+
+```
+Independent Claim 1 (method, broadest scope)
+├── Core inventive feature A
+├── Core inventive feature B
+└── Known feature C (for context)
+
+Dependent Claim 2 → narrows feature A with specific implementation
+Dependent Claim 3 → narrows feature B with specific parameters
+Dependent Claim 4 → depends on 2, adds optional feature D
+Dependent Claim 5 → alternative implementation of feature A
+```
+
+### Step 6: Cross-Model Validation
+
+Call `REVIEWER_MODEL` via `mcp__codex__codex` with xhigh reasoning:
+
+```
+mcp__codex__codex:
+  config: {"model_reasoning_effort": "xhigh"}
+  prompt: |
+    You are a patent attorney reviewing an invention disclosure.
+    Evaluate the structuring choices:
+
+    INVENTION: [Problem-Solution-Advantage summary]
+    DECOMPOSITION: [Core/Supporting/Optional features]
+    CLAIM PLAN: [intended claim categories and hierarchy]
+
+    Please assess:
+    1. Is the Problem-Solution-Advantage framework correctly applied?
+    2. Is the core inventive concept correctly identified? Are there features that should be core but are listed as supporting (or vice versa)?
+    3. Are the planned claim categories sufficient to protect the invention?
+    4. Is the drawing plan adequate for enablement?
+    5. Are there any claimable aspects being missed?
+```
+
+### Step 7: Output
+
+Write `patent/INVENTION_DISCLOSURE.md`:
+
+```markdown
+## Invention Disclosure
+
+### Title
+[invention title]
+
+### Technical Problem
+[formal problem statement]
+
+### Technical Solution
+[formal solution description]
+
+### Advantages
+[measurable advantages]
+
+### Feature Decomposition
+
+#### Core Inventive Concept
+[features that define independent claim scope]
+
+#### Supporting Features
+[features for dependent claims]
+
+#### Optional Features
+[features for embodiments]
+
+### Claimable Subject Matter
+[method, system, product, medium claims planned]
+
+### Drawing Plan
+[figures needed, what each shows]
+
+### Dependency Map
+[claim hierarchy plan]
+
+### Inventor Information
+[names, contributions]
+
+### Target Jurisdiction
+[CN/US/EP/ALL]
+```
+
+## Key Rules
+
+- The Problem must come from prior art deficiencies, not from commercial needs.
+- The Solution must describe the technical mechanism, not just the result.
+- The core inventive concept must be the minimum set of features for patentability.
+- Supporting features should be independently valuable -- each should provide a meaningful technical benefit even if other supporting features are removed.
+- Never invent embodiments that do not correspond to the actual invention or user-provided materials.
+- If `mcp__codex__codex` is not available, skip cross-model validation and note it in the output.

--- a/skills/jurisdiction-format/SKILL.md
+++ b/skills/jurisdiction-format/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: jurisdiction-format
+description: "Compile patent application into jurisdiction-specific filing format. Use when user says \"格式转换\", \"jurisdiction format\", \"国家格式\", \"compile patent\", or wants formatted patent documents for CN/US/EP filing."
+argument-hint: [patent-directory-or-jurisdiction]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
+---
+
+# Jurisdiction Format: Patent Filing Compilation
+
+Compile the patent application into filing-ready format based on: **$ARGUMENTS**
+
+Analogous to `/paper-compile` but for patent document formatting instead of LaTeX.
+
+## Constants
+
+- `JURISDICTION = "auto"` — From pipeline or args: `CN`, `US`, `EP`, `ALL`
+- `PATENT_TYPE = "invention"` — `invention` (发明专利) or `utility_model` (实用新型, CN only)
+- `OUTPUT_FORMAT = "markdown"` — `markdown` (for review) or `docx` (for filing, requires python-docx)
+- `OUTPUT_DIR = "patent/output/"` — Base output directory
+
+## Inputs
+
+1. `patent/CLAIMS.md` — drafted claims
+2. `patent/specification/` — all specification sections (title, technical_field, background, summary, drawings_description, detailed_description, abstract)
+3. `patent/figures/` — figure descriptions and numeral index
+4. `patent/INVENTION_DISCLOSURE.md` — for metadata
+
+## Shared References
+
+Load `../shared-references/patent-format-cn.md` for CNIPA document structure and formatting rules.
+Load `../shared-references/patent-format-us.md` for USPTO document structure.
+Load `../shared-references/patent-format-ep.md` for EPO document structure.
+
+## Workflow
+
+### Step 1: Determine Output Jurisdictions
+
+From `$ARGUMENTS` or constant:
+- `CN` -> Generate CNIPA format only
+- `US` -> Generate USPTO format only
+- `EP` -> Generate EPO format only
+- `ALL` -> Generate all three formats
+
+### Step 2: Generate CN Format (if CN or ALL)
+
+Output to `patent/output/CN/`:
+
+#### 权利要求书 (Claims)
+- Extract claims from `patent/CLAIMS.md`
+- Format per CNIPA conventions:
+  - Independent claims: "1. 一种[主题]的方法，...其特征在于..."
+  - Dependent claims: "2. 根据权利要求1所述的方法，其特征在于..."
+- Ensure Chinese terminology is correct (所述, 其特征在于, 包括, 等)
+
+#### 说明书 (Description)
+Combine all specification sections in CNIPA order:
+1. 发明名称 (from title.md)
+2. 技术领域 (from technical_field.md)
+3. 背景技术 (from background.md)
+4. 发明内容 (from summary.md — split into 技术问题/技术方案/有益效果)
+5. 附图说明 (from drawings_description.md)
+6. 具体实施方式 (from detailed_description.md)
+
+#### 说明书摘要 (Abstract)
+- Extract from abstract.md
+- Verify word count <= 300 Chinese characters
+- Include most representative claim
+
+#### Format as markdown or docx
+If `OUTPUT_FORMAT = "markdown"`:
+- Write as separate .md files with clear section headers
+
+If `OUTPUT_FORMAT = "docx"`:
+- Use python-docx to create Word documents matching CNIPA templates
+- Set font to 宋体 (SimSun) for body, 黑体 (SimHea) for headers
+- Standard margins (上下 2.54cm, 左右 3.17cm)
+
+### Step 3: Generate US Format (if US or ALL)
+
+Output to `patent/output/US/`:
+
+#### Claims Section
+- Number all claims sequentially (1, 2, 3, ...)
+- Format per US conventions:
+  - "1. A method for [purpose], comprising:"
+  - "2. The method of claim 1, wherein..."
+- Ensure antecedent basis is correct ("a" -> "the")
+
+#### Specification
+Combine all sections in USPTO order:
+1. Title
+2. Cross-Reference to Related Applications (if any)
+3. Field of the Invention
+4. Background of the Invention
+5. Brief Summary of the Invention
+6. Brief Description of the Drawings
+7. Detailed Description of Preferred Embodiments
+8. Abstract
+
+Format drawings references as "FIG. 1" (not "Figure 1").
+
+#### Abstract
+- Extract from abstract.md
+- Verify word count <= 150 words / 2500 characters
+
+#### Application Data Sheet (ADS) Template
+Generate a skeleton ADS with:
+- Title
+- Inventor information (placeholder)
+- Application type
+- Entity status (small/micro/large)
+
+### Step 4: Generate EP Format (if EP or ALL)
+
+Output to `patent/output/EP/`:
+
+#### Claims Section
+- Format in two-part form per Rule 43(1) EPC:
+  - "1. A method for [purpose], comprising [known features], characterised in that [inventive features]."
+- Ensure the "characterised in that" phrase is present in all independent claims
+
+#### Description
+Combine all sections in EPO Rule 42 order:
+1. Title of the Invention
+2. Technical Field
+3. Background Art
+4. Disclosure of the Invention (problem-solution-advantage)
+5. Description of Embodiments
+6. Brief Description of Drawings
+7. Reference Signs List (mandatory at EPO)
+
+Format drawings references as "FIG. 1" or "Figure 1".
+
+#### Abstract
+- Extract from abstract.md
+- ~150 words limit
+
+### Step 5: Consistency Check
+
+Verify across all generated formats:
+- [ ] All claims are present in every format
+- [ ] Claim numbering is consistent
+- [ ] Reference numerals match specification across all formats
+- [ ] No format-specific requirements are violated
+- [ ] Language is correct for each jurisdiction (Chinese for CN, English for US/EP)
+
+### Step 6: Output Summary
+
+Write `patent/output/OUTPUT_SUMMARY.md`:
+
+```markdown
+## Patent Filing Documents
+
+### Generated Files
+
+#### CN (CNIPA)
+| File | Description | Status |
+|------|-------------|--------|
+| 权利要求书.md | Claims in CN format | Complete |
+| 说明书.md | Description in CN format | Complete |
+| 说明书摘要.md | Abstract (CN) | Complete |
+
+#### US (USPTO)
+| File | Description | Status |
+|------|-------------|--------|
+| claims.md | Claims in US format | Complete |
+| specification.md | Description in US format | Complete |
+| abstract.md | Abstract (US) | Complete |
+| ads_template.md | Application Data Sheet skeleton | Complete |
+
+#### EP (EPO)
+| File | Description | Status |
+|------|-------------|--------|
+| claims.md | Claims in EP format | Complete |
+| description.md | Description in EP format | Complete |
+| abstract.md | Abstract (EP) | Complete |
+
+### Consistency Check
+- [ ] All claims present in all formats
+- [ ] Reference numerals consistent
+- [ ] Language correct per jurisdiction
+```
+
+## Key Rules
+
+- Never mix jurisdiction formats (e.g., do not include "其特征在于" in US claims).
+- Claims must be identical in technical content across jurisdictions, only the format differs.
+- For CN output, verify Chinese patent terminology is correct and consistent.
+- For EP output, the two-part claim form is mandatory -- every independent claim must have "characterised in that."
+- Abstract word limits are jurisdiction-specific and must be verified.
+- The jurisdiction-format skill does NOT modify claim content -- it reformats existing content only.
+- If `OUTPUT_FORMAT = "docx"`, check that python-docx is available; if not, fall back to markdown.

--- a/skills/patent-novelty-check/SKILL.md
+++ b/skills/patent-novelty-check/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: patent-novelty-check
+description: "Assess patent novelty and non-obviousness against prior art. Use when user says \"专利查新\", \"patent novelty\", \"可专利性评估\", \"patentability check\", or wants to evaluate if an invention is patentable."
+argument-hint: [invention-description-or-brief-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch, mcp__codex__codex
+---
+
+# Patent Novelty and Non-Obviousness Check
+
+Assess patentability of: **$ARGUMENTS**
+
+Adapted from `/novelty-check` for patent legal standards. Research novelty is NOT the same as patent novelty.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — Model used via Codex MCP for cross-model examiner verification
+- `NOVELTY_STANDARD = patent` — Always use legal patentability standard, not research contribution standard
+
+## Inputs
+
+1. Invention description from `$ARGUMENTS`
+2. `patent/PRIOR_ART_REPORT.md` (output of `/prior-art-search`)
+3. `patent/INVENTION_BRIEF.md` if exists
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for novelty/non-obviousness standards.
+Load `../shared-references/patent-format-us.md` for 102/103 analysis framework.
+
+## Workflow
+
+### Step 1: Define Claim Elements
+
+From the invention description, extract the key claim elements that would define the invention's scope:
+1. List the technical features that make the invention novel
+2. Identify which features are known from prior art vs. inventive
+3. Draft preliminary claim language for 2-3 independent claims (method + system)
+
+### Step 2: Anticipation Analysis (Novelty)
+
+For each preliminary claim, test against EACH prior art reference in `PRIOR_ART_REPORT.md`:
+
+**Single-reference test**: Does any single reference disclose ALL claim elements?
+
+| Claim Element | Ref 1 | Ref 2 | Ref 3 | ... |
+|--------------|-------|-------|-------|-----|
+| Feature A | Yes/No + evidence | | | |
+| Feature B | Yes/No + evidence | | | |
+| Feature C | Yes/No + evidence | | | |
+| Feature D | Yes/No + evidence | | | |
+
+**Verdict per reference**:
+- ANTICIPATED: One reference discloses every element → claim is not novel
+- NOT ANTICIPATED: At least one element missing from every single reference → claim is novel
+
+### Step 3: Obviousness Analysis (Inventive Step)
+
+If the invention is novel (passes Step 2), test for obviousness:
+
+**Two/three-reference combination test**: Can 2-3 references be combined to render the claim obvious?
+
+For each combination of the top references:
+1. **Primary reference**: Which reference is closest to the claimed invention?
+2. **Secondary reference(s)**: Which reference(s) teach the missing element(s)?
+3. **Motivation to combine**: Would a POSITA have reason to combine these references?
+   - Explicit suggestion in the references themselves?
+   - Same field, same problem?
+   - Common design incentive?
+   - Known technique for improving similar devices?
+
+Format as a matrix:
+
+| Combination | Primary | Secondary | Missing Elements | Motivation to Combine | Obvious? |
+|-------------|---------|-----------|-----------------|----------------------|----------|
+| Ref1 + Ref2 | Ref1 | Ref2 | Feature D | Same field, similar problem | Yes/No |
+
+### Step 4: Cross-Model Examiner Verification
+
+Call `REVIEWER_MODEL` via `mcp__codex__codex` with xhigh reasoning:
+
+```
+mcp__codex__codex:
+  config: {"model_reasoning_effort": "xhigh"}
+  prompt: |
+    You are a senior patent examiner at the [USPTO/CNIPA/EPO].
+    Examine the following invention for patentability.
+
+    INVENTION: [invention description + preliminary claims]
+
+    PRIOR ART: [prior art references with key teachings]
+
+    Please analyze:
+    1. Anticipation (novelty): Does any single reference anticipate any claim?
+    2. Obviousness: Can any combination of references render claims obvious?
+    3. Claim scope: Are the claims broad enough to be valuable?
+    4. Recommended amendments if any claim is rejected.
+    Be rigorous and cite specific references.
+```
+
+### Step 5: Jurisdiction-Specific Assessment
+
+For each target jurisdiction, provide a patentability assessment:
+
+**Under 35 USC 102/103 (US)**:
+- Novelty: PASS / FAIL (cite specific reference if fail)
+- Non-obviousness: PASS / FAIL (cite combination if fail)
+
+**Under Article 22 CN Patent Law (CN)**:
+- 新颖性 (Novelty): 通过 / 未通过
+- 创造性 (Inventive Step): 通过 / 未通过
+
+**Under Article 54/56 EPC (EP)**:
+- Novelty: PASS / FAIL
+- Inventive step: PASS / FAIL (problem-solution approach)
+
+### Step 6: Output
+
+Write `patent/NOVELTY_ASSESSMENT.md`:
+
+```markdown
+## Patentability Assessment
+
+### Invention Summary
+[description]
+
+### Overall Assessment
+[PATENTABLE / PATENTABLE WITH AMENDMENTS / NOT PATENTABLE]
+
+### Anticipation Analysis
+[claim-by-claim matrix against each reference]
+
+### Obviousness Analysis
+[combination analysis with motivation to combine]
+
+### Cross-Model Examiner Review
+[summary of GPT-5.4 examiner feedback]
+
+### Recommended Claim Amendments
+[If claims need modification to overcome prior art, suggest specific amendments]
+
+### Risk Factors
+[What could cause rejection during actual prosecution?]
+```
+
+## Key Rules
+
+- Patent novelty is absolute: any public disclosure before the priority date counts as prior art, worldwide.
+- Research novelty ("has anyone published this?") is NOT the same as patent novelty ("does any single reference teach every claim element?").
+- Obviousness requires BOTH: (1) a combination of references AND (2) a motivation to combine them.
+- Never assume the invention is patentable just because no identical patent exists.
+- The assessment is advisory only -- actual prosecution may reveal different prior art.
+- If `mcp__codex__codex` is not available, skip cross-model examiner review and note it in the output.

--- a/skills/patent-pipeline/SKILL.md
+++ b/skills/patent-pipeline/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: patent-pipeline
+description: "Full patent drafting pipeline from invention description to jurisdiction-formatted filing documents. Supports CN (CNIPA), US (USPTO), EP (EPO). Supports invention patents and utility models. Use when user says \"写专利\", \"patent pipeline\", \"专利申请\", \"draft patent\", \"写权利要求书\", or wants to draft a complete patent application."
+argument-hint: [invention-description — jurisdiction]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex
+---
+
+# Patent Pipeline: From Invention to Filing
+
+Draft a complete patent application based on: **$ARGUMENTS**
+
+## Overview
+
+This skill orchestrates the full patent drafting lifecycle -- from prior art search through jurisdiction-formatted filing documents. It chains sub-skills into a patent-specific pipeline:
+
+```
+/prior-art-search → /patent-novelty-check → /invention-structuring → /claims-drafting → /specification-writing → /patent-review → /jurisdiction-format
+     (search)           (verify)              (structure)             (claims)            (description)          (examiner)         (compile)
+                                                                                              ├── /figure-description
+                                                                                              └── /embodiment-description
+```
+
+**This is a parallel branch, not part of the linear research pipeline.** After `/idea-discovery` produces validated ideas, the user can either:
+- Go to `/experiment-bridge` → `/auto-review-loop` → `/paper-writing` (publish track)
+- Go to `/grant-proposal` (funding track)
+- Go to `/patent-pipeline` (patent track) **<-- this skill**
+
+```
+                    ┌→ /experiment-bridge → /auto-review-loop → /paper-writing  (publish track)
+/idea-discovery ────┤
+                    ├→ /grant-proposal → [get funded] → ...  (funding track)
+                    └→ /patent-pipeline → [file patent]       (patent track)
+```
+
+Patents are about **protecting inventions** (legal scope), not publishing results (academic contribution). This skill handles the unique requirements of patent drafting: prior art analysis, claims hierarchy design, specification writing with enablement support, embodiment descriptions, and jurisdiction-specific formatting.
+
+## Constants
+
+- **JURISDICTION = `CN`** — Target patent jurisdiction. Options: `CN` (CNIPA), `US` (USPTO), `EP` (EPO), `ALL` (generate all three). Override via argument (e.g., `/patent-pipeline "invention — US"`).
+- **PATENT_TYPE = `invention`** — `invention` (发明专利, 20 year protection) or `utility_model` (实用新型, CN only, 10 year protection, apparatus claims only). Override via argument.
+- **REVIEWER_MODEL = `gpt-5.4`** — Model used via Codex MCP for examiner-style review.
+- **MAX_REVIEW_ROUNDS = 2** — Maximum review-revision cycles.
+- **AUTO_PROCEED = false** — At each checkpoint, **always wait for explicit user confirmation**. Patent applications require inventor judgment at every stage. Set `true` only if user explicitly requests autonomous mode.
+- **LANGUAGE = `auto`** — Output language. Auto-detected from jurisdiction: CN->Chinese, US->English, EP->English. Override explicitly if needed.
+- **OUTPUT_DIR = `patent/`** — Directory for generated patent files.
+- **OUTPUT_FORMAT = `markdown`** — Draft format. `markdown` for review, `docx` for filing-ready.
+
+> Override defaults via arguments: `/patent-pipeline "invention — US, utility model"` or `/patent-pipeline "invention — ALL, language: Chinese"`.
+
+## Patent Type Specifications
+
+### Invention Patent (发明专利)
+
+| Field | Detail |
+|-------|--------|
+| **Protection** | 20 years from filing date |
+| **Subject matter** | Methods, systems, products, compositions, processes |
+| **Examination** | Substantive examination required |
+| **Inventive step** | High (must involve an inventive step / 创造性) |
+| **Timeline** | 2-4 years to grant (CN); 2-3 years (US); 3-5 years (EP) |
+| **Claims** | Method + system + product claims allowed |
+
+### Utility Model (实用新型) — CN Only
+
+| Field | Detail |
+|-------|--------|
+| **Protection** | 10 years from filing date |
+| **Subject matter** | Product shape, structure, or combination thereof only |
+| **Examination** | Formal examination only (no substantive examination) |
+| **Inventive step** | Lower than invention patent |
+| **Timeline** | 6-8 months to grant |
+| **Claims** | Apparatus/device claims only. NO method claims. |
+| **Restriction** | CN jurisdiction only |
+
+## State Persistence (Compact Recovery)
+
+Patent drafting is a long task that may trigger context compaction. Persist state to `patent/PATENT_STATE.json` after each phase:
+
+```json
+{
+  "phase": 3,
+  "jurisdiction": "CN",
+  "patent_type": "invention",
+  "language": "Chinese",
+  "codex_thread_id": "019cfcf4-...",
+  "invention_title": "...",
+  "claims_count": 15,
+  "status": "in_progress",
+  "timestamp": "2026-04-10T15:00:00"
+}
+```
+
+**Write this file at the end of every phase.** On invocation, check for this file:
+- If absent or `status: "completed"` -> fresh start
+- If `status: "in_progress"` and within 24h -> **resume** from saved phase (read output files to restore context)
+- If older than 24h -> fresh start (stale state)
+
+On completion, set `"status": "completed"`.
+
+## Workflow
+
+### Phase 0: Input Parsing & Context Gathering
+
+Parse `$ARGUMENTS` to extract:
+
+1. **Invention description** — may be structured (references INVENTION_BRIEF.md), conversational with figures, or output from IDEA_REPORT.md
+2. **Jurisdiction** — detect from keywords (e.g., "CN" or "中国" -> CN, "US" or "USPTO" -> US, "EP" or "EPO" -> EP, "ALL")
+3. **Patent type** — detect from keywords (e.g., "utility model" or "实用新型" -> utility_model, default -> invention)
+4. **Overrides** — language, output format, review rounds
+
+Then gather context from the project directory:
+
+1. Read `INVENTION_BRIEF.md` if it exists (user filled in the template)
+2. Read `IDEA_REPORT.md` if it exists (from `/idea-discovery` -- can extract invention from research results)
+3. Read `refine-logs/FINAL_PROPOSAL.md` if it exists
+4. Read `NARRATIVE_REPORT.md` if it exists (research results that may be patentable)
+5. Search for user-provided figures (PNG, JPG, SVG, PDF) in the project directory
+6. Check for `patent/PATENT_STATE.json` (resume from prior interrupted run)
+
+If insufficient context exists:
+- No invention description at all -> suggest user describe the invention or fill in `INVENTION_BRIEF.md`
+- Has IDEA_REPORT.md -> extract patentable aspects from the research
+- Has figures -> reference them in the invention brief
+- No figures -> note that figures will be needed and plan what drawings are required
+
+**If the input is conversational** (not a structured brief), parse the description into the invention brief structure and write `patent/INVENTION_BRIEF.md` for downstream phases.
+
+### Phase 1: Prior Art Search & Novelty Assessment
+
+#### 1.1 Prior Art Search
+
+Invoke `/prior-art-search`:
+
+```
+/prior-art-search "patent/INVENTION_BRIEF.md"
+```
+
+This searches patent databases (Google Patents, Espacenet) and academic literature for relevant prior art.
+
+#### 1.2 Novelty Check
+
+Invoke `/patent-novelty-check`:
+
+```
+/patent-novelty-check "patent/INVENTION_BRIEF.md"
+```
+
+This assesses novelty and non-obviousness against the prior art found in step 1.1.
+
+**🚦 Checkpoint:** Present the prior art landscape and novelty assessment:
+
+```
+Prior art search complete:
+- [X] patent references found
+- [Y] non-patent literature references found
+- Closest prior art: [reference] -- [why it's closest]
+- Novelty assessment: [PATENTABLE / PATENTABLE WITH AMENDMENTS / NOT PATENTABLE]
+- Key risk areas: [list]
+
+Ready to proceed with invention structuring?
+```
+
+**⛔ STOP HERE and wait for user response.** Do NOT auto-proceed unless AUTO_PROCEED=true.
+
+Options:
+- Reply **"go"** -> proceed to Phase 2
+- Reply with **adjustments** -> refine the invention scope and re-check novelty
+- Reply **"stop"** -> save progress to `patent/DRAFT_NOTES.md`
+
+**State**: Write `PATENT_STATE.json` with `phase: 1`.
+
+### Phase 2: Invention Structuring & Claims Design
+
+#### 2.1 Structure the Invention
+
+Invoke `/invention-structuring`:
+
+```
+/invention-structuring "patent/INVENTION_BRIEF.md"
+```
+
+This decomposes the invention into core inventive concept, supporting features, and optional features. Produces `patent/INVENTION_DISCLOSURE.md`.
+
+#### 2.2 Draft Claims
+
+Invoke `/claims-drafting`:
+
+```
+/claims-drafting "patent/INVENTION_DISCLOSURE.md"
+```
+
+This drafts the claims hierarchy -- the most critical part of the patent. Produces `patent/CLAIMS.md`.
+
+**🚦 Checkpoint:** Present the invention structure and claims:
+
+```
+Invention structured:
+- Core inventive concept: [summary]
+- Claim categories: [method, system, etc.]
+- Claims drafted: [X] independent + [Y] dependent = [Z] total
+- Independent claim 1 (broadest): [first 50 words of claim 1]
+- Examiner review score: [X]/10
+
+The claims define the legal scope of protection. Please review before proceeding to specification.
+```
+
+**⛔ STOP HERE and wait for user response.** Do NOT auto-proceed unless AUTO_PROCEED=true.
+
+Options:
+- Reply **"go"** -> proceed to Phase 3
+- Reply with **adjustments** (e.g., "broaden claim 1", "add more dependent claims") -> revise claims
+- Reply **"stop"** -> save progress
+
+**State**: Write `PATENT_STATE.json` with `phase: 2`.
+
+### Phase 3: Specification Writing
+
+Invoke `/specification-writing`:
+
+```
+/specification-writing "patent/CLAIMS.md"
+```
+
+This writes the full specification section by section. Internally invokes `/figure-description` (if user-provided figures exist) and `/embodiment-description` for the detailed description. The specification-writing skill handles figure processing and embodiment writing as sub-skills.
+
+**🚦 Checkpoint:** Present the specification overview:
+
+```
+Specification written:
+- Title: [title]
+- Sections: Technical Field, Background, Summary, Drawings Description, Detailed Description, Abstract
+- Embodiments: [X]
+- Reference numerals: [Y] components mapped
+- Abstract length: [Z] words (limit: [jurisdiction limit])
+- Claim support: [all elements covered / X elements missing]
+
+Ready to proceed to review?
+```
+
+**⛔ STOP HERE and wait for user response.**
+
+**State**: Write `PATENT_STATE.json` with `phase: 3`.
+
+### Phase 4: Patent Review
+
+Invoke `/patent-review`:
+
+```
+/patent-review "patent/"
+```
+
+This runs 2 rounds of examiner-style review via GPT-5.4 xhigh. The examiner evaluates clarity, written description, enablement, novelty, non-obviousness, and claim scope.
+
+**State**: Write `PATENT_STATE.json` with `phase: 4` and review score.
+
+### Phase 5: Jurisdiction Formatting & Output
+
+Invoke `/jurisdiction-format`:
+
+```
+/jurisdiction-format "patent/"
+```
+
+This compiles the application into the target jurisdiction format(s).
+
+#### Final Deliverables
+
+| Output | Location | Description |
+|--------|----------|-------------|
+| CN: 权利要求书 | `patent/output/CN/` | Claims in CNIPA format |
+| CN: 说明书 | `patent/output/CN/` | Description in CNIPA format |
+| CN: 说明书摘要 | `patent/output/CN/` | Abstract (CN) |
+| US: Claims | `patent/output/US/` | Claims in USPTO format |
+| US: Specification | `patent/output/US/` | Description in USPTO format |
+| US: Abstract | `patent/output/US/` | Abstract (US) |
+| EP: Claims | `patent/output/EP/` | Claims in EPO format |
+| EP: Description | `patent/output/EP/` | Description in EPO format |
+| EP: Abstract | `patent/output/EP/` | Abstract (EP) |
+
+#### Final Report
+
+```markdown
+## Patent Pipeline Complete
+
+### Application Summary
+- Title: [invention title]
+- Jurisdiction: [CN/US/EP/ALL]
+- Patent Type: [Invention / Utility Model]
+- Language: [Chinese/English]
+- Total Claims: [X] independent + [Y] dependent
+
+### Pipeline Scores
+| Phase | Score |
+|-------|-------|
+| Prior Art Search | [completeness assessment] |
+| Novelty Assessment | [PATENTABLE/PATENTABLE WITH AMENDMENTS/NOT PATENTABLE] |
+| Examiner Review Round 1 | [X]/10 |
+| Examiner Review Round 2 | [Y]/10 |
+| Final | [Z]/10 |
+
+### Output Files
+[Table of all generated files with paths]
+
+### Next Steps
+- [ ] Have a patent attorney review the application
+- [ ] Conduct professional prior art search (this tool's search is preliminary)
+- [ ] Prepare formal drawings (if user figures need professional rendering)
+- [ ] File with the patent office
+- [ ] For utility model (CN): formal examination typically takes 6-8 months
+- [ ] For invention patent: substantive examination may take 2-4 years
+```
+
+**State**: Write `PATENT_STATE.json` with `phase: 5, status: "completed"`.
+
+## Key Rules
+
+- Never fabricate prior art references, patent numbers, or citations.
+- Claims must be supported by the specification (written description requirement).
+- Each jurisdiction has strict format requirements -- do not mix formats.
+- Utility model (实用新型) applies ONLY to CN jurisdiction and ONLY covers apparatus/device claims.
+- AUTO_PROCEED defaults to false -- patent applications require human review at every phase. Sub-skills inherit this flag: when AUTO_PROCEED=false, sub-skills present results and wait at their own internal checkpoints too.
+- The patent pipeline produces drafts for attorney review, not final filing documents.
+- Large file handling: if a Write operation fails, retry with Bash `cat <<'EOF'` heredoc.
+- Never include experimental results or empirical evaluations in the specification.
+- Consistent terminology is mandatory -- same word for the same concept throughout.
+- If `mcp__codex__codex` is not available (no OpenAI API key), skip external cross-model review and note it in the output. The pipeline must not fail due to missing reviewer access.
+
+## Composing with Other Workflows
+
+The patent pipeline can start from multiple entry points:
+
+```
+User describes invention directly ──→ /patent-pipeline
+
+/idea-discovery produces IDEA_REPORT.md ──→ /patent-pipeline (extract patentable aspects)
+
+/research-refine produces FINAL_PROPOSAL.md ──→ /patent-pipeline (from refined research idea)
+
+/auto-review-loop produces strong results ──→ /patent-pipeline (patent the method)
+```
+
+## Acknowledgements
+
+Built on the ARIS (Auto-claude-code-research-in-sleep) skill architecture. Patent writing principles adapted from MPEP (US), CN Patent Examination Guidelines (CN), and EPO Guidelines for Examination (EP).

--- a/skills/patent-review/SKILL.md
+++ b/skills/patent-review/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: patent-review
+description: "Get an external patent examiner review of a patent application. Use when user says \"专利审查\", \"patent review\", \"审查意见\", \"examiner review\", or wants critical feedback on patent claims and specification."
+argument-hint: [patent-directory-or-scope]
+allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, mcp__codex__codex, mcp__codex__codex-reply
+---
+
+# Patent Examiner Review via Codex MCP (xhigh reasoning)
+
+Get a multi-round patent examiner review of the patent application based on: **$ARGUMENTS**
+
+Adapted from `/research-review`. The reviewer persona is a patent examiner, not a paper reviewer.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — Model used via Codex MCP
+- `REVIEW_ROUNDS = 2` — Number of review rounds
+- `EXAMINER_PERSONA = "patent-examiner"` — GPT-5.4 persona
+
+## Prerequisites
+
+- Codex MCP Server configured:
+  ```bash
+  claude mcp add codex -s user -- codex mcp-server
+  ```
+
+## Inputs
+
+1. `patent/CLAIMS.md` — all drafted claims
+2. `patent/specification/` — all specification sections
+3. `patent/figures/numeral_index.md` — reference numeral mapping
+4. `patent/PRIOR_ART_REPORT.md` — known prior art
+5. `patent/INVENTION_DISCLOSURE.md` — invention structure
+
+## Workflow
+
+### Step 1: Gather Patent Context
+
+Before calling the external reviewer, compile a comprehensive briefing:
+1. Read all claims (independent + dependent)
+2. Read specification sections (at least summary and detailed description)
+3. Read prior art report for context
+4. Identify: core inventive concept, claim scope, known prior art, target jurisdiction
+
+### Step 2: Round 1 — Full Examiner Review
+
+Send to `REVIEWER_MODEL` via `mcp__codex__codex` with xhigh reasoning:
+
+```
+mcp__codex__codex:
+  config: {"model_reasoning_effort": "xhigh"}
+  prompt: |
+    You are a senior patent examiner at the [USPTO/CNIPA/EPO].
+    Examine this patent application and issue a detailed office action.
+
+    CLAIMS:
+    [all claims]
+
+    SPECIFICATION SUMMARY:
+    [key sections: title, technical field, background, summary, abstract]
+
+    PRIOR ART KNOWN:
+    [prior art references]
+
+    PATENTABILITY STANDARDS TO APPLY:
+    [US: 35 USC 101/102/103/112 | CN: Articles 22, 26 | EP: Articles 54, 56, 83, 84]
+
+    Please issue an office action covering:
+
+    1. CLAIM CLARITY (112(b)/Art 84):
+       - Are all terms definite?
+       - Any indefinite functional language?
+       - Antecedent basis issues?
+
+    2. WRITTEN DESCRIPTION (112(a)/Art 83 first para):
+       - Does the spec support ALL claim scope?
+       - Any claim elements without spec support?
+
+    3. ENABLEMENT (112(a)/Art 83):
+       - Can a POSITA practice the invention?
+       - Any missing algorithm/structure for functional claims?
+
+    4. NOVELTY (102/Art 54):
+       - Would any known reference anticipate any claim?
+       - Identify the closest single reference.
+
+    5. NON-OBVIOUSNESS (103/Art 56):
+       - Would any combination render claims obvious?
+       - What is the motivation to combine?
+
+    6. CLAIM SCOPE:
+       - Are independent claims broad enough to be commercially valuable?
+       - Do dependent claims provide meaningful fallback positions?
+       - Any claims that are too broad (likely rejected) or too narrow (not valuable)?
+
+    7. SPECIFICATION QUALITY:
+       - Language issues (subjective terms, relative terms, result-to-be-achieved)
+       - Reference numeral consistency
+       - Missing embodiments
+
+    Format your response as a formal office action with:
+    - GROUNDS OF REJECTION for each issue (cite statute)
+    - SUGGESTED AMENDMENTS for each issue
+    - OVERALL PATENTABILITY SCORE: 1-10
+
+    Be rigorous and specific. This is a real examination.
+```
+
+### Step 3: Implement Fixes (Round 1)
+
+Based on the examiner's office action:
+
+1. **CRITICAL issues** (102 rejection, 112 indefiniteness, missing enablement):
+   - Must be fixed before proceeding
+   - Amend claims or add specification support
+
+2. **MAJOR issues** (103 obviousness, weak claim scope, missing support):
+   - Should be fixed or argued
+   - Consider claim amendments or specification additions
+
+3. **MINOR issues** (language quality, numeral consistency, formatting):
+   - Fix if time permits
+   - Document in output for later cleanup
+
+For each fix:
+- Show the specific change (old claim -> new claim)
+- Explain how the fix addresses the examiner's concern
+
+### Step 4: Round 2 — Follow-Up Review
+
+Use `mcp__codex__codex` with the threadId from Round 1:
+
+```
+mcp__codex__codex:
+  threadId: [from Round 1]
+  prompt: |
+    Here is the revised patent application after addressing your office action.
+
+    CHANGES MADE:
+    [list of all changes with rationale]
+
+    REVISED CLAIMS:
+    [updated claims]
+
+    REVISED SPECIFICATION EXCERPTS:
+    [changed sections]
+
+    Please re-examine:
+    1. Are the previous rejections overcome?
+    2. Are there new issues introduced by the amendments?
+    3. What is the updated patentability score?
+    4. Any remaining grounds for rejection?
+```
+
+### Step 5: Generate Improvement Report
+
+Write `patent/PATENT_REVIEW.md`:
+
+```markdown
+## Patent Review Report
+
+### Application Summary
+[Title, claims count, jurisdiction]
+
+### Review Round 1
+#### Office Action Summary
+[Key findings from examiner]
+
+#### Issues Found
+| # | Type | Severity | Claim/Section | Issue | Citation | Fix Applied |
+|---|------|----------|--------------|-------|----------|-------------|
+| 1 | Clarity | CRITICAL | Claim 3 | Indefinite term "rapid" | 112(b) | Defined in spec |
+| 2 | Novelty | MAJOR | Claim 1 | Ref X anticipates element C | 102 | Amended claim |
+
+#### Score After Round 1: [X]/10
+
+### Review Round 2
+#### Follow-Up Assessment
+[Are previous rejections overcome?]
+
+#### Remaining Issues
+[Any issues still outstanding]
+
+#### Score After Round 2: [X]/10
+
+### Recommendations
+[Final recommendations before proceeding to jurisdiction formatting]
+- [ ] All CRITICAL issues resolved
+- [ ] All MAJOR issues resolved or argued
+- [ ] Specification supports all claim amendments
+- [ ] Ready for jurisdiction formatting
+```
+
+## Key Rules
+
+- The reviewer persona must be a patent examiner, not a paper reviewer or academic.
+- Always use `model_reasoning_effort: "xhigh"` for maximum analysis depth.
+- Address CRITICAL and MAJOR issues before proceeding to the next phase.
+- Document all changes in the review report for traceability.
+- If the patentability score is below 5/10 after Round 2, recommend significant rework before filing.
+- The review is advisory -- actual prosecution may proceed differently.

--- a/skills/prior-art-search/SKILL.md
+++ b/skills/prior-art-search/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: prior-art-search
+description: "Search patent databases and academic literature for prior art relevant to an invention. Use when user says \"现有技术检索\", \"prior art search\", \"专利检索\", \"check patents\", or wants to find relevant prior art."
+argument-hint: [invention-description-or-path]
+allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write, Agent
+---
+
+# Prior Art Search
+
+Search patents and literature for prior art relevant to: **$ARGUMENTS**
+
+Adapted from `/research-lit` for patent-specific searching.
+
+## Constants
+
+- `MAX_PATENT_RESULTS = 20` — Maximum patent documents to analyze in detail
+- `MAX_PAPER_RESULTS = 15` — Maximum academic papers to analyze in detail
+- `SEARCH_YEARS = 10` — How many years back to search
+- `PATENT_DATABASES = "google-patents, espacenet"` — Patent databases to search
+
+## Inputs
+
+Read the invention description from:
+1. `$ARGUMENTS` if it contains technical details
+2. `patent/INVENTION_BRIEF.md` if it exists
+3. `INVENTION_BRIEF.md` if it exists at project root
+
+## Shared References
+
+Load `../shared-references/prior-art-databases.md` for search strategy templates and IPC/CPC classification guidance.
+
+## Workflow
+
+### Step 1: Extract Search Concepts
+
+From the invention description, identify:
+1. **Core inventive concept**: The primary technical contribution (1-2 sentences)
+2. **Technical problem**: What problem it solves
+3. **Key technical features**: 4-6 specific technical elements that define the invention
+4. **IPC/CPC classes**: Predict relevant classification codes (e.g., G06N, G06F)
+
+### Step 2: Patent Search
+
+For EACH search concept, search via:
+
+**Google Patents** (via WebSearch):
+```
+WebSearch: "site:patents.google.com [keywords]"
+WebSearch: "[keywords] patent"
+```
+- Try primary keywords + technical problem keywords
+- Search in English regardless of target jurisdiction
+- For CN inventions, also search Chinese keywords via WebSearch
+
+**Espacenet** (via WebFetch):
+- WebFetch worldwide.espacenet.com/search results for key queries
+- Search by predicted IPC/CPC classes
+
+**Assignee/Inventor Search**:
+- If known companies/universities work in this area, search their patent portfolios
+- WebSearch: "[assignee name] patent [technical area]"
+
+For each potentially relevant patent found:
+- WebFetch the patent page to extract: title, abstract, representative claims, filing date, assignee, current status
+- Record IPC/CPC classification codes
+
+### Step 3: Academic Literature Search
+
+Search the same concepts in academic databases:
+
+1. **Google Scholar** (via WebSearch): `WebSearch "[keywords] site:scholar.google.com"`
+2. **arXiv** (via `/arxiv` if available, or WebSearch): Search for preprints
+3. **Semantic Scholar** (via `/semantic-scholar` if API key set, or WebSearch)
+
+For each relevant paper found:
+- Extract title, authors, venue, year, key contribution
+
+### Step 4: Classification and Analysis
+
+For each reference found, assess:
+
+1. **Relevance**: How closely does it relate to the invention?
+2. **Overlap Risk**: Does it disclose the same or similar technical solution?
+   - HIGH: Anticipates one or more claim elements
+   - MEDIUM: Discloses a related but different approach
+   - LOW: Same general field, different approach
+3. **Relationship**: Is it anticipating, relevant, or merely background?
+
+Organize results by IPC/CPC classification to see the technical landscape.
+
+### Step 5: Freedom-to-Operate Assessment (Preliminary)
+
+Based on the search results:
+- Identify patents with claims that potentially cover the invention
+- Note any expired patents (public domain)
+- Flag areas where claim scope overlap is significant
+
+**Disclaimer**: This is a preliminary assessment only. A professional freedom-to-operate analysis by a patent attorney is recommended before filing.
+
+### Step 6: Output
+
+Write `patent/PRIOR_ART_REPORT.md` with:
+
+```markdown
+## Prior Art Search Report
+
+### Invention Summary
+[1-2 sentence description of the searched invention]
+
+### Search Strategy
+- Keywords used: [...]
+- IPC/CPC classes searched: [...]
+- Databases searched: Google Patents, Espacenet, Google Scholar, arXiv
+- Date range: [year] to present
+
+### Patent References Found
+
+| # | Patent No. | Title | Date | Assignee | IPC/CPC | Key Teaching | Overlap Risk |
+|---|-----------|-------|------|----------|---------|-------------|-------------|
+| 1 | CN... / US... | [title] | [date] | [assignee] | [codes] | [2-3 sentences] | HIGH/MEDIUM/LOW |
+
+### Non-Patent Literature Found
+
+| # | Reference | Title | Authors/Venue | Year | Key Contribution | Relevance |
+|---|-----------|-------|--------------|------|-----------------|-----------|
+| 1 | [DOI/link] | [title] | [authors] | [year] | [1-2 sentences] | HIGH/MEDIUM/LOW |
+
+### Prior Art Landscape
+[Organized by technical approach or IPC class, not just chronological]
+
+### Freedom-to-Operate Preliminary Assessment
+[Which existing patents might block the invention? What is the risk level?]
+
+### Recommendations
+- Suggested claim scope adjustments based on prior art
+- Areas where novelty appears strongest
+- References to watch during prosecution
+```
+
+## Key Rules
+
+- Never fabricate patent numbers or citations. Mark uncertain references with `[VERIFY]`.
+- Search in English AND the target jurisdiction language (Chinese for CN).
+- Patent prior art includes everything published before the priority date, not just patents.
+- Academic papers are valid prior art for both novelty and inventive step.
+- Include expired patents -- they are public domain but still relevant for novelty.

--- a/skills/shared-references/patent-format-cn.md
+++ b/skills/shared-references/patent-format-cn.md
@@ -1,0 +1,199 @@
+# CNIPA Patent Format Guide (中国专利格式指南)
+
+Use this reference when drafting Chinese patent applications for filing with CNIPA (国家知识产权局).
+
+## When to Read
+
+- Read when `JURISDICTION = "CN"` or `JURISDICTION = "ALL"`
+- Read before writing claims in Chinese format
+- Read during `/jurisdiction-format` for CN output
+- Read when choosing between invention patent (发明专利) and utility model (实用新型)
+
+## Applicable Law and Regulations
+
+- Patent Law of the People's Republic of China (中华人民共和国专利法, 2020 amendment)
+- Implementing Regulations of the Patent Law (专利法实施细则)
+- Guidelines for Patent Examination (专利审查指南, 2023 revision)
+
+## Document Structure
+
+A CNIPA patent application consists of:
+
+### 1. 权利要求书 (Claims)
+
+**Format rules:**
+- Independent claims use two-part form (two-part form / 两部式):
+  - 前序部分 (Preamble): Known technical features shared with closest prior art
+  - 特征部分 (Characterizing part): After "其特征在于" -- the inventive features
+- Dependent claims: "根据权利要求X所述的..., 其特征在于..."
+- Each claim must be a single technical solution
+- Claims must be clear, concise, and supported by the description
+- Method claims: "一种...的方法，其特征在于，包括以下步骤："
+- Apparatus claims: "一种...的装置/设备/系统，其特征在于，包括："
+
+**Numbering:**
+- Arabic numerals: 权利要求1, 权利要求2, ...
+- Dependent claims must reference prior claims by number
+- Multiple dependent claims are allowed but should be used sparingly
+
+**Example structure:**
+```
+1. 一种[技术主题]的方法，包括：
+   前序部分的已知技术特征；
+   其特征在于，还包括：
+   特征部分的技术特征。
+
+2. 根据权利要求1所述的方法，其特征在于，所述[技术特征]具体为...
+```
+
+### 2. 说明书 (Description)
+
+Required sections in order:
+
+#### 发明名称 (Title)
+- Concise, typically under 25 characters
+- Must reflect the technical content, not marketing language
+- No trademarks, no "新型" or "改进的"
+- Format: "一种[技术领域]的[技术主题]" for methods; "[技术领域]的[技术主题]装置" for apparatus
+
+#### 技术领域 (Technical Field)
+- 1-2 sentences identifying the technical domain
+- Use IPC classification references where appropriate
+
+#### 背景技术 (Background Technology)
+- Describe the closest prior art (引用现有技术)
+- Identify specific deficiencies (不足之处)
+- This is NOT a literature review -- it directly sets up the problem the invention solves
+- Must cite specific prior art documents where possible
+
+#### 发明内容 (Summary of Invention)
+Three parts:
+1. **要解决的技术问题** (Technical Problem to Solve): Derived from background deficiencies
+2. **技术方案** (Technical Solution): How the invention solves the problem, matching claim scope
+3. **有益效果** (Beneficial Effects): Quantifiable advantages over prior art
+
+#### 附图说明 (Brief Description of Drawings)
+- List each figure with a one-sentence description
+- Format: "图1是...的示意图；图2是...的流程图；"
+
+#### 具体实施方式 (Detailed Description of Embodiments)
+- At least one complete embodiment (实施例)
+- Reference numerals must match figures exactly
+- Describe in sufficient detail for a skilled person to practice
+- Include specific parameters, ranges, materials where applicable
+- Multiple embodiments strengthen the application
+
+### 3. 说明书摘要 (Abstract)
+
+- Maximum 300 words (typically Chinese characters)
+- Must summarize the technical solution and key advantages
+- Include the most representative claim number
+- Abstract is for search purposes only, not for interpreting scope
+
+### 4. 摘要附图 (Abstract Drawing)
+
+- Select the most representative figure
+- Must be one of the figures in the application
+
+### 5. 附图 (Drawings)
+
+- Numbered sequentially: 图1, 图2, ...
+- Reference numerals in Arabic: 101, 102, 103...
+- No text in figures except reference numerals and standard terms
+- Black and white preferred; color only when necessary
+
+## Word Limits and Practical Constraints
+
+| Item | Limit |
+|------|-------|
+| Title | Typically under 25 characters |
+| Abstract | 300 words maximum |
+| Claims | No hard limit, but examiners prefer focused sets (10-20 claims typical) |
+| Description | No hard limit, but excessive length delays examination |
+| Figures | No hard limit, but cost increases per page |
+
+## Fees (2026 approximate, in CNY)
+
+| Item | Invention (发明专利) | Utility Model (实用新型) |
+|------|---------------------|------------------------|
+| Filing fee | 900 | 500 |
+| Claims fee (per claim over 10) | 150 each | 150 each |
+| Examination fee (invention only) | 2500 | N/A |
+| Annual fees | Increasing by year | Increasing by year |
+
+## Utility Model (实用新型) Specific Rules
+
+- Covers only product shape/structure or combination thereof (产品的形状、构造或其结合)
+- NO method claims allowed
+- NO process claims allowed
+- Lower inventive step requirement than invention patent
+- No substantive examination -- only formal examination
+- Faster grant: typically 6-8 months vs. 2-4 years for invention
+- Shorter protection: 10 years vs. 20 years
+
+## Critical Chinese Patent Writing Rules
+
+### Claims (权利要求书)
+
+1. **Continuous numbering required**: Claims must be numbered 1, 2, 3, ... sequentially without gaps. Independent and dependent claims are intermixed, NOT grouped separately. Even if independent claims are 1, 5, 8 in the hierarchy, the final numbering must be 1-10 continuous.
+
+2. **No experimental results in claims**: Claims must describe ONLY structural features or method steps. Do NOT include detection principles, signal characteristics, or measurement results (e.g., "产生负脉冲信号", "谐振频率下降" belong in the specification, not in claims).
+
+3. **Standard claim opening formats**:
+   - Product: "1. 一种[主题]，其特征在于，包括：[组件A]、[组件B]和[组件C]。"
+   - Method: "1. 一种[主题]的方法，其特征在于，包括以下步骤：步骤S1...；步骤S2...；"
+   - System: "1. 一种[主题]的系统，其特征在于，包括：[组件]。"
+
+4. **Two-part form (两部式)**: The "其特征在于" separates known features (before) from inventive features (after). Known features should be minimal — just enough to set context.
+
+### Specification (说明书)
+
+5. **No experimental data in 具体实施方式**: The detailed description teaches HOW to make and use the invention. Do NOT include test results, accuracy percentages, detection rates, precision values, or comparative performance data. These belong in papers, not patents.
+
+   WRONG: "传感器对直径超过150μm的金属颗粒实现了100%的检测精度，即使在检测限处仍保持94%的高精度。"
+   RIGHT: "当不锈钢颗粒通过间隙传感区域时，谐振频率下降。颗粒直径越大，频率偏移幅度越大。"
+
+6. **Formulas and principles go in 具体实施方式, NOT 发明内容**: The "发明内容" section is a high-level overview (problem + solution + advantages). Detailed derivation, RLC circuit models, and mathematical formulas belong in "具体实施方式".
+
+7. **有益效果 must be qualitative or derived from structure**: Avoid specific numerical claims unless they appear in the claims themselves. Use structural reasoning: "由于采用了...结构，因此具有...效果。"
+
+8. **Use "所述" consistently**: After first introducing a component with "一个" or "一种", all subsequent references must use "所述" (the said). Example: "一个处理器" → "所述处理器".
+
+### Common CN Patent Phrases
+
+| Usage | Correct Chinese |
+|-------|----------------|
+| Introducing invention | "本发明提供一种..." |
+| Problem statement | "本发明要解决的技术问题是..." |
+| Solution intro | "为解决上述技术问题，本发明采用的技术方案是：" |
+| Benefits intro | "本发明的有益效果是：" |
+| Embodiment intro | "下面结合附图和实施例对本发明作进一步详细描述。" |
+| Referring to figure | "参照图1" |
+| Component reference | "印刷电路板（101）" on first mention, "印刷电路板101" thereafter |
+
+## Chinese Patent Terminology Glossary
+
+| Chinese | English | Usage |
+|---------|---------|-------|
+| 权利要求 | Claim | "权利要求1" |
+| 说明书 | Description | "如说明书所述" |
+| 发明名称 | Title of invention | |
+| 技术领域 | Technical field | |
+| 背景技术 | Background technology | |
+| 发明内容 | Summary of invention | |
+| 附图说明 | Brief description of drawings | |
+| 具体实施方式 | Detailed description of embodiments | |
+| 其特征在于 | Characterized in that | Claim divider |
+| 所述 | Said / The (definite article) | "所述处理器" |
+| 包括 | Comprising (open) | |
+| 由...组成 | Consisting of (closed) | Use rarely |
+| 可选地 | Optionally | |
+| 优选地 | Preferably | |
+| 在一个实施例中 | In one embodiment | |
+| 在另一个实施例中 | In another embodiment | |
+| 进一步地 | Further / Furthermore | Dependent claims |
+| 其中 | Wherein | |
+| 与...通信 | In communication with | |
+| 响应于 | In response to | |
+| 基于 | Based on | |
+| 使得 | Such that | |

--- a/skills/shared-references/patent-format-ep.md
+++ b/skills/shared-references/patent-format-ep.md
@@ -1,0 +1,173 @@
+# EPO Patent Format Guide
+
+Use this reference when drafting European patent applications for filing with the EPO.
+
+## When to Read
+
+- Read when `JURISDICTION = "EP"` or `JURISDICTION = "ALL"`
+- Read before writing claims in EP format
+- Read during `/jurisdiction-format` for EP output
+
+## Applicable Law
+
+- European Patent Convention (EPC), 2000 revision
+- Rules 42-43 EPC (Description and Claims format)
+- EPO Guidelines for Examination, Part F
+- Protocol on the Interpretation of Article 69 EPC
+
+## Document Structure
+
+### 1. Claims (Rule 43 EPC)
+
+**Two-part form is MANDATORY for independent claims (Rule 43(1) EPC):**
+
+The claim must contain:
+- **(a) Characterising portion**: A statement indicating:
+  - The category/title of the invention ("A method of...", "An apparatus for...")
+  - Those features of the invention which are necessary to define the claimed subject-matter but which, in combination, form part of the prior art
+- **(b) Characterising portion**: After the phrase "characterised in that" (or "characterised by")
+  - Those features of the invention for which protection is sought in combination with the features of part (a)
+
+```
+1. A method for [purpose], comprising:
+   [known feature A];
+   [known feature B]; and
+   [known feature C],
+   characterised in that
+   [inventive feature D],
+   [inventive feature E].
+```
+
+```
+10. A system for [purpose], comprising:
+    [known component A] configured to [function];
+    [known component B],
+    characterised in that the system further comprises:
+    [inventive component C] configured to [function].
+```
+
+**Important:** The two-part form separates known features from inventive features. This is NOT optional at the EPO -- it is a formal requirement. The examiner will raise an objection if the form is not followed.
+
+**When two-part form is NOT applicable:**
+- Product-by-process claims (rare exceptions)
+- Claims to new chemical compounds per se
+- Claims where the invention cannot be characterized by prior art features
+
+**Dependent claims (Rule 43(4) EPC):**
+```
+2. The method according to claim 1, characterised in that the [feature] comprises [specific limitation].
+3. The method according to any one of claims 1 to 2, characterised in that [additional limitation].
+```
+
+**Multiple dependent claims:**
+- EPO allows multiple dependent claims (unlike some jurisdictions)
+- May refer to multiple preceding claims: "The method according to any one of claims 1 to 3..."
+- However, examiners may raise clarity objections if excessive
+- Multiple dependent claims referring to other multiple dependent claims are NOT allowed
+
+### 2. Description (Rule 42 EPC)
+
+Required structure:
+
+#### Title of the Invention
+- Must correspond to the title in the claims
+- Should be clear and concise
+- No trademarks
+
+#### Technical Field
+- "The invention relates to..."
+- Identify the technical area
+
+#### Background Art
+- Cite relevant prior art documents
+- "Document D1 (EP XXXXXXXX) discloses..."
+- "However, this approach has the disadvantage that..."
+- Distinguish from "Related Work" in academic papers -- focus on technical deficiencies
+
+#### Disclosure of the Invention
+
+**The EPO has a specific structure for this section:**
+
+1. **Problem to be solved**: State the technical problem underlying the invention
+2. **Solution**: How the invention solves this problem, referencing the claim features
+3. **Advantageous effects**: The advantages of the invention over the prior art
+
+```
+The invention is defined in claim 1.
+
+The problem underlying the present invention is to [state problem].
+
+This problem is solved by [reference to characterising features].
+
+The invention has the advantage that [state advantages].
+```
+
+**Inventive step (Article 56 EPC):**
+- The description should support arguments for inventive step
+- Unexpected technical effects strengthen inventive step arguments
+- "Compared to the closest prior art (D1), the invention achieves [specific technical effect] which would not have been predictable from the prior art"
+
+#### Description of Embodiments
+- Detailed description with reference to figures
+- "FIG. 1 shows..." or "Figure 1 shows..."
+- Reference numerals in brackets: "the processor (102) is connected to the memory (104)"
+- At least one embodiment corresponding to the claims
+- Include variations and alternatives
+
+#### Reference Signs List
+- EPO requires a list of reference signs at the end of the description
+- Format: "LIST OF REFERENCE SIGNS: 102 processor, 104 memory, 106 bus..."
+- Organized by figure or alphabetically
+
+### 3. Abstract
+
+- Maximum 150 words (Rule 47(1) EPO)
+- Should indicate the technical field and the gist of the invention
+- Must not contain statements on the alleged merits or value of the invention
+- Must not contain any matter not disclosed in the application
+
+### 4. Drawings
+
+- Reference numerals must match description
+- Must show all features of at least one claim
+- Format: "FIG. 1" or "Figure 1" (both acceptable)
+
+## Key EPO-Specific Rules
+
+### No Functional Claiming Without Disclosure
+
+The EPO is stricter than USPTO on functional claiming:
+- Features defined by their function are allowed only if the specification provides sufficient disclosure
+- "configured to" is acceptable but must be supported by detailed description
+- Pure result-to-be-achieved claims will be rejected under Article 84 EPC
+
+### Inventive Step (Problem-Solution Approach)
+
+The EPO uses a specific three-step approach:
+1. Determine the closest prior art
+2. Identify the distinguishing features and the objective technical problem
+3. Assess whether the claimed invention would have been obvious to a skilled person
+
+The description should be written to support this analysis.
+
+### Added Matter (Article 123(2) EPC)
+
+The EPO is extremely strict about added matter:
+- Nothing may be added that is not directly and unambiguously derivable from the application as filed
+- Even "implicit" disclosures must be truly unambiguous
+- This is stricter than the US written description standard
+
+### Clarity (Article 84 EPC)
+
+- Claims must be clear and concise
+- Claims must be supported by the description
+- The EPO interprets "supported by" strictly: the description must provide basis for every claim feature
+
+## PCT Entry into European Phase
+
+For PCT applications entering the European phase:
+- Deadline: 31 months from priority date
+- Must file translation if not in EN/FR/DE
+- Must pay designation fees
+- Must file request for examination (can be filed with application)
+- Must respond to Rule 161/162 communication (optional amendment opportunity)

--- a/skills/shared-references/patent-format-us.md
+++ b/skills/shared-references/patent-format-us.md
@@ -1,0 +1,161 @@
+# USPTO Patent Format Guide
+
+Use this reference when drafting US patent applications for filing with USPTO.
+
+## When to Read
+
+- Read when `JURISDICTION = "US"` or `JURISDICTION = "ALL"`
+- Read before writing claims in US format
+- Read during `/jurisdiction-format` for US output
+
+## Applicable Law
+
+- Title 35, United States Code
+- Manual of Patent Examining Procedure (MPEP), 9th Edition, Rev. 2024
+- America Invents Act (AIA, 2011)
+
+## Document Structure
+
+A USPTO patent application consists of:
+
+### 1. Claims Section
+
+**Format rules:**
+- Claims are numbered sequentially with Arabic numerals starting from 1
+- Independent claims stand alone; dependent claims reference prior claims
+- Each claim is a single sentence (grammatically complex but technically one sentence)
+- Use semicolons to separate elements within a claim
+
+**Claim Preamble Types:**
+
+**Process/Method claims:**
+```
+1. A method for [purpose], comprising:
+   [step A];
+   [step B]; and
+   [step C].
+```
+
+**System/Apparatus claims:**
+```
+10. A system for [purpose], comprising:
+    a [component A] configured to [function];
+    a [component B] in communication with the [component A]; and
+    a [component C] configured to [function].
+```
+
+**Computer-readable medium claims (US-specific):**
+```
+15. A non-transitory computer-readable storage medium storing instructions that, when executed by a processor, cause the processor to perform operations comprising:
+    [operation A];
+    [operation B].
+```
+
+**Transitional Phrases:**
+| Phrase | Type | Meaning |
+|--------|------|---------|
+| comprising | Open | Includes the listed elements but may also include others |
+| consisting of | Closed | Limited to ONLY the listed elements |
+| consisting essentially of | Semi-open | Allows only insubstantial additional elements |
+
+**Default: use "comprising"** unless there is a specific reason to use a closed transition.
+
+**Dependent Claim Format:**
+```
+2. The method of claim 1, wherein the [element] comprises [specific limitation].
+3. The method of claim 1 or claim 2, further comprising [additional step].
+4. The system of claim 10, wherein the [component A] is a [specific type].
+```
+
+**Multiple Dependent Claims (US rules):**
+- US allows multiple dependent claims but ONLY in the alternative ("or", not "and")
+- "The method of claim 1 or claim 2, wherein..." -- VALID
+- "The method of claims 1 and 2, wherein..." -- INVALID
+- Each multiple dependent claim counts as one claim for fee purposes
+
+### 2. Specification
+
+#### Title
+- Concise and specific (MPEP 606)
+- No more than 500 characters
+- No trademarks, no "improved", no "new"
+- Must describe the invention, not its use
+
+#### Cross-Reference to Related Applications
+- If claiming priority to earlier applications, include at the very beginning
+- Format: "This application claims the benefit of U.S. Provisional Application No. XX/XXX,XXX, filed [date]"
+
+#### Statement Regarding Federally Sponsored Research
+- Include if invention was made with government funding
+
+#### Field of the Invention
+- 1-2 sentences: "The present invention relates generally to [field], and more particularly to [specific area]."
+
+#### Background of the Invention
+- Describe the field
+- Describe existing approaches and their limitations
+- Do NOT admit prior art as "the best" or "superior"
+- Set up the technical problem the invention solves
+- Do NOT include citations to prior art here (that's for IDS)
+
+#### Brief Summary of the Invention
+- "In accordance with one or more embodiments..."
+- Problem-Solution-Advantage structure
+- Mirror the claim scope
+
+#### Brief Description of the Drawings
+- "FIG. 1 is a block diagram showing..."
+- "FIG. 2 is a flowchart illustrating..."
+- One sentence per figure
+
+#### Detailed Description of Preferred Embodiments
+- Must enable a POSITA to make and use the invention (35 USC 112(a))
+- Must provide written description support for all claim scope (35 USC 112(a))
+- Reference numerals: use consistent numbering (100-series for FIG. 1, 200-series for FIG. 2)
+- Include at least one "preferred embodiment" or "exemplary embodiment"
+- Describe alternatives and variations to support broad claim interpretation
+- Best mode: must disclose the best way known to the inventor (less enforced post-AIA but still required by statute)
+
+#### Abstract
+- 150 words or 2500 characters maximum (37 CFR 1.72(b))
+- Purpose: enable efficient prior art searching
+- Include the most important technical features
+- Do NOT include legal phrases or claim references
+
+### 3. Drawings (Figures)
+
+- Must show every feature specified in the claims
+- Reference numerals must match specification
+- Black and white line drawings preferred
+- Format: "FIG. 1", "FIG. 2" (not "Figure 1")
+- No text except reference numerals and essential labels
+
+## IDS (Information Disclosure Statement)
+
+Under the duty of disclosure (37 CFR 1.56), applicants must cite all known material prior art:
+- List all patents, publications, and other references known to be material
+- Use form PTO/SB/08 for listing references
+- Filed during prosecution, not as part of the initial application
+
+## Means-Plus-Function (35 USC 112(f))
+
+When a claim element uses "means for [function]" or equivalent language:
+- The claim is limited to the corresponding structure, material, or acts described in the specification AND equivalents thereof
+- Must disclose the algorithm/structure that performs the function
+- Software "means for" claims MUST disclose the algorithm (flowchart, pseudocode)
+
+**Safer alternative:** Use "a processor configured to [function]" instead of "means for [function]"
+
+## Continuation and CIP Strategy
+
+- **Continuation**: Same disclosure, new claims
+- **Continuation-in-part (CIP)**: Adds new matter, claims to new matter get new priority date
+- **Divisional**: Required when examiner issues restriction requirement
+
+## Common 102/103 Rejection Responses
+
+Document these patterns for use in `/patent-review`:
+- Amend claims to distinguish over cited reference
+- Argue the reference does not teach a specific claim element
+- Argue the combination of references would not have been obvious
+- Provide evidence of unexpected results or commercial success

--- a/skills/shared-references/patent-writing-principles.md
+++ b/skills/shared-references/patent-writing-principles.md
@@ -1,0 +1,197 @@
+# Patent Writing Principles
+
+Use this reference when `claims-drafting`, `specification-writing`, or `invention-structuring` need guidance on patent-specific writing rules.
+
+## When to Read
+
+- Read before drafting any claims.
+- Read when specification text needs to support claim scope.
+- Read when choosing between claim formats (Jepson vs. two-part vs. open-ended).
+- Read when the language feels too academic or too vague for patent purposes.
+- Read before jurisdiction-specific formatting.
+
+## Contents
+
+- [Core Patent Writing Rules](#core-patent-writing-rules)
+- [Claim Drafting Principles](#claim-drafting-principles)
+- [Specification Writing Rules](#specification-writing-rules)
+- [Common Pitfalls](#common-pitfalls)
+- [Terminology Discipline](#terminology-discipline)
+
+---
+
+## Core Patent Writing Rules
+
+### The Three Requirements
+
+Every patent application must satisfy three fundamental requirements:
+
+1. **Novelty** (新颖性): The invention must be new -- not anticipated by a single prior art reference.
+2. **Inventive Step / Non-obviousness** (创造性): The invention must not be obvious to a person skilled in the art (POSITA) based on prior art.
+3. **Industrial Applicability / Utility** (实用性): The invention must be capable of being made or used in industry.
+
+### The Written Description Requirement
+
+The specification must demonstrate that the inventor was in **possession** of the claimed invention as of the filing date. This means:
+
+- Every element in every claim must find explicit or inherent support in the specification.
+- Broader claims require broader disclosure. If you claim "a processor," the spec must show you had a processor in mind, not just one specific chip.
+- Adding claim scope after filing that wasn't in the original disclosure is not permitted (no new matter).
+
+### The Enablement Requirement
+
+The specification must teach a **Person Skilled in the Art (POSITA)** to make and use the invention without undue experimentation. Test: could a skilled practitioner reproduce the invention from your description alone?
+
+### Claims Define Scope, Specification Enables It
+
+- **Claims** = the legal boundary (what is protected)
+- **Specification** = the teaching (how to practice the invention)
+- **Figures** = the visual aid (reference numerals link claims to specification)
+
+---
+
+## Claim Drafting Principles
+
+### Broadest Reasonable Interpretation (BRI)
+
+Claims are interpreted under the **broadest reasonable interpretation** during prosecution (USPTO standard; EPO uses a different but analogous approach). This means:
+
+- Common words are given their ordinary meaning.
+- Terms are NOT limited to the embodiments described in the specification.
+- If you want a term to have a special meaning, you must explicitly define it in the specification.
+
+### Claim Structure (Universal)
+
+Every claim has:
+1. **Preamble**: Identifies the category of invention (e.g., "A method for...", "A system comprising...", "An apparatus for...")
+2. **Transitional phrase**: Defines scope boundary
+   - "comprising" / "including" / "containing" = OPEN (additional elements allowed)
+   - "consisting of" = CLOSED (no additional elements)
+   - "consisting essentially of" = SEMI-OPEN (allows insubstantial variations)
+3. **Body**: The claim elements/limitations, each separated by semicolons or commas
+
+### Antecedent Basis
+
+- First mention of an element: use indefinite article ("a", "an") -- "a processor"
+- Subsequent mentions: use definite article ("the", "said") -- "the processor"
+- Never use "the" for something not previously introduced in the claim.
+- Never use "a" again for the same element (implies a second instance).
+
+### Independent vs. Dependent Claims
+
+**Independent claims** define the broadest defensible scope. Draft these first.
+
+**Dependent claims** narrow the scope by adding specific limitations. Each dependent claim:
+- Must refer back to a prior claim ("The method of claim 1, wherein...")
+- Must add at least one meaningful limitation
+- Should provide fallback positions if the independent claim is rejected
+- Should cover preferred embodiments described in the specification
+
+### Multiple Claim Categories
+
+For the same invention, draft claims in multiple categories:
+- **Method/process claims**: Steps performed
+- **System/apparatus claims**: Structural components
+- **Computer-readable medium claims**: (US) Tangible medium storing instructions
+- **Product-by-process claims**: (when structure is difficult to define)
+
+This multiplies the scope of protection without requiring separate applications.
+
+---
+
+## Specification Writing Rules
+
+### Section Structure (Universal)
+
+1. **Title**: Concise, matches broadest claim scope, no trademark names, no "improved" or "new"
+2. **Technical Field** (技术领域): 1-2 paragraphs identifying the technical domain
+3. **Background** (背景技术): Prior art and its deficiencies -- NOT a literature review, but specific technical shortcomings that the invention addresses
+4. **Summary** (发明内容): Problem-Solution-Advantage triple
+5. **Brief Description of Drawings** (附图说明): One sentence per figure
+6. **Detailed Description** (具体实施方式): Detailed embodiments with reference numerals
+7. **Abstract** (摘要): Jurisdiction-specific word limits
+
+### Language Rules for Specifications
+
+**DO:**
+- Use "embodiment", "aspect", "implementation", "configuration"
+- Use "optionally", "preferably", "in some implementations"
+- Use "may" for optional features, "shall" or "is configured to" for required features
+- Reference figures by numeral: "As shown in FIG. 1, the processor 102..."
+- Use consistent terminology throughout (same word for same concept)
+
+**DO NOT:**
+- Use subjective adjectives: "excellent", "surprising", "revolutionary", "superior"
+- Use result-to-be-achieved language: "configured to achieve high accuracy" (instead describe HOW)
+- Use relative terms without definition: "thin", "strong", "fast", "small"
+- Admit prior art is better: avoid "unlike the prior art, which works well, we..."
+- Include experimental results tables (save for prosecution arguments, not the spec itself)
+
+### Reference Numeral Convention
+
+- Use consistent numbering series: 100-series for FIG. 1, 200-series for FIG. 2
+- Every component mentioned in specification must have a numeral
+- Every numeral in figures must be explained in the specification
+- Format: "processor 102", "memory 104", "bus 106" (numeral follows the noun)
+
+---
+
+## Common Pitfalls
+
+### Negative Limitations
+
+Avoid claims that define the invention by what it is NOT:
+- Bad: "A method that does not use a database"
+- Good: "A method comprising storing data in a local cache"
+
+Negative limitations are sometimes necessary but require explicit basis in the specification.
+
+### Result-to-Be-Achieved Claims
+
+Do not claim a result without describing the mechanism:
+- Bad: "A method for achieving 99% accuracy in image classification"
+- Good: "A method comprising: extracting features using a convolutional neural network having at least three residual blocks..."
+
+### Indefinite Terms
+
+Avoid terms that create uncertainty about scope:
+- "approximately", "about", "substantially" -- acceptable if the specification defines the range
+- "high quality", "efficient", "optimal" -- too vague, will receive 112(b) rejection (US)
+- "etc.", "and the like", "or similar" -- creates open-ended ambiguity
+
+### Functional Claiming (Means-Plus-Function)
+
+In US practice, "means for [function]" triggers 35 USC 112(f) and is limited to the corresponding structure in the specification. Use with caution:
+- "means for processing" = limited to the specific processor embodiments described
+- "a processor configured to process" = broader (not means-plus-function)
+- In CN/EP practice, functional claiming is generally more restrictive
+
+### Claim Differentiation Doctrine
+
+Dependent claims are presumed to have different scope from their parent claims. Do not:
+- Copy the parent claim verbatim into a dependent claim
+- Add a limitation that is already inherent in the parent claim
+- Create dependent claims that are merely cumulative combinations of other dependent claims
+
+---
+
+## Terminology Discipline
+
+### Consistency Rule
+
+Once a term is introduced, use it identically throughout:
+- Do NOT alternate between "processor", "processing unit", "CPU", "computing device" for the same component
+- If the invention has a specific component, name it once and reuse that name
+
+### Definition Rule
+
+If a term has a meaning specific to your invention:
+1. Define it explicitly in the specification
+2. Use "hereinafter referred to as" or "herein defined as" language
+3. Use the defined term consistently thereafter
+
+### Jurisdiction-Specific Terminology
+
+- **CN**: Use standard patent Chinese. "所述" (said/the), "其特征在于" (characterized in that), "一种...的方法/装置" (a method/apparatus for...)
+- **US**: Use standard patent English. "comprising", "configured to", "in communication with"
+- **EP**: Follow EPO Guidelines for Examination. Two-part claim form mandatory.

--- a/skills/shared-references/prior-art-databases.md
+++ b/skills/shared-references/prior-art-databases.md
@@ -1,0 +1,141 @@
+# Prior Art Search Databases Guide
+
+Use this reference in `/prior-art-search` for systematic patent and literature searching.
+
+## When to Read
+
+- Read when conducting prior art searches
+- Read when formulating search queries for patents
+- Read when classifying search results by IPC/CPC codes
+
+## Patent Databases (Free, Web-Accessible)
+
+### Google Patents
+- **URL**: patents.google.com
+- **Coverage**: US, EP, CN, WIPO, JP, KR, and 100+ jurisdictions
+- **Search syntax**: Full-text search, inventor:, assignee:, CPC:, before:, after:
+- **Strengths**: Best free full-text search, automatic translation of CN/JP/KR patents, family grouping
+- **Weaknesses**: No legal status data, may lag behind official databases by weeks
+- **Usage in skills**: `WebSearch "site:patents.google.com [keywords]"` or `WebFetch` for specific patent pages
+
+### Espacenet (EPO)
+- **URL**: worldwide.espacenet.com
+- **Coverage**: 150+ million patent documents from 100+ authorities
+- **Search syntax**: Classification=(CPC/IPC), Applicant=, Title/Abstract/Claims full text
+- **Strengths**: Most comprehensive free database, machine translation, legal status via INPADOC
+- **Weaknesses**: Interface is less intuitive, some features require registration
+- **Usage**: `WebFetch` for search results and individual patent pages
+
+### CNIPA Patent Search (中国及多国专利审查信息查询)
+- **URL**: pss-system.cponline.cnipa.gov.cn (or similar)
+- **Coverage**: Chinese patents (CN), the authoritative source for CN applications
+- **Strengths**: Official Chinese patent data, full Chinese text, examination status
+- **Weaknesses**: Interface in Chinese only, limited foreign coverage
+- **Usage**: `WebFetch` for Chinese-specific searches
+
+### USPTO Patent Full-Text Databases
+- **PatFT**: patents.google.com/patents (US granted patents)
+- **AppFT**: patents.google.com (US published applications)
+- **PAIR**: patentcenter.uspto.gov (prosecution history)
+- **Coverage**: US patents and applications
+- **Usage**: `WebFetch` for specific US patent numbers
+
+### WIPO PATENTSCOPE
+- **URL**: patentscope.wipo.int
+- **Coverage**: PCT international applications (WO publications)
+- **Strengths**: Full PCT application texts, CLIR cross-lingual search
+- **Usage**: `WebFetch` for PCT applications
+
+## Academic Literature Databases
+
+These are also prior art (non-patent literature, NPL):
+
+| Database | URL | Coverage | API Available |
+|----------|-----|----------|---------------|
+| Google Scholar | scholar.google.com | Broadest academic coverage | No API, use WebSearch |
+| Semantic Scholar | semanticscholar.org | CS, biomedical, 200M+ papers | Yes (SEMANTIC_SCHOLAR_API_KEY) |
+| arXiv | arxiv.org | Preprints (CS, physics, math, etc.) | Yes (arxiv_fetch.py) |
+| DBLP | dblp.org | CS bibliography | Yes (XML API) |
+| CrossRef | crossref.org | DOIs for all published works | Yes (free, no key needed) |
+| OpenAlex | openalex.org | 250M+ scholarly works | Yes (free, no key needed) |
+
+## IPC/CPC Classification System
+
+The International Patent Classification (IPC) and Cooperative Patent Classification (CPC) organize patents hierarchically:
+
+### Structure
+```
+A 61 K  39 / 395
+│  │  │  │   │
+│  │  │  │   └─ Subgroup (specific)
+│  │  │  └─ Group
+│  │  └─ Subclass
+│  └─ Class
+└─ Section (A=Human necessities, B=Performing operations, C=Chemistry, etc.)
+```
+
+### Most Relevant Sections for Software/ML Inventions
+- **G06F**: Electric digital data processing
+- **G06N**: Computing arrangements based on specific computational models (AI/ML)
+- **G06K**: Recognition of data; Presentation of data
+- **G06T**: Image data processing or generation
+- **G06Q**: Data processing systems for business/finance/administration
+- **H04L**: Transmission of digital information (networking)
+- **H04N**: Pictorial communication (video, image)
+
+### Search Strategy with Classifications
+
+1. Identify relevant IPC/CPC classes from the invention description
+2. Search within those classes for targeted results
+3. Expand to parent/child classes for broader coverage
+4. Combine class-restricted searches with keyword searches
+
+## Search Strategy Template
+
+For each invention, execute this search protocol:
+
+### Step 1: Keyword Search
+```
+Primary: [core inventive concept keywords]
+Secondary: [technical problem keywords]
+Tertiary: [advantage/feature keywords]
+```
+
+### Step 2: Classification Search
+```
+IPC/CPC: [identified classes]
+Cross-reference: [related classes]
+```
+
+### Step 3: Assignee/Inventor Search
+```
+Key assignees: [known companies/universities in the field]
+Key inventors: [known researchers in the field]
+```
+
+### Step 4: Citation Analysis
+- Forward citations: who cited the closest prior art?
+- Backward citations: what did the closest prior art cite?
+
+### Step 5: Family Analysis
+- Group results by patent family (same invention, different jurisdictions)
+- Only the most relevant family member needs detailed analysis
+
+## Output Format
+
+For each prior art reference found:
+
+```markdown
+| Field | Content |
+|-------|---------|
+| Reference ID | [Patent number or paper DOI] |
+| Type | Patent / Paper / Other |
+| Title | [Full title] |
+| Date | [Publication/priority date] |
+| Assignee/Authors | [Who] |
+| IPC/CPC | [Classification codes] |
+| Key Teaching | [What does it teach, 2-3 sentences] |
+| Relevant Claims | [Which claims, if patent] |
+| Overlap Risk | HIGH / MEDIUM / LOW |
+| Relationship | [Anticipating / Relevant / Background] |
+```

--- a/skills/specification-writing/SKILL.md
+++ b/skills/specification-writing/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: specification-writing
+description: "Write the full patent specification from claims and invention disclosure. Use when user says \"撰写说明书\", \"write specification\", \"写说明书\", \"patent description\", or wants to draft the complete patent specification."
+argument-hint: [claims-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, Skill, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
+---
+
+# Specification Writing: Section-by-Section Patent Description
+
+Write the patent specification based on: **$ARGUMENTS**
+
+Adapted from `/paper-write` for patent specifications. The specification supports the claims -- it is not a paper.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — External reviewer for specification quality
+- `JURISDICTION = "auto"` — Inherit from pipeline or detect from args; `CN`, `US`, `EP`, `ALL`
+- `OUTPUT_FORMAT = "markdown"` — Markdown drafts; converted to filing format by `/jurisdiction-format`
+- `OUTPUT_DIR = "patent/"` — Base output directory
+- `LANGUAGE = "auto"` — Auto from jurisdiction: CN->Chinese, US/EP->English
+
+## Inputs
+
+1. `patent/CLAIMS.md` — the drafted claims (primary source)
+2. `patent/INVENTION_DISCLOSURE.md` — invention decomposition
+3. `patent/PRIOR_ART_REPORT.md` — for background section
+4. User-provided figures (if any)
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for specification writing rules, language guidelines, and reference numeral conventions.
+Load `../shared-references/patent-format-cn.md` or `patent-format-us.md` or `patent-format-ep.md` based on jurisdiction.
+
+## Workflow
+
+### Step 1: Initialize Specification Structure
+
+Create the output directory and section files:
+
+```
+patent/specification/
+├── title.md
+├── technical_field.md
+├── background.md
+├── summary.md
+├── drawings_description.md
+├── detailed_description.md
+└── abstract.md
+```
+
+### Step 2: Write Title (发明名称)
+
+- Must match the broadest claim scope
+- No trademarks, no "improved" or "new" or "novel"
+- CN format: "一种[领域]的[技术主题]" or "[领域]的[技术主题]装置"
+- US/EP format: "[Technical topic] for [purpose]" or "[Technical topic] and method thereof"
+- Keep concise (CN: typically under 25 characters; US: under 500 characters)
+
+### Step 3: Write Technical Field (技术领域)
+
+1-2 paragraphs identifying the technical domain:
+- "The present invention relates to [broad field], and more particularly to [specific area]."
+- CN: "本发明涉及[技术领域]，具体涉及[具体领域]。"
+
+### Step 4: Write Background (背景技术)
+
+This is NOT a literature review. It directly sets up the problem.
+
+Structure:
+1. Describe the closest prior art approaches (2-3 paragraphs)
+2. Identify specific technical deficiencies of each approach
+3. The deficiencies must be technical, not commercial or social
+4. DO NOT admit the prior art is "superior" or "better"
+5. DO NOT cite specific patent numbers unless they are known prior art (citations go in IDS for US, or Background section for CN)
+
+CN format: "背景技术" section describing existing technology and its shortcomings.
+
+### Step 5: Write Summary (发明内容)
+
+Three parts, directly mirroring INVENTION_DISCLOSURE.md:
+
+**Technical Problem (要解决的技术问题)**:
+- State the problem derived from background deficiencies
+- CN: "本发明要解决的技术问题是..."
+
+**Technical Solution (技术方案)**:
+- Describe how the invention solves the problem
+- Must provide support for ALL claim elements
+- Start from the broadest claim and describe the core inventive concept
+- CN: "为解决上述技术问题，本发明采用的技术方案是：..."
+- **NO formulas, NO mathematical derivations, NO circuit models** — these belong in 具体实施方式, not 发明内容
+
+**Advantages (有益效果)**:
+- Benefits derived from the structural/technical features (qualitative reasoning)
+- CN: "本发明的有益效果是：..."
+- **NO specific numerical results** (e.g., "detection limit 70μm", "response time 105ms") — these are experimental findings, not invention properties
+- Frame advantages structurally: "由于采用了...结构，因此具有...效果"
+
+### Step 6: Write Brief Description of Drawings (附图说明)
+
+Invoke `/figure-description` as a sub-skill if user has provided figures:
+```
+/figure-description "patent/figures/"
+```
+
+If no user figures, describe what figures should exist based on the claims.
+
+Format:
+- CN: "图1是...的示意图；图2是...的流程图；"
+- US: "FIG. 1 is a block diagram showing...; FIG. 2 is a flowchart illustrating..."
+
+### Step 7: Write Detailed Description (具体实施方式)
+
+Invoke `/embodiment-description` as a sub-skill:
+```
+/embodiment-description "patent/CLAIMS.md"
+```
+
+This section must:
+- Describe at least one complete embodiment with reference numerals
+- Enable a POSITA to make and use the invention
+- Support every claim element with explicit description
+- Include variations and alternatives for broader claim interpretation
+
+### Step 8: Write Abstract (摘要)
+
+Jurisdiction-specific word limits:
+
+| Jurisdiction | Word Limit | Notes |
+|-------------|-----------|-------|
+| CN | 300 words (Chinese characters) | Include most representative claim reference |
+| US | 150 words (2500 characters) | Enable efficient searching, no legal phrases |
+| EP | ~150 words | No statements on merits or value |
+
+The abstract summarizes:
+1. The technical field
+2. The problem being solved
+3. The technical solution (core features)
+4. Key advantages
+
+### Step 9: Claim Support Verification
+
+Verify every claim element finds support in the specification:
+
+| Claim | Element | Specification Section | Paragraph(s) | Reference Numeral |
+|-------|---------|----------------------|-------------|-------------------|
+| 1 | step a | detailed_description | ¶3 | 202 |
+| 1 | step b | detailed_description | ¶4 | 204 |
+| X | component A | detailed_description | ¶2 | 102 |
+
+If any element lacks support, add the necessary description before proceeding.
+
+### Step 10: Cross-Model Review
+
+Call `REVIEWER_MODEL` via `mcp__codex__codex` with xhigh reasoning:
+
+```
+mcp__codex__codex:
+  config: {"model_reasoning_effort": "xhigh"}
+  prompt: |
+    You are a patent examiner reviewing a specification for completeness.
+    CLAIMS: [all claims]
+    SPECIFICATION: [all specification sections]
+
+    Check for:
+    1. Written description support: Does every claim element have explicit or inherent support?
+    2. Enablement: Can a POSITA practice the invention from this specification?
+    3. Consistency: Do reference numerals match across figures and specification?
+    4. Language quality: Any subjective terms, relative terms without definition, or result-to-be-achieved language?
+    5. Missing embodiments: Are there claim features that need additional embodiments?
+    6. Background deficiencies: Are they technical and specific enough?
+```
+
+### Step 11: Output
+
+All specification sections are in `patent/specification/`.
+
+Summary file: `patent/specification/SPECIFICATION_INDEX.md` with:
+```markdown
+## Patent Specification
+
+### Sections
+| Section | File | Word Count | Status |
+|---------|------|-----------|--------|
+| Title | title.md | | Complete |
+| Technical Field | technical_field.md | | Complete |
+| Background | background.md | | Complete |
+| Summary | summary.md | | Complete |
+| Drawings Description | drawings_description.md | | Complete |
+| Detailed Description | detailed_description.md | | Complete |
+| Abstract | abstract.md | | Complete |
+
+### Claim Support Status
+| Claim | Elements Supported | Elements Missing |
+|-------|-------------------|-----------------|
+| 1 | All | None |
+| X | All | None |
+```
+
+## Key Rules
+
+- The specification supports the claims, not the other way around. Every claim element must have support.
+- Use consistent terminology -- same word for the same concept throughout.
+- DO NOT include experimental results, accuracy metrics, or empirical evaluations.
+- DO NOT use subjective language ("excellent", "surprising", "superior").
+- Reference numerals must be consistent: same component, same numeral, everywhere.
+- Background section describes specific deficiencies, not general "need for improvement."
+- Multiple embodiments strengthen the specification but are not always required.
+- Large file handling: if a Write operation fails, retry with Bash `cat <<'EOF'` heredoc.
+- If `mcp__codex__codex` is not available, skip cross-model review and note it in the output.

--- a/templates/INVENTION_BRIEF_TEMPLATE.md
+++ b/templates/INVENTION_BRIEF_TEMPLATE.md
@@ -1,0 +1,87 @@
+# Invention Brief
+
+> **Template for input to `/patent-pipeline`.** Provide detailed invention disclosure instead of a one-line prompt. Supports both structured and conversational input.
+
+## Title (发明名称)
+[A concise title reflecting the technical content. e.g., "一种基于注意力机制的图像去噪方法及装置"]
+
+## Technical Field (技术领域)
+[1-2 paragraphs: What technical domain does this invention belong to?]
+
+## Inventors
+- [Name 1 — role/contribution]
+- [Name 2 — role/contribution]
+
+## Background — Known Prior Art (背景技术)
+- **Closest prior art**: [Known patents, papers, or products]
+- **What they do well**: [Strengths of existing approaches]
+- **Their deficiencies**: [Specific technical problems not solved]
+- **Gap**: [What is missing that this invention addresses]
+
+## Technical Problem (要解决的技术问题)
+[State the specific technical problem this invention solves, derived from prior art deficiencies.]
+
+## Proposed Solution (技术方案)
+[Describe the invention's technical solution at a high level. What are the core inventive features?]
+
+## Key Advantages (有益效果)
+[Quantifiable or measurable advantages over prior art.]
+- Advantage 1: [description + evidence if available]
+- Advantage 2: [description + evidence if available]
+- Advantage 3: [description + evidence if available]
+
+## Embodiments (实施例)
+[Describe at least one way to practice the invention. Include specific parameters, components, steps, or configurations.]
+
+### Embodiment 1: [Title]
+[Detailed description]
+
+### Embodiment 2: [Title — optional]
+[Detailed description]
+
+## Figures Available (附图)
+[List available figures. For each figure, briefly describe what it shows.]
+
+| Figure | Description | File |
+|--------|-------------|------|
+| Fig. 1 | [e.g., system architecture block diagram] | [path/to/fig1.png] |
+| Fig. 2 | [e.g., method flowchart] | [path/to/fig2.png] |
+| Fig. 3 | [e.g., experimental comparison chart] | [path/to/fig3.png] |
+
+## Target Jurisdiction
+- [ ] CN (CNIPA — 国家知识产权局)
+- [ ] US (USPTO)
+- [ ] EP (EPO)
+- [ ] ALL
+
+## Patent Type
+- [ ] Invention patent (发明专利) — 20 year protection
+- [ ] Utility model (实用新型, CN only) — 10 year protection, apparatus claims only
+
+## Language
+- [ ] Chinese (中文)
+- [ ] English
+- [ ] Auto (detect from jurisdiction)
+
+## Claimable Subject Matter (可权利化的主题)
+[What types of claims do you expect?]
+- [ ] Method/process claims (方法权利要求)
+- [ ] System/apparatus claims (系统/装置权利要求)
+- [ ] Product claims (产品权利要求)
+- [ ] Computer-readable medium claims (计算机可读存储介质, US)
+- [ ] Other: [describe]
+
+## Known Related Patents/Papers
+[List any patents or papers you have already identified as relevant. Include patent numbers or DOIs.]
+
+| Reference | Type | Title | Why Relevant |
+|-----------|------|-------|-------------|
+| | Patent / Paper | | |
+
+## Filing Timeline
+- **Preferred filing date**: [date or ASAP]
+- **Priority claim**: [if claiming priority to earlier application]
+- **Publication deadline**: [if any]
+
+## Additional Notes
+[Any other information relevant to the patent application.]

--- a/templates/PATENT_CLAIMS_TEMPLATE.md
+++ b/templates/PATENT_CLAIMS_TEMPLATE.md
@@ -1,0 +1,78 @@
+# Patent Claims Worksheet
+
+> **Template for pre-drafting claims structure.** Fill in before running `/claims-drafting`, or use as a reference during claim drafting.
+
+## Invention Summary
+[One-sentence description of the core inventive concept.]
+
+## Independent Claims Plan
+
+### Claim 1: Method Claim (broadest)
+- **Preamble**: A method for [purpose], comprising:
+- **Known features** (from prior art):
+  1. [feature A]
+  2. [feature B]
+- **Inventive features** (novel):
+  1. [feature C]
+  2. [feature D]
+- **Transition**: comprising / characterised in that (per jurisdiction)
+
+### Claim X: System/Apparatus Claim (mirrors Claim 1)
+- **Preamble**: A system for [purpose], comprising:
+- **Structural components mapping to method steps**:
+  1. [component corresponding to step 1]
+  2. [component corresponding to step 2]
+  ...
+
+### Claim Y: Computer-Readable Medium Claim (US only, optional)
+- Maps to method claim 1
+
+## Dependent Claims Plan
+
+| Claim # | Depends On | Adds Feature | Fallback Value |
+|---------|-----------|-------------|----------------|
+| 2 | 1 | [specific limitation of feature C] | Medium |
+| 3 | 1 | [specific limitation of feature D] | Medium |
+| 4 | 2 | [additional narrowing] | Low |
+| 5 | 1 or 2 | [alternative implementation of C] | High |
+
+## Claims Hierarchy (dependency tree)
+
+```
+1. (Independent — method, broadest)
+├── 2. (narrows feature C)
+│   └── 4. (narrows further)
+├── 3. (narrows feature D)
+├── 5. (alternative to 2 or 3)
+│
+X. (Independent — system, mirrors 1)
+├── X+1. (narrows component)
+├── X+2. (narrows component)
+│
+Y. (Independent — medium, US only, mirrors 1)
+```
+
+## Prior Art Avoidance Matrix
+
+| Claim Element | Prior Art Reference | Avoidance Strategy |
+|---------------|--------------------|--------------------|
+| Feature C | [Ref X] | Ref X uses different approach... |
+| Feature D | [Ref Y] | Ref Y doesn't combine C+D... |
+| Combination C+D | [Ref X + Y] | No motivation to combine... |
+
+## Jurisdiction-Specific Formatting Notes
+
+### CN (Chinese)
+- Use "其特征在于" to separate known and inventive features
+- Method: "一种...的方法，包括：...；其特征在于，还包括：..."
+- Apparatus: "一种...的装置，包括：...；其特征在于，还包括：..."
+
+### US
+- Use "comprising" (open transition)
+- Method: "A method for [purpose], comprising: [step A]; [step B];..."
+- System: "A system for [purpose], comprising: [component A]; [component B];..."
+
+### EP
+- Two-part form MANDATORY (Rule 43(1) EPC)
+- "A method for [purpose], comprising [known features], characterised in that [inventive features]."
+- "A system for [purpose], comprising [known components], characterised in that [inventive components]."

--- a/templates/PATENT_SPECIFICATION_TEMPLATE.md
+++ b/templates/PATENT_SPECIFICATION_TEMPLATE.md
@@ -1,0 +1,68 @@
+# Patent Specification Skeleton
+
+> **Template for `/specification-writing`.** Provides pre-structured sections. The skill fills in content based on INVENTION_DISCLOSURE.md and CLAIMS.md.
+
+## Metadata
+- **Title**: [发明名称 / Title of Invention]
+- **Jurisdiction**: [CN / US / EP / ALL]
+- **Patent Type**: [Invention / Utility Model]
+- **Language**: [Chinese / English]
+
+## 1. Technical Field (技术领域)
+[1-2 paragraphs identifying the technical domain]
+
+## 2. Background Technology (背景技术)
+### 2.1 Existing Approaches
+[Describe the closest prior art — patents, papers, or products]
+
+### 2.2 Deficiencies
+[Identify specific technical deficiencies of existing approaches]
+
+## 3. Summary of Invention (发明内容)
+
+### 3.1 Technical Problem
+[State the problem derived from background deficiencies]
+
+### 3.2 Technical Solution
+[Describe the invention's solution, matching the scope of the claims]
+
+### 3.3 Advantages
+[Measurable/quantifiable benefits over prior art]
+
+## 4. Brief Description of Drawings (附图说明)
+
+| Figure | Description |
+|--------|-------------|
+| FIG. 1 | [one-sentence description] |
+| FIG. 2 | [one-sentence description] |
+| FIG. 3 | [one-sentence description] |
+
+## 5. Detailed Description of Embodiments (具体实施方式)
+
+### Embodiment 1: [Title]
+[Detailed description with reference numerals. How to make and use the invention.]
+
+### Embodiment 2: [Title — optional]
+[Alternative embodiment supporting broader claim interpretation]
+
+## 6. Abstract (摘要)
+[150 words (US) / 300 words (CN). Summary of technical solution and key advantages.]
+
+## Reference Numeral Index
+
+| Numeral | Component | Figure(s) |
+|---------|-----------|-----------|
+| 100 | [system] | Fig. 1 |
+| 102 | [processor] | Fig. 1 |
+| 104 | [memory] | Fig. 1 |
+| 200 | [process] | Fig. 2 |
+| 202 | [step A] | Fig. 2 |
+
+## Claim-to-Specification Support Map
+
+| Claim Element | Specification Paragraph(s) | Figure(s) |
+|---------------|---------------------------|-----------|
+| [feature A] | ¶X | Fig. 1 |
+| [feature B] | ¶X-Y | Fig. 1, 2 |
+| [feature C] | ¶Z | Fig. 2 |
+| [feature D] | ¶Z-A | Fig. 2, 3 |

--- a/templates/README.md
+++ b/templates/README.md
@@ -12,6 +12,14 @@ Ready-to-use templates for each ARIS workflow. Copy, fill in your content, and r
 | [NARRATIVE_REPORT_TEMPLATE.md](NARRATIVE_REPORT_TEMPLATE.md) | Workflow 3 | Research narrative with claims, experiments, results |
 | [PAPER_PLAN_TEMPLATE.md](PAPER_PLAN_TEMPLATE.md) | Workflow 3 | Pre-made outline to skip planning phase |
 
+### Patent Templates (`/patent-pipeline`)
+
+| Template | For Workflow | What to do |
+|----------|-------------|------------|
+| [INVENTION_BRIEF_TEMPLATE.md](INVENTION_BRIEF_TEMPLATE.md) | Patent Pipeline | Invention disclosure with technical problem, solution, advantages, figures |
+| [PATENT_CLAIMS_TEMPLATE.md](PATENT_CLAIMS_TEMPLATE.md) | `/claims-drafting` | Claims hierarchy worksheet with examples for CN/US/EP |
+| [PATENT_SPECIFICATION_TEMPLATE.md](PATENT_SPECIFICATION_TEMPLATE.md) | `/specification-writing` | Skeleton specification with all required sections |
+
 ### Compact Mode Templates (`— compact: true`)
 
 | Template | Written by | Purpose |
@@ -22,8 +30,18 @@ Ready-to-use templates for each ARIS workflow. Copy, fill in your content, and r
 
 ## Usage
 
+### Research Pipeline
+
 ```bash
 cp templates/EXPERIMENT_PLAN_TEMPLATE.md refine-logs/EXPERIMENT_PLAN.md
 # Edit with your content, then:
 /experiment-bridge
+```
+
+### Patent Pipeline
+
+```bash
+cp templates/INVENTION_BRIEF_TEMPLATE.md patent/INVENTION_BRIEF.md
+# Edit with your invention details, then:
+/patent-pipeline "patent/INVENTION_BRIEF.md -- CN"
 ```


### PR DESCRIPTION
Summary
Adds a complete patent drafting pipeline as a parallel branch alongside the existing research pipeline. Designed for researchers who want to patent their work without manually navigating jurisdiction-specific requirements.

/patent-pipeline — full orchestrator: prior art → novelty check → invention structuring → claims → specification → examiner review → jurisdiction format
9 sub-skills covering each phase of the patent workflow
Supports CN (CNIPA), US (USPTO), EP (EPO) jurisdictions
Supports both invention patents (发明专利) and utility models (实用新型)
Cross-model examiner review via external LLM (configurable via Codex MCP)
3 templates: invention brief, claims worksheet, specification skeleton
5 shared references: CN/US/EP format guides, patent writing principles, prior art databases
patent/ output directory excluded from git by default (confidential)
Design
Follows the same skill architecture as /grant-proposal — parallel branch, not a replacement for the research pipeline. Intended entry point:


/idea-discovery → /research-pipeline → /patent-pipeline
or standalone from an existing paper or invention description.

This pipeline is designed as a post-validation writing assistant. The intended use case is taking completed experimental work, hardware designs, or implemented algorithms and drafting a patent application from them — not generating invention content from scratch. Most patents require physical experiments or hardware design that ARIS cannot produce; the pipeline's value is in organizing and formalizing what already exists into a properly structured filing draft.

Model Recommendation
Output quality is strongly correlated with model capability. Frontier models (Claude, GPT-4o/GPT-5, Gemini, Grok) produce well-structured claims and specification text that follows jurisdiction-specific rules. Smaller or instruction-following-weak models tend to ignore format constraints and mix experimental data into the specification. Use the strongest model available for patent work.

Test
Tested on a real microwave sensor paper (SRR-based lubricant oil contaminant detection, CN jurisdiction). Pipeline ran end-to-end with Claude Sonnet 4.6.

Notes
AUTO_PROCEED = false by default — patent applications require human review at every phase
Output is a draft for attorney review, not a final filing document
Happy to target a feature branch if you prefer to stage this separately before merging to main