### PR TITLE
feat: support generic anthropic/openai-compatible endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "reqwest",
  "runtime",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aris-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "api",
  "commands",
@@ -129,14 +129,14 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "runtime",
 ]
 
 [[package]]
 name = "compat-harness"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "commands",
  "runtime",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "glob",
  "regex",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "api",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -71,7 +71,21 @@ sudo mv aris /usr/local/bin/aris
 aris
 ```
 
+> The release artifact is a `tar.gz` containing a single `aris` binary, not a `.pkg` installer.
 > Currently supports **macOS Apple Silicon (M1/M2/M3/M4)** only. Support for other platforms is on the roadmap.
+
+### Build And Package Locally
+
+```bash
+git checkout aris-code
+cargo build --release --target aarch64-apple-darwin
+cp target/aarch64-apple-darwin/release/aris ./aris
+chmod +x ./aris
+tar czf aris-code-darwin-arm64.tar.gz aris
+shasum -a 256 aris-code-darwin-arm64.tar.gz > aris-code-darwin-arm64.tar.gz.sha256
+```
+
+The bundled skills are embedded at compile time, so the tarball only needs the `aris` binary.
 
 ---
 
@@ -84,17 +98,23 @@ The first time you run `aris`, an interactive setup wizard launches automaticall
 
 [1/3] Choose Executor provider (primary LLM)
   > Anthropic Claude
+    Anthropic-compatible Proxy
+    OpenAI-compatible Generic
     OpenAI GPT
     Google Gemini
     Zhipu GLM
     MiniMax
+    Kimi (Anthropic-compatible)
 Enter API Key: sk-...
 
 [2/3] Choose Reviewer provider (adversarial LLM)
   > OpenAI GPT
+    OpenAI-compatible Generic
     Google Gemini
     Zhipu GLM
     MiniMax
+    Kimi (Anthropic-compatible)
+    Anthropic-compatible Proxy
 Enter API Key: sk-...
 
 [3/3] Choose language preference
@@ -113,12 +133,50 @@ After setup you drop straight into the REPL. Run `/setup` at any time to reconfi
 | Provider | As Executor | As Reviewer | Key Models |
 |----------|:-----------:|:-----------:|-----------|
 | 🟣 Anthropic Claude | ✅ | — | claude-opus, claude-sonnet, claude-haiku |
+| 🟪 Anthropic-compatible | ✅ | ✅ | claude-opus, claude-sonnet, claude-haiku |
 | 🟢 OpenAI | ✅ | ✅ | gpt-5.4, gpt-5.4-mini, gpt-5.4-nano |
 | 🔵 Google Gemini | ✅ | ✅ | gemini-2.5-pro, gemini-2.5-flash |
 | 🔶 Zhipu GLM | ✅ | ✅ | GLM-5, GLM-5-Turbo |
 | 🔷 MiniMax | ✅ | ✅ | MiniMax-M2.7, MiniMax-M2.7-highspeed |
 
-> **Design note**: Anthropic Claude is Executor-only; all other providers can serve as both Executor and Reviewer. The classic pairing is **Claude Executor + GPT/GLM Reviewer** for true adversarial multi-agent research.
+> **Design note**: ARIS now treats protocol compatibility as the primary interface: any **Anthropic-compatible** `/v1/messages` endpoint and any **OpenAI-compatible** `/v1/chat/completions` endpoint can be used with arbitrary model IDs.
+
+### Anthropic-compatible Configuration
+
+Executor example:
+
+```bash
+ANTHROPIC_AUTH_TOKEN=your-token \
+ANTHROPIC_BASE_URL=https://proxy.example \
+aris --model claude-opus-4-6
+```
+
+Kimi coding preset example:
+
+```bash
+ANTHROPIC_AUTH_TOKEN=your-token \
+ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic \
+aris --model kimi-k2.5
+```
+
+Reviewer example:
+
+```bash
+ARIS_REVIEWER_PROVIDER=anthropic-compat \
+ARIS_REVIEWER_AUTH_TOKEN=your-token \
+ARIS_REVIEWER_BASE_URL=https://proxy.example \
+ARIS_REVIEWER_MODEL=claude-sonnet-4-6 \
+aris
+```
+
+Generic OpenAI-compatible example:
+
+```bash
+EXECUTOR_PROVIDER=openai \
+EXECUTOR_API_KEY=your-token \
+EXECUTOR_BASE_URL=https://endpoint.example/v1 \
+aris --model your-custom-model
+```
 
 ---
 
@@ -306,4 +364,3 @@ MIT License © 2025 ARIS-Code Contributors
 <div align="center">
   <sub>🌙 Let AI do research while you sleep · Built with ❤️ and Rust</sub>
 </div>
-

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Kimi coding preset example:
 
 ```bash
 ANTHROPIC_AUTH_TOKEN=your-token \
-ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic \
+ANTHROPIC_BASE_URL=https://api.kimi.com/coding/ \
 aris --model kimi-k2.5
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -71,7 +71,21 @@ sudo mv aris /usr/local/bin/aris
 aris
 ```
 
+> 发布产物是只包含单个 `aris` 二进制的 `tar.gz`，不是 `.pkg` 安装器。
 > 目前仅支持 macOS Apple Silicon（M1/M2/M3/M4）。其他平台支持正在规划中。
+
+### 本地编译打包
+
+```bash
+git checkout aris-code
+cargo build --release --target aarch64-apple-darwin
+cp target/aarch64-apple-darwin/release/aris ./aris
+chmod +x ./aris
+tar czf aris-code-darwin-arm64.tar.gz aris
+shasum -a 256 aris-code-darwin-arm64.tar.gz > aris-code-darwin-arm64.tar.gz.sha256
+```
+
+内置 skills 会在编译期直接嵌入二进制，所以打包时只需要 `aris` 一个文件。
 
 ---
 
@@ -84,17 +98,23 @@ aris
 
 [1/3] 选择 Executor 提供商（主力执行 LLM）
   > Anthropic Claude
+    Anthropic-compatible Proxy
+    OpenAI-compatible Generic
     OpenAI GPT
     Google Gemini
     Zhipu GLM
     MiniMax
+    Kimi（Anthropic-compatible）
 请输入 API Key: sk-...
 
 [2/3] 选择 Reviewer 提供商（对抗审查 LLM）
   > OpenAI GPT
+    OpenAI-compatible Generic
     Google Gemini
     Zhipu GLM
     MiniMax
+    Kimi（Anthropic-compatible）
+    Anthropic-compatible Proxy
 请输入 API Key: sk-...
 
 [3/3] 选择语言偏好
@@ -113,12 +133,50 @@ aris
 | 提供商 | 作为 Executor | 作为 Reviewer | 主要模型 |
 |--------|:------------:|:------------:|---------|
 | 🟣 Anthropic Claude | ✅ | — | claude-opus, claude-sonnet, claude-haiku |
+| 🟪 Anthropic-compatible | ✅ | ✅ | claude-opus, claude-sonnet, claude-haiku |
 | 🟢 OpenAI | ✅ | ✅ | gpt-5.4, gpt-5.4-mini, gpt-5.4-nano |
 | 🔵 Google Gemini | ✅ | ✅ | gemini-2.5-pro, gemini-2.5-flash |
 | 🔶 Zhipu GLM | ✅ | ✅ | GLM-5, GLM-5-Turbo |
 | 🔷 MiniMax | ✅ | ✅ | MiniMax-M2.7, MiniMax-M2.7-highspeed |
 
-> **设计说明**：Anthropic Claude 仅作 Executor，其他四家可同时作 Executor 和 Reviewer。推荐经典搭配：**Claude Executor + GPT/GLM Reviewer**，构成真正的对抗多智能体。
+> **设计说明**：ARIS 现在优先按协议兼容性接入模型：任何 **Anthropic-compatible** 的 `/v1/messages` 端点，和任何 **OpenAI-compatible** 的 `/v1/chat/completions` 端点，都可以直接配合任意模型 ID 使用。
+
+### Anthropic-compatible 配置示例
+
+Executor 示例：
+
+```bash
+ANTHROPIC_AUTH_TOKEN=your-token \
+ANTHROPIC_BASE_URL=https://proxy.example \
+aris --model claude-opus-4-6
+```
+
+Kimi Coding 预设示例：
+
+```bash
+ANTHROPIC_AUTH_TOKEN=your-token \
+ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic \
+aris --model kimi-k2.5
+```
+
+Reviewer 示例：
+
+```bash
+ARIS_REVIEWER_PROVIDER=anthropic-compat \
+ARIS_REVIEWER_AUTH_TOKEN=your-token \
+ARIS_REVIEWER_BASE_URL=https://proxy.example \
+ARIS_REVIEWER_MODEL=claude-sonnet-4-6 \
+aris
+```
+
+通用 OpenAI-compatible 示例：
+
+```bash
+EXECUTOR_PROVIDER=openai \
+EXECUTOR_API_KEY=your-token \
+EXECUTOR_BASE_URL=https://endpoint.example/v1 \
+aris --model your-custom-model
+```
 
 ---
 
@@ -299,4 +357,3 @@ MIT License © 2025 ARIS-Code Contributors
 <div align="center">
   <sub>🌙 让 AI 在你睡觉时帮你做研究 · Built with ❤️ and Rust</sub>
 </div>
-

--- a/README_CN.md
+++ b/README_CN.md
@@ -155,7 +155,7 @@ Kimi Coding 预设示例：
 
 ```bash
 ANTHROPIC_AUTH_TOKEN=your-token \
-ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic \
+ANTHROPIC_BASE_URL=https://api.kimi.com/coding/ \
 aris --model kimi-k2.5
 ```
 

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -14,7 +14,7 @@ const CONFIG_FILE: &str = "config.json";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ArisConfig {
-    /// "anthropic" or "openai"
+    /// "anthropic", "anthropic-compat", or "openai"
     #[serde(default)]
     pub executor_provider: Option<String>,
     #[serde(default)]
@@ -23,7 +23,7 @@ pub struct ArisConfig {
     pub executor_base_url: Option<String>,
     #[serde(default)]
     pub executor_model: Option<String>,
-    /// "gemini" or "openai"
+    /// "openai", "gemini", "glm", "minimax", "kimi", or "anthropic-compat"
     #[serde(default)]
     pub reviewer_provider: Option<String>,
     #[serde(default)]
@@ -62,9 +62,8 @@ impl ArisConfig {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let json = serde_json::to_string_pretty(self).map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, e)
-        })?;
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         fs::write(&path, json)
     }
 
@@ -94,6 +93,8 @@ impl ArisConfig {
             std::env::remove_var("GLM_API_KEY");
             std::env::remove_var("MINIMAX_API_KEY");
             std::env::remove_var("KIMI_API_KEY");
+            std::env::remove_var("ARIS_REVIEWER_PROVIDER");
+            std::env::remove_var("ARIS_REVIEWER_AUTH_TOKEN");
             std::env::remove_var("ARIS_REVIEWER_MODEL");
             std::env::remove_var("ARIS_REVIEWER_BASE_URL");
         }
@@ -144,6 +145,9 @@ impl ArisConfig {
 
         // Reviewer API key
         if let Some(reviewer_provider) = &self.reviewer_provider {
+            if force || std::env::var("ARIS_REVIEWER_PROVIDER").is_err() {
+                std::env::set_var("ARIS_REVIEWER_PROVIDER", reviewer_provider);
+            }
             if let Some(key) = &self.reviewer_api_key {
                 match reviewer_provider.as_str() {
                     "gemini" => {
@@ -169,6 +173,11 @@ impl ArisConfig {
                     "kimi" => {
                         if force || std::env::var("KIMI_API_KEY").is_err() {
                             std::env::set_var("KIMI_API_KEY", key);
+                        }
+                    }
+                    "anthropic-compat" => {
+                        if force || std::env::var("ARIS_REVIEWER_AUTH_TOKEN").is_err() {
+                            std::env::set_var("ARIS_REVIEWER_AUTH_TOKEN", key);
                         }
                     }
                     _ => {}
@@ -212,7 +221,9 @@ impl ArisConfig {
 
     /// Check if we have minimum viable config (at least an executor API key).
     pub fn has_executor_key(&self) -> bool {
-        self.executor_api_key.as_ref().is_some_and(|k| !k.is_empty())
+        self.executor_api_key
+            .as_ref()
+            .is_some_and(|k| !k.is_empty())
     }
 }
 
@@ -225,33 +236,86 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
 
     // ── Step 1+2: Executor provider + key + model ──
     println!("\x1b[1m[1/3] Executor (main LLM)\x1b[0m");
-    println!("  1. Anthropic   (claude-opus / sonnet / haiku)");
-    println!("  2. OpenAI      (gpt-5.4)");
-    println!("  3. Gemini      (gemini-2.5-pro)");
-    println!("  4. GLM         (GLM-5)");
-    println!("  5. MiniMax     (MiniMax-M2.7)");
-    println!("  6. Kimi        (kimi-k2.5)");
+    println!("  1. Anthropic official           (Claude API / OAuth)");
+    println!("  2. Anthropic-compatible proxy   (any /v1/messages endpoint)");
+    println!("  3. OpenAI                       (official API)");
+    println!("  4. OpenAI-compatible generic    (any /v1/chat/completions endpoint)");
+    println!("  5. Gemini                       (preset OpenAI-compatible endpoint)");
+    println!("  6. GLM                          (preset OpenAI-compatible endpoint)");
+    println!("  7. MiniMax                      (preset OpenAI-compatible endpoint)");
+    println!("  8. Kimi                         (preset Anthropic-compatible endpoint)");
 
     let default_executor = match config.executor_provider.as_deref() {
+        Some("anthropic-compat") => "2",
         Some("openai") => match config.executor_base_url.as_deref() {
-            Some(u) if u.contains("googleapis") => "3",
-            Some(u) if u.contains("bigmodel") => "4",
-            Some(u) if u.contains("minimax") => "5",
-            Some(u) if u.contains("moonshot") => "6",
-            _ => "2",
+            Some(u) if u.contains("api.openai.com") => "3",
+            Some(u) if u.contains("googleapis") => "5",
+            Some(u) if u.contains("bigmodel") => "6",
+            Some(u) if u.contains("minimax") => "7",
+            _ => "4",
         },
         _ => "1",
     };
-    let exec_choice = prompt_with_default("  Choose [1-6]", default_executor)?;
+    let exec_choice = prompt_with_default("  Choose [1-8]", default_executor)?;
 
     // (provider, key_env, key_label, base_url, default_model)
     let exec_info: (&str, &str, &str, Option<&str>, &str) = match exec_choice.trim() {
-        "2" => ("openai", "EXECUTOR_API_KEY", "OpenAI API key", Some("https://api.openai.com/v1"), "gpt-5.4"),
-        "3" => ("openai", "EXECUTOR_API_KEY", "Gemini API key", Some("https://generativelanguage.googleapis.com/v1beta/openai"), "gemini-2.5-pro"),
-        "4" => ("openai", "EXECUTOR_API_KEY", "GLM API key", Some("https://open.bigmodel.cn/api/paas/v4"), "GLM-5"),
-        "5" => ("openai", "EXECUTOR_API_KEY", "MiniMax API key", Some("https://api.minimax.chat/v1"), "MiniMax-M2.7"),
-        "6" => ("openai", "EXECUTOR_API_KEY", "Kimi API key", Some("https://api.moonshot.cn/v1"), "kimi-k2.5"),
-        _ => ("anthropic", "ANTHROPIC_API_KEY", "Anthropic API key", None, "claude-opus-4-6"),
+        "2" => (
+            "anthropic-compat",
+            "ANTHROPIC_AUTH_TOKEN",
+            "Anthropic-compatible bearer token",
+            None,
+            "claude-opus-4-6",
+        ),
+        "3" => (
+            "openai",
+            "EXECUTOR_API_KEY",
+            "OpenAI API key",
+            Some("https://api.openai.com/v1"),
+            "gpt-5.4",
+        ),
+        "4" => (
+            "openai",
+            "EXECUTOR_API_KEY",
+            "OpenAI-compatible API key",
+            None,
+            "gpt-4o",
+        ),
+        "5" => (
+            "openai",
+            "EXECUTOR_API_KEY",
+            "Gemini API key",
+            Some("https://generativelanguage.googleapis.com/v1beta/openai"),
+            "gemini-2.5-pro",
+        ),
+        "6" => (
+            "openai",
+            "EXECUTOR_API_KEY",
+            "GLM API key",
+            Some("https://open.bigmodel.cn/api/paas/v4"),
+            "GLM-5",
+        ),
+        "7" => (
+            "openai",
+            "EXECUTOR_API_KEY",
+            "MiniMax API key",
+            Some("https://api.minimax.chat/v1"),
+            "MiniMax-M2.7",
+        ),
+        "8" => (
+            "anthropic-compat",
+            "ANTHROPIC_AUTH_TOKEN",
+            "Kimi API key",
+            Some("https://api.moonshot.cn/anthropic"),
+            "kimi-k2.5",
+        ),
+        _ => (
+            "anthropic",
+            "ANTHROPIC_API_KEY",
+            "Anthropic API key",
+            None,
+            "claude-opus-4-6",
+        ),
     };
 
     config.executor_provider = Some(exec_info.0.into());
@@ -268,10 +332,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         .filter(|k| k.len() > 8)
         .map(|k| format!("{}...{}", &k[..4], &k[k.len() - 4..]))
         .unwrap_or_else(|| "(not set)".into());
-    let new_key = prompt_with_default(
-        &format!("  {} [{current_key_masked}]", exec_info.2),
-        "",
-    )?;
+    let new_key = prompt_with_default(&format!("  {} [{current_key_masked}]", exec_info.2), "")?;
     if !new_key.is_empty() {
         config.executor_api_key = Some(new_key);
     }
@@ -279,49 +340,86 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     // Ask for proxy/custom base URL (all providers)
     let current_url_hint = config.executor_base_url.as_deref().unwrap_or("default");
     let custom_url = prompt_with_default(
-        &format!("  Proxy base URL [{current_url_hint}] (Enter for default)"),
+        &format!("  Base URL [{current_url_hint}] (Enter for default)"),
         "",
     )?;
     if !custom_url.is_empty() {
-        config.executor_base_url = Some(custom_url.clone());
-        // Anthropic + custom URL → switch to anthropic-compat (Bearer token mode)
-        if exec_info.0 == "anthropic" {
-            config.executor_provider = Some("anthropic-compat".into());
-        }
+        config.executor_base_url = Some(custom_url);
+    } else if exec_info.3.is_none() {
+        config.executor_base_url = None;
     }
 
-    // Auto-set best model for the chosen provider
-    config.executor_model = Some(exec_info.4.to_string());
-    println!("  \x1b[2mModel: {}\x1b[0m", exec_info.4);
+    let current_executor_model = config.executor_model.as_deref().unwrap_or(exec_info.4);
+    let executor_model = prompt_with_default(
+        &format!("  Model [{current_executor_model}]"),
+        current_executor_model,
+    )?;
+    config.executor_model = Some(executor_model.clone());
+    println!("  \x1b[2mModel: {executor_model}\x1b[0m");
 
     // ── Step 4: Reviewer ──
     println!("\n\x1b[1m[2/3] Reviewer (for LlmReview tool)\x1b[0m");
-    println!("  1. OpenAI    (gpt-5.4)");
-    println!("  2. Gemini    (gemini-2.5-pro)");
-    println!("  3. GLM       (GLM-5)");
-    println!("  4. MiniMax   (MiniMax-M2.7)");
-    println!("  5. Kimi      (kimi-k2.5)");
-    println!("  6. Skip (no reviewer)");
+    println!("  1. OpenAI                 (official API)");
+    println!("  2. OpenAI-compatible      (any /v1/chat/completions endpoint)");
+    println!("  3. Gemini                 (preset OpenAI-compatible endpoint)");
+    println!("  4. GLM                    (preset OpenAI-compatible endpoint)");
+    println!("  5. MiniMax                (preset OpenAI-compatible endpoint)");
+    println!("  6. Kimi                   (preset Anthropic-compatible endpoint)");
+    println!("  7. Anthropic-compatible   (any /v1/messages endpoint)");
+    println!("  8. Skip (no reviewer)");
     let reviewer_choice = prompt_with_default(
-        "  Choose [1-6]",
+        "  Choose [1-8]",
         match config.reviewer_provider.as_deref() {
-            Some("openai") => "1",
-            Some("gemini") => "2",
-            Some("glm") => "3",
-            Some("minimax") => "4",
-            Some("kimi") => "5",
+            Some("openai") => match config.reviewer_base_url.as_deref() {
+                Some(url) if !url.contains("api.openai.com") => "2",
+                _ => "1",
+            },
+            Some("gemini") => "3",
+            Some("glm") => "4",
+            Some("minimax") => "5",
+            Some("anthropic-compat") => match config.reviewer_base_url.as_deref() {
+                Some(url) if url.contains("moonshot") => "6",
+                _ => "7",
+            },
             None => "1",
-            _ => "6",
+            _ => "8",
         },
     )?;
 
     // (provider_name, key_env_var, key_label, default_model)
     let reviewer_info: Option<(&str, &str, &str, &str)> = match reviewer_choice.trim() {
         "1" => Some(("openai", "OPENAI_API_KEY", "OpenAI API key", "gpt-5.4")),
-        "2" => Some(("gemini", "GEMINI_API_KEY", "Gemini API key", "gemini-2.5-pro")),
-        "3" => Some(("glm", "GLM_API_KEY", "GLM API key", "GLM-5")),
-        "4" => Some(("minimax", "MINIMAX_API_KEY", "MiniMax API key", "MiniMax-M2.7")),
-        "5" => Some(("kimi", "KIMI_API_KEY", "Kimi API key", "kimi-k2.5")),
+        "2" => Some((
+            "openai",
+            "OPENAI_API_KEY",
+            "OpenAI-compatible API key",
+            "gpt-4o",
+        )),
+        "3" => Some((
+            "gemini",
+            "GEMINI_API_KEY",
+            "Gemini API key",
+            "gemini-2.5-pro",
+        )),
+        "4" => Some(("glm", "GLM_API_KEY", "GLM API key", "GLM-5")),
+        "5" => Some((
+            "minimax",
+            "MINIMAX_API_KEY",
+            "MiniMax API key",
+            "MiniMax-M2.7",
+        )),
+        "6" => Some((
+            "anthropic-compat",
+            "KIMI_API_KEY",
+            "Kimi API key",
+            "kimi-k2.5",
+        )),
+        "7" => Some((
+            "anthropic-compat",
+            "ARIS_REVIEWER_AUTH_TOKEN",
+            "Anthropic-compatible bearer token",
+            "claude-opus-4-6",
+        )),
         _ => None,
     };
 
@@ -335,10 +433,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             .filter(|k| k.len() > 8)
             .map(|k| format!("{}...{}", &k[..4], &k[k.len() - 4..]))
             .unwrap_or_else(|| "(not set)".into());
-        let new_key = prompt_with_default(
-            &format!("  {key_label} [{current_masked}]"),
-            "",
-        )?;
+        let new_key = prompt_with_default(&format!("  {key_label} [{current_masked}]"), "")?;
         if !new_key.is_empty() {
             config.reviewer_api_key = Some(new_key.clone());
             std::env::set_var(key_env, &new_key);
@@ -348,9 +443,17 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
 
         // Ask for proxy/custom base URL for reviewer
         let current_reviewer_url = config.reviewer_base_url.as_deref().unwrap_or("default");
+        let reviewer_default_url = match reviewer_choice.trim() {
+            "2" => "",
+            "3" => "https://generativelanguage.googleapis.com/v1beta/openai",
+            "4" => "https://open.bigmodel.cn/api/paas/v4",
+            "5" => "https://api.minimax.chat/v1",
+            "6" => "https://api.moonshot.cn/anthropic",
+            _ => "",
+        };
         let custom_reviewer_url = prompt_with_default(
-            &format!("  Proxy base URL [{current_reviewer_url}] (Enter for default)"),
-            "",
+            &format!("  Base URL [{current_reviewer_url}] (Enter for default)"),
+            reviewer_default_url,
         )?;
         if !custom_reviewer_url.is_empty() {
             config.reviewer_base_url = Some(custom_reviewer_url);
@@ -358,9 +461,13 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             config.reviewer_base_url = None;
         }
 
-        // Auto-set best model for the chosen reviewer provider
-        config.reviewer_model = Some(default_model.to_string());
-        println!("  \x1b[2mModel: {default_model}\x1b[0m");
+        let current_reviewer_model = config.reviewer_model.as_deref().unwrap_or(default_model);
+        let reviewer_model = prompt_with_default(
+            &format!("  Model [{current_reviewer_model}]"),
+            current_reviewer_model,
+        )?;
+        config.reviewer_model = Some(reviewer_model.clone());
+        println!("  \x1b[2mModel: {reviewer_model}\x1b[0m");
     } else {
         config.reviewer_provider = None;
         config.reviewer_api_key = None;
@@ -379,7 +486,14 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             _ => "1",
         },
     )?;
-    config.language = Some(if lang_choice.trim() == "2" { "en" } else { "cn" }.into());
+    config.language = Some(
+        if lang_choice.trim() == "2" {
+            "en"
+        } else {
+            "cn"
+        }
+        .into(),
+    );
 
     // ── Save ──
     println!("\n\x1b[1mSaving configuration\x1b[0m");
@@ -402,5 +516,77 @@ fn prompt_with_default(prompt: &str, default: &str) -> io::Result<String> {
         Ok(default.to_string())
     } else {
         Ok(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ArisConfig;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn anthropic_compat_executor_sets_expected_env_vars() {
+        let _lock = env_lock();
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("ANTHROPIC_BASE_URL");
+
+        let config = ArisConfig {
+            executor_provider: Some("anthropic-compat".into()),
+            executor_api_key: Some("token-123".into()),
+            executor_base_url: Some("https://proxy.example".into()),
+            ..ArisConfig::default()
+        };
+        config.force_apply_to_env();
+
+        assert_eq!(
+            std::env::var("ANTHROPIC_AUTH_TOKEN").as_deref(),
+            Ok("token-123")
+        );
+        assert_eq!(
+            std::env::var("ANTHROPIC_BASE_URL").as_deref(),
+            Ok("https://proxy.example")
+        );
+    }
+
+    #[test]
+    fn anthropic_compat_reviewer_sets_expected_env_vars() {
+        let _lock = env_lock();
+        std::env::remove_var("ARIS_REVIEWER_PROVIDER");
+        std::env::remove_var("ARIS_REVIEWER_AUTH_TOKEN");
+        std::env::remove_var("ARIS_REVIEWER_BASE_URL");
+        std::env::remove_var("ARIS_REVIEWER_MODEL");
+
+        let config = ArisConfig {
+            reviewer_provider: Some("anthropic-compat".into()),
+            reviewer_api_key: Some("reviewer-token".into()),
+            reviewer_base_url: Some("https://reviewer.example".into()),
+            reviewer_model: Some("claude-sonnet-4-6".into()),
+            ..ArisConfig::default()
+        };
+        config.force_apply_to_env();
+
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_PROVIDER").as_deref(),
+            Ok("anthropic-compat")
+        );
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_AUTH_TOKEN").as_deref(),
+            Ok("reviewer-token")
+        );
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_BASE_URL").as_deref(),
+            Ok("https://reviewer.example")
+        );
+        assert_eq!(
+            std::env::var("ARIS_REVIEWER_MODEL").as_deref(),
+            Ok("claude-sonnet-4-6")
+        );
     }
 }

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -306,7 +306,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             "anthropic-compat",
             "ANTHROPIC_AUTH_TOKEN",
             "Kimi API key",
-            Some("https://api.moonshot.cn/anthropic"),
+            Some("https://api.kimi.com/coding/"),
             "kimi-k2.5",
         ),
         _ => (
@@ -378,7 +378,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             Some("glm") => "4",
             Some("minimax") => "5",
             Some("anthropic-compat") => match config.reviewer_base_url.as_deref() {
-                Some(url) if url.contains("moonshot") => "6",
+                Some(url) if url.contains("moonshot") || url.contains("api.kimi.com") => "6",
                 _ => "7",
             },
             None => "1",
@@ -448,7 +448,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             "3" => "https://generativelanguage.googleapis.com/v1beta/openai",
             "4" => "https://open.bigmodel.cn/api/paas/v4",
             "5" => "https://api.minimax.chat/v1",
-            "6" => "https://api.moonshot.cn/anthropic",
+            "6" => "https://api.kimi.com/coding/",
             _ => "",
         };
         let custom_reviewer_url = prompt_with_default(

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -1227,7 +1227,7 @@ impl LiveCli {
                 "GLM"
             } else if base.contains("minimax") {
                 "MiniMax"
-            } else if base.contains("moonshot") {
+            } else if base.contains("moonshot") || base.contains("api.kimi.com") {
                 "Moonshot"
             } else if base.contains("dashscope") || base.contains("qwen") {
                 "Qwen"
@@ -1238,7 +1238,7 @@ impl LiveCli {
             }
         } else {
             let base = std::env::var("ANTHROPIC_BASE_URL").unwrap_or_default();
-            if base.contains("moonshot") {
+            if base.contains("moonshot") || base.contains("api.kimi.com") {
                 "Kimi"
             } else if base.is_empty() {
                 "Anthropic"
@@ -4129,7 +4129,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
-        "  Kimi coding: ANTHROPIC_AUTH_TOKEN=xxx ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic aris --model kimi-k2.5"
+        "  Kimi coding: ANTHROPIC_AUTH_TOKEN=xxx ANTHROPIC_BASE_URL=https://api.kimi.com/coding/ aris --model kimi-k2.5"
     )?;
     writeln!(out)?;
     writeln!(out, "Interactive slash commands:")?;

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -996,7 +996,10 @@ fn run_repl(
     permission_mode: PermissionMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode)?;
-    let mut editor = input::LineEditor::new("\x1b[38;5;74m❯\x1b[0m ", slash_command_completion_candidates());
+    let mut editor = input::LineEditor::new(
+        "\x1b[38;5;74m❯\x1b[0m ",
+        slash_command_completion_candidates(),
+    );
     println!("{}", cli.startup_banner());
 
     loop {
@@ -1018,7 +1021,9 @@ fn run_repl(
                 }
                 editor.push_history(input);
                 // Visual separator before assistant response
-                let term_w = crossterm::terminal::size().map(|(w, _)| w as usize).unwrap_or(80);
+                let term_w = crossterm::terminal::size()
+                    .map(|(w, _)| w as usize)
+                    .unwrap_or(80);
                 let sep = "─".repeat(term_w.min(80));
                 println!("\x1b[38;5;240m{sep}\x1b[0m");
                 cli.run_turn(&trimmed)?;
@@ -1081,7 +1086,11 @@ impl LiveCli {
             .ok()
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| {
-                if std::env::var("GEMINI_API_KEY").is_ok() {
+                if std::env::var("ARIS_REVIEWER_PROVIDER").ok().as_deref()
+                    == Some("anthropic-compat")
+                {
+                    "claude-opus-4-6".to_string()
+                } else if std::env::var("GEMINI_API_KEY").is_ok() {
                     "gemini-2.5-pro".to_string()
                 } else {
                     "gpt-5.4".to_string()
@@ -1228,19 +1237,34 @@ impl LiveCli {
                 "OpenAI"
             }
         } else {
-            "Anthropic"
+            let base = std::env::var("ANTHROPIC_BASE_URL").unwrap_or_default();
+            if base.contains("moonshot") {
+                "Kimi"
+            } else if base.is_empty() {
+                "Anthropic"
+            } else {
+                "Anthropic-compatible"
+            }
         };
 
         let info_lines = [
-            format!("\x1b[2mExecutor\x1b[0m     {executor_label} · {}", self.model),
+            format!(
+                "\x1b[2mExecutor\x1b[0m     {executor_label} · {}",
+                self.model
+            ),
             format!("\x1b[2mReviewer\x1b[0m     {}", self.reviewer_model),
-            format!("\x1b[2mPermissions\x1b[0m  {}", self.permission_mode.as_str()),
+            format!(
+                "\x1b[2mPermissions\x1b[0m  {}",
+                self.permission_mode.as_str()
+            ),
             format!("\x1b[2mDirectory\x1b[0m    {cwd}"),
             format!("\x1b[2mSession\x1b[0m      {}", self.session.id),
         ];
 
         // Box drawing
-        let term_w = crossterm::terminal::size().map(|(w, _)| w as usize).unwrap_or(80);
+        let term_w = crossterm::terminal::size()
+            .map(|(w, _)| w as usize)
+            .unwrap_or(80);
         let box_w = term_w.min(76);
         let hr = "─".repeat(box_w.saturating_sub(2));
         let dim = "\x1b[38;5;240m";
@@ -1248,7 +1272,10 @@ impl LiveCli {
 
         let mut banner = String::new();
         // Top border with title
-        banner.push_str(&format!("{dim}╭─ {reset}ARIS-Code v{VERSION}{dim} {hr}{reset}\n", hr = "─".repeat(box_w.saturating_sub(18 + VERSION.len()))));
+        banner.push_str(&format!(
+            "{dim}╭─ {reset}ARIS-Code v{VERSION}{dim} {hr}{reset}\n",
+            hr = "─".repeat(box_w.saturating_sub(18 + VERSION.len()))
+        ));
         // Sprite lines
         for line in &sprite_lines {
             banner.push_str(&format!("{dim}│{reset} {line}\n"));
@@ -1536,9 +1563,15 @@ impl LiveCli {
                 } else {
                     // Anthropic mode
                     vec![
-                        ("claude-opus-4-6", "Opus 4.6 · Most capable for complex work"),
+                        (
+                            "claude-opus-4-6",
+                            "Opus 4.6 · Most capable for complex work",
+                        ),
                         ("claude-sonnet-4-6", "Sonnet 4.6 · Best for everyday tasks"),
-                        ("claude-haiku-4-5-20251001", "Haiku 4.5 · Fastest for quick answers"),
+                        (
+                            "claude-haiku-4-5-20251001",
+                            "Haiku 4.5 · Fastest for quick answers",
+                        ),
                     ]
                     .into_iter()
                     .map(|(name, desc)| input::SelectItem {
@@ -1549,7 +1582,11 @@ impl LiveCli {
                     .collect()
                 };
 
-                match input::select_menu("Select executor model", "Switch the model used for the main conversation.", &items)? {
+                match input::select_menu(
+                    "Select executor model",
+                    "Switch the model used for the main conversation. Use `/model <name>` for any custom model id.",
+                    &items,
+                )? {
                     Some(idx) => items[idx].label.clone(),
                     None => return Ok(false),
                 }
@@ -1597,8 +1634,24 @@ impl LiveCli {
             None => {
                 let has_gemini = std::env::var("GEMINI_API_KEY").is_ok();
                 let has_openai = std::env::var("OPENAI_API_KEY").is_ok();
+                let has_anthropic_compat = std::env::var("ARIS_REVIEWER_PROVIDER").ok().as_deref()
+                    == Some("anthropic-compat")
+                    && std::env::var("ARIS_REVIEWER_AUTH_TOKEN").is_ok();
 
                 let mut items: Vec<input::SelectItem> = Vec::new();
+                if has_anthropic_compat {
+                    for (name, desc) in [
+                        ("claude-opus-4-6", "Anthropic-compatible · Most capable"),
+                        ("claude-sonnet-4-6", "Anthropic-compatible · Balanced"),
+                        ("claude-haiku-4-5-20251001", "Anthropic-compatible · Fast"),
+                    ] {
+                        items.push(input::SelectItem {
+                            label: name.to_string(),
+                            description: desc.to_string(),
+                            is_current: self.reviewer_model == name,
+                        });
+                    }
+                }
                 if has_gemini {
                     for (name, desc) in [
                         ("gemini-2.5-pro", "Google · Most capable, deep reasoning"),
@@ -1629,7 +1682,10 @@ impl LiveCli {
                 // MiniMax models
                 if std::env::var("MINIMAX_API_KEY").is_ok() {
                     for (name, desc) in [
-                        ("MiniMax-M2.7", "MiniMax · Latest, recursive self-improvement"),
+                        (
+                            "MiniMax-M2.7",
+                            "MiniMax · Latest, recursive self-improvement",
+                        ),
                         ("MiniMax-M2.7-highspeed", "MiniMax · Fast inference"),
                         ("MiniMax-M2.5", "MiniMax · Code generation"),
                     ] {
@@ -1642,9 +1698,7 @@ impl LiveCli {
                 }
                 // Kimi models
                 if std::env::var("KIMI_API_KEY").is_ok() {
-                    for (name, desc) in [
-                        ("kimi-k2.5", "Kimi · K2.5 reasoning"),
-                    ] {
+                    for (name, desc) in [("kimi-k2.5", "Kimi · K2.5 reasoning")] {
                         items.push(input::SelectItem {
                             label: name.to_string(),
                             description: desc.to_string(),
@@ -1668,11 +1722,15 @@ impl LiveCli {
                 }
 
                 if items.is_empty() {
-                    println!("No reviewer API key found. Set GEMINI_API_KEY or OPENAI_API_KEY.");
+                    println!("No reviewer API key found. Set reviewer env vars or re-run /setup.");
                     return Ok(false);
                 }
 
-                match input::select_menu("Select reviewer model", "Switch the model used by LlmReview for external reviews.", &items)? {
+                match input::select_menu(
+                    "Select reviewer model",
+                    "Switch the model used by LlmReview for external reviews. Use `/reviewer <name>` for any custom model id.",
+                    &items,
+                )? {
                     Some(idx) => items[idx].label.clone(),
                     None => return Ok(false),
                 }
@@ -1746,8 +1804,12 @@ impl LiveCli {
                         } else {
                             println!("\x1b[1mTasks\x1b[0m\n");
                             for todo in &todos {
-                                let status = todo.get("status").and_then(|s| s.as_str()).unwrap_or("pending");
-                                let content_text = todo.get("content").and_then(|c| c.as_str()).unwrap_or("?");
+                                let status = todo
+                                    .get("status")
+                                    .and_then(|s| s.as_str())
+                                    .unwrap_or("pending");
+                                let content_text =
+                                    todo.get("content").and_then(|c| c.as_str()).unwrap_or("?");
                                 let icon = match status {
                                     "completed" => "\x1b[1;32m✓\x1b[0m",
                                     "in_progress" => "\x1b[1;33m●\x1b[0m",
@@ -1852,7 +1914,10 @@ impl LiveCli {
             None => {
                 let items: Vec<input::SelectItem> = vec![
                     ("read-only", "Safe · Read files only, no writes or commands"),
-                    ("workspace-write", "Normal · Read + write files in workspace"),
+                    (
+                        "workspace-write",
+                        "Normal · Read + write files in workspace",
+                    ),
                     ("danger-full-access", "Full · All tools, no restrictions"),
                 ]
                 .into_iter()
@@ -2056,20 +2121,18 @@ impl LiveCli {
                     println!("Usage: /meta-optimize apply <proposal-number>");
                     return Ok(());
                 };
-                let id: usize = id_str.parse().map_err(|_| {
-                    format!("Invalid proposal number: {id_str}")
-                })?;
+                let id: usize = id_str
+                    .parse()
+                    .map_err(|_| format!("Invalid proposal number: {id_str}"))?;
                 match meta_optimize::apply_proposal(id) {
                     Ok(msg) => println!("{msg}"),
                     Err(e) => eprintln!("\x1b[1;31mError\x1b[0m: {e}"),
                 }
             }
-            Some("status") | None => {
-                match meta_optimize::status_report() {
-                    Ok(report) => println!("{report}"),
-                    Err(e) => eprintln!("\x1b[1;31mError\x1b[0m: {e}"),
-                }
-            }
+            Some("status") | None => match meta_optimize::status_report() {
+                Ok(report) => println!("{report}"),
+                Err(e) => eprintln!("\x1b[1;31mError\x1b[0m: {e}"),
+            },
             Some(other) => {
                 // Anything else (e.g., a skill name or "all") → run as skill invocation
                 let args = if let Some(t) = target {
@@ -2949,7 +3012,8 @@ fn build_system_prompt(model_id: Option<&str>) -> Result<Vec<String>, Box<dyn st
     prompt.push(
         "IMPORTANT: When a skill instructs you to use `mcp__codex__codex` or `mcp__codex__codex-reply` \
          for external LLM review, use the `LlmReview` tool instead. The LlmReview tool calls \
-         Gemini or OpenAI directly (via GEMINI_API_KEY or OPENAI_API_KEY) without needing MCP. \
+         the configured reviewer provider directly (OpenAI-compatible or Anthropic-compatible) \
+         without needing MCP. \
          Pass the full review prompt as the `prompt` parameter to LlmReview."
             .to_string(),
     );
@@ -2994,11 +3058,17 @@ fn build_system_prompt(model_id: Option<&str>) -> Result<Vec<String>, Box<dyn st
         if let Ok(content) = fs::read_to_string(&tasks_path) {
             if let Ok(todos) = serde_json::from_str::<Vec<serde_json::Value>>(&content) {
                 if !todos.is_empty() {
-                    let summary: Vec<String> = todos.iter().map(|t| {
-                        let status = t.get("status").and_then(|s| s.as_str()).unwrap_or("pending");
-                        let text = t.get("content").and_then(|c| c.as_str()).unwrap_or("?");
-                        format!("- [{status}] {text}")
-                    }).collect();
+                    let summary: Vec<String> = todos
+                        .iter()
+                        .map(|t| {
+                            let status = t
+                                .get("status")
+                                .and_then(|s| s.as_str())
+                                .unwrap_or("pending");
+                            let text = t.get("content").and_then(|c| c.as_str()).unwrap_or("?");
+                            format!("- [{status}] {text}")
+                        })
+                        .collect();
                     prompt.push(format!(
                         "# ARIS Task List\n\
                          Current tasks:\n{}\n\n\
@@ -3031,10 +3101,12 @@ fn aris_tasks_path() -> PathBuf {
 /// Ensure TodoWrite uses ARIS tasks path.
 fn init_aris_tasks_env() {
     if env::var("CLAWD_TODO_STORE").is_err() {
-        env::set_var("CLAWD_TODO_STORE", aris_tasks_path().to_string_lossy().as_ref());
+        env::set_var(
+            "CLAWD_TODO_STORE",
+            aris_tasks_path().to_string_lossy().as_ref(),
+        );
     }
 }
-
 
 fn build_runtime_feature_config(
 ) -> Result<runtime::RuntimeFeatureConfig, Box<dyn std::error::Error>> {
@@ -3095,8 +3167,7 @@ fn build_runtime(
 fn build_event_sink(
     _feature_config: &runtime::RuntimeFeatureConfig,
 ) -> Box<dyn runtime::EventSink> {
-    let level_str = std::env::var("ARIS_META_LOGGING")
-        .unwrap_or_default();
+    let level_str = std::env::var("ARIS_META_LOGGING").unwrap_or_default();
     let level = runtime::MetaLoggingLevel::parse(&level_str);
     if level == runtime::MetaLoggingLevel::Off {
         return Box::new(runtime::NoopEventSink);
@@ -3333,7 +3404,12 @@ impl ApiClient for AnthropicRuntimeClient {
                         events.push(AssistantEvent::MessageStop);
                     }
                     ApiStreamEvent::Error(e) => {
-                        let msg = e.error.get("message").and_then(|v| v.as_str()).unwrap_or("stream error").to_string();
+                        let msg = e
+                            .error
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("stream error")
+                            .to_string();
                         return Err(RuntimeError::new(msg));
                     }
                 }
@@ -3513,9 +3589,7 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
         _ => summarize_tool_payload(input),
     };
 
-    format!(
-        "\x1b[38;5;74m●\x1b[0m \x1b[1m{name}\x1b[0m\x1b[38;5;245m({detail})\x1b[0m"
-    )
+    format!("\x1b[38;5;74m●\x1b[0m \x1b[1m{name}\x1b[0m\x1b[38;5;245m({detail})\x1b[0m")
 }
 
 fn format_tool_result(name: &str, output: &str, is_error: bool) -> String {
@@ -4001,7 +4075,10 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         "      Inspect or maintain a saved session without entering the REPL"
     )?;
     writeln!(out, "  aris setup                                          Initialize ARIS (install skills, configure MCP)")?;
-    writeln!(out, "  aris doctor                                         Health check")?;
+    writeln!(
+        out,
+        "  aris doctor                                         Health check"
+    )?;
     writeln!(out, "  aris dump-manifests")?;
     writeln!(out, "  aris bootstrap-plan")?;
     writeln!(out, "  aris system-prompt [--cwd PATH] [--date YYYY-MM-DD]")?;
@@ -4033,17 +4110,14 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(out)?;
     writeln!(out, "Executor providers:")?;
+    writeln!(out, "  Default:   Anthropic Claude (ANTHROPIC_API_KEY)")?;
     writeln!(
         out,
-        "  Default:   Anthropic Claude (ANTHROPIC_API_KEY)"
+        "  Anthropic-compatible: ANTHROPIC_AUTH_TOKEN=xxx ANTHROPIC_BASE_URL=https://proxy.example aris --model claude-opus-4-6"
     )?;
     writeln!(
         out,
-        "  OpenAI:    EXECUTOR_PROVIDER=openai EXECUTOR_API_KEY=xxx aris --model gpt-4o"
-    )?;
-    writeln!(
-        out,
-        "  DeepSeek:  EXECUTOR_PROVIDER=openai EXECUTOR_BASE_URL=https://api.deepseek.com EXECUTOR_API_KEY=xxx aris --model deepseek-chat"
+        "  OpenAI/OpenAI-compatible: EXECUTOR_PROVIDER=openai EXECUTOR_BASE_URL=https://endpoint.example/v1 EXECUTOR_API_KEY=xxx aris --model your-model-id"
     )?;
     writeln!(
         out,
@@ -4052,6 +4126,10 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(
         out,
         "  Gemini:    EXECUTOR_PROVIDER=openai EXECUTOR_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai EXECUTOR_API_KEY=xxx aris --model gemini-2.5-pro"
+    )?;
+    writeln!(
+        out,
+        "  Kimi coding: ANTHROPIC_AUTH_TOKEN=xxx ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic aris --model kimi-k2.5"
     )?;
     writeln!(out)?;
     writeln!(out, "Interactive slash commands:")?;
@@ -4068,6 +4146,10 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out, "Resume-safe commands: {resume_commands}")?;
     writeln!(out, "Examples:")?;
     writeln!(out, "  aris --model claude-opus \"summarize this repo\"")?;
+    writeln!(
+        out,
+        "  aris --model your-custom-model \"run against a third-party endpoint\""
+    )?;
     writeln!(
         out,
         "  aris --output-format json prompt \"explain src/main.rs\""
@@ -4099,13 +4181,20 @@ fn check_auth_status() -> &'static str {
         return "OK (bearer token)";
     }
     let home = runtime::home_dir();
-    let creds_path = PathBuf::from(&home).join(".claude").join("credentials.json");
+    let creds_path = PathBuf::from(&home)
+        .join(".claude")
+        .join("credentials.json");
     if creds_path.exists() {
         return "OK (OAuth saved)";
     }
     // Check macOS Keychain for Claude Code's OAuth token
     if let Ok(output) = Command::new("security")
-        .args(["find-generic-password", "-s", "Claude Code-credentials", "-w"])
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
         .output()
     {
         if output.status.success() {
@@ -4218,10 +4307,12 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
     let mut all_ok = true;
 
     // Check 0: Executor provider
-    let executor_provider = std::env::var("EXECUTOR_PROVIDER").unwrap_or_else(|_| "anthropic".into());
+    let executor_provider =
+        std::env::var("EXECUTOR_PROVIDER").unwrap_or_else(|_| "anthropic".into());
     print!("  Executor:     ");
     if executor_provider == "openai" {
-        let base = std::env::var("EXECUTOR_BASE_URL").unwrap_or_else(|_| "https://api.openai.com/v1".into());
+        let base = std::env::var("EXECUTOR_BASE_URL")
+            .unwrap_or_else(|_| "https://api.openai.com/v1".into());
         let has_key = std::env::var("EXECUTOR_API_KEY")
             .or_else(|_| std::env::var("OPENAI_API_KEY"))
             .is_ok();
@@ -4231,6 +4322,10 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
             println!("OpenAI-compat (NO API KEY!)");
             all_ok = false;
         }
+    } else if std::env::var("ANTHROPIC_AUTH_TOKEN").is_ok() {
+        let base = std::env::var("ANTHROPIC_BASE_URL")
+            .unwrap_or_else(|_| "https://api.anthropic.com".into());
+        println!("Anthropic-compatible ({base})");
     } else {
         println!("Anthropic (default)");
     }
@@ -4238,7 +4333,9 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
     // Check 1: API auth
     let auth_status = check_auth_status();
     println!("  API auth:     {auth_status}");
-    if auth_status == "NOT FOUND" && executor_provider != "openai" { all_ok = false; }
+    if auth_status == "NOT FOUND" && executor_provider != "openai" {
+        all_ok = false;
+    }
 
     // Check 2: Skills directory + discovered skills
     let skills_dir = dirs_claude_skills();
@@ -4261,19 +4358,37 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check 2b: Reviewer API (LlmReview)
     print!("  Reviewer API: ");
-    if std::env::var("GEMINI_API_KEY").is_ok() {
+    let reviewer_provider = std::env::var("ARIS_REVIEWER_PROVIDER").ok();
+    if reviewer_provider.as_deref() == Some("anthropic-compat") {
+        let base = std::env::var("ARIS_REVIEWER_BASE_URL")
+            .unwrap_or_else(|_| "https://api.anthropic.com".into());
+        if std::env::var("ARIS_REVIEWER_AUTH_TOKEN").is_ok() {
+            println!("OK (Anthropic-compatible via {base})");
+        } else {
+            println!("NOT FOUND (set ARIS_REVIEWER_AUTH_TOKEN for Anthropic-compatible reviewer)");
+            all_ok = false;
+        }
+    } else if std::env::var("GEMINI_API_KEY").is_ok() {
         println!("OK (Gemini)");
     } else if std::env::var("OPENAI_API_KEY").is_ok() {
         println!("OK (OpenAI)");
+    } else if std::env::var("GLM_API_KEY").is_ok() {
+        println!("OK (GLM)");
+    } else if std::env::var("MINIMAX_API_KEY").is_ok() {
+        println!("OK (MiniMax)");
+    } else if std::env::var("KIMI_API_KEY").is_ok() {
+        println!("OK (Kimi)");
     } else {
-        println!("NOT FOUND (set GEMINI_API_KEY or OPENAI_API_KEY for LlmReview)");
+        println!("NOT FOUND (set reviewer API env vars for LlmReview)");
     }
 
     // Check 3: Codex CLI
     print!("  Codex CLI:    ");
     match which_codex() {
         Some(path) => println!("OK ({})", path.display()),
-        None => { println!("NOT FOUND (optional)"); }
+        None => {
+            println!("NOT FOUND (optional)");
+        }
     }
 
     // Check 4: Codex MCP in config
@@ -4283,7 +4398,8 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
     if config_path.exists() {
         if let Ok(content) = fs::read_to_string(&config_path) {
             if let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) {
-                if config.get("mcpServers")
+                if config
+                    .get("mcpServers")
                     .and_then(|s| s.as_object())
                     .map_or(false, |s| s.contains_key("codex"))
                 {
@@ -4313,7 +4429,10 @@ fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
 /// ARIS-specific skills directory (highest priority).
 fn dirs_aris_skills() -> PathBuf {
     let home = runtime::home_dir();
-    PathBuf::from(home).join(".config").join("aris").join("skills")
+    PathBuf::from(home)
+        .join(".config")
+        .join("aris")
+        .join("skills")
 }
 
 /// Claude Code user skills directory.
@@ -4351,7 +4470,11 @@ fn which_codex() -> Option<PathBuf> {
     let output = Command::new("which").arg("codex").output().ok()?;
     if output.status.success() {
         let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if path.is_empty() { None } else { Some(PathBuf::from(path)) }
+        if path.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(path))
+        }
     } else {
         None
     }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1292,7 +1292,11 @@ fn execute_todo_write(input: TodoWriteInput) -> Result<TodoWriteOutput, String> 
 }
 
 fn execute_skill(input: SkillInput) -> Result<SkillOutput, String> {
-    let requested = input.skill.trim().trim_start_matches('/').trim_start_matches('$');
+    let requested = input
+        .skill
+        .trim()
+        .trim_start_matches('/')
+        .trim_start_matches('$');
 
     // Try filesystem search roots first (user overrides take priority)
     if let Ok(skill_path) = resolve_skill_path(requested) {
@@ -1372,10 +1376,19 @@ fn skill_search_roots() -> Vec<std::path::PathBuf> {
 
     // 1. ~/.config/aris/skills/ (ARIS user-level, highest priority)
     let home = runtime::home_dir();
-    roots.push(std::path::PathBuf::from(&home).join(".config").join("aris").join("skills"));
+    roots.push(
+        std::path::PathBuf::from(&home)
+            .join(".config")
+            .join("aris")
+            .join("skills"),
+    );
 
     // 2. ~/.claude/skills/ (Claude Code compat, user-level)
-    roots.push(std::path::PathBuf::from(&home).join(".claude").join("skills"));
+    roots.push(
+        std::path::PathBuf::from(&home)
+            .join(".claude")
+            .join("skills"),
+    );
 
     // 3. Project-level .claude/skills/
     if let Ok(cwd) = std::env::current_dir() {
@@ -1390,7 +1403,8 @@ fn skill_search_roots() -> Vec<std::path::PathBuf> {
     // 4. ARIS bundled share/skills/ (next to binary)
     if let Ok(exe) = std::env::current_exe() {
         if let Some(bin_dir) = exe.parent() {
-            let share_skills = bin_dir.parent()
+            let share_skills = bin_dir
+                .parent()
                 .map(|p| p.join("share").join("aris").join("skills"))
                 .unwrap_or_else(|| bin_dir.join("share").join("aris").join("skills"));
             roots.push(share_skills);
@@ -1490,7 +1504,11 @@ pub fn discover_skills() -> Vec<SkillMeta> {
             continue;
         }
         seen.insert(name.to_string());
-        let meta = parse_skill_frontmatter(name, content, std::path::PathBuf::from(format!("<bundled:{name}>")));
+        let meta = parse_skill_frontmatter(
+            name,
+            content,
+            std::path::PathBuf::from(format!("<bundled:{name}>")),
+        );
         skills.push(meta);
     }
 
@@ -1501,11 +1519,7 @@ pub fn discover_skills() -> Vec<SkillMeta> {
 /// Parse YAML frontmatter from a SKILL.md file.
 /// Expects `---` delimited YAML block at the top with fields like
 /// name, description, argument-hint, allowed-tools.
-fn parse_skill_frontmatter(
-    dir_name: &str,
-    content: &str,
-    path: std::path::PathBuf,
-) -> SkillMeta {
+fn parse_skill_frontmatter(dir_name: &str, content: &str, path: std::path::PathBuf) -> SkillMeta {
     let mut name = dir_name.to_string();
     let mut description = None;
     let mut argument_hint = None;
@@ -1575,7 +1589,10 @@ pub fn render_skill_discovery_section() -> Option<String> {
         let desc = skill.description.as_deref().unwrap_or("No description");
         // Truncate description to 200 chars (char-safe for CJK)
         let desc_short: String = desc.chars().take(200).collect();
-        let hint = skill.argument_hint.as_deref().map_or(String::new(), |h| format!(" {h}"));
+        let hint = skill
+            .argument_hint
+            .as_deref()
+            .map_or(String::new(), |h| format!(" {h}"));
         lines.push(format!("- `/{}{hint}` — {}", skill.name, desc_short));
     }
 
@@ -1986,7 +2003,12 @@ impl ApiClient for AnthropicRuntimeClient {
                         events.push(AssistantEvent::MessageStop);
                     }
                     ApiStreamEvent::Error(e) => {
-                        let msg = e.error.get("message").and_then(|v| v.as_str()).unwrap_or("stream error").to_string();
+                        let msg = e
+                            .error
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("stream error")
+                            .to_string();
                         return Err(RuntimeError::new(msg));
                     }
                 }
@@ -3154,45 +3176,95 @@ struct LlmReviewInput {
     model: Option<String>,
 }
 
+fn normalize_openai_compat_chat_completions_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/chat/completions") {
+        trimmed.to_string()
+    } else if trimmed.ends_with("/v1") {
+        format!("{trimmed}/chat/completions")
+    } else {
+        format!("{trimmed}/v1/chat/completions")
+    }
+}
+
+fn normalize_anthropic_messages_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/v1/messages") {
+        trimmed.to_string()
+    } else if trimmed.ends_with("/v1") {
+        format!("{trimmed}/messages")
+    } else {
+        format!("{trimmed}/v1/messages")
+    }
+}
+
 fn run_llm_review(input: LlmReviewInput) -> Result<String, String> {
     // Resolve which model to use
-    let env_reviewer_model = std::env::var("ARIS_REVIEWER_MODEL").ok().filter(|s| !s.is_empty());
+    let env_reviewer_model = std::env::var("ARIS_REVIEWER_MODEL")
+        .ok()
+        .filter(|s| !s.is_empty());
     let model = input
         .model
         .as_deref()
         .or(env_reviewer_model.as_deref())
         .unwrap_or("gpt-5.4");
 
+    let reviewer_provider = std::env::var("ARIS_REVIEWER_PROVIDER")
+        .ok()
+        .filter(|s| !s.is_empty());
+
     // Check for user-configured reviewer proxy base URL
-    let custom_base_url = std::env::var("ARIS_REVIEWER_BASE_URL").ok().filter(|s| !s.is_empty());
+    let custom_base_url = std::env::var("ARIS_REVIEWER_BASE_URL")
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    if reviewer_provider.as_deref() == Some("anthropic-compat") {
+        let base_url = custom_base_url
+            .as_deref()
+            .map(normalize_anthropic_messages_url)
+            .unwrap_or_else(|| "https://api.anthropic.com/v1/messages".to_string());
+        let key = std::env::var("ARIS_REVIEWER_AUTH_TOKEN")
+            .ok()
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| {
+                format!("LlmReview: ARIS_REVIEWER_AUTH_TOKEN not set (needed for model '{model}')")
+            })?;
+        return call_anthropic_compat_reviewer(&key, &base_url, model, &input.prompt);
+    }
 
     // Route by model name to the correct API endpoint and key
     let (key_env, default_base_url) = if model.contains("gemini") {
-        ("GEMINI_API_KEY", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")
+        (
+            "GEMINI_API_KEY",
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+        )
     } else if model.contains("glm") || model.contains("GLM") {
-        ("GLM_API_KEY", "https://open.bigmodel.cn/api/paas/v4/chat/completions")
+        (
+            "GLM_API_KEY",
+            "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+        )
     } else if model.starts_with("MiniMax") || model.starts_with("minimax") {
-        ("MINIMAX_API_KEY", "https://api.minimax.chat/v1/chat/completions")
+        (
+            "MINIMAX_API_KEY",
+            "https://api.minimax.chat/v1/chat/completions",
+        )
     } else if model.contains("kimi") || model.contains("moonshot") {
-        ("KIMI_API_KEY", "https://api.moonshot.cn/v1/chat/completions")
+        (
+            "KIMI_API_KEY",
+            "https://api.moonshot.cn/v1/chat/completions",
+        )
     } else {
         // Default: OpenAI (also covers gpt, o3, o4, deepseek via OPENAI_API_KEY)
-        ("OPENAI_API_KEY", "https://api.openai.com/v1/chat/completions")
+        (
+            "OPENAI_API_KEY",
+            "https://api.openai.com/v1/chat/completions",
+        )
     };
 
-    // Use custom base URL if provided, appending /chat/completions if needed
-    let base_url = if let Some(ref custom) = custom_base_url {
-        let trimmed = custom.trim_end_matches('/');
-        if trimmed.ends_with("/chat/completions") {
-            trimmed.to_string()
-        } else if trimmed.ends_with("/v1") {
-            format!("{trimmed}/chat/completions")
-        } else {
-            format!("{trimmed}/v1/chat/completions")
-        }
-    } else {
-        default_base_url.to_string()
-    };
+    let base_url = custom_base_url
+        .as_deref()
+        .map(normalize_openai_compat_chat_completions_url)
+        .unwrap_or_else(|| default_base_url.to_string());
 
     let key = std::env::var(key_env)
         .ok()
@@ -3267,6 +3339,35 @@ fn call_openai_compat_reviewer(
         .and_then(|c| c.as_str())
         .map(ToOwned::to_owned)
         .ok_or_else(|| format!("LlmReview: unexpected response format: {json}"))
+}
+
+#[cfg(test)]
+mod llm_review_tests {
+    use super::{normalize_anthropic_messages_url, normalize_openai_compat_chat_completions_url};
+
+    #[test]
+    fn normalizes_openai_compat_root_url() {
+        assert_eq!(
+            normalize_openai_compat_chat_completions_url("https://proxy.example"),
+            "https://proxy.example/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn normalizes_anthropic_root_url() {
+        assert_eq!(
+            normalize_anthropic_messages_url("https://proxy.example"),
+            "https://proxy.example/v1/messages"
+        );
+    }
+
+    #[test]
+    fn keeps_anthropic_messages_url_if_complete() {
+        assert_eq!(
+            normalize_anthropic_messages_url("https://proxy.example/v1/messages"),
+            "https://proxy.example/v1/messages"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -3614,7 +3715,12 @@ mod tests {
         // Point HOME to temp dir so ~/.claude/skills/ resolves there
         let _guard = env_lock();
         let original_home = std::env::var("HOME").ok();
-        let claude_skills = tmp.parent().unwrap().join("claude-home").join(".claude").join("skills");
+        let claude_skills = tmp
+            .parent()
+            .unwrap()
+            .join("claude-home")
+            .join(".claude")
+            .join("skills");
         fs::create_dir_all(&claude_skills).expect("create claude skills dir");
         // Copy the skill into the claude skills dir
         let target_skill = claude_skills.join("test-skill");


### PR DESCRIPTION
## Summary

  This PR makes ARIS CLI protocol-first instead of preset-first.

  It adds support for arbitrary third-party:

  - Anthropic-compatible `/v1/messages` endpoints
  - OpenAI-compatible `/v1/chat/completions` endpoints

  It also fixes the Kimi For Coding preset to use the actual Anthropic-compatible endpoint.

  ## What changed

  - formalized `anthropic-compat` executor/reviewer configuration
  - added generic custom base URL + custom model flows in setup
  - routed reviewer requests through Anthropic-compatible mode when configured
  - fixed Kimi For Coding preset to use:
    - `https://api.kimi.com/coding/`
  - updated help text and README / README_CN examples

  ## Why

  This makes the CLI usable with:

  - coding subscriptions and vendor gateways that expose Anthropic-compatible APIs
  - OpenAI-compatible endpoints
  - local/self-hosted models that expose OpenAI-compatible APIs

  This moves ARIS closer to a simplified protocol-switching model rather than a hardcoded preset list.

  ## Validation

  - `cargo test -p aris-cli config::tests -- --nocapture`
  - `cargo test -p tools llm_review_tests -- --nocapture`
  - `cargo build --release --target aarch64-apple-darwin`
  - verified live Kimi For Coding request via `https://api.kimi.com/coding/v1/messages`
  - verified `aris --model kimi-k2.5 --output-format text prompt '请只回复 ok'`