### PR TITLE
Fix Linux release compatibility with Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact: aris-code-darwin-x64
-          - os: ubuntu-latest
+          # Build Linux releases on Ubuntu 22.04 so the resulting GNU binary
+          # stays compatible with Ubuntu 22.04 users (glibc 2.35).
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact: aris-code-linux-x64
           - os: windows-latest
@@ -67,7 +69,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
## Summary
Build Linux release artifacts on `ubuntu-22.04` instead of `ubuntu-latest`.

## Problem
The current Linux release binary is built on a newer Ubuntu image and ends up requiring `GLIBC_2.39`. That binary cannot run on Ubuntu 22.04, even though the official install command downloads and extracts successfully.

## Reproduction on Ubuntu 22.04
```bash
curl -fsSL https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/releases/latest/download/aris-code-linux-x64.tar.gz | tar xz
./aris --help
```

Observed error:
```text
./aris: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

## Verification
I verified locally on Ubuntu 22.04 that:
- the current released binary fails with `GLIBC_2.39 not found`
- the project builds successfully from source after this change
- the locally built `target/release/aris --help` runs successfully on Ubuntu 22.04
- the locally built binary only requires up to `GLIBC_2.34`, so it should remain compatible with Ubuntu 22.04 and newer Ubuntu releases

## Why this fix
Building on Ubuntu 22.04 keeps the glibc floor low enough for Ubuntu 22.04 users while remaining compatible with newer Ubuntu versions.
