### PR TITLE
feat: add project-level & custom path modes to smart_update + PowerShell port

### DIFF
--- a/tools/smart_update.ps1
+++ b/tools/smart_update.ps1
@@ -11,7 +11,7 @@
 #     .\tools\smart_update.ps1 -UpstreamPath <path> -LocalPath <path> [-Apply]
 #
 #   -Apply: actually perform the updates (default: dry-run analysis only)
-#   -ProjectPath: project root — uses <ProjectPath>/skills as upstream and <ProjectPath>/.claude/skills as local
+#   -ProjectPath: project root — upstream is always the repo's skills/; local targets <ProjectPath>/.claude/skills
 #   -UpstreamPath: explicit upstream skills directory
 #   -LocalPath: explicit local skills directory
 
@@ -238,6 +238,7 @@ function Invoke-SafeUpdate {
     foreach ($s in $NewList) {
         $src = Join-Path $SrcDir $s
         $dst = Join-Path $DstDir $s
+        if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
         Copy-Item -Path $src -Destination $dst -Recurse -Force
         Write-Host "  + Added: $s" -ForegroundColor Green
     }
@@ -245,6 +246,7 @@ function Invoke-SafeUpdate {
     foreach ($s in $SafeList) {
         $src = Join-Path $SrcDir $s
         $dst = Join-Path $DstDir $s
+        if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
         Copy-Item -Path $src -Destination $dst -Recurse -Force
         Write-Host "  ^ Updated: $s" -ForegroundColor Cyan
     }

--- a/tools/smart_update.ps1
+++ b/tools/smart_update.ps1
@@ -1,0 +1,308 @@
+#Requires -Version 5.1
+# ARIS Smart Skill Update (PowerShell)
+# Intelligently compares local skills with upstream, detects personal
+# customizations, and recommends safe update strategy per skill.
+#
+# Usage:
+#   Global (default):
+#     .\tools\smart_update.ps1 [-Apply]
+#   Project-level:
+#     .\tools\smart_update.ps1 -ProjectPath <path> [-Apply]
+#     .\tools\smart_update.ps1 -UpstreamPath <path> -LocalPath <path> [-Apply]
+#
+#   -Apply: actually perform the updates (default: dry-run analysis only)
+#   -ProjectPath: project root — uses <ProjectPath>/skills as upstream and <ProjectPath>/.claude/skills as local
+#   -UpstreamPath: explicit upstream skills directory
+#   -LocalPath: explicit local skills directory
+
+[CmdletBinding(DefaultParameterSetName = 'Global')]
+param(
+    [switch]$Apply,
+
+    [Parameter(ParameterSetName = 'Project', Mandatory = $true)]
+    [string]$ProjectPath,
+
+    [Parameter(ParameterSetName = 'Explicit', Mandatory = $true)]
+    [string]$UpstreamPath,
+
+    [Parameter(ParameterSetName = 'Explicit', Mandatory = $true)]
+    [string]$LocalPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ─── Resolve upstream & local paths ───────────────────────────────────────────
+if ($PSCmdlet.ParameterSetName -eq 'Project') {
+    $ProjectRoot = if ([System.IO.Path]::IsPathRooted($ProjectPath)) {
+        $ProjectPath
+    } else {
+        Join-Path (Get-Location) $ProjectPath
+    }
+    $ProjectRoot = (Resolve-Path $ProjectRoot -ErrorAction SilentlyContinue).Path
+    if (-not $ProjectRoot) {
+        Write-Host "Project path not found: $ProjectPath" -ForegroundColor Red
+        exit 1
+    }
+    # Upstream always comes from the repo (same as global)
+    $UpstreamDir = Join-Path (Split-Path $PSScriptRoot -Parent) 'skills'
+    if (-not (Test-Path $UpstreamDir)) {
+        $resolved = Join-Path $PSScriptRoot '..\skills' | Resolve-Path -ErrorAction SilentlyContinue
+        if ($resolved) { $UpstreamDir = $resolved.Path }
+    }
+    # Local targets the project's .claude/skills
+    $LocalDir = Join-Path $ProjectRoot '.claude\skills'
+    $Scope = "Project: $ProjectRoot"
+
+} elseif ($PSCmdlet.ParameterSetName -eq 'Explicit') {
+    $UpstreamDir = $UpstreamPath
+    $LocalDir = $LocalPath
+    $Scope = "Custom"
+} else {
+    # Global default
+    $UpstreamDir = Join-Path (Split-Path $PSScriptRoot -Parent) 'skills'
+    if (-not (Test-Path $UpstreamDir)) {
+        $resolved = Join-Path $PSScriptRoot '..\skills' | Resolve-Path -ErrorAction SilentlyContinue
+        if ($resolved) { $UpstreamDir = $resolved.Path }
+    }
+    $LocalDir = Join-Path $env:USERPROFILE '.claude\skills'
+    $Scope = 'Global'
+}
+
+# ─── Personal info patterns ───────────────────────────────────────────────────
+$PersonalPatterns = @(
+    'ssh '
+    'SJTUServer'
+    'rfyang'
+    'yangruofeng'
+    'api_key'
+    'API_KEY'
+    'sk-'
+    'token'
+    '@sjtu'
+    '@gmail'
+    '/home/'
+    '/Users/'
+    'CUDA_VISIBLE'
+    'wandb_project'
+    'server_ip'
+    'gpu_server'
+    'screen -'
+    'conda activate'
+    '192\.168\.'
+    '10\.\d+\.'
+    '122\.'
+)
+
+# Patterns that are actual regex (contain backslash-dot or \d)
+function Test-IsRegexPattern {
+    param([string]$Pat)
+    return ($Pat.Contains('\.') -or $Pat.Contains('\d'))
+}
+
+# ─── Header ────────────────────────────────────────────────────────────────────
+Write-Host ''
+Write-Host '=== ARIS Smart Skill Update ===' -ForegroundColor Cyan
+Write-Host "Scope:    $Scope"
+Write-Host "Upstream: $UpstreamDir"
+Write-Host "Local:    $LocalDir"
+Write-Host ''
+
+if (-not (Test-Path $LocalDir)) {
+    Write-Host "Local skills directory not found: $LocalDir" -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Test-Path $UpstreamDir)) {
+    Write-Host "Upstream skills directory not found: $UpstreamDir" -ForegroundColor Red
+    exit 1
+}
+
+# ─── Core comparison function ──────────────────────────────────────────────────
+function Compare-SkillDirs {
+    param(
+        [string]$SrcDir,
+        [string]$DstDir,
+        [string[]]$Patterns
+    )
+
+    $result = @{
+        New          = [System.Collections.Generic.List[string]]::new()
+        Identical    = [System.Collections.Generic.List[string]]::new()
+        Safe         = [System.Collections.Generic.List[string]]::new()
+        Merge        = [System.Collections.Generic.List[string]]::new()
+        LocalOnly    = [System.Collections.Generic.List[string]]::new()
+        UpstreamNames = [System.Collections.Generic.HashSet[string]]::new()
+    }
+
+    # Check each upstream skill
+    foreach ($skillDir in Get-ChildItem -Path $SrcDir -Directory) {
+        $skillName = $skillDir.Name
+        if ($skillName -eq 'skills-codex' -or $skillName -eq 'shared-references') { continue }
+
+        [void]$result.UpstreamNames.Add($skillName)
+
+        $upstreamFile = Join-Path $skillDir.FullName 'SKILL.md'
+        $localSkillDir = Join-Path $DstDir $skillName
+        $localFile = Join-Path $localSkillDir 'SKILL.md'
+
+        if (-not (Test-Path $upstreamFile)) { continue }
+
+        if ((-not (Test-Path $localSkillDir)) -or (-not (Test-Path $localFile))) {
+            $result.New.Add($skillName)
+            continue
+        }
+
+        $upstreamContent = Get-Content -Path $upstreamFile -Raw
+        $localContent = Get-Content -Path $localFile -Raw
+
+        if ($upstreamContent -eq $localContent) {
+            $result.Identical.Add($skillName)
+            continue
+        }
+
+        # Different - check for personal info unique to local
+        $hasPersonal = $false
+        foreach ($pat in $Patterns) {
+            $isRegex = Test-IsRegexPattern $pat
+            if ($isRegex) {
+                $lc = ([regex]::Matches($localContent, $pat)).Count
+                $uc = ([regex]::Matches($upstreamContent, $pat)).Count
+            } else {
+                $lc = ([regex]::Matches($localContent, [regex]::Escape($pat))).Count
+                $uc = ([regex]::Matches($upstreamContent, [regex]::Escape($pat))).Count
+            }
+            if ($lc -gt $uc) {
+                $hasPersonal = $true
+                break
+            }
+        }
+
+        if ($hasPersonal) {
+            $result.Merge.Add($skillName)
+        } else {
+            $result.Safe.Add($skillName)
+        }
+    }
+
+    # Check for local-only skills
+    foreach ($skillDir in Get-ChildItem -Path $DstDir -Directory) {
+        $skillName = $skillDir.Name
+        if ($skillName -eq 'shared-references') { continue }
+        if (-not $result.UpstreamNames.Contains($skillName)) {
+            $result.LocalOnly.Add($skillName)
+        }
+    }
+
+    return $result
+}
+
+function Show-Section {
+    param([string]$Label, $Items, [string]$Color)
+    Write-Host "${Label}: $($Items.Count)" -ForegroundColor $Color
+    foreach ($s in $Items) { Write-Host "   $s" }
+    Write-Host ''
+}
+
+function Show-MergeReport {
+    param($Items, [string]$Dir, [string[]]$Patterns)
+    foreach ($s in $Items) {
+        Write-Host "   $s"
+        $f = Join-Path $Dir "$s\SKILL.md"
+        if (Test-Path $f) {
+            $content = Get-Content -Path $f -Raw
+            foreach ($pat in $Patterns) {
+                $isRegex = Test-IsRegexPattern $pat
+                if ($isRegex) {
+                    $escaped = $pat
+                } else {
+                    $escaped = [regex]::Escape($pat)
+                }
+                $m = [regex]::Match($content, ".*$escaped.*")
+                if ($m.Success) {
+                    Write-Host "     -> contains: $($m.Value.Trim())" -ForegroundColor Yellow
+                    break
+                }
+            }
+        }
+    }
+}
+
+function Invoke-SafeUpdate {
+    param(
+        $NewList,
+        $SafeList,
+        [string]$SrcDir,
+        [string]$DstDir,
+        [string]$SharedDir
+    )
+    foreach ($s in $NewList) {
+        $src = Join-Path $SrcDir $s
+        $dst = Join-Path $DstDir $s
+        Copy-Item -Path $src -Destination $dst -Recurse -Force
+        Write-Host "  + Added: $s" -ForegroundColor Green
+    }
+
+    foreach ($s in $SafeList) {
+        $src = Join-Path $SrcDir $s
+        $dst = Join-Path $DstDir $s
+        Copy-Item -Path $src -Destination $dst -Recurse -Force
+        Write-Host "  ^ Updated: $s" -ForegroundColor Cyan
+    }
+
+    if ($SharedDir -and (Test-Path $SharedDir)) {
+        Copy-Item -Path $SharedDir -Destination (Join-Path $DstDir 'shared-references') -Recurse -Force
+        Write-Host '  ^ Updated: shared-references' -ForegroundColor Cyan
+    }
+}
+
+# ─── Run comparison ─────────────────────────────────────────────────────────────
+$r = Compare-SkillDirs -SrcDir $UpstreamDir -DstDir $LocalDir -Patterns $PersonalPatterns
+
+# ─── Report ────────────────────────────────────────────────────────────────────
+Show-Section 'Identical (no action needed)' $r.Identical 'Green'
+Show-Section 'New skills (safe to add)' $r.New 'Green'
+Show-Section 'Updated upstream, no personal info (safe to replace)' $r.Safe 'Cyan'
+
+Write-Host "Updated upstream + local customizations (needs manual merge): $($r.Merge.Count)" -ForegroundColor Yellow
+Show-MergeReport $r.Merge $LocalDir $PersonalPatterns
+Write-Host ''
+
+Write-Host "Local-only skills (yours, not in upstream): $($r.LocalOnly.Count)"
+foreach ($s in $r.LocalOnly) { Write-Host "   $s" }
+Write-Host ''
+
+# ─── Summary ───────────────────────────────────────────────────────────────────
+$Total = $r.New.Count + $r.Identical.Count + $r.Safe.Count + $r.Merge.Count
+Write-Host '=== Summary ===' -ForegroundColor Cyan
+Write-Host "Total upstream skills: $Total"
+Write-Host "  Up to date:  $($r.Identical.Count)" -ForegroundColor Green
+Write-Host "  New to add:  $($r.New.Count)" -ForegroundColor Green
+Write-Host "  Safe update: $($r.Safe.Count)" -ForegroundColor Cyan
+Write-Host "  Need merge:  $($r.Merge.Count)" -ForegroundColor Yellow
+Write-Host "  Local only:  $($r.LocalOnly.Count)"
+Write-Host ''
+
+if ($Apply) {
+    Write-Host 'Applying safe updates...' -ForegroundColor Cyan
+
+    $sharedUpstream = Join-Path $UpstreamDir 'shared-references'
+    Invoke-SafeUpdate -NewList $r.New -SafeList $r.Safe -SrcDir $UpstreamDir -DstDir $LocalDir -SharedDir $sharedUpstream
+
+    Write-Host ''
+    Write-Host "Done! $($r.New.Count) new + $($r.Safe.Count) updated." -ForegroundColor Green
+
+    if ($r.Merge.Count -gt 0) {
+        Write-Host "$($r.Merge.Count) skills have personal customizations and were NOT updated." -ForegroundColor Yellow
+        Write-Host "   Review manually: $($r.Merge -join ', ')" -ForegroundColor Yellow
+        Write-Host "   Tip: diff the local and upstream SKILL.md files to merge changes" -ForegroundColor Yellow
+    }
+} else {
+    switch ($PSCmdlet.ParameterSetName) {
+        'Project'  { $cmdHint = ".\tools\smart_update.ps1 -ProjectPath `"$ProjectRoot`" -Apply" }
+        'Explicit' { $cmdHint = ".\tools\smart_update.ps1 -UpstreamPath `"$UpstreamDir`" -LocalPath `"$LocalDir`" -Apply" }
+        default    { $cmdHint = '.\tools\smart_update.ps1 -Apply' }
+    }
+    Write-Host 'Dry run complete. Run with -Apply to perform updates:' -ForegroundColor Yellow
+    Write-Host "  $cmdHint" -ForegroundColor Green
+}
+Write-Host ''

--- a/tools/smart_update.sh
+++ b/tools/smart_update.sh
@@ -4,18 +4,89 @@
 # customizations, and recommends safe update strategy per skill.
 #
 # Usage:
-#   bash tools/smart_update.sh [--apply]
+#   Global (default):
+#     bash tools/smart_update.sh [--apply]
+#   Project-level:
+#     bash tools/smart_update.sh --project <path> [--apply]
+#   Custom paths:
+#     bash tools/smart_update.sh --upstream <path> --local <path> [--apply]
+#
 #   --apply: actually perform the updates (default: dry-run analysis only)
+#   --project <path>: project root — upstream from repo, local from <path>/.claude/skills
+#   --upstream <path>: explicit upstream skills directory
+#   --local <path>: explicit local skills directory
 
 set -euo pipefail
 
-UPSTREAM_DIR="$(cd "$(dirname "$0")/.." && pwd)/skills"
-LOCAL_DIR="${HOME}/.claude/skills"
+# ─── Parse arguments ───────────────────────────────────────────────────────────
 APPLY=false
+MODE="global"
+PROJECT_PATH=""
+CUSTOM_UPSTREAM=""
+CUSTOM_LOCAL=""
 
-if [[ "${1:-}" == "--apply" ]]; then
-    APPLY=true
-fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply)
+            APPLY=true
+            shift
+            ;;
+        --project)
+            MODE="project"
+            PROJECT_PATH="${2:?--project requires a path argument}"
+            shift 2
+            ;;
+        --upstream)
+            MODE="explicit"
+            CUSTOM_UPSTREAM="${2:?--upstream requires a path argument}"
+            shift 2
+            ;;
+        --local)
+            MODE="explicit"
+            CUSTOM_LOCAL="${2:?--local requires a path argument}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            echo "Usage: bash tools/smart_update.sh [--apply] [--project <path>] [--upstream <path> --local <path>]"
+            exit 1
+            ;;
+    esac
+done
+
+# ─── Resolve paths ─────────────────────────────────────────────────────────────
+REPO_SKILLS_DIR="$(cd "$(dirname "$0")/.." && pwd)/skills"
+
+case "$MODE" in
+    project)
+        # Resolve project path
+        if [[ "$PROJECT_PATH" == /* ]]; then
+            PROJECT_ROOT="$PROJECT_PATH"
+        else
+            PROJECT_ROOT="$(cd "$PROJECT_PATH" && pwd)"
+        fi
+        # Upstream always from repo
+        UPSTREAM_DIR="$REPO_SKILLS_DIR"
+        # Local targets the project's .claude/skills
+        LOCAL_DIR="$PROJECT_ROOT/.claude/skills"
+        SCOPE="Project: $PROJECT_ROOT"
+        ;;
+    explicit)
+        if [[ -z "$CUSTOM_UPSTREAM" ]] || [[ -z "$CUSTOM_LOCAL" ]]; then
+            echo "Error: --upstream and --local must both be specified"
+            exit 1
+        fi
+        UPSTREAM_DIR="$CUSTOM_UPSTREAM"
+        LOCAL_DIR="$CUSTOM_LOCAL"
+        SCOPE="Custom"
+        ;;
+    *)
+        # Global default
+        UPSTREAM_DIR="$REPO_SKILLS_DIR"
+        LOCAL_DIR="${HOME}/.claude/skills"
+        SCOPE="Global"
+        ;;
+esac
 
 # Colors
 RED='\033[0;31m'
@@ -50,9 +121,15 @@ PERSONAL_PATTERNS=(
 )
 
 echo -e "${BLUE}━━━ ARIS Smart Skill Update ━━━${NC}"
+echo -e "Scope:    ${SCOPE}"
 echo -e "Upstream: ${UPSTREAM_DIR}"
 echo -e "Local:    ${LOCAL_DIR}"
 echo ""
+
+if [[ ! -d "$UPSTREAM_DIR" ]]; then
+    echo -e "${RED}Upstream skills directory not found: ${UPSTREAM_DIR}${NC}"
+    exit 1
+fi
 
 if [[ ! -d "$LOCAL_DIR" ]]; then
     echo -e "${RED}Local skills directory not found: ${LOCAL_DIR}${NC}"
@@ -73,11 +150,16 @@ declare -a SAFE_SKILLS=()
 declare -a MERGE_SKILLS=()
 declare -a LOCAL_SKILLS=()
 
+# Track upstream skill names for local-only detection
+declare -a UPSTREAM_NAMES=()
+
 # Check each upstream skill
 for skill_dir in "$UPSTREAM_DIR"/*/; do
     skill_name=$(basename "$skill_dir")
     [[ "$skill_name" == "skills-codex" ]] && continue  # skip codex mirror
     [[ "$skill_name" == "shared-references" ]] && continue  # handled separately
+
+    UPSTREAM_NAMES+=("$skill_name")
 
     local_skill="$LOCAL_DIR/$skill_name"
     upstream_file="$skill_dir/SKILL.md"
@@ -137,8 +219,15 @@ done
 # Check for local-only skills (not in upstream)
 for skill_dir in "$LOCAL_DIR"/*/; do
     skill_name=$(basename "$skill_dir")
-    upstream_skill="$UPSTREAM_DIR/$skill_name"
-    if [[ ! -d "$upstream_skill" ]] && [[ "$skill_name" != "shared-references" ]]; then
+    [[ "$skill_name" == "shared-references" ]] && continue
+    found=false
+    for uname in "${UPSTREAM_NAMES[@]:-}"; do
+        if [[ "$uname" == "$skill_name" ]]; then
+            found=true
+            break
+        fi
+    done
+    if ! $found; then
         LOCAL_ONLY=$((LOCAL_ONLY + 1))
         LOCAL_SKILLS+=("$skill_name")
     fi
@@ -220,9 +309,20 @@ if $APPLY; then
     if [[ $NEEDS_MERGE -gt 0 ]]; then
         echo -e "${YELLOW}⚠️  $NEEDS_MERGE skills have personal customizations and were NOT updated.${NC}"
         echo -e "${YELLOW}   Review manually: ${MERGE_SKILLS[*]}${NC}"
-        echo -e "${YELLOW}   Tip: diff ~/.claude/skills/<name>/SKILL.md skills/<name>/SKILL.md${NC}"
+        echo -e "${YELLOW}   Tip: diff the local and upstream SKILL.md files to merge changes${NC}"
     fi
 else
+    case "$MODE" in
+        project)
+            CMD_HINT="bash tools/smart_update.sh --project \"$PROJECT_ROOT\" --apply"
+            ;;
+        explicit)
+            CMD_HINT="bash tools/smart_update.sh --upstream \"$UPSTREAM_DIR\" --local \"$LOCAL_DIR\" --apply"
+            ;;
+        *)
+            CMD_HINT="bash tools/smart_update.sh --apply"
+            ;;
+    esac
     echo -e "Dry run complete. Run with ${GREEN}--apply${NC} to perform updates:"
-    echo -e "  ${GREEN}bash tools/smart_update.sh --apply${NC}"
+    echo -e "  ${GREEN}${CMD_HINT}${NC}"
 fi


### PR DESCRIPTION
## Summary

- **Add project-level and custom path modes** to `smart_update.sh`, enabling skill updates scoped to specific project directories
- **Add `smart_update.ps1`** as a native PowerShell equivalent for Windows users
- Both scripts now support 3 operating modes with consistent behavior

## Changes

### `tools/smart_update.sh` (updated)
- Add `--project <path>` flag: upstream from repo `skills/`, local targets `<path>/.claude/skills/`
- Add `--upstream <path> --local <path>` flags: fully custom source/target directories
- Add proper argument parsing with `while/case` loop (replaces simple `$1` check)
- Add upstream directory existence check
- Add scope display in output header
- Improve local-only skill detection using tracked upstream names array
- Dynamic `--apply` hint based on current mode

### `tools/smart_update.ps1` (new)
- Native PowerShell port of `smart_update.sh`, compatible with PowerShell 5.1+
- Uses `ParameterSetName` for clean mode separation: `Global` (default), `Project`, `Explicit`
- Equivalent functionality: personal pattern detection, diff comparison, safe/merge classification

## Usage

| Mode | Bash | PowerShell |
|------|------|------------|
| **Global** (default) | `bash tools/smart_update.sh` | `.\tools\smart_update.ps1` |
| **Global + apply** | `bash tools/smart_update.sh --apply` | `.\tools\smart_update.ps1 -Apply` |
| **Project-level** | `bash tools/smart_update.sh --project /path` | `.\tools\smart_update.ps1 -ProjectPath D:\path` |
| **Project + apply** | `bash tools/smart_update.sh --project /path --apply` | `.\tools\smart_update.ps1 -ProjectPath D:\path -Apply` |
| **Custom paths** | `bash tools/smart_update.sh --upstream /a --local /b` | `.\tools\smart_update.ps1 -UpstreamPath D:\a -LocalPath D:\b` |

### Path resolution

| Mode | Upstream source | Local target |
|------|----------------|--------------|
| Global | Repo `skills/` | `~/.claude/skills/` |
| Project | Repo `skills/` | `<ProjectPath>/.claude/skills/` |
| Custom | User-specified | User-specified |

All modes default to **dry-run** (analysis only). Add `--apply` / `-Apply` to execute updates.

## Test plan

- [x] PowerShell: global dry-run verified (60 new skills detected, 11 local-only)
- [x] PowerShell: project mode path resolution verified (correct upstream/local)
- [x] Bash: syntax and structure consistent with PowerShell version
