### PR TITLE
fix: skip beta flags for third-party API providers

### DIFF
--- a/crates/api/src/client.rs
+++ b/crates/api/src/client.rs
@@ -108,6 +108,7 @@ pub struct AnthropicClient {
     max_retries: u32,
     initial_backoff: Duration,
     max_backoff: Duration,
+    send_betas: bool,
 }
 
 impl AnthropicClient {
@@ -120,6 +121,7 @@ impl AnthropicClient {
             max_retries: DEFAULT_MAX_RETRIES,
             initial_backoff: DEFAULT_INITIAL_BACKOFF,
             max_backoff: DEFAULT_MAX_BACKOFF,
+            send_betas: true,
         }
     }
 
@@ -132,11 +134,14 @@ impl AnthropicClient {
             max_retries: DEFAULT_MAX_RETRIES,
             initial_backoff: DEFAULT_INITIAL_BACKOFF,
             max_backoff: DEFAULT_MAX_BACKOFF,
+            send_betas: true,
         }
     }
 
     pub fn from_env() -> Result<Self, ApiError> {
-        Ok(Self::from_auth(AuthSource::from_env_or_saved()?).with_base_url(read_base_url()))
+        Ok(Self::from_auth(AuthSource::from_env_or_saved()?)
+            .with_base_url(read_base_url())
+            .with_send_betas(read_send_betas()))
     }
 
     #[must_use]
@@ -173,6 +178,12 @@ impl AnthropicClient {
     #[must_use]
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
+        self
+    }
+
+    #[must_use]
+    pub fn with_send_betas(mut self, send_betas: bool) -> Self {
+        self.send_betas = send_betas;
         self
     }
 
@@ -311,14 +322,13 @@ impl AnthropicClient {
         request: &MessageRequest,
     ) -> Result<reqwest::Response, ApiError> {
         let is_oauth = self.auth.bearer_token().is_some() && self.auth.api_key().is_none();
-        let is_custom_base = self.base_url != DEFAULT_BASE_URL;
         let request_url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let mut request_builder = self
             .http
             .post(&request_url)
             .header("anthropic-version", ANTHROPIC_VERSION)
             .header("content-type", "application/json");
-        if is_oauth && !is_custom_base {
+        if is_oauth && self.send_betas {
             let model = &request.model;
             let is_haiku = model.contains("haiku");
             let mut betas = vec!["oauth-2025-04-20"];
@@ -575,6 +585,16 @@ fn read_auth_token() -> Option<String> {
 #[must_use]
 pub fn read_base_url() -> String {
     std::env::var("ANTHROPIC_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string())
+}
+
+/// Returns `false` when `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` is set to a truthy value,
+/// indicating that Anthropic-specific beta headers should not be sent. This is needed for
+/// third-party API providers (e.g. AWS Bedrock proxies) that reject unknown beta flags.
+#[must_use]
+pub fn read_send_betas() -> bool {
+    !std::env::var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
 }
 
 fn request_id_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {

--- a/crates/api/src/client.rs
+++ b/crates/api/src/client.rs
@@ -311,13 +311,14 @@ impl AnthropicClient {
         request: &MessageRequest,
     ) -> Result<reqwest::Response, ApiError> {
         let is_oauth = self.auth.bearer_token().is_some() && self.auth.api_key().is_none();
+        let is_custom_base = self.base_url != DEFAULT_BASE_URL;
         let request_url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let mut request_builder = self
             .http
             .post(&request_url)
             .header("anthropic-version", ANTHROPIC_VERSION)
             .header("content-type", "application/json");
-        if is_oauth {
+        if is_oauth && !is_custom_base {
             let model = &request.model;
             let is_haiku = model.contains("haiku");
             let mut betas = vec!["oauth-2025-04-20"];

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -4,8 +4,8 @@ mod sse;
 mod types;
 
 pub use client::{
-    oauth_token_is_expired, read_base_url, resolve_saved_oauth_token, resolve_startup_auth_source,
-    AnthropicClient, AuthSource, MessageStream, OAuthTokenSet,
+    oauth_token_is_expired, read_base_url, read_send_betas, resolve_saved_oauth_token,
+    resolve_startup_auth_source, AnthropicClient, AuthSource, MessageStream, OAuthTokenSet,
 };
 pub use error::ApiError;
 pub use sse::{parse_frame, SseParser};

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -473,3 +473,155 @@ fn prompt_with_default(prompt: &str, default: &str) -> io::Result<String> {
         Ok(trimmed)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env mutation must be serialized across tests in this module — they all
+    // read/write the same process-global env vars.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvSnapshot {
+        vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture(names: &[&'static str]) -> Self {
+            let vars = names
+                .iter()
+                .map(|n| (*n, std::env::var(n).ok()))
+                .collect();
+            // Clear them so the test starts from a known state.
+            for n in names {
+                std::env::remove_var(n);
+            }
+            Self { vars }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (name, prior) in &self.vars {
+                match prior {
+                    Some(v) => std::env::set_var(name, v),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    const EXECUTOR_ENV_VARS: &[&str] = &[
+        "EXECUTOR_PROVIDER",
+        "EXECUTOR_API_KEY",
+        "EXECUTOR_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+    ];
+
+    #[test]
+    fn anthropic_with_custom_base_url_sets_base_url_and_disables_betas() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _snap = EnvSnapshot::capture(EXECUTOR_ENV_VARS);
+
+        let config = ArisConfig {
+            executor_provider: Some("anthropic".into()),
+            executor_api_key: Some("sk-ant-test".into()),
+            executor_base_url: Some("https://bedrock-proxy.example.com".into()),
+            ..Default::default()
+        };
+        config.force_apply_to_env();
+
+        assert_eq!(
+            std::env::var("ANTHROPIC_API_KEY").ok().as_deref(),
+            Some("sk-ant-test")
+        );
+        assert_eq!(
+            std::env::var("ANTHROPIC_BASE_URL").ok().as_deref(),
+            Some("https://bedrock-proxy.example.com")
+        );
+        assert_eq!(
+            std::env::var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS").ok().as_deref(),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn anthropic_without_custom_base_url_leaves_betas_enabled() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _snap = EnvSnapshot::capture(EXECUTOR_ENV_VARS);
+
+        let config = ArisConfig {
+            executor_provider: Some("anthropic".into()),
+            executor_api_key: Some("sk-ant-test".into()),
+            executor_base_url: None,
+            ..Default::default()
+        };
+        config.force_apply_to_env();
+
+        // Official api.anthropic.com path: no base URL override, betas stay on.
+        assert!(std::env::var("ANTHROPIC_BASE_URL").is_err());
+        assert!(std::env::var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS").is_err());
+    }
+
+    #[test]
+    fn anthropic_compat_with_base_url_sets_auth_token_base_url_and_disables_betas() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _snap = EnvSnapshot::capture(EXECUTOR_ENV_VARS);
+
+        let config = ArisConfig {
+            executor_provider: Some("anthropic-compat".into()),
+            executor_api_key: Some("mx-token".into()),
+            executor_base_url: Some("https://minimax.example.com/anthropic".into()),
+            ..Default::default()
+        };
+        config.force_apply_to_env();
+
+        assert_eq!(
+            std::env::var("ANTHROPIC_AUTH_TOKEN").ok().as_deref(),
+            Some("mx-token")
+        );
+        assert_eq!(
+            std::env::var("ANTHROPIC_BASE_URL").ok().as_deref(),
+            Some("https://minimax.example.com/anthropic")
+        );
+        assert_eq!(
+            std::env::var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS").ok().as_deref(),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn force_apply_executor_env_clears_stale_beta_disable_flag() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _snap = EnvSnapshot::capture(EXECUTOR_ENV_VARS);
+
+        // Simulate a prior run that had a custom base URL and thus set the flag.
+        std::env::set_var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "1");
+        std::env::set_var("ANTHROPIC_BASE_URL", "https://old-proxy.example.com");
+
+        // User then reconfigured to official api.anthropic.com (no base URL).
+        let config = ArisConfig {
+            executor_provider: Some("anthropic".into()),
+            executor_api_key: Some("sk-ant-test".into()),
+            executor_base_url: None,
+            ..Default::default()
+        };
+        config.force_apply_executor_env();
+
+        // Stale flags from the prior custom-URL run must be gone, otherwise
+        // the Anthropic client would keep stripping beta headers against the
+        // official API and we'd lose OAuth/long-context/interleaved-thinking.
+        assert!(
+            std::env::var("ANTHROPIC_BASE_URL").is_err(),
+            "expected ANTHROPIC_BASE_URL to be cleared by force_apply_executor_env"
+        );
+        assert!(
+            std::env::var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS").is_err(),
+            "expected CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS to be cleared too"
+        );
+    }
+}

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -117,6 +117,10 @@ impl ArisConfig {
             std::env::remove_var("ANTHROPIC_API_KEY");
             std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
             std::env::remove_var("ANTHROPIC_BASE_URL");
+            // `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` is executor-scoped (it
+            // controls whether the Anthropic client attaches beta headers),
+            // so it belongs in the executor clear block, not the reviewer one.
+            std::env::remove_var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS");
         }
         if force_rev {
             // Clear reviewer-related env vars — only when user explicitly
@@ -155,6 +159,10 @@ impl ArisConfig {
                         if force || std::env::var("ANTHROPIC_BASE_URL").is_err() {
                             std::env::set_var("ANTHROPIC_BASE_URL", url);
                         }
+                        // Third-party providers may reject Anthropic-specific beta flags
+                        if force || std::env::var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS").is_err() {
+                            std::env::set_var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "1");
+                        }
                     }
                 }
                 "anthropic-compat" => {
@@ -165,6 +173,10 @@ impl ArisConfig {
                     if let Some(url) = &self.executor_base_url {
                         if force || std::env::var("ANTHROPIC_BASE_URL").is_err() {
                             std::env::set_var("ANTHROPIC_BASE_URL", url);
+                        }
+                        // Third-party providers may reject Anthropic-specific beta flags
+                        if force || std::env::var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS").is_err() {
+                            std::env::set_var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "1");
                         }
                     }
                 }

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -151,6 +151,11 @@ impl ArisConfig {
                     if force || std::env::var("ANTHROPIC_API_KEY").is_err() {
                         std::env::set_var("ANTHROPIC_API_KEY", key);
                     }
+                    if let Some(url) = &self.executor_base_url {
+                        if force || std::env::var("ANTHROPIC_BASE_URL").is_err() {
+                            std::env::set_var("ANTHROPIC_BASE_URL", url);
+                        }
+                    }
                 }
                 "anthropic-compat" => {
                     // MiniMax etc: Anthropic-compatible endpoint with bearer token

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -3453,7 +3453,8 @@ impl AnthropicRuntimeClient {
         Ok(Self {
             runtime: tokio::runtime::Runtime::new()?,
             client: AnthropicClient::from_auth(resolve_cli_auth_source()?)
-                .with_base_url(api::read_base_url()),
+                .with_base_url(api::read_base_url())
+                .with_send_betas(api::read_send_betas()),
             model,
             enable_tools,
             emit_output,


### PR DESCRIPTION
## Summary

- **Skip `anthropic-beta` header when using a custom base URL.** Third-party providers (e.g. AWS Bedrock proxies) reject Anthropic-specific beta flags (`oauth-2025-04-20`, `claude-code-20250219`, `interleaved-thinking-2025-05-14`, `context-1m-2025-08-07`), causing `400 Bad Request: invalid beta flag` errors.
- **Propagate `executor_base_url` → `ANTHROPIC_BASE_URL` for the `"anthropic"` provider.** Previously only `"anthropic-compat"` mode set this env var, so users with `"anthropic"` provider + custom proxy URL would silently send requests to the official `api.anthropic.com`, resulting in `401 Unauthorized`.

## Motivation

不同的第三方 API 提供商（如基于 AWS Bedrock 的代理）不支持 Anthropic 官方的 beta 标志。当用户通过代理使用 `anthropic-compat` 模式时，代码会错误地发送这些 beta header，导致 400 错误。同时 `"anthropic"` provider 模式下配置的自定义 base URL 不会生效，导致请求发到官方 API 返回 401。

## Changes

| File | Change |
|------|--------|
| `crates/api/src/client.rs` | Add `is_custom_base` check; only send `anthropic-beta` header when targeting official Anthropic API |
| `crates/aris-cli/src/config.rs` | Set `ANTHROPIC_BASE_URL` env var for `"anthropic"` provider when `executor_base_url` is configured |

## Test plan

- [x] Verified API call succeeds via Bedrock proxy without beta flags (curl + aris REPL)
- [x] Verified `"anthropic"` provider with custom base URL correctly routes to proxy
- [x] `cargo build --release` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)