### PR TITLE
feat: add /arxivsub-skill — arXivSub API paper search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,7 @@ export OPENAI_API_KEY="your-key"
 |-------|-------------|:---:|
 | 📄 [`arxiv`](skills/arxiv/SKILL.md) | Search, download, and summarize arXiv papers. Standalone or `/research-lit` supplement | No |
 | 🔎 [`semantic-scholar`](skills/semantic-scholar/SKILL.md) | Search published venue papers (IEEE, ACM, Springer) via Semantic Scholar API. Citation counts, venue metadata, TLDR | No |
+| 🗂️ [`arxivsub-skill`](skills/arxivsub-skill/SKILL.md) | Search arXiv and major AI/CV conferences (CVPR, ICCV, ICLR, ICML, NeurIPS, AAAI, MICCAI) via arXivSub API. Bundled Python scripts (`search.py`, `fetch.py`). Requires `ARXIVSUB_SKILL_KEY` | Yes (`ARXIVSUB_SKILL_KEY`) |
 | 📚 [`deepxiv`](skills/deepxiv/SKILL.md) | Progressive paper retrieval via DeepXiv CLI: search, brief, section map, section reads, trending, web search | Yes (`pip install deepxiv-sdk`) |
 | 🔎 [`exa-search`](skills/exa-search/SKILL.md) | AI-powered broad web search via Exa: blogs, docs, news, companies, research papers with content extraction (highlights, text, summaries) | Yes (`pip install exa-py`) |
 | 📝 [`alphaxiv`](skills/alphaxiv/SKILL.md) | Quick single-paper lookup via [AlphaXiv](https://alphaxiv.org) LLM-optimized summaries. Three-tier fallback: overview → full markdown → LaTeX source | No |

--- a/skills/arxivsub-skill/SKILL.md
+++ b/skills/arxivsub-skill/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: arxivsub-skill
+description: >
+  Academic paper search assistant that queries the arXivSub API to find the latest research papers
+  from arXiv and major AI/CV conferences (CVPR, ICCV, ICLR, ICML, NeurIPS, AAAI, MICCAI).
+  Use this skill whenever the user wants to search for academic papers, find recent research,
+  look up conference publications, discover what's new in a research area, or explore literature
+  on any AI/ML/CV topic. Trigger even for casual phrasing like "find papers on X", "what are
+  the latest papers about Y", "search arXiv for Z", or "any recent work on W".
+---
+
+# arxivsub-skill
+
+Search academic papers via the arXivSub API.
+
+Two bundled scripts handle all processing: `scripts/search.py` (API fetch + parse) and `scripts/fetch.py` (index/detail retrieval).
+
+---
+
+## Language Rule
+
+**Always respond in the same language the user is using.**
+
+---
+
+## Step 0: Authentication
+
+The API key is read automatically by `search.py` from the environment — never ask the user for it and never pass it as a CLI argument.
+
+If `search.py` exits with a non-zero code mentioning `ARXIVSUB_SKILL_KEY`, tell the user (in their language) to set it up via **one** of these methods:
+
+1. Export as a shell environment variable (add to `~/.zshrc` or `~/.bashrc` for persistence):
+   ```
+   export ARXIVSUB_SKILL_KEY=your_key_here
+   ```
+2. Add to a `.env` file in the working directory:
+   ```
+   ARXIVSUB_SKILL_KEY=your_key_here
+   ```
+
+Their API key is found on the Skills page of the arXivSub website.
+
+---
+
+## Step 1: Show Search Parameters and Execute
+
+Before calling the API, briefly show the interpreted parameters in one line (in the user's language), then proceed immediately without waiting:
+
+> Searching: query=`"..."`, locations=`[...]`, time=`...`, limit=`...`
+
+Only pause to ask for confirmation if the search intent is genuinely ambiguous (e.g. the user named a term that could mean multiple very different topics).
+
+---
+
+## Step 2: Fetch and Parse with search.py
+
+Run `scripts/search.py` via bash (omit `--arxiv-days` / `--conf-years` if not applicable):
+
+```bash
+python3 <SKILL_DIR>/scripts/search.py \
+  --query "<search terms>" \
+  --locations arxiv CVPR NeurIPS \
+  --limit 10 \
+  --arxiv-days 7 \
+  --conf-years 2024 2025
+```
+
+The script fetches the API, parses the response, and writes full paper details to `./tmp/arxivsub_papers.json`. It prints `quota_remaining`, `total_papers`, and the output path to stdout.
+
+---
+
+## Step 3: Filter and Rank
+
+Get the concise index (id, title, what_about) to identify the most relevant papers:
+
+```bash
+python3 <SKILL_DIR>/scripts/fetch.py ./tmp/arxivsub_papers.json --for-ranking
+```
+
+Read the returned index and select the **top 5–10** paper IDs using this priority:
+1. **Relevance first** — how directly the paper addresses the user's query
+2. **Recency as tiebreaker** — among equally relevant papers, prefer the most recent
+
+---
+
+## Step 4: Fetch Full Details and Respond
+
+Fetch full details for the selected papers:
+
+```bash
+python3 <SKILL_DIR>/scripts/fetch.py ./tmp/arxivsub_papers.json <id1> <id2> ...
+```
+
+Use the returned full paper details to compose the response. **Never mention files, scripts, or internal mechanics.**
+
+### Output structure (translate headers to user's language):
+
+**[Research Findings]** — Synthesize insights. Answer the user's question directly.
+
+**[Recommended Papers]** — For each paper, use the full details to write a substantive description (not just `what_about`). Cover: what problem it solves, the key method or contribution, and notable results or significance. Typically 3–5 sentences.
+
+```
+**[Title]**
+📍 [conference / arXiv] · [year if available]
+👥 [first_author] ([first_aff]) · [last_author] ([last_aff])
+📄 [synthesized description based on full paper details]
+🔗 [pdf_url]
+```
+
+At the bottom, show quota in user's language as subscript:
+English: `Daily quota remaining: N searches` / Chinese: `当日剩余搜索额度：N 次`
+
+---
+
+## Key Rules
+
+- `locations` is **case-sensitive**: `arxiv`, `CVPR`, `ICCV`, `ICLR`, `ICML`, `NeurIPS`, `AAAI`, `MICCAI`
+- Show parameters as a one-liner before calling the API; only ask for confirmation if the intent is ambiguous
+- If `search.py` exits with a non-zero code or stderr contains an error, classify and handle it:
+  - **Retryable** (network timeout, temporary server error): inform the user and offer to retry automatically
+  - **Needs user intervention**:
+    - Quota exhausted → tell user their daily quota is used up, no retry
+    - Auth failure / missing key → direct to Step 0 setup instructions
+    - Empty results → suggest broadening the query (fewer locations, wider date range, looser terms)
+    - JSON parse failure → report it as an unexpected error and ask user to try again later
+- Never output raw JSON or expose internal mechanics

--- a/skills/arxivsub-skill/scripts/fetch.py
+++ b/skills/arxivsub-skill/scripts/fetch.py
@@ -1,0 +1,45 @@
+"""
+fetch.py — arXivSub paper detail fetcher
+Bundled with arxivsub-skill.
+
+Two modes:
+  --for-ranking   Print concise [{id, title, what_about}, ...] for all papers
+                  (feed into LLM to select relevant paper IDs before fetching full details)
+  <id1> <id2>...  Print full details for the given paper IDs
+
+Usage (called by Claude via bash_tool):
+    python3 fetch.py ./tmp/arxivsub_papers.json --for-ranking
+    python3 fetch.py ./tmp/arxivsub_papers.json <id1> <id2> ...
+"""
+
+import json
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.stderr.write("Usage: fetch.py <papers_path> --for-ranking\n"
+                         "       fetch.py <papers_path> <id1> [id2 ...]\n")
+        sys.exit(1)
+
+    papers_path = sys.argv[1]
+    with open(papers_path) as f:
+        papers = json.load(f)
+
+    if sys.argv[2] == "--for-ranking":
+        index = [{"id": p["id"], "title": p["title"], "what_about": p["what_about"]} for p in papers]
+        print(json.dumps(index, ensure_ascii=False, indent=2))
+        return
+
+    requested_ids = set(sys.argv[2:])
+    results = [p for p in papers if p.get("id") in requested_ids]
+
+    if not results:
+        sys.stderr.write("No papers found for the given IDs.\n")
+        sys.exit(1)
+
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/arxivsub-skill/scripts/search.py
+++ b/skills/arxivsub-skill/scripts/search.py
@@ -1,0 +1,192 @@
+"""
+search.py — arXivSub API client + parser
+Bundled with arxivsub-skill.
+
+Fetches papers from the arXivSub API, parses the response, and writes full
+paper details to ./tmp/arxivsub_papers.json.
+
+The API key is read from the ARXIVSUB_SKILL_KEY environment variable or a .env
+file in the current directory. Never pass it as a command-line argument.
+
+Usage (called by Claude via bash_tool):
+    python3 search.py \
+        --query  "LLM safety alignment" \
+        --locations arxiv NeurIPS ICLR \
+        --limit  10 \
+        --arxiv-days 14 \
+        --conf-years 2024 2025
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+API_URL = "https://qtevnmgyobilaanrzidq.supabase.co/functions/v1/agent-skills-gateway"
+
+
+def load_api_key() -> str:
+    """Read API key from environment or .env file. Exit with setup instructions if missing."""
+    key = os.environ.get("ARXIVSUB_SKILL_KEY", "").strip()
+    if key:
+        return key
+
+    # Fallback: parse a .env file in the current directory
+    env_file = os.path.join(os.getcwd(), ".env")
+    if os.path.isfile(env_file):
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("ARXIVSUB_SKILL_KEY="):
+                    key = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if key:
+                        return key
+
+    sys.stderr.write(
+        "ARXIVSUB_SKILL_KEY is not set.\n"
+        "Set it up using one of these methods:\n"
+        "  1. Export as an environment variable:\n"
+        "       export ARXIVSUB_SKILL_KEY=your_key_here\n"
+        "  2. Add it to a .env file in your working directory:\n"
+        "       ARXIVSUB_SKILL_KEY=your_key_here\n"
+        "Your API key can be found on the Skills page of the arXivSub website.\n"
+    )
+    sys.exit(1)
+
+
+def _parse_summary(summary_content: str) -> dict:
+    """
+    Split summary_content by <SEG> and extract structured fields.
+
+    Layout after adjustment (0-indexed):
+      [0] what it's about   [1] innovations   [2] techniques
+      [3] datasets          [4] results       [5] limitations
+      [6] first_author_name [7] first_aff     [8] last_author_name [9] last_aff
+
+    If 11 segments: skip segment[0] (duplicate title), use [1..10].
+    If 10 segments: use [0..9] directly.
+    """
+    segments = summary_content.split("<SEG>")
+    content = segments[1:] if len(segments) == 11 else segments
+
+    if len(content) < 10:
+        return {
+            "what_about":  summary_content[:300],
+            "innovations": "",
+            "techniques":  "",
+            "datasets":    "",
+            "results":     "",
+            "limitations": "",
+        }
+
+    return {
+        "what_about":  content[0].strip(),
+        "innovations": content[1].strip(),
+        "techniques":  content[2].strip(),
+        "datasets":    content[3].strip(),
+        "results":     content[4].strip(),
+        "limitations": content[5].strip(),
+    }
+
+
+def parse_response(raw: str):
+    """
+    Parse the raw JSON string returned by the arXivSub API.
+
+    Returns (papers, quota):
+        papers  — list of fully structured paper dicts
+        quota   — quota_remaining (int) or None
+    """
+    data = json.loads(raw)
+
+    all_papers = []
+    for source in ("arxiv", "conferences"):
+        for paper in data.get(source, []):
+            paper["_source"] = source
+            all_papers.append(paper)
+
+    papers = []
+    for p in all_papers:
+        parsed = _parse_summary(p.get("summary_content", ""))
+
+        authors = p.get("authors", [])
+        first = next((a for a in authors if a.get("is_first_author")), authors[0] if authors else {})
+        last  = next((a for a in authors if a.get("is_last_author")),  authors[-1] if authors else {})
+
+        papers.append({
+            "id":           p.get("id"),
+            "title":        p.get("title"),
+            "source":       p.get("_source"),
+            "conference":   p.get("conference_name", "arXiv"),
+            "year":         p.get("publish_year"),
+            "arxiv_id":     p.get("arxiv_id"),
+            "pdf_url":      p.get("pdf_url"),
+            "first_author": first.get("name", ""),
+            "first_aff":    first.get("affiliation", ""),
+            "last_author":  last.get("name", ""),
+            "last_aff":     last.get("affiliation", ""),
+            "keywords":     [k["name"] for k in p.get("keywords", [])],
+            **parsed,
+        })
+
+    quota = data.get("quota_remaining")
+    return papers, quota
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--query",       required=True,  help="Search query string")
+    parser.add_argument("--locations",   nargs="+",      default=["arxiv"],
+                        help="Sources: arxiv CVPR ICCV ICLR ICML NeurIPS AAAI MICCAI (case-sensitive)")
+    parser.add_argument("--limit",       type=int,       default=10)
+    parser.add_argument("--arxiv-days",  type=int,       default=None)
+    parser.add_argument("--conf-years",  type=int,       nargs="+", default=None)
+    parser.add_argument("--language",    default="en")
+    args = parser.parse_args()
+
+    api_key = load_api_key()
+
+    body = {
+        "query":     args.query,
+        "language":  args.language,
+        "locations": args.locations,
+        "limit":     args.limit,
+    }
+    if args.arxiv_days is not None:
+        body["arxiv_days"] = args.arxiv_days
+    if args.conf_years is not None:
+        body["conference_years"] = args.conf_years
+
+    payload = json.dumps(body).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "x-agent-skill-key": api_key,
+    }
+
+    req = urllib.request.Request(API_URL, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8")
+        sys.stderr.write(f"HTTP {e.code}: {error_body}\n")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        sys.stderr.write(f"Request failed: {e.reason}\n")
+        sys.exit(1)
+
+    papers, quota = parse_response(raw)
+
+    out_dir = os.path.join(os.getcwd(), "tmp")
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, "arxivsub_papers.json")
+    with open(out_path, "w") as f:
+        json.dump(papers, f, ensure_ascii=False, indent=2)
+
+    print(f"quota_remaining={quota}, total_papers={len(papers)}, output={out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary                                                                    
          
- Adds `/arxivsub-skill`: searches arXiv and major AI/CV conferences (CVPR,   
ICCV, ICLR, ICML, NeurIPS, AAAI, MICCAI) via the arXivSub API                 
- arXivSub maintains a managed database of papers, making it easy to find the
newest research quickly                                                       
- Requires `ARXIVSUB_SKILL_KEY` — get your API key at                         
https://arxivsub.comfyai.app/
                                   
## Test plan                                                                  
                                                                           
- [ ] Set `ARXIVSUB_SKILL_KEY` (refer to [arxivsub-skill](https://github.com/arxivsub/arxivsub-skill)) and run `/arxivsub-skill` in Claude Code       
- [ ] Verify search results are returned for an arXiv query                   
- [ ] Verify conference-specific search (e.g. `locations: NeurIPS`) works