### PR TITLE
[codex] Add paper-illustration-image2 bridge for native Codex image generation

### DIFF
--- a/mcp-servers/codex-image2/README.md
+++ b/mcp-servers/codex-image2/README.md
@@ -8,7 +8,7 @@ This bridge is intentionally narrow:
 - it accepts **text prompts**
 - it waits for a native `imageGeneration` event from Codex
 - it rejects runs that fall back to shell/Python-based image creation
-- it copies the generated image into your requested workspace path
+- it copies the generated image only into `cwd/figures/ai_generated/`
 
 ## Requirements
 
@@ -28,9 +28,11 @@ claude mcp add codex-image2 -s user -- python3 ~/.claude/mcp-servers/codex-image
 
 ## Exposed Tools
 
-- `generate`
 - `generate_start`
 - `generate_status`
+
+The bridge is intentionally **async-first**. Call `generate_start`, then poll
+`generate_status`.
 
 ## Smoke Test
 
@@ -48,8 +50,16 @@ Generate a clean blue circle on white background.
 
 Then poll `mcp__codex-image2__generate_status` until `done=true`.
 
+`outputPath` must stay under `figures/ai_generated/` inside the provided `cwd`.
+The server rejects writes outside that workspace root.
+
 ## Current Limitations
 
 - The bridge uses the current Codex app-server path and is **experimental**
 - It is optimized for **one-shot generation** rather than conversational thread replay
 - Reference images are passed as path hints in the prompt; if Codex exposes local image viewing in that session, it may inspect them
+
+## Logging
+
+- Debug logging is opt-in via `CODEX_IMAGE2_DEBUG_LOG=/path/to/debug.log`
+- Raw Codex stdout/stderr run logs are off by default; enable only when needed with `CODEX_IMAGE2_SAVE_RUN_LOGS=1`

--- a/mcp-servers/codex-image2/README.md
+++ b/mcp-servers/codex-image2/README.md
@@ -1,0 +1,55 @@
+# codex-image2 MCP Bridge
+
+Experimental bridge that lets **Claude Code** ask the local **Codex desktop app**
+to generate an image through Codex's native app-server image-generation path.
+
+This bridge is intentionally narrow:
+
+- it accepts **text prompts**
+- it waits for a native `imageGeneration` event from Codex
+- it rejects runs that fall back to shell/Python-based image creation
+- it copies the generated image into your requested workspace path
+
+## Requirements
+
+- Codex desktop app installed and signed in
+- `codex` CLI available on `PATH`
+- `codex debug app-server send-message-v2 "ping"` works on your machine
+
+## Install for Claude Code
+
+```bash
+mkdir -p ~/.claude/mcp-servers/codex-image2
+cp mcp-servers/codex-image2/server.py ~/.claude/mcp-servers/codex-image2/server.py
+chmod +x ~/.claude/mcp-servers/codex-image2/server.py
+
+claude mcp add codex-image2 -s user -- python3 ~/.claude/mcp-servers/codex-image2/server.py
+```
+
+## Exposed Tools
+
+- `generate`
+- `generate_start`
+- `generate_status`
+
+## Smoke Test
+
+After registering the server in Claude Code, ask Claude to call:
+
+```text
+mcp__codex-image2__generate_start
+```
+
+with a prompt like:
+
+```text
+Generate a clean blue circle on white background.
+```
+
+Then poll `mcp__codex-image2__generate_status` until `done=true`.
+
+## Current Limitations
+
+- The bridge uses the current Codex app-server path and is **experimental**
+- It is optimized for **one-shot generation** rather than conversational thread replay
+- Reference images are passed as path hints in the prompt; if Codex exposes local image viewing in that session, it may inspect them

--- a/mcp-servers/codex-image2/server.py
+++ b/mcp-servers/codex-image2/server.py
@@ -18,7 +18,7 @@ import sys
 import time
 import traceback
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -29,10 +29,19 @@ sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)
 SERVER_NAME = os.environ.get("CODEX_IMAGE2_SERVER_NAME", "codex-image2")
 CODEX_BIN = os.environ.get("CODEX_IMAGE2_CODEX_BIN", "codex")
 DEFAULT_TIMEOUT_SEC = int(os.environ.get("CODEX_IMAGE2_TIMEOUT_SEC", "600"))
-DEFAULT_MODEL = os.environ.get("CODEX_IMAGE2_MODEL", "")
-DEBUG_LOG = Path(
-    os.environ.get("CODEX_IMAGE2_DEBUG_LOG", f"/tmp/{SERVER_NAME}-mcp-debug.log")
+DEFAULT_JOB_EXPIRY_GRACE_SEC = int(
+    os.environ.get("CODEX_IMAGE2_JOB_EXPIRY_GRACE_SEC", "60")
 )
+MAX_STATUS_WAIT_SEC = int(os.environ.get("CODEX_IMAGE2_MAX_STATUS_WAIT_SEC", "30"))
+DEFAULT_MODEL = os.environ.get("CODEX_IMAGE2_MODEL", "")
+DEBUG_LOG_RAW = os.environ.get("CODEX_IMAGE2_DEBUG_LOG", "").strip()
+DEBUG_LOG = Path(DEBUG_LOG_RAW).expanduser() if DEBUG_LOG_RAW else None
+SAVE_RUN_LOGS = os.environ.get("CODEX_IMAGE2_SAVE_RUN_LOGS", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 STATE_DIR = Path(
     os.environ.get(
         "CODEX_IMAGE2_STATE_DIR",
@@ -43,10 +52,13 @@ JOBS_DIR = STATE_DIR / "jobs"
 RUNS_DIR = STATE_DIR / "runs"
 
 TERMINAL_JOB_STATES = {"completed", "failed"}
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 _use_ndjson = False
 
 
 def debug_log(message: str) -> None:
+    if DEBUG_LOG is None:
+        return
     try:
         DEBUG_LOG.parent.mkdir(parents=True, exist_ok=True)
         with DEBUG_LOG.open("a", encoding="utf-8") as fh:
@@ -109,6 +121,21 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def parse_utc_timestamp(raw_value: Any) -> datetime | None:
+    if not isinstance(raw_value, str) or not raw_value:
+        return None
+    try:
+        return datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def utc_after_seconds(seconds: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).replace(
+        microsecond=0
+    ).isoformat().replace("+00:00", "Z")
+
+
 def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = path.with_suffix(path.suffix + ".tmp")
@@ -124,14 +151,22 @@ def job_state_path(job_id: str) -> Path:
     return JOBS_DIR / f"{job_id}.json"
 
 
-def is_pid_alive(pid: int | None) -> bool:
+def classify_worker_state(pid: int | None) -> str:
     if not pid or pid <= 0:
-        return False
+        return "missing"
     try:
-        os.kill(pid, 0)
+        waited_pid, _ = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return "exited"
+        return "running"
     except OSError:
-        return False
-    return True
+        return "exited"
+    if waited_pid == 0:
+        return "running"
+    return "exited"
 
 
 def find_codex_bin() -> str | None:
@@ -183,6 +218,66 @@ def resolve_output_path(raw_output_path: str | None, *, cwd: Path, job_id: str) 
     else:
         path = cwd / "figures" / "ai_generated" / f"codex-image2-{job_id}.png"
     return path.resolve()
+
+
+def allowed_output_root(*, cwd: Path) -> Path:
+    return (cwd / "figures" / "ai_generated").resolve()
+
+
+def validate_output_path(output_path: Path, *, cwd: Path) -> str | None:
+    root = allowed_output_root(cwd=cwd)
+    try:
+        output_path.relative_to(root)
+    except ValueError:
+        return f"outputPath must stay under {root}"
+    if output_path == root:
+        return f"outputPath must be a file under {root}, not the directory itself"
+    return None
+
+
+def parse_timeout_seconds(raw_value: Any) -> tuple[int | None, str | None]:
+    if raw_value is None:
+        return DEFAULT_TIMEOUT_SEC, None
+    try:
+        timeout_sec = int(raw_value)
+    except (TypeError, ValueError):
+        return None, "timeoutSeconds must be an integer"
+    if timeout_sec <= 0:
+        return None, "timeoutSeconds must be positive"
+    return timeout_sec, None
+
+
+def is_png_bytes(raw_bytes: bytes) -> bool:
+    return raw_bytes.startswith(PNG_SIGNATURE)
+
+
+def maybe_run_log_path(run_id: str) -> Path | None:
+    if not SAVE_RUN_LOGS:
+        return None
+    return RUNS_DIR / f"{run_id}.log"
+
+
+def scrub_job_request(job: dict[str, Any]) -> None:
+    request = job.get("request")
+    if not isinstance(request, dict):
+        return
+    job["request"] = {
+        "cwd": request.get("cwd"),
+        "outputPath": request.get("outputPath"),
+        "timeoutSec": request.get("timeoutSec"),
+    }
+
+
+def fail_job(job_path: Path, job: dict[str, Any], message: str) -> dict[str, Any]:
+    finished_at = utc_now()
+    job["status"] = "failed"
+    job["error"] = message
+    job["completedAt"] = finished_at
+    job["updatedAt"] = finished_at
+    job["result"] = None
+    scrub_job_request(job)
+    write_json(job_path, job)
+    return job
 
 
 def build_bridge_prompt(
@@ -297,6 +392,9 @@ def materialize_generated_image(
     if isinstance(saved_path_value, str) and saved_path_value:
         source_path = Path(saved_path_value).expanduser()
         if source_path.is_file():
+            source_bytes = source_path.read_bytes()
+            if not is_png_bytes(source_bytes):
+                return None, None, None, "imageGeneration savedPath did not contain a PNG image"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, output_path)
             return output_path, str(source_path), revised_prompt_text, None
@@ -307,6 +405,8 @@ def materialize_generated_image(
             decoded = base64.b64decode(raw_result)
         except ValueError as exc:
             return None, None, None, f"imageGeneration result was not valid base64: {exc}"
+        if not is_png_bytes(decoded):
+            return None, None, None, "imageGeneration result did not decode to a PNG image"
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_bytes(decoded)
         return output_path, None, revised_prompt_text, None
@@ -328,6 +428,11 @@ def run_codex_image(
     bin_path = find_codex_bin()
     if not bin_path:
         return None, f"Codex CLI not found: {CODEX_BIN}"
+
+    output_path = output_path.resolve()
+    output_path_error = validate_output_path(output_path, cwd=cwd)
+    if output_path_error:
+        return None, output_path_error
 
     normalized_refs = reference_image_paths or []
     prompt_text = build_bridge_prompt(
@@ -441,6 +546,7 @@ def serialize_job(job: dict[str, Any]) -> dict[str, Any]:
         "startedAt": job.get("startedAt"),
         "completedAt": job.get("completedAt"),
         "updatedAt": job.get("updatedAt"),
+        "expiresAt": job.get("expiresAt"),
         "resumeHint": "Call generate_status with this jobId until done=true.",
     }
 
@@ -453,6 +559,7 @@ def start_async_generate(
     system: str | None = None,
     model: str | None = None,
     reference_image_paths: Any = None,
+    timeout_seconds: Any = None,
 ) -> tuple[dict[str, Any] | None, str | None]:
     resolved_cwd, cwd_error = resolve_cwd(cwd)
     if cwd_error:
@@ -462,8 +569,15 @@ def start_async_generate(
     if refs_error:
         return None, refs_error
 
+    timeout_sec, timeout_error = parse_timeout_seconds(timeout_seconds)
+    if timeout_error:
+        return None, timeout_error
+
     job_id = uuid.uuid4().hex
     resolved_output_path = resolve_output_path(output_path, cwd=resolved_cwd, job_id=job_id)
+    output_path_error = validate_output_path(resolved_output_path, cwd=resolved_cwd)
+    if output_path_error:
+        return None, output_path_error
     created_at = utc_now()
     job = {
         "jobId": job_id,
@@ -472,6 +586,7 @@ def start_async_generate(
         "startedAt": None,
         "completedAt": None,
         "updatedAt": created_at,
+        "expiresAt": utc_after_seconds(timeout_sec + DEFAULT_JOB_EXPIRY_GRACE_SEC),
         "error": None,
         "result": None,
         "workerPid": None,
@@ -482,6 +597,7 @@ def start_async_generate(
             "system": system,
             "model": model,
             "referenceImagePaths": refs,
+            "timeoutSec": timeout_sec,
         },
     }
 
@@ -520,12 +636,14 @@ def get_generate_status(job_id: str, *, wait_seconds: int = 0) -> tuple[dict[str
     deadline = time.monotonic() + max(wait_seconds, 0)
     while True:
         job = read_json(job_path)
-        if job.get("status") in {"queued", "running"} and not is_pid_alive(job.get("workerPid")):
-            job["status"] = "failed"
-            job["error"] = "Background image worker exited before writing a final result"
-            job["completedAt"] = utc_now()
-            job["updatedAt"] = job["completedAt"]
-            write_json(job_path, job)
+        if job.get("status") in {"queued", "running"}:
+            expires_at = parse_utc_timestamp(job.get("expiresAt"))
+            if expires_at is not None and datetime.now(timezone.utc) > expires_at:
+                job = fail_job(job_path, job, "Background image worker exceeded its deadline before writing a final result")
+            else:
+                worker_state = classify_worker_state(job.get("workerPid"))
+                if worker_state in {"missing", "exited"}:
+                    job = fail_job(job_path, job, "Background image worker exited before writing a final result")
         if job.get("status") in TERMINAL_JOB_STATES:
             return serialize_job(job), None
         if time.monotonic() >= deadline:
@@ -548,7 +666,7 @@ def run_async_job(job_id: str) -> int:
     debug_log(f"JOB_RUNNING job_id={job_id} worker_pid={os.getpid()}")
 
     request = job.get("request") or {}
-    run_log_path = RUNS_DIR / f"{job_id}.log"
+    run_log_path = maybe_run_log_path(job_id)
     try:
         payload, error = run_codex_image(
             str(request.get("prompt", "")),
@@ -557,6 +675,7 @@ def run_async_job(job_id: str) -> int:
             system=request.get("system"),
             model=request.get("model"),
             reference_image_paths=request.get("referenceImagePaths") or [],
+            timeout_sec=request.get("timeoutSec"),
             run_log_path=run_log_path,
         )
     except Exception as exc:
@@ -569,16 +688,14 @@ def run_async_job(job_id: str) -> int:
     job["updatedAt"] = finished_at
     job["completedAt"] = finished_at
     if error:
-        job["status"] = "failed"
-        job["error"] = error
-        job["result"] = None
-        write_json(job_path, job)
+        fail_job(job_path, job, error)
         debug_log(f"JOB_FAILED job_id={job_id} error={error}")
         return 1
 
     job["status"] = "completed"
     job["error"] = None
     job["result"] = payload
+    scrub_job_request(job)
     write_json(job_path, job)
     debug_log(f"JOB_COMPLETED job_id={job_id} output={(payload or {}).get('outputPath')}")
     return 0
@@ -609,7 +726,9 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
     request_id = request.get("id")
     method = request.get("method", "")
     params = request.get("params", {})
-    debug_log(f"REQUEST id={request_id!r} method={method} params={json.dumps(params, ensure_ascii=False)}")
+    if DEBUG_LOG is not None:
+        param_keys = sorted(params.keys()) if isinstance(params, dict) else []
+        debug_log(f"REQUEST id={request_id!r} method={method} param_keys={param_keys}")
 
     if request_id is None:
         if method in {"notifications/initialized", "initialized"}:
@@ -646,28 +765,6 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
             "result": {
                 "tools": [
                     {
-                        "name": "generate",
-                        "description": "Generate a raster image through the local Codex app-server native image tool and return the copied output path.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "prompt": {"type": "string", "description": "Image generation prompt"},
-                                "cwd": {"type": "string", "description": "Optional working directory"},
-                                "outputPath": {"type": "string", "description": "Optional output file path; defaults to figures/ai_generated"},
-                                "system": {"type": "string", "description": "Optional extra bridge instructions"},
-                                "model": {"type": "string", "description": "Optional Codex text model override"},
-                                "referenceImagePaths": {
-                                    "oneOf": [
-                                        {"type": "string"},
-                                        {"type": "array", "items": {"type": "string"}},
-                                    ],
-                                    "description": "Optional local reference image paths that Codex may inspect before generating",
-                                },
-                            },
-                            "required": ["prompt"],
-                        },
-                    },
-                    {
                         "name": "generate_start",
                         "description": "Start a background native image generation job through the Codex app-server.",
                         "inputSchema": {
@@ -685,6 +782,10 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
                                     ],
                                     "description": "Optional local reference image paths that Codex may inspect before generating",
                                 },
+                                "timeoutSeconds": {
+                                    "type": "integer",
+                                    "description": "Optional positive timeout for the underlying Codex image call",
+                                },
                             },
                             "required": ["prompt"],
                         },
@@ -697,7 +798,10 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
                             "properties": {
                                 "jobId": {"type": "string", "description": "Background image job id"},
                                 "job_id": {"type": "string", "description": "Alias of jobId"},
-                                "waitSeconds": {"type": "integer", "description": "Optional bounded wait before returning status"},
+                                "waitSeconds": {
+                                    "type": "integer",
+                                    "description": "Optional bounded wait before returning status; capped to keep the MCP server responsive",
+                                },
                             },
                             "required": ["jobId"],
                         },
@@ -712,31 +816,6 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
         if not isinstance(args, dict):
             return tool_error(request_id, "tool arguments must be an object")
 
-        if name == "generate":
-            prompt = str(args.get("prompt", "")).strip()
-            if not prompt:
-                return tool_error(request_id, "prompt is required")
-            resolved_cwd, cwd_error = resolve_cwd(args.get("cwd"))
-            if cwd_error:
-                return tool_error(request_id, cwd_error)
-            refs, refs_error = normalize_string_list(args.get("referenceImagePaths"))
-            if refs_error:
-                return tool_error(request_id, refs_error)
-            output_path = resolve_output_path(args.get("outputPath"), cwd=resolved_cwd, job_id=uuid.uuid4().hex)
-            run_log_path = RUNS_DIR / f"sync-{uuid.uuid4().hex}.log"
-            payload, error = run_codex_image(
-                prompt,
-                cwd=resolved_cwd,
-                output_path=output_path,
-                system=args.get("system"),
-                model=args.get("model"),
-                reference_image_paths=refs,
-                run_log_path=run_log_path,
-            )
-            if error:
-                return tool_error(request_id, error)
-            return tool_success(request_id, payload or {})
-
         if name == "generate_start":
             prompt = str(args.get("prompt", "")).strip()
             if not prompt:
@@ -748,6 +827,7 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
                 system=args.get("system"),
                 model=args.get("model"),
                 reference_image_paths=args.get("referenceImagePaths"),
+                timeout_seconds=args.get("timeoutSeconds"),
             )
             if error:
                 return tool_error(request_id, error)
@@ -762,7 +842,8 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
                 wait_seconds = int(wait_seconds)
             except (TypeError, ValueError):
                 wait_seconds = 0
-            payload, error = get_generate_status(str(job_id), wait_seconds=max(wait_seconds, 0))
+            wait_seconds = min(max(wait_seconds, 0), MAX_STATUS_WAIT_SEC)
+            payload, error = get_generate_status(str(job_id), wait_seconds=wait_seconds)
             if error:
                 return tool_error(request_id, error)
             return tool_success(request_id, payload or {})

--- a/mcp-servers/codex-image2/server.py
+++ b/mcp-servers/codex-image2/server.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+"""Codex app-server image bridge for Claude-first ARIS workflows.
+
+This server exposes a narrow MCP interface that asks the local Codex desktop
+app to generate an image through the app-server path. It is intentionally kept
+small and dependency-free so users can copy it into `~/.claude/mcp-servers/`
+and register it with Claude Code.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)
+sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)
+
+SERVER_NAME = os.environ.get("CODEX_IMAGE2_SERVER_NAME", "codex-image2")
+CODEX_BIN = os.environ.get("CODEX_IMAGE2_CODEX_BIN", "codex")
+DEFAULT_TIMEOUT_SEC = int(os.environ.get("CODEX_IMAGE2_TIMEOUT_SEC", "600"))
+DEFAULT_MODEL = os.environ.get("CODEX_IMAGE2_MODEL", "")
+DEBUG_LOG = Path(
+    os.environ.get("CODEX_IMAGE2_DEBUG_LOG", f"/tmp/{SERVER_NAME}-mcp-debug.log")
+)
+STATE_DIR = Path(
+    os.environ.get(
+        "CODEX_IMAGE2_STATE_DIR",
+        str(Path.home() / ".claude" / "state" / SERVER_NAME),
+    )
+)
+JOBS_DIR = STATE_DIR / "jobs"
+RUNS_DIR = STATE_DIR / "runs"
+
+TERMINAL_JOB_STATES = {"completed", "failed"}
+_use_ndjson = False
+
+
+def debug_log(message: str) -> None:
+    try:
+        DEBUG_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with DEBUG_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(f"{message}\n")
+    except OSError:
+        pass
+
+
+def send_response(response: dict[str, Any]) -> None:
+    global _use_ndjson
+
+    payload = json.dumps(response, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    debug_log(f"SEND {payload.decode('utf-8', errors='replace')}")
+    if _use_ndjson:
+        sys.stdout.write(payload + b"\n")
+    else:
+        header = f"Content-Length: {len(payload)}\r\n\r\n".encode("utf-8")
+        sys.stdout.write(header + payload)
+    sys.stdout.flush()
+
+
+def read_message() -> dict[str, Any] | None:
+    global _use_ndjson
+
+    line = sys.stdin.readline()
+    if not line:
+        return None
+
+    line_text = line.decode("utf-8").rstrip("\r\n")
+    if line_text.lower().startswith("content-length:"):
+        try:
+            content_length = int(line_text.split(":", 1)[1].strip())
+        except ValueError:
+            return None
+
+        while True:
+            header_line = sys.stdin.readline()
+            if not header_line:
+                return None
+            if header_line in {b"\r\n", b"\n"}:
+                break
+
+        body = sys.stdin.read(content_length)
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            return None
+
+    if line_text.startswith("{") or line_text.startswith("["):
+        _use_ndjson = True
+        try:
+            return json.loads(line_text)
+        except json.JSONDecodeError:
+            return None
+
+    return None
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    temp_path.replace(path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def job_state_path(job_id: str) -> Path:
+    return JOBS_DIR / f"{job_id}.json"
+
+
+def is_pid_alive(pid: int | None) -> bool:
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def find_codex_bin() -> str | None:
+    if Path(CODEX_BIN).is_file():
+        return CODEX_BIN
+    return shutil.which(CODEX_BIN)
+
+
+def normalize_string_list(raw_value: Any) -> tuple[list[str], str | None]:
+    if raw_value is None:
+        return [], None
+    if isinstance(raw_value, str):
+        candidate = raw_value.strip()
+        return ([candidate] if candidate else []), None
+    if not isinstance(raw_value, list):
+        return [], "referenceImagePaths must be a string or an array of strings"
+
+    values: list[str] = []
+    for item in raw_value:
+        if not isinstance(item, str):
+            return [], "referenceImagePaths entries must be strings"
+        candidate = item.strip()
+        if candidate:
+            values.append(candidate)
+    return values, None
+
+
+def resolve_cwd(raw_cwd: str | None) -> tuple[Path, str | None]:
+    if raw_cwd:
+        cwd = Path(raw_cwd).expanduser()
+    else:
+        cwd = Path.cwd()
+    try:
+        cwd = cwd.resolve()
+    except OSError as exc:
+        return cwd, f"failed to resolve cwd {raw_cwd!r}: {exc}"
+    if not cwd.exists():
+        return cwd, f"working directory does not exist: {cwd}"
+    if not cwd.is_dir():
+        return cwd, f"working directory is not a directory: {cwd}"
+    return cwd, None
+
+
+def resolve_output_path(raw_output_path: str | None, *, cwd: Path, job_id: str) -> Path:
+    if raw_output_path:
+        path = Path(raw_output_path).expanduser()
+        if not path.is_absolute():
+            path = cwd / path
+    else:
+        path = cwd / "figures" / "ai_generated" / f"codex-image2-{job_id}.png"
+    return path.resolve()
+
+
+def build_bridge_prompt(
+    prompt: str,
+    *,
+    system: str | None,
+    reference_image_paths: list[str],
+) -> str:
+    sections: list[str] = [
+        "You are operating behind a Codex native image-generation MCP bridge.",
+        "Use native image generation through the Codex app-server.",
+        "Do not use shell commands, Python, SVG, HTML, Canvas, or manual bitmap encoding.",
+        "Do not fabricate success. If native image generation is unavailable, reply exactly NATIVE_IMAGE_UNAVAILABLE.",
+        "Generate exactly one publication-quality raster image unless the user explicitly requests multiple variants.",
+        "",
+    ]
+    selected_system = (system or "").strip()
+    if selected_system:
+        sections.extend(["## System Instructions", selected_system, ""])
+    if reference_image_paths:
+        sections.append("## Reference Images")
+        sections.append(
+            "These local image files are available. If image viewing tools are available in this Codex session, inspect them before generating."
+        )
+        for path in reference_image_paths:
+            sections.append(f"- {path}")
+        sections.append("")
+    sections.extend(["## User Request", prompt.strip()])
+    return "\n".join(sections).strip()
+
+
+def parse_debug_json_messages(raw_stdout: str) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    buffer: list[str] = []
+    collecting = False
+
+    for raw_line in raw_stdout.splitlines():
+        if not collecting:
+            if raw_line.startswith("< {"):
+                collecting = True
+                buffer = [raw_line[2:]]
+            continue
+
+        if not raw_line.startswith("< "):
+            collecting = False
+            buffer = []
+            continue
+
+        buffer.append(raw_line[2:])
+        candidate = "\n".join(buffer)
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        messages.append(payload)
+        collecting = False
+        buffer = []
+
+    return messages
+
+
+def extract_run_summary(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    thread_id: str | None = None
+    agent_messages: list[str] = []
+    image_items: list[dict[str, Any]] = []
+    command_items: list[dict[str, Any]] = []
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        params = message.get("params")
+        if isinstance(params, dict):
+            candidate_thread_id = params.get("threadId")
+            if isinstance(candidate_thread_id, str) and candidate_thread_id:
+                thread_id = candidate_thread_id
+            item = params.get("item")
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                if item_type == "agentMessage":
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        agent_messages.append(text)
+                elif item_type == "imageGeneration":
+                    image_items.append(item)
+                elif item_type == "commandExecution":
+                    command_items.append(item)
+
+        result = message.get("result")
+        if isinstance(result, dict):
+            thread = result.get("thread")
+            if isinstance(thread, dict):
+                candidate_thread_id = thread.get("id")
+                if isinstance(candidate_thread_id, str) and candidate_thread_id:
+                    thread_id = candidate_thread_id
+
+    return {
+        "threadId": thread_id,
+        "agentMessages": agent_messages,
+        "imageItems": image_items,
+        "commandItems": command_items,
+    }
+
+
+def materialize_generated_image(
+    image_item: dict[str, Any],
+    output_path: Path,
+) -> tuple[Path | None, str | None, str | None, str | None]:
+    saved_path_value = image_item.get("savedPath")
+    revised_prompt = image_item.get("revisedPrompt")
+    revised_prompt_text = revised_prompt if isinstance(revised_prompt, str) else None
+
+    if isinstance(saved_path_value, str) and saved_path_value:
+        source_path = Path(saved_path_value).expanduser()
+        if source_path.is_file():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, output_path)
+            return output_path, str(source_path), revised_prompt_text, None
+
+    raw_result = image_item.get("result")
+    if isinstance(raw_result, str) and raw_result.strip():
+        try:
+            decoded = base64.b64decode(raw_result)
+        except ValueError as exc:
+            return None, None, None, f"imageGeneration result was not valid base64: {exc}"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(decoded)
+        return output_path, None, revised_prompt_text, None
+
+    return None, None, None, "imageGeneration item did not contain a savedPath or decodable result"
+
+
+def run_codex_image(
+    prompt: str,
+    *,
+    cwd: Path,
+    output_path: Path,
+    system: str | None = None,
+    model: str | None = None,
+    reference_image_paths: list[str] | None = None,
+    timeout_sec: int | None = None,
+    run_log_path: Path | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    bin_path = find_codex_bin()
+    if not bin_path:
+        return None, f"Codex CLI not found: {CODEX_BIN}"
+
+    normalized_refs = reference_image_paths or []
+    prompt_text = build_bridge_prompt(
+        prompt,
+        system=system,
+        reference_image_paths=normalized_refs,
+    )
+    cmd = [bin_path]
+    selected_model = model or DEFAULT_MODEL
+    if selected_model:
+        cmd.extend(["-c", f'model="{selected_model}"'])
+    cmd.extend(["debug", "app-server", "send-message-v2", prompt_text])
+
+    effective_timeout = timeout_sec or DEFAULT_TIMEOUT_SEC
+    debug_log(f"RUN {' '.join(cmd)} cwd={cwd}")
+    try:
+        started = time.monotonic()
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            cwd=str(cwd),
+            timeout=effective_timeout,
+            check=False,
+        )
+        duration_ms = int((time.monotonic() - started) * 1000)
+    except subprocess.TimeoutExpired:
+        return None, f"Codex image generation timed out after {effective_timeout} seconds"
+
+    if run_log_path is not None:
+        run_log_path.parent.mkdir(parents=True, exist_ok=True)
+        run_log_path.write_text(
+            result.stdout + ("\n[stderr]\n" + result.stderr if result.stderr else ""),
+            encoding="utf-8",
+        )
+
+    messages = parse_debug_json_messages(result.stdout)
+    summary = extract_run_summary(messages)
+
+    if summary["commandItems"]:
+        return None, (
+            "Codex attempted shell-based image creation instead of native image generation. "
+            "This bridge only accepts native imageGeneration events."
+        )
+
+    image_items = summary["imageItems"]
+    if not image_items:
+        final_message = ""
+        for candidate in reversed(summary["agentMessages"]):
+            if candidate and candidate.strip():
+                final_message = candidate.strip()
+                break
+        stderr_text = result.stderr.strip()
+        if final_message == "NATIVE_IMAGE_UNAVAILABLE":
+            return None, "Codex app-server reported that native image generation is unavailable in this session."
+        if final_message:
+            return None, f"Codex did not emit an imageGeneration item. Final message: {final_message}"
+        if stderr_text:
+            return None, f"Codex did not emit an imageGeneration item. stderr: {stderr_text}"
+        return None, "Codex did not emit an imageGeneration item."
+
+    image_item = image_items[-1]
+    generated_output, source_saved_path, revised_prompt, materialize_error = materialize_generated_image(
+        image_item,
+        output_path,
+    )
+    if materialize_error:
+        return None, materialize_error
+    if generated_output is None:
+        return None, "Codex image bridge failed to materialize the generated image"
+
+    response_text = ""
+    for candidate in reversed(summary["agentMessages"]):
+        if candidate is not None:
+            response_text = candidate
+            break
+
+    return {
+        "threadId": summary["threadId"],
+        "response": response_text,
+        "model": selected_model or None,
+        "duration_ms": duration_ms,
+        "nativeToolConfirmed": True,
+        "imageCount": len(image_items),
+        "outputPath": str(generated_output),
+        "sourceSavedPath": source_saved_path,
+        "revisedPrompt": revised_prompt,
+        "runLogPath": str(run_log_path) if run_log_path is not None else None,
+    }, None
+
+
+def serialize_job(job: dict[str, Any]) -> dict[str, Any]:
+    result = job.get("result") or {}
+    return {
+        "jobId": job.get("jobId"),
+        "status": job.get("status"),
+        "done": job.get("status") in TERMINAL_JOB_STATES,
+        "threadId": result.get("threadId"),
+        "response": result.get("response"),
+        "model": result.get("model"),
+        "duration_ms": result.get("duration_ms"),
+        "nativeToolConfirmed": result.get("nativeToolConfirmed"),
+        "imageCount": result.get("imageCount"),
+        "outputPath": result.get("outputPath"),
+        "sourceSavedPath": result.get("sourceSavedPath"),
+        "revisedPrompt": result.get("revisedPrompt"),
+        "runLogPath": result.get("runLogPath"),
+        "error": job.get("error"),
+        "createdAt": job.get("createdAt"),
+        "startedAt": job.get("startedAt"),
+        "completedAt": job.get("completedAt"),
+        "updatedAt": job.get("updatedAt"),
+        "resumeHint": "Call generate_status with this jobId until done=true.",
+    }
+
+
+def start_async_generate(
+    prompt: str,
+    *,
+    cwd: str | None = None,
+    output_path: str | None = None,
+    system: str | None = None,
+    model: str | None = None,
+    reference_image_paths: Any = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    resolved_cwd, cwd_error = resolve_cwd(cwd)
+    if cwd_error:
+        return None, cwd_error
+
+    refs, refs_error = normalize_string_list(reference_image_paths)
+    if refs_error:
+        return None, refs_error
+
+    job_id = uuid.uuid4().hex
+    resolved_output_path = resolve_output_path(output_path, cwd=resolved_cwd, job_id=job_id)
+    created_at = utc_now()
+    job = {
+        "jobId": job_id,
+        "status": "queued",
+        "createdAt": created_at,
+        "startedAt": None,
+        "completedAt": None,
+        "updatedAt": created_at,
+        "error": None,
+        "result": None,
+        "workerPid": None,
+        "request": {
+            "prompt": prompt,
+            "cwd": str(resolved_cwd),
+            "outputPath": str(resolved_output_path),
+            "system": system,
+            "model": model,
+            "referenceImagePaths": refs,
+        },
+    }
+
+    job_path = job_state_path(job_id)
+    write_json(job_path, job)
+
+    try:
+        worker = subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), "--run-job", job_id],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        job["status"] = "failed"
+        job["completedAt"] = utc_now()
+        job["updatedAt"] = job["completedAt"]
+        job["error"] = f"Failed to launch background image worker: {exc}"
+        write_json(job_path, job)
+        return None, job["error"]
+
+    job["workerPid"] = worker.pid
+    job["updatedAt"] = utc_now()
+    write_json(job_path, job)
+    debug_log(f"JOB_START job_id={job_id} worker_pid={worker.pid}")
+    return serialize_job(job), None
+
+
+def get_generate_status(job_id: str, *, wait_seconds: int = 0) -> tuple[dict[str, Any] | None, str | None]:
+    job_path = job_state_path(job_id)
+    if not job_path.exists():
+        return None, f"Unknown jobId: {job_id}"
+
+    deadline = time.monotonic() + max(wait_seconds, 0)
+    while True:
+        job = read_json(job_path)
+        if job.get("status") in {"queued", "running"} and not is_pid_alive(job.get("workerPid")):
+            job["status"] = "failed"
+            job["error"] = "Background image worker exited before writing a final result"
+            job["completedAt"] = utc_now()
+            job["updatedAt"] = job["completedAt"]
+            write_json(job_path, job)
+        if job.get("status") in TERMINAL_JOB_STATES:
+            return serialize_job(job), None
+        if time.monotonic() >= deadline:
+            return serialize_job(job), None
+        time.sleep(min(0.5, max(deadline - time.monotonic(), 0.0)))
+
+
+def run_async_job(job_id: str) -> int:
+    job_path = job_state_path(job_id)
+    if not job_path.exists():
+        debug_log(f"JOB_MISSING job_id={job_id}")
+        return 1
+
+    job = read_json(job_path)
+    job["status"] = "running"
+    job["startedAt"] = utc_now()
+    job["updatedAt"] = job["startedAt"]
+    job["workerPid"] = os.getpid()
+    write_json(job_path, job)
+    debug_log(f"JOB_RUNNING job_id={job_id} worker_pid={os.getpid()}")
+
+    request = job.get("request") or {}
+    run_log_path = RUNS_DIR / f"{job_id}.log"
+    try:
+        payload, error = run_codex_image(
+            str(request.get("prompt", "")),
+            cwd=Path(str(request.get("cwd"))),
+            output_path=Path(str(request.get("outputPath"))),
+            system=request.get("system"),
+            model=request.get("model"),
+            reference_image_paths=request.get("referenceImagePaths") or [],
+            run_log_path=run_log_path,
+        )
+    except Exception as exc:
+        payload = None
+        error = f"Background image generation crashed: {exc}"
+        debug_log(traceback.format_exc())
+
+    finished_at = utc_now()
+    job = read_json(job_path)
+    job["updatedAt"] = finished_at
+    job["completedAt"] = finished_at
+    if error:
+        job["status"] = "failed"
+        job["error"] = error
+        job["result"] = None
+        write_json(job_path, job)
+        debug_log(f"JOB_FAILED job_id={job_id} error={error}")
+        return 1
+
+    job["status"] = "completed"
+    job["error"] = None
+    job["result"] = payload
+    write_json(job_path, job)
+    debug_log(f"JOB_COMPLETED job_id={job_id} output={(payload or {}).get('outputPath')}")
+    return 0
+
+
+def tool_success(request_id: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False)}],
+        },
+    }
+
+
+def tool_error(request_id: Any, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "content": [{"type": "text", "text": json.dumps({"error": message}, ensure_ascii=False)}],
+            "isError": True,
+        },
+    }
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    request_id = request.get("id")
+    method = request.get("method", "")
+    params = request.get("params", {})
+    debug_log(f"REQUEST id={request_id!r} method={method} params={json.dumps(params, ensure_ascii=False)}")
+
+    if request_id is None:
+        if method in {"notifications/initialized", "initialized"}:
+            return None
+        return None
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": "0.1.0"},
+            },
+        }
+
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {}}
+
+    if method == "resources/list":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"resources": []}}
+
+    if method == "resources/templates/list":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"resourceTemplates": []}}
+
+    if method in {"notifications/initialized", "initialized"}:
+        return {"jsonrpc": "2.0", "id": request_id, "result": {}}
+
+    if method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "tools": [
+                    {
+                        "name": "generate",
+                        "description": "Generate a raster image through the local Codex app-server native image tool and return the copied output path.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "prompt": {"type": "string", "description": "Image generation prompt"},
+                                "cwd": {"type": "string", "description": "Optional working directory"},
+                                "outputPath": {"type": "string", "description": "Optional output file path; defaults to figures/ai_generated"},
+                                "system": {"type": "string", "description": "Optional extra bridge instructions"},
+                                "model": {"type": "string", "description": "Optional Codex text model override"},
+                                "referenceImagePaths": {
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {"type": "array", "items": {"type": "string"}},
+                                    ],
+                                    "description": "Optional local reference image paths that Codex may inspect before generating",
+                                },
+                            },
+                            "required": ["prompt"],
+                        },
+                    },
+                    {
+                        "name": "generate_start",
+                        "description": "Start a background native image generation job through the Codex app-server.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "prompt": {"type": "string", "description": "Image generation prompt"},
+                                "cwd": {"type": "string", "description": "Optional working directory"},
+                                "outputPath": {"type": "string", "description": "Optional output file path; defaults to figures/ai_generated"},
+                                "system": {"type": "string", "description": "Optional extra bridge instructions"},
+                                "model": {"type": "string", "description": "Optional Codex text model override"},
+                                "referenceImagePaths": {
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {"type": "array", "items": {"type": "string"}},
+                                    ],
+                                    "description": "Optional local reference image paths that Codex may inspect before generating",
+                                },
+                            },
+                            "required": ["prompt"],
+                        },
+                    },
+                    {
+                        "name": "generate_status",
+                        "description": "Check whether a background image generation job has finished and fetch the output path when available.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "jobId": {"type": "string", "description": "Background image job id"},
+                                "job_id": {"type": "string", "description": "Alias of jobId"},
+                                "waitSeconds": {"type": "integer", "description": "Optional bounded wait before returning status"},
+                            },
+                            "required": ["jobId"],
+                        },
+                    },
+                ]
+            },
+        }
+
+    if method == "tools/call":
+        name = params.get("name", "")
+        args = params.get("arguments", {})
+        if not isinstance(args, dict):
+            return tool_error(request_id, "tool arguments must be an object")
+
+        if name == "generate":
+            prompt = str(args.get("prompt", "")).strip()
+            if not prompt:
+                return tool_error(request_id, "prompt is required")
+            resolved_cwd, cwd_error = resolve_cwd(args.get("cwd"))
+            if cwd_error:
+                return tool_error(request_id, cwd_error)
+            refs, refs_error = normalize_string_list(args.get("referenceImagePaths"))
+            if refs_error:
+                return tool_error(request_id, refs_error)
+            output_path = resolve_output_path(args.get("outputPath"), cwd=resolved_cwd, job_id=uuid.uuid4().hex)
+            run_log_path = RUNS_DIR / f"sync-{uuid.uuid4().hex}.log"
+            payload, error = run_codex_image(
+                prompt,
+                cwd=resolved_cwd,
+                output_path=output_path,
+                system=args.get("system"),
+                model=args.get("model"),
+                reference_image_paths=refs,
+                run_log_path=run_log_path,
+            )
+            if error:
+                return tool_error(request_id, error)
+            return tool_success(request_id, payload or {})
+
+        if name == "generate_start":
+            prompt = str(args.get("prompt", "")).strip()
+            if not prompt:
+                return tool_error(request_id, "prompt is required")
+            payload, error = start_async_generate(
+                prompt,
+                cwd=args.get("cwd"),
+                output_path=args.get("outputPath"),
+                system=args.get("system"),
+                model=args.get("model"),
+                reference_image_paths=args.get("referenceImagePaths"),
+            )
+            if error:
+                return tool_error(request_id, error)
+            return tool_success(request_id, payload or {})
+
+        if name == "generate_status":
+            job_id = args.get("jobId") or args.get("job_id")
+            if not job_id:
+                return tool_error(request_id, "jobId or job_id is required")
+            wait_seconds = args.get("waitSeconds", 0)
+            try:
+                wait_seconds = int(wait_seconds)
+            except (TypeError, ValueError):
+                wait_seconds = 0
+            payload, error = get_generate_status(str(job_id), wait_seconds=max(wait_seconds, 0))
+            if error:
+                return tool_error(request_id, error)
+            return tool_success(request_id, payload or {})
+
+        return tool_error(request_id, f"unknown tool: {name}")
+
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32601, "message": f"Unknown method: {method}"},
+    }
+
+
+def main() -> int:
+    if len(sys.argv) == 3 and sys.argv[1] == "--run-job":
+        return run_async_job(sys.argv[2])
+
+    while True:
+        request = read_message()
+        if request is None:
+            return 0
+        response = handle_request(request)
+        if response is not None:
+            send_response(response)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/paper-illustration-image2/SKILL.md
+++ b/skills/paper-illustration-image2/SKILL.md
@@ -74,6 +74,7 @@ and a **local Codex app-server MCP bridge** as the raster renderer.
 - **OUTPUT_DIR = `figures/ai_generated/`** — Output directory
 - **TEXT_LANGUAGE = `English`** — Default figure text language unless the user requests otherwise
 - **NATIVE_IMAGE_REQUIREMENT = `strict`** — Accept only native `imageGeneration` output; reject shell/Python fallbacks
+- **CANONICAL_HELPER = `python3 tools/paper_illustration_image2.py`** — Preflight, finalize, verify, and repair path for this integration
 
 ## CVPR/ICLR/NeurIPS Top-Tier Conference Style Guide
 
@@ -147,13 +148,32 @@ and a **local Codex app-server MCP bridge** as the raster renderer.
 
 ### Step 0: Pre-flight Check
 
+Render this checklist explicitly before starting:
+
+```text
+📋 paper-illustration-image2 integration checklist:
+   [ ] 1. python3 tools/paper_illustration_image2.py preflight --workspace <cwd> --json-out figures/ai_generated/preflight.json
+   [ ] 2. Confirm preflight JSON says ok=true before rendering
+   [ ] 3. Render via mcp__codex-image2__generate_start + generate_status
+   [ ] 4. Finalize via python3 tools/paper_illustration_image2.py finalize --workspace <cwd> --best-image <best_png>
+   [ ] 5. Verify artifacts via python3 tools/paper_illustration_image2.py verify --workspace <cwd> --json-out figures/ai_generated/verify.json
+```
+
 1. Create `figures/ai_generated/` if it does not exist.
 2. Confirm the request is suitable for a raster illustration:
    - architecture diagram
    - conceptual method figure
    - workflow illustration
 3. Prefer **English figure text** unless the user asked otherwise.
-4. If the `codex-image2` MCP bridge is unavailable, stop and say so clearly.
+4. Run:
+
+```bash
+python3 tools/paper_illustration_image2.py preflight \
+  --workspace <cwd> \
+  --json-out figures/ai_generated/preflight.json
+```
+
+5. If preflight is not `ok=true`, stop and say so clearly.
 
 ## Step 1: Claude Plans the Figure
 
@@ -213,6 +233,7 @@ Call `mcp__codex-image2__generate_start` with:
 - `cwd`: current project root or paper workspace
 - `outputPath`: `figures/ai_generated/figure_v1.png`
 - `system`: a short instruction like `Academic paper figure. Prefer crisp English labels.`
+- `timeoutSeconds`: a bounded render timeout such as `180`
 
 Then call `mcp__codex-image2__generate_status` with bounded waits until:
 
@@ -247,13 +268,26 @@ Keep refinement feedback concrete:
 - `Make the off-target branch thinner and secondary`
 - `Use cleaner English labels: "Candidate sgRNA library", not "sgRNA library 23 bp"`
 
-## Step 7: Finalize
+## Step 7: Finalize And Verify
 
 When accepted:
 
-- copy or reuse the best generated file as `figures/ai_generated/figure_final.png`
-- write `figures/ai_generated/latex_include.tex`
-- write `figures/ai_generated/review_log.json`
+- run the canonical helper to promote the best image to `figure_final.png`
+- let the helper write `latex_include.tex`
+- let the helper write `review_log.json`
+- run helper verification before claiming success
+
+```bash
+python3 tools/paper_illustration_image2.py finalize \
+  --workspace <cwd> \
+  --best-image figures/ai_generated/figure_vN.png \
+  --score 9 \
+  --review-summary "Accepted after strict review; labels and arrows are paper-ready."
+
+python3 tools/paper_illustration_image2.py verify \
+  --workspace <cwd> \
+  --json-out figures/ai_generated/verify.json
+```
 
 Suggested LaTeX:
 
@@ -279,25 +313,45 @@ Suggested LaTeX:
 9. Use specific, actionable refinement feedback instead of vague comments.
 10. Review arrow direction, label clarity, and visual hierarchy every round.
 11. Accept only figures that look paper-ready, not slide-ready.
+12. Always use `tools/paper_illustration_image2.py finalize` to emit the final artifacts.
+13. Always use `tools/paper_illustration_image2.py verify` before claiming success.
+
+## Repair Path
+
+If rendering succeeded but final artifacts were skipped, repair the integration explicitly:
+
+```bash
+python3 tools/paper_illustration_image2.py finalize \
+  --workspace <cwd> \
+  --best-image figures/ai_generated/figure_vN.png
+
+python3 tools/paper_illustration_image2.py verify \
+  --workspace <cwd> \
+  --json-out figures/ai_generated/verify.json
+```
 
 ## Output Structure
 
 ```text
 figures/ai_generated/
+├── preflight.json         # Helper preflight receipt
 ├── figure_v1.png          # Iteration 1
 ├── figure_v2.png          # Iteration 2
 ├── figure_v3.png          # Iteration 3
 ├── figure_final.png       # Accepted version (copy of best, score ≥ 9)
 ├── latex_include.tex      # LaTeX snippet
-└── review_log.json        # Review notes and refinement history
+├── review_log.json        # Review notes and refinement history
+└── verify.json            # Helper verification diagnostic
 ```
 
 ## Model Summary
 
 | Stage | Agent / Tool | Purpose |
 |-------|--------------|---------|
+| Step 0 | `python3 tools/paper_illustration_image2.py preflight` | Observable activation predicate and preflight receipt |
 | Step 1 | Claude | Parse request and create the initial figure prompt |
 | Step 2 | Claude (+ optional Codex critique) | Refine layout, grouping, spacing, and arrow routing |
 | Step 3 | Claude (+ optional Codex critique) | Verify academic visual style before rendering |
 | Step 4 | `mcp__codex-image2__generate_start` + `generate_status` | Native raster image generation through Codex app-server |
 | Step 5 | Claude | Strict visual review and scoring |
+| Step 7 | `python3 tools/paper_illustration_image2.py finalize` + `verify` | Emit canonical artifacts and external verification receipt |

--- a/skills/paper-illustration-image2/SKILL.md
+++ b/skills/paper-illustration-image2/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: paper-illustration-image2
+description: "Generate publication-quality academic illustrations through a local Codex app-server bridge that uses Codex native image generation. This is a separate experimental alternative to `paper-illustration`, intended for Claude Code users who want a GPT-image-style renderer without modifying the original skill."
+argument-hint: [description-or-method-file]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, mcp__codex-image2__generate, mcp__codex-image2__generate_start, mcp__codex-image2__generate_status, mcp__codex__codex, mcp__codex__codex-reply
+---
+
+# Paper Illustration Image2
+
+Generate publication-quality paper figures using **Claude as the planner/reviewer**
+and a **local Codex app-server MCP bridge** as the raster renderer.
+
+## Core Design Philosophy
+
+```text
+┌──────────────────────────────────────────────────────────────────────────┐
+│                    MULTI-STAGE ITERATIVE WORKFLOW                        │
+├──────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   User Request                                                           │
+│       │                                                                  │
+│       ▼                                                                  │
+│   ┌─────────────┐                                                        │
+│   │   Claude    │ ◄─── Step 1: Parse request, create initial prompt     │
+│   │  (Planner)  │      - Extract components, labels, and data flow       │
+│   │             │      - Write a paper-ready figure brief                │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │Claude/Codex │ ◄─── Step 2: Optimize layout description               │
+│   │   Layout    │      - Refine component positioning                    │
+│   │   Review    │      - Optimize spacing and grouping                   │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │Claude/Codex │ ◄─── Step 3: CVPR/NeurIPS style verification           │
+│   │   Style     │      - Check palette, arrows, and label standards      │
+│   │   Check     │      - Tighten the prompt before rendering             │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │ codex-image2│ ◄─── Step 4: Native image generation via bridge        │
+│   │ MCP bridge  │      - Call generate_start / generate_status           │
+│   │ + app-server│      - Accept only native imageGeneration output       │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   ┌─────────────┐                                                        │
+│   │   Claude    │ ◄─── Step 5: STRICT visual review + SCORE (1-10)      │
+│   │  (Reviewer) │      - Verify logic, labels, arrows, and aesthetics    │
+│   │   STRICT!   │      - Reject unclear or non-paper-ready figures       │
+│   └──────┬──────┘                                                        │
+│          │                                                               │
+│          ▼                                                               │
+│   Score ≥ 9? ──YES──► Accept & Output                                    │
+│          │                                                               │
+│          NO                                                              │
+│          │                                                               │
+│          ▼                                                               │
+│   Generate SPECIFIC improvement feedback ──► Loop back to Step 2        │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Constants
+
+- **RENDERER = `codex-image2`** — Native image generation bridge exposed through local Codex app-server
+- **OPTIONAL_TEXT_CRITIC = `mcp__codex__codex`** — Optional text-only second opinion for layout/style checks
+- **MAX_ITERATIONS = 5** — Maximum refinement rounds
+- **TARGET_SCORE = 9** — Minimum acceptable score (1-10)
+- **OUTPUT_DIR = `figures/ai_generated/`** — Output directory
+- **TEXT_LANGUAGE = `English`** — Default figure text language unless the user requests otherwise
+- **NATIVE_IMAGE_REQUIREMENT = `strict`** — Accept only native `imageGeneration` output; reject shell/Python fallbacks
+
+## CVPR/ICLR/NeurIPS Top-Tier Conference Style Guide
+
+**What "CVPR Style" Actually Means:**
+
+### Visual Standards
+- **Clean white background** — No decorative patterns or gradients unless extremely subtle
+- **Sans-serif fonts** — Arial, Helvetica, or similarly clean paper-friendly typography
+- **Subtle color palette** — Use 3-5 coordinated colors, not rainbow colors
+- **Print-friendly** — Must remain understandable in grayscale
+- **Professional borders** — Thin to medium, clean, and consistent
+
+### Layout Standards
+- **Horizontal flow** — Left-to-right is the default for pipelines
+- **Clear grouping** — Use spacing or subtle grouping boxes for related modules
+- **Consistent sizing** — Similar components should have similar sizes
+- **Balanced whitespace** — Avoid both cramped and overly sparse layouts
+
+### Arrow Standards (MOST CRITICAL)
+- **Thick strokes** — Arrows must remain visible after paper scaling
+- **Clear arrowheads** — Large, unmistakable arrowheads
+- **Dark colors** — Prefer black or dark gray arrows
+- **Labeled** — Important arrows should show what flows through them
+- **No crossings** — Reorganize the figure to avoid crossings where possible
+- **CORRECT DIRECTION** — Arrows must point to the right target
+
+### Visual Appeal (Academic Professional Style)
+
+**目标：既不保守也不花哨，找到平衡点**
+
+#### ✅ Should have
+- **Subtle gradients** — Gentle same-family gradients are acceptable
+- **Rounded corners** — Modern but restrained rounded blocks
+- **Clear hierarchy** — Main modules larger, secondary modules smaller
+- **Consistent color coding** — Stable mapping between module types and colors
+- **Professional typography** — Clean labels with readable size hierarchy
+
+#### ❌ Avoid
+- ❌ Rainbow gradients
+- ❌ Heavy drop shadows
+- ❌ 3D perspective effects
+- ❌ Glowing effects
+- ❌ Decorative clip-art icons
+- ❌ Slide-deck styling that feels flashy rather than paper-ready
+
+#### ✓ Ideal effect
+- Looks intentional, professional, and immediately readable
+- Has moderate visual appeal without becoming decorative
+- Feels appropriate for a top-tier conference paper figure
+- Survives PDF scaling and grayscale printing
+
+### What to AVOID (CRITICAL)
+- ❌ Thin, hairline arrows
+- ❌ Unlabeled or ambiguous connections
+- ❌ Tiny unreadable text
+- ❌ Flat, boring box soup with no hierarchy
+- ❌ Over-decorated figures with shadows/glows/icons
+- ❌ Wrong arrow directions
+
+## Scope
+
+| Figure Type | Quality | Examples |
+|-------------|---------|----------|
+| **Architecture diagrams** | Excellent | Model architecture, pipeline, encoder-decoder |
+| **Method illustrations** | Excellent | Conceptual diagrams, algorithm flowcharts |
+| **Conceptual figures** | Good | Comparison diagrams, taxonomy trees |
+
+**Not for:** Statistical plots (use `/paper-figure`), deterministic vector topology figures (prefer `/figure-spec`), photo-realistic scenes
+
+## Workflow: MUST EXECUTE ALL STEPS
+
+### Step 0: Pre-flight Check
+
+1. Create `figures/ai_generated/` if it does not exist.
+2. Confirm the request is suitable for a raster illustration:
+   - architecture diagram
+   - conceptual method figure
+   - workflow illustration
+3. Prefer **English figure text** unless the user asked otherwise.
+4. If the `codex-image2` MCP bridge is unavailable, stop and say so clearly.
+
+## Step 1: Claude Plans the Figure
+
+Turn the user request into a **fully specified image prompt**. Include:
+
+- figure type
+- exact modules / stages
+- flow direction
+- labels to show
+- data-flow arrows
+- style constraints
+- what to avoid
+
+When the input is a method note or a paper section, summarize it first into a
+clean figure brief before writing the final image prompt.
+
+## Step 2: Layout Optimization
+
+This step is required. Before rendering, refine the prompt into a concrete
+layout plan:
+
+- exact module order
+- spacing and grouping
+- relative module prominence
+- arrow routing and likely collision points
+
+If `mcp__codex__codex` is available, you may ask it for a short second-opinion
+layout critique here, but Claude should still complete this step even without
+Codex.
+
+Use Codex layout critique for:
+
+- missing components
+- confusing layout
+- weak flow hierarchy
+- likely arrow-direction ambiguity or clutter
+
+## Step 3: Style Verification
+
+This step is also required. Check the prompt against the intended paper style
+before rendering:
+
+- palette is restrained and academic
+- arrows are thick, dark, and readable
+- labels are concise and in English unless requested otherwise
+- the figure will read clearly in grayscale / print
+- no glow, rainbow gradient, or slide-deck decoration slips in
+
+If `mcp__codex__codex` is available, you may ask it for a short text-only
+style audit, but do not block on it.
+
+## Step 4: Generate Through the Bridge
+
+Call `mcp__codex-image2__generate_start` with:
+
+- `prompt`: the final image prompt
+- `cwd`: current project root or paper workspace
+- `outputPath`: `figures/ai_generated/figure_v1.png`
+- `system`: a short instruction like `Academic paper figure. Prefer crisp English labels.`
+
+Then call `mcp__codex-image2__generate_status` with bounded waits until:
+
+- `done=true` and `status=completed`, or
+- `done=true` and `status=failed`
+
+If generation fails, report the bridge error directly instead of hiding it.
+
+## Step 5: Review the Output
+
+Review the generated image with a strict checklist:
+
+- are all major components present?
+- is the logical flow obvious?
+- are labels readable?
+- do arrows point the right way?
+- does the figure look paper-ready rather than like a slide?
+
+Score it from 1-10.
+
+## Step 6: Refine if Needed
+
+If score < 9, write a targeted refinement prompt:
+
+- say exactly what was wrong
+- say what to preserve
+- regenerate to `figure_v2.png`, `figure_v3.png`, etc.
+
+Keep refinement feedback concrete:
+
+- `Increase spacing between genome scan and scoring modules`
+- `Make the off-target branch thinner and secondary`
+- `Use cleaner English labels: "Candidate sgRNA library", not "sgRNA library 23 bp"`
+
+## Step 7: Finalize
+
+When accepted:
+
+- copy or reuse the best generated file as `figures/ai_generated/figure_final.png`
+- write `figures/ai_generated/latex_include.tex`
+- write `figures/ai_generated/review_log.json`
+
+Suggested LaTeX:
+
+```latex
+\begin{figure*}[t]
+    \centering
+    \includegraphics[width=0.95\textwidth]{figures/ai_generated/figure_final.png}
+    \caption{[Replace with a paper-ready caption].}
+    \label{fig:[replace-me]}
+\end{figure*}
+```
+
+## Key Rules
+
+1. Never skip Step 2 or Step 3; layout and style checks are required.
+2. Never skip the final visual review.
+3. Never accept a figure that is logically wrong just because it looks attractive.
+4. Use the `codex-image2` bridge only for **native image generation**.
+5. If the bridge says native image generation is unavailable, surface that honestly.
+6. Reject any shell/Python/manual bitmap fallback masquerading as image generation.
+7. Keep figure text in English unless the user requested another language.
+8. Prefer 1-3 strong refinement rounds over many shallow ones.
+9. Use specific, actionable refinement feedback instead of vague comments.
+10. Review arrow direction, label clarity, and visual hierarchy every round.
+11. Accept only figures that look paper-ready, not slide-ready.
+
+## Output Structure
+
+```text
+figures/ai_generated/
+├── figure_v1.png          # Iteration 1
+├── figure_v2.png          # Iteration 2
+├── figure_v3.png          # Iteration 3
+├── figure_final.png       # Accepted version (copy of best, score ≥ 9)
+├── latex_include.tex      # LaTeX snippet
+└── review_log.json        # Review notes and refinement history
+```
+
+## Model Summary
+
+| Stage | Agent / Tool | Purpose |
+|-------|--------------|---------|
+| Step 1 | Claude | Parse request and create the initial figure prompt |
+| Step 2 | Claude (+ optional Codex critique) | Refine layout, grouping, spacing, and arrow routing |
+| Step 3 | Claude (+ optional Codex critique) | Verify academic visual style before rendering |
+| Step 4 | `mcp__codex-image2__generate_start` + `generate_status` | Native raster image generation through Codex app-server |
+| Step 5 | Claude | Strict visual review and scoring |

--- a/skills/shared-references/integration-contract.md
+++ b/skills/shared-references/integration-contract.md
@@ -145,6 +145,7 @@ When reviewing a new integration proposal, reject any of:
 |---|---|---|---|---|---|---|
 | Submission audits (`max`/`beast`) | `paper/.aris/assurance.txt = submission` | `verify_paper_audits.sh` + 3 audit skills emit JSON | `paper/PROOF_AUDIT.json`, `PAPER_CLAIM_AUDIT.json`, `CITATION_AUDIT.json` + `paper/.aris/audit-verifier-report.json` | Phase 6.0 pre-flight checklist | Rerun the failed audit | `verify_paper_audits.sh` (exit 1 blocks) |
 | Research wiki ingest | `research-wiki/` exists | `research_wiki.py ingest_paper` | `research-wiki/papers/<slug>.md` + `log.md` entry | Step in each paper-reading skill | `research_wiki.py sync --arxiv-ids …` | `verify_wiki_coverage.sh` (diagnostic) |
+| paper-illustration-image2 finalization | `tools/paper_illustration_image2.py preflight --workspace <cwd>` returns `ok=true` | `paper_illustration_image2.py` (`preflight`, `finalize`, `verify`) | `figures/ai_generated/figure_final.png`, `latex_include.tex`, `review_log.json` | Step 0 checklist in `paper-illustration-image2` | `paper_illustration_image2.py finalize --workspace <cwd> --best-image <png>` | `paper_illustration_image2.py verify` (diagnostic, exit 1 on missing artifacts) |
 
 When adding a new cross-skill integration, add a row to the table above
 and confirm all six columns are populated.

--- a/tests/test_codex_image2_server.py
+++ b/tests/test_codex_image2_server.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -16,16 +19,18 @@ MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
 
-SAMPLE_STDOUT = """
+PNG_BYTES = MODULE.PNG_SIGNATURE + b"fake-png-payload"
+
+SAMPLE_IMAGE_STDOUT = """
 < {
 <   "method": "item/completed",
 <   "params": {
 <     "item": {
 <       "type": "imageGeneration",
 <       "id": "ig_test",
-<       "status": "generating",
+<       "status": "completed",
 <       "revisedPrompt": "blue circle",
-<       "result": "aGVsbG8="
+<       "result": "iVBORw0KGgpmYWtlLXBuZy1wYXlsb2Fk"
 <     },
 <     "threadId": "thread-123",
 <     "turnId": "turn-123"
@@ -47,6 +52,21 @@ SAMPLE_STDOUT = """
 < }
 """
 
+SAMPLE_NATIVE_UNAVAILABLE_STDOUT = """
+< {
+<   "method": "item/completed",
+<   "params": {
+<     "item": {
+<       "type": "agentMessage",
+<       "id": "msg-1",
+<       "text": "NATIVE_IMAGE_UNAVAILABLE",
+<       "phase": "final_answer"
+<     },
+<     "threadId": "thread-123",
+<     "turnId": "turn-123"
+<   }
+< }
+"""
 
 SAMPLE_WITH_COMMAND = """
 < {
@@ -71,15 +91,37 @@ SAMPLE_WITH_COMMAND = """
 < }
 """
 
+SAMPLE_BAD_IMAGE_STDOUT = """
+< {
+<   "method": "item/completed",
+<   "params": {
+<     "item": {
+<       "type": "imageGeneration",
+<       "id": "ig_test",
+<       "status": "completed",
+<       "revisedPrompt": "blue circle",
+<       "result": "aGVsbG8="
+<     },
+<     "threadId": "thread-123",
+<     "turnId": "turn-123"
+<   }
+< }
+"""
+
+
+class _FakePopen:
+    def __init__(self, pid: int = 12345) -> None:
+        self.pid = pid
+
 
 class CodexImage2ServerTests(unittest.TestCase):
     def test_parse_debug_json_messages(self) -> None:
-        messages = MODULE.parse_debug_json_messages(SAMPLE_STDOUT)
+        messages = MODULE.parse_debug_json_messages(SAMPLE_IMAGE_STDOUT)
         self.assertEqual(len(messages), 2)
         self.assertEqual(messages[0]["params"]["item"]["type"], "imageGeneration")
 
     def test_extract_run_summary(self) -> None:
-        messages = MODULE.parse_debug_json_messages(SAMPLE_STDOUT + SAMPLE_WITH_COMMAND)
+        messages = MODULE.parse_debug_json_messages(SAMPLE_IMAGE_STDOUT + SAMPLE_WITH_COMMAND)
         summary = MODULE.extract_run_summary(messages)
         self.assertEqual(summary["threadId"], "thread-123")
         self.assertEqual(len(summary["imageItems"]), 1)
@@ -96,7 +138,28 @@ class CodexImage2ServerTests(unittest.TestCase):
         self.assertIn("Draw a workflow.", prompt)
         self.assertIn("native image generation", prompt)
 
-    def test_materialize_generated_image_from_base64(self) -> None:
+    def test_materialize_generated_image_from_saved_path_validates_png(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_root = Path(tmpdir)
+            source_path = temp_root / "source.png"
+            source_path.write_bytes(PNG_BYTES)
+            output_path = temp_root / "out.png"
+            image_item = {
+                "type": "imageGeneration",
+                "revisedPrompt": "blue circle",
+                "savedPath": str(source_path),
+            }
+            generated_path, source_saved_path, revised_prompt, error = MODULE.materialize_generated_image(
+                image_item,
+                output_path,
+            )
+            self.assertEqual(generated_path, output_path)
+            self.assertEqual(source_saved_path, str(source_path))
+            self.assertEqual(revised_prompt, "blue circle")
+            self.assertIsNone(error)
+            self.assertEqual(output_path.read_bytes(), PNG_BYTES)
+
+    def test_materialize_generated_image_rejects_non_png_base64(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "out.png"
             image_item = {
@@ -108,11 +171,251 @@ class CodexImage2ServerTests(unittest.TestCase):
                 image_item,
                 output_path,
             )
-            self.assertEqual(generated_path, output_path)
+            self.assertIsNone(generated_path)
             self.assertIsNone(source_saved_path)
-            self.assertEqual(revised_prompt, "blue circle")
+            self.assertIsNone(revised_prompt)
+            self.assertIn("PNG", error or "")
+
+    def test_validate_output_path_rejects_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            outside = Path(tmpdir) / "outside.png"
+            cwd.mkdir()
+            error = MODULE.validate_output_path(outside.resolve(), cwd=cwd.resolve())
+            self.assertIn("outputPath must stay under", error or "")
+
+    def test_run_codex_image_returns_error_when_codex_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            output_path = cwd / "figures" / "ai_generated" / "out.png"
+            cwd.mkdir()
+            with mock.patch.object(MODULE, "find_codex_bin", return_value=None):
+                payload, error = MODULE.run_codex_image(
+                    "Draw a workflow.",
+                    cwd=cwd,
+                    output_path=output_path,
+                )
+            self.assertIsNone(payload)
+            self.assertIn("Codex CLI not found", error or "")
+
+    def test_run_codex_image_times_out(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            output_path = cwd / "figures" / "ai_generated" / "out.png"
+            cwd.mkdir()
+            with mock.patch.object(MODULE, "find_codex_bin", return_value="codex"), mock.patch.object(
+                MODULE.subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired(cmd=["codex"], timeout=5),
+            ):
+                payload, error = MODULE.run_codex_image(
+                    "Draw a workflow.",
+                    cwd=cwd,
+                    output_path=output_path,
+                    timeout_sec=5,
+                )
+            self.assertIsNone(payload)
+            self.assertIn("timed out", error or "")
+
+    def test_run_codex_image_surfaces_native_unavailable(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["codex"],
+            returncode=0,
+            stdout=SAMPLE_NATIVE_UNAVAILABLE_STDOUT,
+            stderr="",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            output_path = cwd / "figures" / "ai_generated" / "out.png"
+            cwd.mkdir()
+            with mock.patch.object(MODULE, "find_codex_bin", return_value="codex"), mock.patch.object(
+                MODULE.subprocess,
+                "run",
+                return_value=completed,
+            ):
+                payload, error = MODULE.run_codex_image(
+                    "Draw a workflow.",
+                    cwd=cwd,
+                    output_path=output_path,
+                )
+            self.assertIsNone(payload)
+            self.assertIn("native image generation is unavailable", error or "")
+
+    def test_run_codex_image_rejects_command_execution(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["codex"],
+            returncode=0,
+            stdout=SAMPLE_WITH_COMMAND,
+            stderr="",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            output_path = cwd / "figures" / "ai_generated" / "out.png"
+            cwd.mkdir()
+            with mock.patch.object(MODULE, "find_codex_bin", return_value="codex"), mock.patch.object(
+                MODULE.subprocess,
+                "run",
+                return_value=completed,
+            ):
+                payload, error = MODULE.run_codex_image(
+                    "Draw a workflow.",
+                    cwd=cwd,
+                    output_path=output_path,
+                )
+            self.assertIsNone(payload)
+            self.assertIn("shell-based image creation", error or "")
+
+    def test_run_codex_image_rejects_malformed_image_payload(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["codex"],
+            returncode=0,
+            stdout=SAMPLE_BAD_IMAGE_STDOUT,
+            stderr="",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            output_path = cwd / "figures" / "ai_generated" / "out.png"
+            cwd.mkdir()
+            with mock.patch.object(MODULE, "find_codex_bin", return_value="codex"), mock.patch.object(
+                MODULE.subprocess,
+                "run",
+                return_value=completed,
+            ):
+                payload, error = MODULE.run_codex_image(
+                    "Draw a workflow.",
+                    cwd=cwd,
+                    output_path=output_path,
+                )
+            self.assertIsNone(payload)
+            self.assertIn("PNG", error or "")
+
+    def test_run_codex_image_accepts_valid_png_result(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["codex"],
+            returncode=0,
+            stdout=SAMPLE_IMAGE_STDOUT,
+            stderr="",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            output_path = cwd / "figures" / "ai_generated" / "out.png"
+            cwd.mkdir()
+            with mock.patch.object(MODULE, "find_codex_bin", return_value="codex"), mock.patch.object(
+                MODULE.subprocess,
+                "run",
+                return_value=completed,
+            ):
+                payload, error = MODULE.run_codex_image(
+                    "Draw a workflow.",
+                    cwd=cwd,
+                    output_path=output_path,
+                )
             self.assertIsNone(error)
-            self.assertEqual(output_path.read_bytes(), b"hello")
+            self.assertEqual(payload["outputPath"], str(output_path.resolve()))
+            self.assertEqual(output_path.read_bytes(), PNG_BYTES)
+
+    def test_start_async_generate_rejects_output_outside_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            cwd.mkdir()
+            with mock.patch.object(MODULE.subprocess, "Popen", return_value=_FakePopen()):
+                payload, error = MODULE.start_async_generate(
+                    "Draw a workflow.",
+                    cwd=str(cwd),
+                    output_path=str(Path(tmpdir) / "escape.png"),
+                )
+            self.assertIsNone(payload)
+            self.assertIn("outputPath must stay under", error or "")
+
+    def test_start_async_generate_persists_timeout_and_expiry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = Path(tmpdir) / "workspace"
+            jobs_dir = Path(tmpdir) / "jobs"
+            cwd.mkdir()
+            with mock.patch.object(MODULE, "JOBS_DIR", jobs_dir), mock.patch.object(
+                MODULE.subprocess,
+                "Popen",
+                return_value=_FakePopen(pid=4321),
+            ):
+                payload, error = MODULE.start_async_generate(
+                    "Draw a workflow.",
+                    cwd=str(cwd),
+                    timeout_seconds=45,
+                )
+            self.assertIsNone(error)
+            self.assertEqual(payload["status"], "queued")
+            job_file = jobs_dir / f"{payload['jobId']}.json"
+            job = json.loads(job_file.read_text(encoding="utf-8"))
+            self.assertEqual(job["request"]["timeoutSec"], 45)
+            self.assertIsNotNone(job["expiresAt"])
+
+    def test_get_generate_status_marks_stale_job_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jobs_dir = Path(tmpdir) / "jobs"
+            jobs_dir.mkdir()
+            job_id = "stale-job"
+            job_path = jobs_dir / f"{job_id}.json"
+            job = {
+                "jobId": job_id,
+                "status": "running",
+                "createdAt": MODULE.utc_now(),
+                "startedAt": MODULE.utc_now(),
+                "completedAt": None,
+                "updatedAt": MODULE.utc_now(),
+                "expiresAt": "2000-01-01T00:00:00Z",
+                "workerPid": 123,
+                "error": None,
+                "result": None,
+                "request": {
+                    "prompt": "sensitive prompt",
+                    "cwd": "/tmp/workspace",
+                    "outputPath": "/tmp/workspace/figures/ai_generated/out.png",
+                    "timeoutSec": 5,
+                },
+            }
+            job_path.write_text(json.dumps(job), encoding="utf-8")
+            with mock.patch.object(MODULE, "JOBS_DIR", jobs_dir):
+                payload, error = MODULE.get_generate_status(job_id)
+            self.assertIsNone(error)
+            self.assertEqual(payload["status"], "failed")
+            stored = json.loads(job_path.read_text(encoding="utf-8"))
+            self.assertNotIn("prompt", stored["request"])
+            self.assertIn("deadline", stored["error"])
+
+    def test_get_generate_status_marks_exited_worker_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jobs_dir = Path(tmpdir) / "jobs"
+            jobs_dir.mkdir()
+            job_id = "dead-worker"
+            job_path = jobs_dir / f"{job_id}.json"
+            job = {
+                "jobId": job_id,
+                "status": "running",
+                "createdAt": MODULE.utc_now(),
+                "startedAt": MODULE.utc_now(),
+                "completedAt": None,
+                "updatedAt": MODULE.utc_now(),
+                "expiresAt": "2999-01-01T00:00:00Z",
+                "workerPid": 321,
+                "error": None,
+                "result": None,
+                "request": {
+                    "prompt": "sensitive prompt",
+                    "cwd": "/tmp/workspace",
+                    "outputPath": "/tmp/workspace/figures/ai_generated/out.png",
+                    "timeoutSec": 5,
+                },
+            }
+            job_path.write_text(json.dumps(job), encoding="utf-8")
+            with mock.patch.object(MODULE, "JOBS_DIR", jobs_dir), mock.patch.object(
+                MODULE,
+                "classify_worker_state",
+                return_value="exited",
+            ):
+                payload, error = MODULE.get_generate_status(job_id)
+            self.assertIsNone(error)
+            self.assertEqual(payload["status"], "failed")
+            self.assertIn("exited before writing", payload["error"])
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_image2_server.py
+++ b/tests/test_codex_image2_server.py
@@ -1,0 +1,119 @@
+"""Unit tests for the experimental codex-image2 MCP bridge."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVER_PATH = ROOT / "mcp-servers" / "codex-image2" / "server.py"
+SPEC = importlib.util.spec_from_file_location("codex_image2_server", SERVER_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+SAMPLE_STDOUT = """
+< {
+<   "method": "item/completed",
+<   "params": {
+<     "item": {
+<       "type": "imageGeneration",
+<       "id": "ig_test",
+<       "status": "generating",
+<       "revisedPrompt": "blue circle",
+<       "result": "aGVsbG8="
+<     },
+<     "threadId": "thread-123",
+<     "turnId": "turn-123"
+<   }
+< }
+< {
+<   "method": "item/completed",
+<   "params": {
+<     "item": {
+<       "type": "agentMessage",
+<       "id": "msg-1",
+<       "text": "",
+<       "phase": "final_answer",
+<       "memoryCitation": null
+<     },
+<     "threadId": "thread-123",
+<     "turnId": "turn-123"
+<   }
+< }
+"""
+
+
+SAMPLE_WITH_COMMAND = """
+< {
+<   "method": "item/completed",
+<   "params": {
+<     "item": {
+<       "type": "commandExecution",
+<       "id": "cmd-1",
+<       "command": "python3 make_png.py",
+<       "cwd": "/tmp",
+<       "processId": null,
+<       "source": "model",
+<       "status": "completed",
+<       "commandActions": [],
+<       "aggregatedOutput": "",
+<       "exitCode": 0,
+<       "durationMs": 12
+<     },
+<     "threadId": "thread-123",
+<     "turnId": "turn-123"
+<   }
+< }
+"""
+
+
+class CodexImage2ServerTests(unittest.TestCase):
+    def test_parse_debug_json_messages(self) -> None:
+        messages = MODULE.parse_debug_json_messages(SAMPLE_STDOUT)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0]["params"]["item"]["type"], "imageGeneration")
+
+    def test_extract_run_summary(self) -> None:
+        messages = MODULE.parse_debug_json_messages(SAMPLE_STDOUT + SAMPLE_WITH_COMMAND)
+        summary = MODULE.extract_run_summary(messages)
+        self.assertEqual(summary["threadId"], "thread-123")
+        self.assertEqual(len(summary["imageItems"]), 1)
+        self.assertEqual(len(summary["commandItems"]), 1)
+
+    def test_build_bridge_prompt_includes_references(self) -> None:
+        prompt = MODULE.build_bridge_prompt(
+            "Draw a workflow.",
+            system="Academic style only.",
+            reference_image_paths=["/tmp/ref1.png", "/tmp/ref2.png"],
+        )
+        self.assertIn("Academic style only.", prompt)
+        self.assertIn("/tmp/ref1.png", prompt)
+        self.assertIn("Draw a workflow.", prompt)
+        self.assertIn("native image generation", prompt)
+
+    def test_materialize_generated_image_from_base64(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "out.png"
+            image_item = {
+                "type": "imageGeneration",
+                "revisedPrompt": "blue circle",
+                "result": "aGVsbG8=",
+            }
+            generated_path, source_saved_path, revised_prompt, error = MODULE.materialize_generated_image(
+                image_item,
+                output_path,
+            )
+            self.assertEqual(generated_path, output_path)
+            self.assertIsNone(source_saved_path)
+            self.assertEqual(revised_prompt, "blue circle")
+            self.assertIsNone(error)
+            self.assertEqual(output_path.read_bytes(), b"hello")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/paper_illustration_image2.py
+++ b/tools/paper_illustration_image2.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Integration helper for the paper-illustration-image2 workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def resolve_workspace(raw_workspace: str | None) -> Path:
+    workspace = Path(raw_workspace).expanduser() if raw_workspace else Path.cwd()
+    return workspace.resolve()
+
+
+def output_dir(workspace: Path) -> Path:
+    return (workspace / "figures" / "ai_generated").resolve()
+
+
+def ensure_png_file(path: Path) -> None:
+    if not path.is_file():
+        raise FileNotFoundError(f"missing PNG file: {path}")
+    if not path.read_bytes().startswith(PNG_SIGNATURE):
+        raise ValueError(f"expected a PNG file: {path}")
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def emit_json(payload: dict, *, json_out: Path | None = None) -> int:
+    if json_out is not None:
+        write_json(json_out, payload)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0 if payload.get("ok", False) else 1
+
+
+def run_preflight(workspace: Path, *, json_out: Path | None = None) -> int:
+    figures_dir = output_dir(workspace)
+    figures_dir.mkdir(parents=True, exist_ok=True)
+    codex_bin = shutil.which("codex")
+    payload = {
+        "ok": False,
+        "workspace": str(workspace),
+        "outputDir": str(figures_dir),
+        "codexBin": codex_bin,
+        "checkedAt": utc_now(),
+    }
+    if codex_bin is None:
+        payload["error"] = "codex CLI not found on PATH"
+        return emit_json(payload, json_out=json_out)
+
+    try:
+        result = subprocess.run(
+            [codex_bin, "debug", "app-server", "send-message-v2", "ping"],
+            cwd=str(workspace),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        payload["error"] = "codex app-server ping timed out"
+        return emit_json(payload, json_out=json_out)
+
+    payload["returncode"] = result.returncode
+    payload["ok"] = result.returncode == 0
+    if result.returncode != 0:
+        payload["error"] = (result.stderr or result.stdout or "codex app-server ping failed").strip()
+    return emit_json(payload, json_out=json_out)
+
+
+def build_latex_include(caption: str, label: str) -> str:
+    return "\n".join(
+        [
+            r"\begin{figure*}[t]",
+            r"    \centering",
+            r"    \includegraphics[width=0.95\textwidth]{figures/ai_generated/figure_final.png}",
+            f"    \\caption{{{caption}}}",
+            f"    \\label{{{label}}}",
+            r"\end{figure*}",
+            "",
+        ]
+    )
+
+
+def run_finalize(
+    workspace: Path,
+    *,
+    best_image: Path,
+    caption: str,
+    label: str,
+    score: float | None,
+    review_summary: str | None,
+    json_out: Path | None = None,
+) -> int:
+    figures_dir = output_dir(workspace)
+    figures_dir.mkdir(parents=True, exist_ok=True)
+    best_image = best_image.expanduser().resolve()
+    ensure_png_file(best_image)
+
+    final_image = figures_dir / "figure_final.png"
+    latex_include = figures_dir / "latex_include.tex"
+    review_log = figures_dir / "review_log.json"
+
+    shutil.copy2(best_image, final_image)
+    latex_include.write_text(build_latex_include(caption, label), encoding="utf-8")
+
+    review_payload = {
+        "ok": True,
+        "finalizedAt": utc_now(),
+        "workspace": str(workspace),
+        "bestImage": str(best_image),
+        "finalImage": str(final_image),
+        "score": score,
+        "reviewSummary": review_summary,
+        "caption": caption,
+        "label": label,
+    }
+    write_json(review_log, review_payload)
+
+    payload = {
+        "ok": True,
+        "workspace": str(workspace),
+        "artifacts": {
+            "figureFinal": str(final_image),
+            "latexInclude": str(latex_include),
+            "reviewLog": str(review_log),
+        },
+        "score": score,
+        "reviewSummary": review_summary,
+        "finalizedAt": review_payload["finalizedAt"],
+    }
+    return emit_json(payload, json_out=json_out)
+
+
+def run_verify(workspace: Path, *, json_out: Path | None = None) -> int:
+    figures_dir = output_dir(workspace)
+    final_image = figures_dir / "figure_final.png"
+    latex_include = figures_dir / "latex_include.tex"
+    review_log = figures_dir / "review_log.json"
+
+    errors: list[str] = []
+    artifacts = {
+        "figureFinal": {"path": str(final_image), "exists": final_image.is_file()},
+        "latexInclude": {"path": str(latex_include), "exists": latex_include.is_file()},
+        "reviewLog": {"path": str(review_log), "exists": review_log.is_file()},
+    }
+
+    if final_image.is_file():
+        try:
+            ensure_png_file(final_image)
+        except (FileNotFoundError, ValueError) as exc:
+            errors.append(str(exc))
+    else:
+        errors.append(f"missing artifact: {final_image}")
+
+    if latex_include.is_file():
+        latex_text = latex_include.read_text(encoding="utf-8")
+        if "figure_final.png" not in latex_text:
+            errors.append("latex_include.tex does not reference figures/ai_generated/figure_final.png")
+    else:
+        errors.append(f"missing artifact: {latex_include}")
+
+    if review_log.is_file():
+        try:
+            review_payload = json.loads(review_log.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"review_log.json is not valid JSON: {exc}")
+        else:
+            if str(review_payload.get("finalImage")) != str(final_image):
+                errors.append("review_log.json does not point at figure_final.png")
+    else:
+        errors.append(f"missing artifact: {review_log}")
+
+    payload = {
+        "ok": not errors,
+        "workspace": str(workspace),
+        "checkedAt": utc_now(),
+        "artifacts": artifacts,
+        "errors": errors,
+    }
+    return emit_json(payload, json_out=json_out)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    preflight = subparsers.add_parser("preflight", help="Check that Codex image generation is available")
+    preflight.add_argument("--workspace", help="Paper or project workspace root")
+    preflight.add_argument("--json-out", help="Optional path to save the JSON result")
+
+    finalize = subparsers.add_parser("finalize", help="Finalize the accepted figure artifacts")
+    finalize.add_argument("--workspace", help="Paper or project workspace root")
+    finalize.add_argument("--best-image", required=True, help="Accepted PNG to promote to figure_final.png")
+    finalize.add_argument(
+        "--caption",
+        default="[Replace with a paper-ready caption].",
+        help="Caption text to place in latex_include.tex",
+    )
+    finalize.add_argument("--label", default="fig:replace-me", help="LaTeX figure label")
+    finalize.add_argument("--score", type=float, help="Final review score")
+    finalize.add_argument("--review-summary", help="Short review summary for review_log.json")
+    finalize.add_argument("--json-out", help="Optional path to save the JSON result")
+
+    verify = subparsers.add_parser("verify", help="Verify that final artifacts were emitted correctly")
+    verify.add_argument("--workspace", help="Paper or project workspace root")
+    verify.add_argument("--json-out", help="Optional path to save the JSON result")
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    workspace = resolve_workspace(getattr(args, "workspace", None))
+    json_out = Path(args.json_out).expanduser().resolve() if getattr(args, "json_out", None) else None
+
+    if args.command == "preflight":
+        return run_preflight(workspace, json_out=json_out)
+
+    if args.command == "finalize":
+        return run_finalize(
+            workspace,
+            best_image=Path(args.best_image),
+            caption=args.caption,
+            label=args.label,
+            score=args.score,
+            review_summary=args.review_summary,
+            json_out=json_out,
+        )
+
+    if args.command == "verify":
+        return run_verify(workspace, json_out=json_out)
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

This PR adds a new `paper-illustration-image2` skill without modifying the existing `paper-illustration` workflow.

The new path is designed for Claude-first workflows that want to trigger native Codex image generation via a local MCP bridge instead of relying on external image APIs.

## Highlights

- add a new `skills/paper-illustration-image2/` skill modeled after the existing illustration workflow
- add a new `mcp-servers/codex-image2/` MCP bridge that calls the local Codex app-server image-generation path
- reject shell / Python bitmap fallbacks and require a real native `imageGeneration` event before reporting success
- add unit coverage for the bridge behavior in `tests/test_codex_image2_server.py`

## Scope note

This path targets native raster image generation through Codex. It does not claim direct SVG/vector export from GPT Image, since the official public docs currently describe raster output formats rather than SVG output.

## Why

`paper-illustration` is currently centered around Gemini image generation. For Codex users, native image generation can already be available locally, so this PR adds a separate skill that keeps the original workflow intact while enabling a Codex-native path.

## Validation

- `python3 -m unittest tests/test_codex_image2_server.py`
- `python3 -m py_compile mcp-servers/codex-image2/server.py`
- `git diff --check`
- live smoke test through the MCP bridge with native image generation
- semi-cold-start verification showing the bridge works without conversation context and mainly depends on local Codex auth state
