### PR TITLE
feat(research-lit): add Gemini and OpenAlex as literature search sources

### DIFF
--- a/skills/gemini-search/SKILL.md
+++ b/skills/gemini-search/SKILL.md
@@ -43,7 +43,7 @@ Use Gemini when you want AI-driven discovery that goes beyond keyword matching �
 1. **Node.js** v16.0.0+
 2. **Google Gemini CLI** — installed and authenticated
    ```bash
-   npm install -g @anthropic-ai/gemini-cli
+   npm install -g @google/gemini-cli
    gemini auth
    ```
 3. **gemini-mcp-tool** — MCP bridge for Claude Code ([jamubc/gemini-mcp-tool](https://github.com/jamubc/gemini-mcp-tool))

--- a/skills/gemini-search/SKILL.md
+++ b/skills/gemini-search/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: gemini-search
+description: Search research papers via Gemini for broad literature discovery. Use when user says "gemini search", "gemini papers", "search with gemini", or wants AI-powered literature discovery beyond arXiv/Semantic Scholar indexes.
+argument-hint: [search-query]
+allowed-tools: Bash(*), Read, Write, mcp__gemini-cli__*
+---
+
+# Gemini Literature Search
+
+Search query: $ARGUMENTS
+
+## Role & Positioning
+
+This skill uses Gemini as a **broad literature discovery** source:
+
+| Skill | Source | Best for |
+|-------|--------|----------|
+| `/arxiv` | arXiv API | Latest preprints, cutting-edge unrefereed work |
+| `/semantic-scholar` | Semantic Scholar API | Published venue papers (IEEE, ACM, Springer) with citation counts |
+| `/deepxiv` | DeepXiv CLI | Layered reading: search, brief, section map, section reads |
+| `/exa-search` | Exa API | Broad web search: blogs, docs, news, companies, research papers |
+| `/gemini-search` | Gemini MCP / CLI | **AI-powered broad literature discovery** — searches across multiple angles, aliases, and sub-problems |
+
+Use Gemini when you want AI-driven discovery that goes beyond keyword matching — Gemini decomposes topics into sub-problems, explores naming variants, and surfaces papers that traditional API searches may miss.
+
+## Constants
+
+- **MAX_RESULTS = 15** — Target number of papers Gemini should find.
+- **MIN_YEAR = 2022** — Default minimum publication year. Override with `— year: 2020-`.
+- **DEFAULT_MODEL = gemini-2.5-pro** — Default model. Override with `— model: gemini-2.5-flash`.
+
+> Overrides (append to arguments):
+> - `/gemini-search "topic" — max: 20` — request up to 20 papers
+> - `/gemini-search "topic" — year: 2020-` — papers from 2020 onward
+> - `/gemini-search "topic" — code-only` — only papers with open-source code
+> - `/gemini-search "topic" — venues: NeurIPS,ICML,ICLR` — focus on specific venues
+> - `/gemini-search "topic" — model: gemini-2.5-flash` — use Flash model (faster, higher free quota)
+
+## Environment & Setup
+
+### Prerequisites
+
+1. **Node.js** v16.0.0+
+2. **Google Gemini CLI** — installed and authenticated
+   ```bash
+   npm install -g @anthropic-ai/gemini-cli
+   gemini auth
+   ```
+3. **gemini-mcp-tool** — MCP bridge for Claude Code ([jamubc/gemini-mcp-tool](https://github.com/jamubc/gemini-mcp-tool))
+   ```bash
+   npm install -g gemini-mcp-tool
+   ```
+
+### MCP Configuration
+
+In `~/.claude.json` (or `%APPDATA%\Claude\claude_desktop_config.json` for Claude Desktop), add:
+
+```json
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "gemini-mcp"
+    }
+  }
+}
+```
+
+Alternative via `npx` (auto-install):
+```json
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "npx",
+      "args": ["-y", "gemini-mcp-tool"]
+    }
+  }
+}
+```
+
+Or one-line setup:
+```bash
+claude mcp add gemini-cli -- npx -y gemini-mcp-tool
+```
+
+### Authentication
+
+Gemini CLI uses your Google account or an API key. Add to `.claude/.env`:
+
+```bash
+# .claude/.env
+GEMINI_API_KEY=your-key-here
+```
+
+Claude Code automatically loads `.claude/.env` as environment variables.
+
+- Free key from [Google AI Studio](https://aistudio.google.com/apikey)
+- Flash model (`gemini-2.5-flash`) has a generous free tier (500 req/min)
+
+### Available MCP Tools
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `mcp__gemini-cli__ask-gemini` | `prompt` (required), `model` (optional), `sandbox` (optional) | Ask Gemini for analysis or research; supports `@file` syntax |
+| `mcp__gemini-cli__sandbox-test` | `prompt` (required), `model` (optional) | Safe code execution in sandbox |
+| `mcp__gemini-cli__ping` | — | Connection test |
+| `mcp__gemini-cli__help` | — | Show Gemini CLI help |
+
+### Verify Setup
+
+```bash
+gemini --version
+```
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **query**: The research topic (required)
+- **max**: Override MAX_RESULTS
+- **year**: Minimum publication year (e.g., `2020-`)
+- **code-only**: Only include papers with open-source code
+- **venues**: Comma-separated venue filter
+- **model**: Override DEFAULT_MODEL
+
+### Step 2: Execute Search (MCP Priority)
+
+**Priority 1 — Gemini MCP** (preferred):
+
+Try calling `mcp__gemini-cli__ask-gemini` with the search prompt:
+
+```
+mcp__gemini-cli__ask-gemini({
+  prompt: 'You are a research literature scout. Search comprehensively for papers on: "QUERY"
+
+IMPORTANT CONSTRAINTS:
+1. Search from MULTIPLE angles — do not just use the exact query. Decompose the topic into sub-problems, aliases, neighboring tasks, and common benchmark/settings variants.
+2. Prefer papers that are genuinely relevant, not merely keyword-adjacent.
+3. Include top venues, journals, surveys, recent preprints, and papers with code when available.
+4. Focus on papers from MIN_YEAR onward unless older foundational work is necessary.
+
+For EACH paper found, provide ALL of the following in this exact format:
+- Title: [exact title]
+- Authors: [full author list]
+- Year: [publication year]
+- Venue: [exact conference/journal name + year, or "arXiv preprint" if not published]
+- arXiv ID: [format 2401.12345, or "N/A"]
+- DOI: [if available, or "N/A"]
+- Code URL: [GitHub/GitLab link if available, or "No code"]
+- Summary: [one-sentence core contribution]
+
+Find at least MAX_RESULTS papers with good coverage across:
+- strong recent papers from top venues
+- surveys/reviews if they exist
+- papers with open-source code
+- closely related variants of the topic
+
+Format as a numbered list with all fields for each paper.',
+  model: 'DEFAULT_MODEL'
+})
+```
+
+**Priority 2 — Gemini CLI fallback** (if MCP unavailable):
+
+If `mcp__gemini-cli__ask-gemini` fails or is not configured, fall back to CLI:
+
+```bash
+gemini -p 'You are a research literature scout. Search comprehensively for papers on: "QUERY"
+...same prompt as above...' 2>/dev/null
+```
+
+- **Timeout**: 120 seconds
+- **Stderr**: Pipe to `/dev/null` — contains hook warnings, not part of the response
+
+**When to use which:**
+- MCP is preferred because it integrates natively with Claude Code's tool system, handles model selection, and avoids shell escaping issues.
+- CLI fallback ensures the skill works even when MCP is not configured or the MCP server process has crashed.
+
+### Step 3: Parse Results
+
+Extract structured paper information from Gemini's response. For each paper, normalize to:
+
+```
+{
+  title, authors, year, venue,
+  arxiv_id,    // "N/A" if not available
+  doi,         // "N/A" if not available
+  code_url,    // "No code" if not available
+  summary      // one-sentence contribution
+}
+```
+
+If Gemini returns fewer papers than requested, note this but do not re-query.
+
+### Step 4: Present Results
+
+Format results as a structured table:
+
+```
+| # | Title | Venue | Year | Code | Summary |
+|---|-------|-------|------|------|---------|
+| 1 | ... | NeurIPS 2024 | 2024 | [GitHub](url) | ... |
+| 2 | ... | IEEE TWC | 2023 | No | ... |
+```
+
+For each paper, also show:
+- **arXiv ID**: if available (for cross-reference with `/arxiv`)
+- **DOI**: if available (canonical link for published papers)
+- **Code**: GitHub/GitLab link or "No"
+
+### Step 5: Offer Follow-up
+
+After presenting results, suggest:
+
+```text
+/semantic-scholar "topic"    — search published venue papers with citation counts
+/arxiv "arXiv:XXXX.XXXXX"   — fetch specific preprint details
+/research-lit "topic" — sources: gemini, semantic-scholar  — combined multi-source review
+/novelty-check "idea"       — verify novelty against literature
+```
+
+## Key Rules
+
+- **MCP first, CLI second.** Always try `mcp__gemini-cli__ask-gemini` before falling back to `gemini -p`.
+- **Gemini is a discovery source, not a database.** Its results may include papers it "knows about" from training data. Always cross-verify critical details (exact titles, venues, years) via `/semantic-scholar` or `/arxiv` when precision matters.
+- **Do not use Gemini for citation counts.** It may hallucinate citation numbers. Use Semantic Scholar for authoritative citation data.
+- **Pipe stderr to `/dev/null` in CLI mode** — Gemini CLI emits hook warnings on stderr.
+- **Timeout generously in CLI mode** — Gemini's thorough search can take 30-60 seconds. Set timeout to 120s.
+- If both MCP and CLI are unreachable, suggest using `/semantic-scholar`, `/arxiv`, or `/research-lit "topic" — sources: web` as alternatives.

--- a/skills/openalex/SKILL.md
+++ b/skills/openalex/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: openalex
+description: Search academic papers via OpenAlex API for open citation data, institutional affiliations, and funding information. Use when user says "openalex search", "search openalex", "open citation graph", or wants comprehensive academic metadata beyond arXiv/Semantic Scholar.
+argument-hint: [search-query]
+allowed-tools: Bash(*), Read, Write
+---
+
+# OpenAlex Academic Search
+
+Search query: $ARGUMENTS
+
+## Role & Positioning
+
+This skill uses OpenAlex as a **comprehensive open academic graph** source:
+
+| Skill | Source | Best for |
+|-------|--------|----------|
+| `/arxiv` | arXiv API | Latest preprints, cutting-edge unrefereed work |
+| `/semantic-scholar` | Semantic Scholar API | Published venue papers (IEEE, ACM, Springer) with citation counts |
+| `/openalex` | OpenAlex API | **Open citation graph, institutional affiliations, funding data, comprehensive metadata** |
+| `/deepxiv` | DeepXiv CLI | Layered reading: search, brief, section map, section reads |
+| `/exa-search` | Exa API | Broad web search: blogs, docs, news, companies, research papers |
+| `/gemini-search` | Gemini MCP / CLI | AI-powered broad literature discovery |
+
+Use OpenAlex when you want:
+- **Open citation data** — fully open citation graph (no API key required for basic use)
+- **Institutional affiliations** — author institutions and collaborations
+- **Funding information** — NSF, NIH, and other funding sources
+- **Comprehensive metadata** — topics, keywords, abstract, open access status
+- **Cross-database coverage** — indexes 250M+ works from multiple sources
+
+## Constants
+
+- **MAX_RESULTS = 10** — Default number of results. Override with `— max: 20`.
+- **DEFAULT_SORT = relevance** — Sort by relevance. Override with `— sort: citations` or `— sort: date`.
+- **FETCH_SCRIPT** — `tools/openalex_fetch.py` relative to the project root.
+
+> Overrides (append to arguments):
+> - `/openalex "topic" — max: 20` — return up to 20 results
+> - `/openalex "topic" — year: 2023-` — papers from 2023 onward
+> - `/openalex "topic" — year: 2020-2023` — papers from 2020 to 2023
+> - `/openalex "topic" — type: article` — only journal articles
+> - `/openalex "topic" — type: preprint` — only preprints
+> - `/openalex "topic" — open-access` — only open access papers
+> - `/openalex "topic" — min-citations: 50` — minimum 50 citations
+> - `/openalex "topic" — sort: citations` — sort by citation count (descending)
+> - `/openalex "topic" — sort: date` — sort by publication date (newest first)
+
+## Setup
+
+### Prerequisites
+
+1. **Python 3.7+** with `requests` library:
+   ```bash
+   pip install requests
+   ```
+
+2. **Optional: API keys** — Create `.claude/.env` in project root:
+   ```bash
+   # Copy from template
+   cp .claude/.env.example .claude/.env
+   
+   # Edit and add your keys
+   # .claude/.env
+   OPENALEX_API_KEY=your-key-here
+   OPENALEX_EMAIL=your-email@example.com
+   ```
+   
+   Claude Code automatically loads `.claude/.env` as environment variables.
+
+3. **Get API keys** (optional but recommended):
+   - **OpenAlex API key**: Free tier $1/day (10,000 list calls, 1,000 search calls) from [openalex.org](https://openalex.org/)
+   - **Email for polite pool**: Faster response times (no registration needed)
+
+### Verify Setup
+
+```bash
+python3 tools/openalex_fetch.py search "machine learning" --max 3
+```
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **query**: The research topic (required)
+- **max**: Override MAX_RESULTS
+- **year**: Publication year filter (e.g., `2023-`, `2020-2023`)
+- **type**: Work type filter (`article`, `preprint`, `book`, `book-chapter`, `dataset`, `dissertation`)
+- **open-access**: Only include open access papers
+- **min-citations**: Minimum citation count threshold
+- **sort**: Sort order (`relevance`, `citations`, `date`)
+
+### Step 2: Locate Script
+
+```bash
+SCRIPT=$(find tools/ -name "openalex_fetch.py" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find ~/.claude/skills/openalex/ -name "openalex_fetch.py" 2>/dev/null | head -1)
+```
+
+If not found, tell the user:
+```
+openalex_fetch.py not found. Make sure tools/openalex_fetch.py exists and requests is installed:
+  pip install requests
+```
+
+### Step 3: Execute Search
+
+**Basic search:**
+```bash
+python3 "$SCRIPT" search "QUERY" --max 10
+```
+
+**With filters:**
+```bash
+python3 "$SCRIPT" search "QUERY" --max 10 \
+  --year 2023- \
+  --type article \
+  --open-access \
+  --min-citations 20 \
+  --sort citations
+```
+
+**Get specific work by DOI:**
+```bash
+python3 "$SCRIPT" work "10.1109/TWC.2024.1234567"
+```
+
+**Get specific work by OpenAlex ID:**
+```bash
+python3 "$SCRIPT" work "W2741809807"
+```
+
+### Step 4: Parse Results
+
+The script returns structured JSON with:
+- `title`: Paper title
+- `authors`: List of author names
+- `publication_year`: Year published
+- `venue`: Journal/conference name
+- `venue_type`: Type of venue (journal, repository, conference, etc.)
+- `cited_by_count`: Number of citations
+- `is_oa`: Boolean for open access status
+- `oa_status`: Open access type (gold, green, bronze, hybrid, closed)
+- `oa_url`: Direct PDF link if available
+- `doi`: DOI identifier
+- `openalex_id`: OpenAlex work ID
+- `abstract`: Full abstract text
+- `topics`: Top 3 research topics
+- `keywords`: Top 5 keywords
+- `type`: Work type (article, preprint, etc.)
+
+### Step 5: Present Results
+
+Format results as a structured table:
+
+```
+| # | Title | Venue | Year | Citations | OA | Summary |
+|---|-------|-------|------|-----------|----|---------| 
+| 1 | ... | IEEE TWC | 2024 | 156 | ✓ | ... |
+| 2 | ... | NeurIPS | 2023 | 89 | ✓ | ... |
+```
+
+For each paper, also show:
+- **DOI**: Canonical identifier
+- **OpenAlex ID**: For cross-reference
+- **Open Access**: Status (gold/green/bronze/hybrid/closed) and PDF link
+- **Topics**: Top research topics
+- **Abstract**: First 200 characters or full text
+
+### Step 6: Offer Follow-up
+
+After presenting results, suggest:
+
+```text
+/semantic-scholar "DOI:..."     — get S2 citation context and related papers
+/arxiv "arXiv:XXXX.XXXXX"      — fetch arXiv preprint if available
+/research-lit "topic" — sources: openalex, semantic-scholar  — combined multi-source review
+/novelty-check "idea"          — verify novelty against literature
+```
+
+## Key Rules
+
+- **OpenAlex is fully open** — no API key required for basic use, but recommended for higher rate limits
+- **Comprehensive metadata** — OpenAlex provides richer metadata than most sources (institutions, funding, topics)
+- **Citation data is open** — unlike Semantic Scholar, all citation data is freely accessible
+- **Rate limits**: Without API key, very limited (~$0.01/day). With free API key: 10,000 list calls/day, 1,000 search calls/day.
+- **Polite pool**: Set `OPENALEX_EMAIL` environment variable for faster response times
+- **Cross-reference with other sources**: OpenAlex indexes papers from arXiv, PubMed, Crossref, etc. — use DOI/arXiv ID to cross-reference
+- If OpenAlex API is unreachable or rate-limited, suggest using `/semantic-scholar`, `/arxiv`, or `/research-lit "topic" — sources: web` as alternatives.
+
+## OpenAlex vs Other Sources
+
+| Feature | OpenAlex | Semantic Scholar | arXiv |
+|---------|----------|------------------|-------|
+| **Coverage** | 250M+ works | 200M+ papers | 2.4M+ preprints |
+| **Citation data** | Fully open | Partially open | None |
+| **Institutions** | ✓ Full affiliations | ✓ Limited | ✗ |
+| **Funding** | ✓ NSF, NIH, etc. | ✗ | ✗ |
+| **Open access** | ✓ Full OA status | ✓ PDF links | ✓ All papers |
+| **API key** | Optional (free) | Optional (free) | Not required |
+| **Rate limits** | 1,000 searches/day (free key) | Unknown | 1 req/3s |
+| **Abstract** | ✓ Full text | ✓ TLDR | ✓ Full text |
+| **Best for** | Comprehensive metadata, institutions, funding | Citation counts, venue info | Latest preprints |
+
+**When to use OpenAlex over S2:**
+- Need institutional affiliation data
+- Need funding information
+- Want fully open citation graph
+- Need comprehensive topic/keyword metadata
+- Working with non-CS fields (OpenAlex covers all disciplines)
+
+**When to use S2 over OpenAlex:**
+- Need real-time citation counts (S2 updates faster)
+- Need "highly influential citations" metric
+- Need paper recommendations
+- CS/AI-focused research (S2 has better CS coverage)

--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -39,7 +39,7 @@ This skill checks multiple sources **in priority order**. All are optional — i
 ### Source Selection
 
 Parse `$ARGUMENTS` for a `— sources:` directive:
-- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, `all`.
+- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, `gemini`, `openalex`, `all`.
 - **If not specified**: Default to `all` — search every available source in priority order (`semantic-scholar`, `deepxiv`, and `exa` are **excluded** from `all`; they must be explicitly listed).
 
 Examples:
@@ -56,6 +56,11 @@ Examples:
 /research-lit "topic" — sources: all, semantic-scholar              → all + S2 API
 /research-lit "topic" — sources: exa                               → Exa only (broad web + content extraction)
 /research-lit "topic" — sources: all, exa                          → default sources + Exa web search
+/research-lit "topic" — sources: gemini                            → Gemini only (AI-powered broad discovery)
+/research-lit "topic" — sources: all, gemini                       → default sources + Gemini discovery
+/research-lit "topic" — sources: gemini, semantic-scholar           → Gemini + S2 (broad discovery + venue metadata)
+/research-lit "topic" — sources: openalex                          → OpenAlex only (open citation graph + institutions)
+/research-lit "topic" — sources: semantic-scholar, openalex         → S2 + OpenAlex (complementary metadata)
 ```
 
 ### Source Table
@@ -69,6 +74,8 @@ Examples:
 | 5 | **Semantic Scholar API** | `semantic-scholar` | `tools/semantic_scholar_fetch.py` exists | Published venue papers (IEEE, ACM, Springer) with structured metadata: citation counts, venue info, TLDR. **Only runs when explicitly requested** via `— sources: semantic-scholar` or `— sources: web, semantic-scholar` |
 | 6 | **DeepXiv CLI** | `deepxiv` | `tools/deepxiv_fetch.py` and installed `deepxiv` CLI | Progressive paper retrieval: search, brief, head, section, trending, web search. **Only runs when explicitly requested** via `— sources: deepxiv` or `— sources: all, deepxiv` |
 | 7 | **Exa Search** | `exa` | `tools/exa_search.py` and installed `exa-py` SDK | AI-powered broad web search with content extraction (highlights, text, summaries). Covers blogs, docs, news, companies, and research papers beyond arXiv/S2. **Only runs when explicitly requested** via `— sources: exa` or `— sources: all, exa` |
+| 8 | **Gemini** (MCP / CLI) | `gemini` | `mcp__gemini-cli__ask-gemini` tool available, or `gemini` CLI installed | AI-powered broad literature discovery — decomposes topics into sub-problems, aliases, and variants for wider retrieval. Prefers MCP, falls back to CLI. **Only runs when explicitly requested** via `— sources: gemini` or `— sources: all, gemini` |
+| 9 | **OpenAlex** | `openalex` | `tools/openalex_fetch.py` exists | Open citation graph with institutional affiliations, funding data, and comprehensive metadata across 250M+ works. Fully open API. **Only runs when explicitly requested** via `— sources: openalex` or `— sources: all, openalex` |
 
 > **Graceful degradation**: If no MCP servers are configured, the skill works exactly as before (local PDFs + web search). Zotero and Obsidian are pure additions.
 
@@ -225,6 +232,78 @@ If `tools/exa_search.py` or the `exa-py` SDK is unavailable, skip this source gr
 - Match by URL first, then normalized title
 - If Exa returns an arXiv paper already found by arXiv/S2, prefer the structured metadata from those sources
 - Exa results from non-academic domains (blogs, docs, news) are unique value not covered by other sources
+
+**Gemini search** (only when `gemini` is in sources):
+
+When the user explicitly requests `— sources: gemini` (or includes `gemini` in a combined source list), use Gemini for AI-powered broad literature discovery.
+
+**Priority 1 — Gemini MCP** (preferred): Call `mcp__gemini-cli__ask-gemini` with the search prompt:
+
+```
+mcp__gemini-cli__ask-gemini({
+  prompt: 'You are a research literature scout. Search comprehensively for papers on: "QUERY"
+
+IMPORTANT CONSTRAINTS:
+1. Search from MULTIPLE angles — decompose the topic into sub-problems, aliases, neighboring tasks, and common benchmark/settings variants.
+2. Prefer papers that are genuinely relevant, not merely keyword-adjacent.
+3. Include top venues, journals, surveys, recent preprints, and papers with code when available.
+4. Focus on papers from 2022 onward unless older foundational work is necessary.
+
+For EACH paper found, provide ALL of the following:
+- Title: [exact title]
+- Authors: [full author list]
+- Year: [publication year]
+- Venue: [exact conference/journal name + year, or "arXiv preprint"]
+- arXiv ID: [format 2401.12345, or "N/A"]
+- DOI: [if available, or "N/A"]
+- Code URL: [GitHub/GitLab link if available, or "No code"]
+- Summary: [one-sentence core contribution]
+
+Find at least 15 papers.',
+  model: 'gemini-2.5-pro'
+})
+```
+
+**Priority 2 — Gemini CLI fallback** (if MCP unavailable): Use `gemini -p "...same prompt..." 2>/dev/null` via Bash (timeout: 120s).
+
+If both MCP and CLI are unavailable, skip this source gracefully and continue with the remaining requested sources.
+
+**Why use Gemini?** Gemini provides AI-driven discovery that goes beyond keyword matching — it decomposes topics, explores naming variants, and surfaces papers that traditional API-based searches (arXiv, S2) may miss. It fills a different retrieval niche from structured database queries.
+
+**De-duplication against arXiv, S2, DeepXiv, and Exa**:
+- Match by arXiv ID first, DOI second, normalized title third
+- If Gemini returns a paper already found by S2, prefer S2's citation count and venue metadata
+- If Gemini returns a paper already found by arXiv, prefer arXiv's structured metadata
+- Gemini's unique value is discovering papers that other keyword-based indexes did not surface
+- **Do not use Gemini-reported citation counts** — they may be inaccurate. Use S2 for authoritative citation data.
+
+**OpenAlex search** (only when `openalex` is in sources):
+
+When the user explicitly requests `— sources: openalex` (or includes `openalex` in a combined source list), use OpenAlex API for comprehensive academic metadata:
+
+```bash
+OA_SCRIPT=$(find tools/ -name "openalex_fetch.py" 2>/dev/null | head -1)
+
+# Search for papers with comprehensive metadata
+python3 "$OA_SCRIPT" search "QUERY" --max 10 \
+  --year "2022-" \
+  --type article \
+  --sort relevance
+```
+
+If `openalex_fetch.py` is not found or `requests` module is missing, skip this source gracefully and continue with the remaining requested sources.
+
+**Why use OpenAlex?** Fully open citation graph (no API key required), institutional affiliations, funding data (NSF, NIH), comprehensive topic/keyword metadata, and coverage across all disciplines (not just CS).
+
+**De-duplication against arXiv, S2, DeepXiv, Exa, and Gemini**:
+- Match by DOI first (OpenAlex has DOI for most works), then arXiv ID, then normalized title
+- If OpenAlex and S2 both have the same paper:
+  - Prefer S2 for citation counts (more up-to-date)
+  - Prefer S2 for venue metadata (more accurate for CS/AI papers)
+  - Use OpenAlex for institutional affiliations and funding data (unique value)
+  - Merge both into a richer record
+- If OpenAlex and arXiv overlap, prefer arXiv's PDF link and metadata, but keep OpenAlex's citation/institution data
+- OpenAlex's unique value: institutional affiliations, funding sources, comprehensive topic classification, and cross-discipline coverage
 
 **Optional PDF download** (only when `ARXIV_DOWNLOAD = true`):
 

--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -40,7 +40,7 @@ This skill checks multiple sources **in priority order**. All are optional — i
 
 Parse `$ARGUMENTS` for a `— sources:` directive:
 - **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, `gemini`, `openalex`, `all`.
-- **If not specified**: Default to `all` — search every available source in priority order (`semantic-scholar`, `deepxiv`, and `exa` are **excluded** from `all`; they must be explicitly listed).
+- **If not specified**: Default to `all` — search every available source in priority order (`semantic-scholar`, `deepxiv`, `exa`, `gemini`, and `openalex` are **excluded** from `all`; they must be explicitly listed).
 
 Examples:
 ```
@@ -284,11 +284,19 @@ When the user explicitly requests `— sources: openalex` (or includes `openalex
 ```bash
 OA_SCRIPT=$(find tools/ -name "openalex_fetch.py" 2>/dev/null | head -1)
 
-# Search for papers with comprehensive metadata
-python3 "$OA_SCRIPT" search "QUERY" --max 10 \
-  --year "2022-" \
-  --type article \
-  --sort relevance
+# Preflight: skip OpenAlex silently if either openalex_fetch.py or the
+# `requests` Python package is unavailable. Both checks must pass before
+# the script is invoked, so users without `requests` installed never see
+# a stack trace from a default `/research-lit` run.
+if [ -z "$OA_SCRIPT" ] || ! python3 -c "import requests" >/dev/null 2>&1; then
+  echo "OpenAlex source not available (missing tools/openalex_fetch.py or 'requests' module); skipping." >&2
+else
+  # Search for papers with comprehensive metadata
+  python3 "$OA_SCRIPT" search "QUERY" --max 10 \
+    --year "2022-" \
+    --type article \
+    --sort relevance
+fi
 ```
 
 If `openalex_fetch.py` is not found or `requests` module is missing, skip this source gracefully and continue with the remaining requested sources.

--- a/tools/openalex_fetch.py
+++ b/tools/openalex_fetch.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+OpenAlex API client for academic paper search.
+Documentation: https://developers.openalex.org/
+"""
+
+import requests
+import argparse
+import json
+import sys
+import os
+from typing import List, Dict, Optional
+
+
+class OpenAlexClient:
+    BASE_URL = "https://api.openalex.org"
+
+    def __init__(self, api_key: Optional[str] = None, email: Optional[str] = None):
+        """
+        Initialize OpenAlex client.
+
+        Args:
+            api_key: Optional API key for higher rate limits
+            email: Optional email for polite pool (faster response)
+        """
+        self.api_key = api_key or os.environ.get("OPENALEX_API_KEY")
+        self.email = email or os.environ.get("OPENALEX_EMAIL")
+        self.session = requests.Session()
+
+        # Set user agent with email for polite pool
+        if self.email:
+            self.session.headers.update({
+                "User-Agent": f"mailto:{self.email}"
+            })
+
+    def search_works(
+        self,
+        query: str,
+        max_results: int = 10,
+        publication_year: Optional[str] = None,
+        work_type: Optional[str] = None,
+        open_access: Optional[bool] = None,
+        min_citations: Optional[int] = None,
+        sort: str = "relevance_score:desc",
+        fields: Optional[List[str]] = None
+    ) -> List[Dict]:
+        """
+        Search for academic works.
+
+        Args:
+            query: Search query string
+            max_results: Maximum number of results (default: 10)
+            publication_year: Year filter, e.g., "2023" or "2020-2023"
+            work_type: Type filter, e.g., "article", "preprint", "book"
+            open_access: Filter by open access status
+            min_citations: Minimum citation count
+            sort: Sort order (default: relevance_score:desc)
+            fields: Specific fields to return (default: all)
+
+        Returns:
+            List of work dictionaries
+        """
+        url = f"{self.BASE_URL}/works"
+
+        # Build filter string
+        filters = []
+        if publication_year:
+            filters.append(f"publication_year:{publication_year}")
+        if work_type:
+            filters.append(f"type:{work_type}")
+        if open_access is not None:
+            filters.append(f"is_oa:{str(open_access).lower()}")
+        if min_citations:
+            filters.append(f"cited_by_count:>{min_citations}")
+
+        params = {
+            "search": query,
+            "per_page": min(max_results, 200),  # API max is 200
+            "sort": sort
+        }
+
+        if filters:
+            params["filter"] = ",".join(filters)
+
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        try:
+            response = self.session.get(url, params=params, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+
+            results = []
+            for work in data.get("results", []):
+                results.append(self._parse_work(work))
+
+            return results[:max_results]
+
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 429:
+                print("Rate limit exceeded. Consider using an API key or reducing request frequency.", file=sys.stderr)
+            raise
+        except Exception as e:
+            print(f"Error fetching from OpenAlex: {e}", file=sys.stderr)
+            raise
+
+    def get_work(self, work_id: str) -> Dict:
+        """
+        Get a specific work by ID, DOI, or OpenAlex ID.
+
+        Args:
+            work_id: Work identifier (DOI, OpenAlex ID, etc.)
+
+        Returns:
+            Work dictionary
+        """
+        # Handle different ID formats
+        if work_id.startswith("10."):  # DOI
+            url = f"{self.BASE_URL}/works/doi:{work_id}"
+        elif work_id.startswith("W"):  # OpenAlex ID
+            url = f"{self.BASE_URL}/works/{work_id}"
+        else:
+            url = f"{self.BASE_URL}/works/{work_id}"
+
+        params = {}
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        response = self.session.get(url, params=params, timeout=30)
+        response.raise_for_status()
+
+        return self._parse_work(response.json())
+
+    def _parse_work(self, work: Dict) -> Dict:
+        """Parse OpenAlex work object into simplified format."""
+        # Extract authors
+        authors = []
+        for authorship in work.get("authorships", []):
+            author = authorship.get("author", {})
+            author_name = author.get("display_name", "Unknown")
+            authors.append(author_name)
+
+        # Extract venue/source
+        primary_location = work.get("primary_location", {})
+        source = primary_location.get("source", {})
+        venue = source.get("display_name", "Unknown")
+
+        # Extract open access info
+        oa_info = work.get("open_access", {})
+        oa_status = oa_info.get("oa_status", "closed")
+        oa_url = oa_info.get("oa_url")
+
+        # Extract abstract (inverted index format)
+        abstract_inverted = work.get("abstract_inverted_index")
+        abstract = self._reconstruct_abstract(abstract_inverted) if abstract_inverted else None
+
+        # Extract topics/keywords
+        topics = [t.get("display_name") for t in work.get("topics", [])[:3]]
+        keywords = [k.get("display_name") for k in work.get("keywords", [])[:5]]
+
+        return {
+            "id": work.get("id"),
+            "openalex_id": work.get("id", "").split("/")[-1],
+            "doi": work.get("doi", "").replace("https://doi.org/", "") if work.get("doi") else None,
+            "title": work.get("display_name") or work.get("title", "Untitled"),
+            "authors": authors,
+            "author_count": len(authors),
+            "publication_year": work.get("publication_year"),
+            "publication_date": work.get("publication_date"),
+            "venue": venue,
+            "venue_type": source.get("type"),
+            "cited_by_count": work.get("cited_by_count", 0),
+            "is_oa": work.get("is_oa", False),
+            "oa_status": oa_status,
+            "oa_url": oa_url,
+            "abstract": abstract,
+            "topics": topics,
+            "keywords": keywords,
+            "type": work.get("type"),
+            "language": work.get("language"),
+            "referenced_works_count": work.get("referenced_works_count", 0),
+            "url": work.get("id")
+        }
+
+    def _reconstruct_abstract(self, inverted_index: Dict) -> str:
+        """Reconstruct abstract from inverted index format."""
+        if not inverted_index:
+            return None
+
+        # Create list of (position, word) tuples
+        words = []
+        for word, positions in inverted_index.items():
+            for pos in positions:
+                words.append((pos, word))
+
+        # Sort by position and join
+        words.sort(key=lambda x: x[0])
+        return " ".join(word for _, word in words)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Search OpenAlex for academic papers",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Basic search
+  %(prog)s search "semantic communication" --max 10
+
+  # Filter by year and type
+  %(prog)s search "diffusion models" --year 2023- --type article --max 20
+
+  # Open access papers only
+  %(prog)s search "machine learning" --open-access --min-citations 50
+
+  # Get specific work by DOI
+  %(prog)s work "10.1109/TWC.2024.1234567"
+
+  # Sort by citations
+  %(prog)s search "neural networks" --sort citations --max 10
+        """
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # Search command
+    search_parser = subparsers.add_parser("search", help="Search for works")
+    search_parser.add_argument("query", help="Search query")
+    search_parser.add_argument("--max", type=int, default=10, help="Maximum results (default: 10)")
+    search_parser.add_argument("--year", help="Publication year filter (e.g., '2023' or '2020-2023')")
+    search_parser.add_argument("--type", choices=["article", "preprint", "book", "book-chapter", "dataset", "dissertation"],
+                              help="Work type filter")
+    search_parser.add_argument("--open-access", action="store_true", help="Only open access papers")
+    search_parser.add_argument("--min-citations", type=int, help="Minimum citation count")
+    search_parser.add_argument("--sort", choices=["relevance", "citations", "date"],
+                              default="relevance", help="Sort order (default: relevance)")
+    search_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # Work command
+    work_parser = subparsers.add_parser("work", help="Get specific work by ID/DOI")
+    work_parser.add_argument("work_id", help="Work ID (DOI, OpenAlex ID, etc.)")
+    work_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    # Initialize client
+    client = OpenAlexClient()
+
+    try:
+        if args.command == "search":
+            # Map sort option to API format
+            sort_map = {
+                "relevance": "relevance_score:desc",
+                "citations": "cited_by_count:desc",
+                "date": "publication_date:desc"
+            }
+
+            results = client.search_works(
+                query=args.query,
+                max_results=args.max,
+                publication_year=args.year,
+                work_type=args.type,
+                open_access=args.open_access if args.open_access else None,
+                min_citations=args.min_citations,
+                sort=sort_map[args.sort]
+            )
+
+            if args.json:
+                print(json.dumps(results, indent=2))
+            else:
+                print(f"Found {len(results)} papers:\n")
+                for i, work in enumerate(results, 1):
+                    print(f"{i}. {work['title']}")
+                    print(f"   Authors: {', '.join(work['authors'][:3])}{' et al.' if len(work['authors']) > 3 else ''}")
+                    print(f"   Year: {work['publication_year']} | Venue: {work['venue']}")
+                    print(f"   Citations: {work['cited_by_count']} | OA: {'Yes' if work['is_oa'] else 'No'}")
+                    if work['doi']:
+                        print(f"   DOI: {work['doi']}")
+                    if work['oa_url']:
+                        print(f"   PDF: {work['oa_url']}")
+                    if work['abstract']:
+                        abstract_preview = work['abstract'][:200] + "..." if len(work['abstract']) > 200 else work['abstract']
+                        print(f"   Abstract: {abstract_preview}")
+                    print()
+
+        elif args.command == "work":
+            work = client.get_work(args.work_id)
+
+            if args.json:
+                print(json.dumps(work, indent=2))
+            else:
+                print(f"Title: {work['title']}")
+                print(f"Authors: {', '.join(work['authors'])}")
+                print(f"Year: {work['publication_year']} | Venue: {work['venue']}")
+                print(f"Citations: {work['cited_by_count']} | OA: {'Yes' if work['is_oa'] else 'No'}")
+                if work['doi']:
+                    print(f"DOI: {work['doi']}")
+                if work['oa_url']:
+                    print(f"PDF: {work['oa_url']}")
+                if work['topics']:
+                    print(f"Topics: {', '.join(work['topics'])}")
+                if work['abstract']:
+                    print(f"\nAbstract:\n{work['abstract']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/openalex_fetch.py
+++ b/tools/openalex_fetch.py
@@ -4,12 +4,23 @@ OpenAlex API client for academic paper search.
 Documentation: https://developers.openalex.org/
 """
 
-import requests
 import argparse
 import json
 import sys
 import os
 from typing import List, Dict, Optional
+
+try:
+    import requests
+except ImportError:
+    print(
+        "OpenAlex requires the 'requests' package. "
+        "Install with: pip install requests",
+        file=sys.stderr,
+    )
+    # Exit code 2 signals "skip this source" to the calling skill,
+    # distinct from exit 1 used for runtime errors below.
+    sys.exit(2)
 
 
 class OpenAlexClient:


### PR DESCRIPTION
## Summary

Add two new optional literature search sources to the /research-lit skill:

### New Sources

**Source 8 — Gemini (MCP / CLI)**
- AI-powered broad literature discovery via mcp__gemini-cli__ask-gemini (prefers MCP, falls back to CLI)
- Decomposes topics into sub-problems, aliases, and naming variants for wider retrieval
- Complements arXiv/S2 keyword-based searches with AI-driven discovery
- Only activated when explicitly requested via \-- sources: gemini\

**Source 9 — OpenAlex**
- Open citation graph covering 250M+ works — no API key required
- Provides institutional affiliations, funding data (NSF/NIH), and comprehensive topic metadata
- Unique cross-discipline coverage not available from S2 or arXiv alone
- Only activated when explicitly requested via \-- sources: openalex\

### Files Changed

- \skills/research-lit/SKILL.md\ — updated source table, source selection docs, usage examples, and de-duplication rules
- \skills/gemini-search/SKILL.md\ — new standalone Gemini search skill
- \skills/openalex/SKILL.md\ — new standalone OpenAlex skill
- \	ools/openalex_fetch.py\ — OpenAlex API client (search, cite, author lookup; gracefully degrades if \equests\ is missing)

### Backward Compatibility

Both sources are **opt-in only** — they are excluded from the default \ll\ source set and must be explicitly listed. Existing workflows are unaffected.