### PR TITLE
Rebuild Codex skill mirror and install chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ cd Auto-claude-code-research-in-sleep && git pull
 bash tools/smart_update.sh          # dry-run: shows what's new/changed/safe
 bash tools/smart_update.sh --apply  # apply: adds new + updates safe ones
 
+# Optional Codex mirror managed project install
+bash tools/install_aris_codex.sh ~/your-codex-project
+
+# Managed Codex project update
+cd Auto-claude-code-research-in-sleep && git pull
+bash tools/install_aris_codex.sh ~/your-codex-project --reconcile
+
+# Copied Codex installs only (not for projects installed by install_aris_codex.sh)
+bash tools/smart_update_codex.sh --local ~/.codex/skills
+bash tools/smart_update_codex.sh --local ~/.codex/skills --apply
+
 # 2. Set up Codex MCP (for review skills)
 npm install -g @openai/codex
 codex setup                    # set model to gpt-5.4 when prompted
@@ -298,6 +309,8 @@ claude
 > **Want Codex to execute but Claude Code to review?** See [`docs/CODEX_CLAUDE_REVIEW_GUIDE.md`](docs/CODEX_CLAUDE_REVIEW_GUIDE.md). That path installs the base `skills/skills-codex/*`, then overlays `skills/skills-codex-claude-review/*`, and routes review-heavy skills through the local `claude-review` MCP bridge.
 
 > **Want Codex to execute but Gemini to review locally?** See [`docs/CODEX_GEMINI_REVIEW_GUIDE.md`](docs/CODEX_GEMINI_REVIEW_GUIDE.md) and [CN](docs/CODEX_GEMINI_REVIEW_GUIDE_CN.md). That path installs the base `skills/skills-codex/*`, then overlays `skills/skills-codex-gemini-review/*`, and routes the reviewer-aware predefined skills through the local `gemini-review` MCP bridge using direct Gemini API by default.
+
+> **Want the Codex mirror install chain?** Use `tools/install_aris_codex.sh` for managed project installs and `tools/smart_update_codex.sh` for copied Codex installs. The Claude scripts remain the mainline entry points for Claude projects.
 
 See [full setup guide](#%EF%B8%8F-setup) for details and [alternative model combinations](#-alternative-model-combinations) if you don't have Claude/OpenAI API.
 
@@ -1196,6 +1209,8 @@ export OPENAI_API_KEY="your-key"
 ### Install Skills
 
 > 💡 **Recommended: project-local flat symlink install** (since 2026-04-20). Each ARIS skill is symlinked individually into `.claude/skills/<skill-name>`, so Claude Code's slash-command discovery picks them up. A manifest at `.aris/installed-skills.txt` tracks what ARIS installed — uninstall and reconcile only ever touch managed entries, never your own skills.
+>
+> 🤖 **Codex mirror route:** keep Claude on `install_aris.sh` / `smart_update.sh`. For Codex-native project installs, use `install_aris_codex.sh`; for copied Codex installs, use `smart_update_codex.sh`.
 
 ```bash
 # 1. Clone ARIS once to a stable location

--- a/README_CN.md
+++ b/README_CN.md
@@ -151,6 +151,17 @@ ARIS 读论文 → 找弱点 → 克隆代码 → 针对*那些*弱点用*那套
 git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git
 cp -r Auto-claude-code-research-in-sleep/skills/* ~/.claude/skills/
 
+# 可选：Codex mirror 项目级受管安装
+bash Auto-claude-code-research-in-sleep/tools/install_aris_codex.sh ~/your-codex-project
+
+# Codex 受管项目更新
+cd Auto-claude-code-research-in-sleep && git pull
+bash Auto-claude-code-research-in-sleep/tools/install_aris_codex.sh ~/your-codex-project --reconcile
+
+# 仅用于 Codex copy install（不要用于 install_aris_codex.sh 管理的项目）
+bash Auto-claude-code-research-in-sleep/tools/smart_update_codex.sh --local ~/.codex/skills
+bash Auto-claude-code-research-in-sleep/tools/smart_update_codex.sh --local ~/.codex/skills --apply
+
 # 2. 配置 Codex MCP（review 类 skill 需要）
 npm install -g @openai/codex
 codex setup                    # 提示选模型时选 gpt-5.4
@@ -246,6 +257,8 @@ claude
 > **想让 Codex 执行、Claude Code 审稿？** 见 [`docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md`](docs/CODEX_CLAUDE_REVIEW_GUIDE_CN.md)。这条路径会先安装基础 `skills/skills-codex/*`，再叠加 `skills/skills-codex-claude-review/*`，并通过本地 `claude-review` MCP bridge 转发 review-heavy skill 的审稿请求。
 
 > **想让 Codex 执行、Gemini 在本地做审稿？** 见 [`docs/CODEX_GEMINI_REVIEW_GUIDE_CN.md`](docs/CODEX_GEMINI_REVIEW_GUIDE_CN.md) 和[英文版](docs/CODEX_GEMINI_REVIEW_GUIDE.md)。这条路径会先安装基础 `skills/skills-codex/*`，再叠加 `skills/skills-codex-gemini-review/*`，并通过本地 `gemini-review` MCP bridge 转发 reviewer-aware 预定义 skills 的审稿请求，默认 direct Gemini API。
+
+> **想走 Codex mirror 安装链？** 项目级受管安装用 `tools/install_aris_codex.sh`，copy 安装更新用 `tools/smart_update_codex.sh`。Claude 脚本仍然是 Claude 主线入口。
 
 详见[完整安装指南](#%EF%B8%8F-安装)和[替代模型组合](#-替代模型组合)（无需 Claude/OpenAI API）。
 
@@ -851,6 +864,8 @@ export OPENAI_API_KEY="your-key"         # API 模式（快）
 ### 安装 Skills
 
 > 💡 **推荐：项目级扁平 symlink 安装**（2026-04-20 起）。每个 ARIS skill 独立 symlink 到 `.claude/skills/<skill-name>`，让 Claude Code 的 slash command 自动补全能直接发现。manifest 在 `.aris/installed-skills.txt` 跟踪 ARIS 装了什么——uninstall 和 reconcile 只动 manifest 里的条目，绝不碰你自己的 skill。
+>
+> 🤖 **Codex mirror 路线：** Claude 主线继续使用 `install_aris.sh` / `smart_update.sh`。Codex 原生项目安装请用 `install_aris_codex.sh`，Codex copy 安装更新请用 `smart_update_codex.sh`。
 
 ```bash
 # 1. 克隆 ARIS 一次到稳定位置

--- a/skills/skills-codex-claude-review/README.md
+++ b/skills/skills-codex-claude-review/README.md
@@ -27,17 +27,16 @@ Current overrides:
 
 ## Install
 
-1. Install the base Codex-native skills first:
+1. Install the base Codex-native mirror first:
 
 ```bash
-mkdir -p ~/.codex/skills
-cp -a skills/skills-codex/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project
 ```
 
-2. Install the Claude-review overrides second:
+2. Re-run with the Claude overlay enabled:
 
 ```bash
-cp -a skills/skills-codex-claude-review/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-claude-review-overlay
 ```
 
 3. Register the local reviewer bridge:

--- a/skills/skills-codex-claude-review/README_CN.md
+++ b/skills/skills-codex-claude-review/README_CN.md
@@ -27,17 +27,16 @@
 
 ## 安装方式
 
-1. 先安装上游原生 Codex 技能包：
+1. 先安装上游原生 Codex 基座：
 
 ```bash
-mkdir -p ~/.codex/skills
-cp -a skills/skills-codex/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project
 ```
 
-2. 再安装这个 Claude-review 覆盖层：
+2. 再用 Claude overlay 重跑一次：
 
 ```bash
-cp -a skills/skills-codex-claude-review/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-claude-review-overlay
 ```
 
 3. 注册本地 reviewer bridge：

--- a/skills/skills-codex-gemini-review/README.md
+++ b/skills/skills-codex-gemini-review/README.md
@@ -94,17 +94,16 @@ Optional fallback only:
 
 - **Gemini CLI**: install `gemini` and complete login/auth if you explicitly want `GEMINI_REVIEW_BACKEND=cli`
 
-1. Install the base Codex-native skills first:
+1. Install the base Codex-native mirror first:
 
 ```bash
-mkdir -p ~/.codex/skills
-cp -a skills/skills-codex/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project
 ```
 
-2. Install the Gemini-review overrides second:
+2. Re-run with the Gemini overlay enabled:
 
 ```bash
-cp -a skills/skills-codex-gemini-review/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-gemini-review-overlay
 ```
 
 3. Register the local reviewer bridge:

--- a/skills/skills-codex-gemini-review/README_CN.md
+++ b/skills/skills-codex-gemini-review/README_CN.md
@@ -94,17 +94,16 @@
 
 - **Gemini CLI**：只有在你明确想用 `GEMINI_REVIEW_BACKEND=cli` 时，才需要本机安装 `gemini` 并完成登录/认证
 
-1. 先安装上游原生 Codex 技能包：
+1. 先安装上游原生 Codex 基座：
 
 ```bash
-mkdir -p ~/.codex/skills
-cp -a skills/skills-codex/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project
 ```
 
-2. 再安装这个 Gemini-review 覆盖层：
+2. 再用 Gemini overlay 重跑一次：
 
 ```bash
-cp -a skills/skills-codex-gemini-review/* ~/.codex/skills/
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-gemini-review-overlay
 ```
 
 3. 注册本地 reviewer bridge：

--- a/skills/skills-codex/README.md
+++ b/skills/skills-codex/README.md
@@ -1,70 +1,99 @@
 # `skills-codex`
 
-Codex-native mirror of the base ARIS skill set.
+Codex-native mirror and adaptation layer for the main ARIS `skills/` package.
 
 ## Scope
 
-This package keeps the main `skills/` workflows available for OpenAI Codex CLI.
+- Base mirror coverage: all `67` mainline skills under `skills/`
+- Support directory: `shared-references/`
+- Default reviewer contract for reviewer-heavy skills:
+  - round 1: `spawn_agent`
+  - follow-up: `send_input`
+  - reasoning effort: `xhigh`
+- Optional overlays:
+  - `skills-codex-claude-review`
+  - `skills-codex-gemini-review`
 
-Recent core workflow follow-up skills mirrored here include:
+This package is still an appendage to the Claude mainline, not a separate Codex-first product line.
 
-- `training-check`
-- `result-to-claim`
-- `ablation-planner`
+## Recommended Install
 
-These skills cover the experiment follow-up chain:
-
-1. monitor training quality early
-2. judge what claims the results actually support
-3. design reviewer-facing ablations before paper writing
-
-## Install
-
-> 💡 **Recommended: project-local symlink** (since v0.4.2). Project isolation keeps ARIS workflows separate from other community skill packs (Superpowers, etc.). See issue [#118](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/issues/118).
+Project-local install is the default path for Codex:
 
 ```bash
-# 1. Clone ARIS once to a stable location
 git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git ~/aris_repo
+cd ~/your-project
 
-# 2. Attach to a Codex project (auto-detects platform from AGENTS.md):
-cd ~/your-paper-project
-bash ~/aris_repo/tools/install_aris.sh
-# → creates .agents/skills/aris symlink → <aris-repo>/skills/skills-codex/
-# → adds managed block to AGENTS.md telling agent to use only project-local skills
-
-# Windows (PowerShell, junctions need admin or developer mode):
-.\tools\install_aris.ps1 C:\path\to\your-paper-project
+bash ~/aris_repo/tools/install_aris_codex.sh .
 ```
 
-<details>
-<summary><b>Alternative: legacy global install (`~/.codex/skills/`)</b></summary>
+This creates a flat managed layout:
+
+```text
+.agents/skills/<skill-name> -> ~/aris_repo/skills/skills-codex/<skill-name>
+.aris/installed-skills-codex.txt
+AGENTS.md   # managed Codex block
+```
+
+Reconcile after upstream changes:
 
 ```bash
-cp -a ~/aris_repo/skills/skills-codex/* ~/.codex/skills/
+cd ~/aris_repo && git pull
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile
 ```
 
-Global install increases the risk of skill name collisions when other community skill packs are also installed globally. Use only if you understand the trade-off and don't mix ARIS with other packs.
-
-</details>
-
-<details>
-<summary><b>Alternative: project-local copy (per-project customization)</b></summary>
+Uninstall only managed Codex entries:
 
 ```bash
-mkdir -p ~/your-project/.agents/skills
-bash ~/aris_repo/tools/smart_update.sh \
-    --project ~/your-project \
-    --target-subdir .agents/skills/aris \
-    --apply
-# Update with the same command (smart_update detects personal customizations)
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --uninstall
 ```
 
-</details>
+## Optional Overlays
 
-Optional companion dependency for the `deepxiv` skill:
+Install the base first, then choose an overlay:
 
 ```bash
-pip install deepxiv-sdk
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-claude-review-overlay
 ```
 
-If you also use reviewer overlay packages, install this base package first, then apply the overlay on top.
+```bash
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-gemini-review-overlay
+```
+
+Overlays only replace reviewer routing. They do not replace the base mirror or the executor model.
+
+## Copy Install and Update
+
+If you intentionally use a copied Codex install instead of managed project symlinks:
+
+```bash
+mkdir -p ~/.codex/skills
+cp -a ~/aris_repo/skills/skills-codex/. ~/.codex/skills/
+```
+
+Update copied installs with:
+
+```bash
+bash ~/aris_repo/tools/smart_update_codex.sh
+bash ~/aris_repo/tools/smart_update_codex.sh --apply
+```
+
+For a copied project-local Codex install:
+
+```bash
+bash ~/aris_repo/tools/smart_update_codex.sh --project ~/your-project
+bash ~/aris_repo/tools/smart_update_codex.sh --project ~/your-project --apply
+```
+
+`smart_update_codex.sh` refuses symlink-managed installs and redirects them to `install_aris_codex.sh --reconcile`.
+
+## Non-Degrading Skills
+
+The following Codex skills must not silently degrade when their required capability is missing:
+
+- `comm-lit-review`
+- `research-lit`
+- `paper-poster`
+- `pixel-art`
+
+If the required source, reviewer, or local preview capability is unavailable, the skill should stop and tell the user what to configure.

--- a/skills/skills-codex/README_CN.md
+++ b/skills/skills-codex/README_CN.md
@@ -1,81 +1,97 @@
-# skills-codex 说明
+# `skills-codex` 说明
 
-## 1. 这个包是什么
+这是主线 `skills/` 的 Codex 原生镜像 / 适配层，不是独立主线产品。
 
-这是一个面向 **Codex** 的技能包目录，当前版本已经与主线 `skills/` 对齐：
+## 当前范围
 
-- 保留主线科研技能的同名同步集
-- 同步包含 `training-check`、`ablation-planner`、`result-to-claim`、`rebuttal`
-- 同步包含 `mermaid-diagram`
-- 附带 `shared-references/`，但它**不计入 skill 数量**
+- 基座覆盖：主线 `skills/` 的 `67` 个 skill 全量同步
+- 支持目录：`shared-references/`
+- reviewer-heavy skill 的默认 reviewer 契约：
+  - 首轮：`spawn_agent`
+  - 续接：`send_input`
+  - 推理强度：`xhigh`
+- 可选 overlay：
+  - `skills-codex-claude-review`
+  - `skills-codex-gemini-review`
 
-数量对比：
+## 推荐安装方式
 
-- 主线 `skills/` 当前技能数：`39`
-- 本包技能数：`39`
-- 另附支持目录：`shared-references/`
+Codex 路线默认推荐项目级安装：
 
-本包路径结构是：
+```bash
+git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git ~/aris_repo
+cd ~/your-project
 
-```text
-skills/skills-codex/
-  <skill-name>/
-    SKILL.md
-    ...
-  shared-references/
-    ...
+bash ~/aris_repo/tools/install_aris_codex.sh .
 ```
 
-## 2. 和主线相比做了哪些变动
+安装后会形成扁平布局：
 
-### 2.1 范围控制
+```text
+.agents/skills/<skill-name> -> ~/aris_repo/skills/skills-codex/<skill-name>
+.aris/installed-skills-codex.txt
+AGENTS.md   # 自动写入 Codex 管理块
+```
 
-本包只保留：
+上游更新后收敛：
 
-- 主线 `skills/` 中已有的同名技能
-- 少量确实需要的资源目录
+```bash
+cd ~/aris_repo && git pull
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile
+```
 
-因此，本包 **不包含**：
+只卸载受管的 Codex skill：
 
-- `doc`
-- `pdf`
-- `.system/*`
+```bash
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --uninstall
+```
 
-### 2.2 Codex 适配原则
+## Overlay 安装
 
-- 保留原技能的任务边界和工作流
-- 旧的控制型写法改成 `spawn_agent` / `send_input`
-- 外部能力接入说明可以保留，但不迁移对应服务配置
-- 尽量做最小修改，不把技能重写成另一套风格
+先装基座，再选装 overlay：
 
-### 2.3 哪些不是单文件
+```bash
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-claude-review-overlay
+```
 
-当前不是单文件的有：
+```bash
+bash ~/aris_repo/tools/install_aris_codex.sh ~/your-project --reconcile --with-gemini-review-overlay
+```
 
-- `paper-write`
-- `comm-lit-review`
-- `shared-references`
+overlay 只替换 reviewer 路由，不替换基座 mirror，也不改变 executor 语义。
 
-原因：
+## Copy 安装与更新
 
-- `paper-write` 依赖 `templates/`
-- `comm-lit-review` 依赖 `references/`
-- `paper-plan` / `paper-write` 会引用 `shared-references/`
-
-## 3. 如何安装
+如果你明确想用 copy 安装，而不是受管 symlink：
 
 ```bash
 mkdir -p ~/.codex/skills
-cp -a skills/skills-codex/* ~/.codex/skills/
+cp -a ~/aris_repo/skills/skills-codex/. ~/.codex/skills/
 ```
 
-## 4. 安装时需要知道的边界
+更新 copy 安装请使用：
 
-本包只处理**技能文件**，不处理：
+```bash
+bash ~/aris_repo/tools/smart_update_codex.sh
+bash ~/aris_repo/tools/smart_update_codex.sh --apply
+```
 
-- Python 依赖
-- LaTeX / Poppler / GPU / SSH / conda 环境
-- MCP 配置
-- API Key / 环境变量
+项目级 copy 安装则使用：
 
-也就是说，本包解决的是 **技能文件迁移**，不是 **运行环境迁移**。
+```bash
+bash ~/aris_repo/tools/smart_update_codex.sh --project ~/your-project
+bash ~/aris_repo/tools/smart_update_codex.sh --project ~/your-project --apply
+```
+
+`smart_update_codex.sh` 会拒绝更新由 `install_aris_codex.sh` 管理的 symlink 安装，并提示改用 `install_aris_codex.sh --reconcile`。
+
+## 不允许降级的 Skill
+
+以下 4 个 skill 不允许静默降级：
+
+- `comm-lit-review`
+- `research-lit`
+- `paper-poster`
+- `pixel-art`
+
+如果缺少所需能力，必须明确提示用户去配置，不允许自动改成简化路径继续跑。

--- a/skills/skills-codex/ablation-planner/SKILL.md
+++ b/skills/skills-codex/ablation-planner/SKILL.md
@@ -10,10 +10,6 @@ Systematically design ablation studies that answer the questions reviewers will 
 
 ## Context: $ARGUMENTS
 
-## Constants
-
-- **REVIEWER_MODEL = `gpt-5.4`** - Used via a secondary Codex agent for reviewer-style ablation design.
-
 ## When to Use
 
 - Main results pass `/result-to-claim` with `claim_supported = yes` or `partial`
@@ -31,11 +27,11 @@ Read available project files to build the full picture:
 - Confirmed and intended claims (from `/result-to-claim` output or project notes)
 - Available compute resources (from server notes, run configs, or user-provided budget)
 
-### Step 2: Secondary Codex Designs Ablations
+### Step 2: Codex Designs Ablations
 
 ```text
 spawn_agent:
-  model: REVIEWER_MODEL
+  model: gpt-5.4
   reasoning_effort: xhigh
   message: |
     You are a rigorous ML reviewer planning ablation studies.
@@ -102,9 +98,9 @@ Normalize the response into a structured format:
 [Total GPU-hours]
 ```
 
-### Step 4: Review Feasibility
+### Step 4: CC Reviews Feasibility
 
-Before running anything, check:
+Before running anything, the local executor checks:
 
 - Compute budget - Can you afford all ablations with available GPUs?
 - Code changes - Which ablations need code modifications vs config-only changes?

--- a/skills/skills-codex/alphaxiv/SKILL.md
+++ b/skills/skills-codex/alphaxiv/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: alphaxiv
+description: Quick single-paper lookup via AlphaXiv LLM-optimized summaries with tiered source fallback. Use when user says "explain this paper", "summarize paper", pastes an arXiv/AlphaXiv URL, or provides a bare arXiv ID for quick understanding - not for broad literature search.
+argument-hint: [arxiv-id-or-url]
+allowed-tools: Bash(*), Read, Write, WebFetch, Glob
+---
+
+# AlphaXiv Paper Lookup
+
+Lookup paper: $ARGUMENTS
+
+> Quick single-paper reader with tiered source fallback (overview → full markdown → LaTeX source). Powered by [AlphaXiv](https://alphaxiv.org).
+
+## Role & Positioning
+
+This skill is the **quick single-paper reader** that returns LLM-optimized summaries:
+
+| Skill | Source | Best for |
+|-------|--------|----------|
+| `/arxiv` | arXiv API | Batch search, PDF download, metadata |
+| `/deepxiv` | DeepXiv SDK | Progressive section-level reading |
+| `/semantic-scholar` | S2 API | Published venue metadata, citation counts |
+| **`/alphaxiv`** | **alphaxiv.org** | **Instant LLM-optimized summary of one paper, with LaTeX source fallback** |
+
+**Do NOT use this skill for** topic discovery, broad literature search, or multi-paper surveys — use `/research-lit` or `/arxiv` instead.
+
+## Constants
+
+- **OVERVIEW_URL** = `https://alphaxiv.org/overview/{PAPER_ID}.md`
+- **ABS_URL** = `https://alphaxiv.org/abs/{PAPER_ID}.md`
+- **ARXIV_SRC_URL** = `https://arxiv.org/src/{PAPER_ID}`
+
+> Overrides (append to arguments):
+> - `/alphaxiv 2401.12345` — quick overview
+> - `/alphaxiv "https://arxiv.org/abs/2401.12345"` — auto-extract ID
+> - `/alphaxiv 2401.12345 - depth: src` — force LaTeX source inspection
+> - `/alphaxiv 2401.12345 - depth: abs` — force full markdown
+
+## Workflow
+
+### Step 1: Parse Arguments & Extract Paper ID
+
+Parse `$ARGUMENTS` to extract a bare arXiv paper ID. Accept these input formats:
+
+- `https://arxiv.org/abs/2401.12345` or `https://arxiv.org/abs/2401.12345v2`
+- `https://arxiv.org/pdf/2401.12345`
+- `https://alphaxiv.org/overview/2401.12345`
+- `https://alphaxiv.org/abs/2401.12345`
+- `2401.12345` or `2401.12345v2`
+
+Strip version suffixes (`v1`, `v2`, ...) for API calls. Store as `PAPER_ID`.
+
+Parse optional directives:
+- **`- depth: overview|abs|src`**: force a specific tier instead of cascading
+
+### Step 2: Fetch AlphaXiv Overview (Tier 1 — Fastest)
+
+Fetch the structured overview from `https://alphaxiv.org/overview/{PAPER_ID}.md`.
+
+This returns a **structured, LLM-optimized report** designed for machine consumption. Use this as the default and preferred source.
+
+If the overview answers the user's question, **stop here**. Do not fetch deeper tiers unnecessarily.
+
+If the request fails (HTTP 404 — paper not yet processed) or the content is insufficient, proceed to Step 3.
+
+### Step 3: Fetch Full AlphaXiv Markdown (Tier 2 — More Detail)
+
+Fetch the full paper markdown from `https://alphaxiv.org/abs/{PAPER_ID}.md`.
+
+This provides the full paper body as markdown. Use when the user needs:
+- Specific methodology details
+- Detailed experimental results
+- Particular sections not covered in the overview
+
+If this still does not answer the question, proceed to Step 4.
+
+### Step 4: Fetch arXiv LaTeX Source (Tier 3 — Deepest)
+
+When the overview and full markdown are both insufficient (e.g., the user asks about equations, proofs, appendix details, or implementation specifics), download the paper's LaTeX source from `https://arxiv.org/src/{PAPER_ID}`.
+
+The source is a `.tar.gz` archive. Download it to a temporary directory, extract it, and list the `.tex` files inside.
+
+Then inspect **only** the files needed to answer the question. Prioritize:
+
+1. Top-level `*.tex` files (usually the main document)
+2. Files referenced by `\input{}` or `\include{}`
+3. Appendices, tables, or sections directly related to the user's question
+
+**Do NOT read the entire source tree by default.** Read selectively.
+
+Temporary source artifacts live under `/tmp`. Do not rely on persistence.
+
+### Step 5: Present Results
+
+#### Default Answer Shape
+
+```markdown
+## [Paper Title]
+
+- **arXiv**: [PAPER_ID] — https://arxiv.org/abs/[PAPER_ID]
+- **Source depth**: overview | abs | src
+
+### Summary
+[2-3 sentence summary]
+
+### Key Points
+- [point 1]
+- [point 2]
+- [point 3]
+
+### Answer to Your Question
+[Direct answer if the user asked a specific question]
+```
+
+If the user only asks for one specific detail, answer it directly — skip the full template.
+
+#### Suggest Follow-Up Skills
+
+```text
+/arxiv "PAPER_ID" - download          - download the PDF to local library
+/deepxiv "PAPER_ID" - section: Methods  - read a specific section progressively
+/research-lit "related topic"        - multi-source literature survey
+/novelty-check "idea from paper"     - verify novelty against this paper's area
+```
+
+## Update Research Wiki (if active)
+
+**Required when `research-wiki/` exists in the project**; skip silently
+otherwise. After presenting the paper summary, ingest the single paper
+that was read:
+
+```
+if [ -d research-wiki/ ]:
+    ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+    WIKI_SCRIPT=""
+    [ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+    [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+        --arxiv-id "<paper_arxiv_id>" \
+        [--thesis "<one-line thesis from the Tier 1 overview>"]
+```
+
+The helper handles metadata fetch, slug, dedup, page creation, index
+rebuild, and log append — **do not handwrite `papers/<slug>.md`**. See
+[`shared-references/integration-contract.md`](../shared-references/integration-contract.md).
+If wiki was not present at read time, the user can backfill via
+`python3 "$WIKI_SCRIPT" sync research-wiki/ --arxiv-ids <id>` after resolving `WIKI_SCRIPT` as above.
+
+## Key Rules
+
+- **Overview first**: `overview` is the fastest path and must always be tried before deeper tiers. Only escalate when needed.
+- **Minimal reads**: At `src` tier, read only the files that answer the question. Full-tree reads waste tokens.
+- **Cross-platform**: When downloading and extracting the source archive, prefer cross-platform approaches (e.g., Python stdlib) over platform-specific commands to ensure Windows/WSL compatibility.
+- **No PDF parsing**: This skill reads structured markdown and LaTeX source, not raw PDFs. For PDF content, suggest `/arxiv` with download.
+- **Rate limiting**: arXiv source download may rate-limit. If HTTP 429 occurs, wait 5 seconds and retry once. If still blocked, report the error and suggest `/deepxiv` as alternative.
+- **Complementary, not competing**: This skill complements `/arxiv` (search + download) and `/deepxiv` (progressive reading). Do not re-implement their functionality.
+
+## Integration with Other Skills
+
+### As enrichment in `/research-lit`
+
+`/research-lit` can use this skill's Tier 1 (overview) as a fast enrichment step between search and deep analysis. After finding arXiv papers in Step 1, fetch AlphaXiv overviews to quickly assess relevance before committing to full-text reads:
+
+```
+Step 1: Search → list of arXiv IDs
+Step 1.5: AlphaXiv overview for top 5-8 papers (this skill, Tier 1 only)
+Step 2: Deep analysis only for papers that pass the relevance filter
+```
+
+This saves significant tokens by filtering out marginally relevant papers before deep reading.
+
+### As follow-up from other skills
+
+After `/research-lit`, `/novelty-check`, or `/idea-discovery` surface a specific paper, users can invoke `/alphaxiv PAPER_ID` for a fast deep-dive without re-running the full survey.

--- a/skills/skills-codex/arxiv/SKILL.md
+++ b/skills/skills-codex/arxiv/SKILL.md
@@ -11,7 +11,7 @@ Search topic or arXiv paper ID: $ARGUMENTS
 
 - **PAPER_DIR** - Local directory to save downloaded PDFs. Default: `papers/` in the current project directory.
 - **MAX_RESULTS = 10** - Default number of search results.
-- **FETCH_SCRIPT** - `tools/arxiv_fetch.py` relative to the ARIS install, or the same path relative to the current project. Fall back to inline Python if not found.
+- **FETCH_SCRIPT** - `$ARIS_REPO/tools/arxiv_fetch.py` from the ARIS repo recorded by the Codex install manifest. Fall back to inline Python if not found.
 
 > Overrides (append to arguments):
 > - `/arxiv "attention mechanism" - max: 20` - return up to 20 results
@@ -35,16 +35,21 @@ If the argument matches an arXiv ID pattern (`YYMM.NNNNN` or `category/NNNNNNN`)
 
 ### Step 2: Search arXiv
 
-Locate the fetch script:
+Locate the fetch script. Prefer the Codex managed install manifest when present, then fall back to the same project/global copy-install lookup style as the Claude skill:
 
 ```bash
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+export ARIS_REPO
 SCRIPT=$(python3 -c "
 import pathlib
+import os
 candidates = [
+    pathlib.Path(os.environ['ARIS_REPO']) / 'tools' / 'arxiv_fetch.py'
+    if os.environ.get('ARIS_REPO') else None,
     pathlib.Path('tools/arxiv_fetch.py'),
     pathlib.Path.home() / '.codex' / 'skills' / 'arxiv' / 'arxiv_fetch.py',
 ]
-for p in candidates:
+for p in [c for c in candidates if c is not None]:
     if p.exists():
         print(p)
         break
@@ -108,7 +113,7 @@ Present results as a table:
 When a single paper ID is requested (either directly or from Step 2):
 
 ```bash
-python3 "$SCRIPT" search "id:ARXIV_ID" --max 1
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" search "id:ARXIV_ID" --max 1
 # or fallback:
 python3 -c "
 import urllib.request, xml.etree.ElementTree as ET
@@ -128,7 +133,7 @@ When download is requested, for each paper ID to download:
 
 ```bash
 # Using fetch script:
-python3 "$SCRIPT" download ARXIV_ID --dir PAPER_DIR
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" download ARXIV_ID --dir PAPER_DIR
 
 # Fallback:
 mkdir -p PAPER_DIR && python3 -c "
@@ -175,7 +180,16 @@ For each paper (downloaded or fetched by API):
 - **Local PDF**: papers/[ID].pdf (if downloaded)
 ```
 
-### Step 6: Final Output
+### Step 6: Update Research Wiki (if active)
+
+If the project has an active research wiki, update it after search or download:
+
+1. Add each accepted paper to the canonical paper table.
+2. Record arXiv ID, title, authors, abstract URL, PDF URL, local PDF path, and source query.
+3. Follow the integration contract in [`shared-references/integration-contract.md`](../shared-references/integration-contract.md).
+4. If the wiki path or schema is unclear, ask before writing rather than inventing a location.
+
+### Step 7: Final Output
 
 Summarize what was done:
 
@@ -199,4 +213,3 @@ Suggest follow-up skills:
 - Handle both arXiv ID formats: new (`2301.07041`) and old (`cs/0601001`)
 - PAPER_DIR is created automatically if it does not exist
 - If the arXiv API is unreachable, report the error clearly and suggest using `/research-lit` with `- sources: web` as a fallback
-

--- a/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: "auto-paper-improvement-loop"
-description: "Autonomously improve a generated paper via GPT-5.4 xhigh review \u2192 implement fixes \u2192 recompile, for 2 rounds. Use when user says \\\"\u6539\u8bba\u6587\\\", \\\"improve paper\\\", \\\"\u8bba\u6587\u6da6\u8272\u5faa\u73af\\\", \\\"auto improve\\\", or wants to iteratively polish a generated paper."
+name: auto-paper-improvement-loop
+description: "Autonomously improve a generated paper via GPT-5.4 xhigh review → implement fixes → recompile, for 2 rounds. Use when user says \"改论文\", \"improve paper\", \"论文润色循环\", \"auto improve\", or wants to iteratively polish a generated paper."
+argument-hint: [paper-directory]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
 ---
 
 # Auto Paper Improvement Loop: Review → Fix → Recompile
@@ -16,7 +18,8 @@ Unlike `/auto-review-loop` (which iterates on **research** — running experimen
 ## Constants
 
 - **MAX_ROUNDS = 2** — Two rounds of review→fix→recompile. Empirically, Round 1 catches structural issues (4→6/10), Round 2 catches remaining presentation issues (6→7/10). Diminishing returns beyond 2 rounds for writing-only improvements.
-- **REVIEWER_MODEL = `gpt-5.4`** — Model used via a secondary Codex agent for paper review.
+- **REVIEWER_MODEL = `gpt-5.4`** — Model used via Codex MCP for paper review.
+- **REVIEWER_BIAS_GUARD = true** — When `true`, every review round uses a fresh `spawn_agent` reviewer with no prior review context. Do not use stale self-reported context for review rounds. Set to `false` only for deliberate debugging of the legacy behavior. **Empirical evidence (April 2026):** running the same paper with `codex-reply` + "since last round we did X" prompts inflated scores from real 3/10 → fake 8/10 across 5 rounds; switching to fresh threads recovered the true 3/10 assessment.
 - **REVIEW_LOG = `PAPER_IMPROVEMENT_LOG.md`** — Cumulative log of all rounds, stored in paper directory.
 - **HUMAN_CHECKPOINT = false** — When `true`, pause after each round's review and present score + weaknesses to the user. The user can approve fixes, provide custom modification instructions, skip specific fixes, or stop early. When `false` (default), runs fully autonomously.
 
@@ -29,7 +32,7 @@ Unlike `/auto-review-loop` (which iterates on **research** — running experimen
 
 ## State Persistence (Compact Recovery)
 
-If the context window fills up mid-loop, Codex auto-compacts. To recover, this skill writes `PAPER_IMPROVEMENT_STATE.json` after each round:
+If the context window fills up mid-loop, Claude Code auto-compacts. To recover, this skill writes `PAPER_IMPROVEMENT_STATE.json` after each round:
 
 ```json
 {
@@ -44,6 +47,20 @@ If the context window fills up mid-loop, Codex auto-compacts. To recover, this s
 **On startup**: if `PAPER_IMPROVEMENT_STATE.json` exists with `"status": "in_progress"` AND `timestamp` is within 24 hours, read it + `PAPER_IMPROVEMENT_LOG.md` to recover context, then resume from the next round. Otherwise (file absent, `"status": "completed"`, or older than 24 hours), start fresh.
 
 **After each round**: overwrite the state file. **On completion**: set `"status": "completed"`.
+
+## Reviewer Independence Protocol
+
+The reviewer must be context-naive on every round. Prior-round summaries, fix lists, and executor explanations are not evidence; they are a source of confirmation bias. If the reviewer is told what changed, scores tend to drift upward even when the manuscript itself has not materially improved.
+
+Rules:
+- Every round starts with a fresh `spawn_agent` reviewer call, not a stale continuation prompt.
+- Never pass a prior agent_id into the next review prompt.
+- Never include "since last round", "we fixed", "after applying", or any fix summary in the reviewer prompt.
+- The only acceptable evidence of improvement is the current `.tex` source and compiled PDF.
+- If a fix cannot be observed in the files, the reviewer should not be told it happened.
+- If recovery metadata is needed, store the returned agent_id for crash recovery only; do not use it to preserve review context.
+
+Set `REVIEWER_BIAS_GUARD = false` only if you explicitly want the legacy, context-carrying behavior for debugging.
 
 ## Workflow
 
@@ -67,17 +84,21 @@ done > /tmp/paper_full_text.txt
 
 ### Step 2: Round 1 Review
 
-Send the full paper text to GPT-5.4 xhigh:
+Send the full paper text AND compiled PDF to GPT-5.4 xhigh:
 
-```
+```text
 spawn_agent:
   model: gpt-5.4
   reasoning_effort: xhigh
   message: |
     You are reviewing a [VENUE] paper. Please provide a detailed, structured review.
 
-    ## Full Paper Text:
-    [paste concatenated sections]
+    ## Paper Files:
+    - LaTeX source: [list all section .tex files]
+    - Compiled PDF: paper/main.pdf
+    - Figures: [list figure files]
+
+    Read BOTH the LaTeX source (for content/logic) AND the compiled PDF (for visual presentation).
 
     ## Review Instructions
     Please act as a senior ML reviewer ([VENUE] level). Provide:
@@ -87,13 +108,19 @@ spawn_agent:
     4. **Weaknesses** (bullet list, ranked: CRITICAL > MAJOR > MINOR)
     5. **For each CRITICAL/MAJOR weakness**: A specific, actionable fix
     6. **Missing References** (if any)
-    7. **Verdict**: Ready for submission? Yes / Almost / No
+    7. **Visual Review** (from the PDF):
+       - Figure quality: readable? labels legible? colors distinguishable in grayscale?
+       - Figure-caption alignment: does each caption match its figure?
+       - Layout: orphaned headers, awkward page breaks, figures far from references?
+       - Table formatting: aligned columns, consistent decimals, bold for best results?
+       - Visual consistency: same color scheme across all figures?
+    8. **Verdict**: Ready for submission? Yes / Almost / No
 
     Focus on: theoretical rigor, claims vs evidence alignment, writing clarity,
-    self-containedness, notation consistency.
+    self-containedness, notation consistency, AND visual presentation quality.
 ```
 
-Save the agent id for Round 2.
+Save the agent_id for Round 2.
 
 ### Step 2b: Human Checkpoint (if enabled)
 
@@ -135,6 +162,10 @@ Parse the review and implement fixes by severity:
 | Notation confusion | Rename conflicting symbols globally, add Notation paragraph |
 | Missing references | Add to `references.bib`, cite in appropriate locations |
 | Theory-practice gap | Explicitly frame theory as idealized; add synthetic validation subsection |
+| Proof gap (theory papers) | Run `/proof-checker` if PROOF_AUDIT.md doesn't exist yet; fix FATAL/CRITICAL issues |
+| Writing clutter / passive voice | Apply sciwrite 5-pass audit: clutter extraction → active voice → sentence architecture → keyword consistency → numerical integrity. See `paper-write` Step 5 |
+| Number mismatch (paper vs results) | Run `/paper-claim-audit` if PAPER_CLAIM_AUDIT.md doesn't exist; fix any `number_mismatch` or `aggregation_mismatch` claims |
+| Keyword inconsistency | The "Banana Rule": if Methods says "obese group", Results must not say "heavier group". Extract key terms, verify consistency across all sections |
 
 ### Step 4: Recompile Round 1
 
@@ -145,26 +176,106 @@ cp main.pdf main_round1.pdf
 
 Verify: 0 undefined references, 0 undefined citations.
 
+### Step 4.5: Restatement Regression Test
+
+After every recompilation, rerun a theorem-statement consistency check so fix rounds cannot reintroduce appendix drift. **Run this after Step 4 and again after Step 7 before the final format check.**
+
+**Scope**
+- Compare only theorem/lemma/proposition/corollary statements, not proof bodies.
+- Classify files by `main.tex` input order: files before `\appendix` are main body; files after `\appendix` are appendix.
+
+**Normalized comparison logic**
+- Strip comments, `\label{...}`, `\ref{...}`, `\eqref{...}`, `\cite...{...}`, and whitespace-only differences.
+- Collapse formatting-only macros such as `\emph{}`, `\textbf{}`, `\textit{}`, `\mathrm{}`, `\mathbf{}`, `\mathcal{}`, and `\operatorname{}` to their contents.
+- Preserve quantifiers, case splits, assumptions, and the literal names of defined objects.
+- Compare by theorem label when available; otherwise compare by theorem type and order.
+- Flag any change in hypotheses, case splits, quantifier order, or terminology (`stationary` vs `terminal`) as regression drift.
+
+```bash
+python3 - <<'PY'
+import re
+def normalize(s):
+    s = re.sub(r'%.*', '', s)
+    s = re.sub(r'\\label\{[^}]*\}', '', s)
+    s = re.sub(r'\\(?:ref|eqref|cref|Cref|cite[a-zA-Z]*)\{[^}]*\}', '', s)
+    s = re.sub(r'\\(?:emph|textbf|textit|mathrm|mathbf|mathsf|mathcal|operatorname)\{([^{}]*)\}', r'\1', s)
+    s = re.sub(r'\\begin\{[^}]+\}|\\end\{[^}]+\}', '', s)
+    s = re.sub(r'\s+', ' ', s)
+    return s.strip().lower()
+# Compare normalized theorem blocks from the current main-body files
+# against their appendix restatements. Any mismatch blocks completion.
+PY
+```
+
+**Empirical motivation:** in our April 2026 NeurIPS run, `thm:dsm-oracle` had a 3-case split (w=0/1/>1) in main but no case split in appendix; `nu_T` was named "stationary" in main and "terminal" in appendix. These drifted multiple times across fix rounds because no automated check caught regression.
+
 ### Step 5: Round 2 Review
 
-Use `send_input` with the saved agent id:
+If `REVIEWER_BIAS_GUARD = true` (default), use a **fresh** `spawn_agent` reviewer for Round 2. Do not ask the reviewer to reward the Round 1 fix summary for prompting. Save the returned agent_id only for recovery bookkeeping.
 
-```
-send_input:
-  id: [saved from Round 1]
+```text
+spawn_agent:
   model: gpt-5.4
   reasoning_effort: xhigh
   message: |
-    [Round 2 update]
+    You are reviewing a [VENUE] paper. This is a fresh, zero-context review.
+    Ignore any prior review rounds, prior fix lists, or executor explanations.
+    Judge the paper only from the current LaTeX source and compiled PDF.
 
-    Since your last review, we have implemented:
-    1. [Fix 1]: [description]
-    2. [Fix 2]: [description]
-    ...
+    ## Paper Files:
+    - LaTeX source: [list all section .tex files]
+    - Compiled PDF: paper/main.pdf
+    - Figures: [list figure files]
 
-    Please re-score and re-assess. Same format:
-    Score, Summary, Strengths, Weaknesses, Actionable fixes, Verdict.
+    Read BOTH the LaTeX source (for content/logic) AND the compiled PDF (for visual presentation).
+
+    ## Review Instructions
+    Please act as a senior ML reviewer ([VENUE] level). Provide:
+    1. **Overall Score** (1-10, where 6 = weak accept, 7 = accept)
+    2. **Summary** (2-3 sentences)
+    3. **Strengths** (bullet list, ranked)
+    4. **Weaknesses** (bullet list, ranked: CRITICAL > MAJOR > MINOR)
+    5. **For each CRITICAL/MAJOR weakness**: A specific, actionable fix
+    6. **Missing References** (if any)
+    7. **Visual Review** (from the PDF):
+       - Figure quality: readable? labels legible? colors distinguishable in grayscale?
+       - Figure-caption alignment: does each caption match its figure?
+       - Layout: orphaned headers, awkward page breaks, figures far from references?
+       - Table formatting: aligned columns, consistent decimals, bold for best results?
+       - Visual consistency: same color scheme across all figures?
+    8. **Verdict**: Ready for submission? Yes / Almost / No
+
+    Focus on: theoretical rigor, claims vs evidence alignment, writing clarity,
+    self-containedness, notation consistency, and visual presentation quality.
 ```
+
+If `REVIEWER_BIAS_GUARD = false` (legacy debugging only), use `send_input` with the saved reviewer id; this is **not** the recommended path.
+
+### Step 5.5: Kill Argument Exercise (theory papers only)
+
+Run this only if the paper is theory-heavy (≥5 `\begin{theorem}|\begin{lemma}|\begin{proposition}|\begin{corollary}` environments in the source) and only on the final scheduled round (`current_round == MAX_ROUNDS`).
+
+This is a late-stage adversarial check. It must always use **fresh** `spawn_agent` reviewers, never `codex-reply`, and it must not reuse any prior review context.
+
+**Thread 1: Attack**
+- Use a fresh thread with only the current paper files.
+- Prompt: "Construct the single best argument to reject this paper in 200 words. Focus on theorem validity, assumption mismatch, missing proof obligations, limit-order ambiguity, and claim/evidence gaps. Do not reference prior rounds or fixes."
+
+**Thread 2: Defense**
+- Use a second fresh thread with the current paper files plus the attack memo.
+- Prompt: "Now defend the paper against the attack memo. For each rejection point, classify it as already fixed, partially fixed, or still unresolved, and cite the current files. Do not reuse prior review context."
+
+**Merge rule**
+- Dedupe attack points against the Round 2 weakness list by semantic overlap.
+- Append any novel unresolved attack point to the Step 6 fix list before implementation.
+- If the defense cannot refute a point, keep it at the original severity or raise it by one level if it exposes a main-theorem or core-assumption failure.
+- If the defense shows the issue is already fixed in the current files, only downgrade after verifying the file evidence.
+- Record both memos in `PAPER_IMPROVEMENT_LOG.md`.
+- If `HUMAN_CHECKPOINT = true`, include the merged findings in the checkpoint summary before asking the user to proceed.
+
+This phase feeds directly into Step 6. The attack/defense findings must be merged before the final recompile.
+
+**Empirical motivation:** in our April 2026 NeurIPS run, after 5 rounds of standard improvement (score 7-8/10), the kill-argument exercise surfaced framing weaknesses that no prior review caught (e.g., "width-w is mostly conditional", "CRF irrelevant to real D-LLMs"). Author rebuttal forced explicit scope qualifications in abstract and discussion.
 
 ### Step 5b: Human Checkpoint (if enabled)
 
@@ -187,37 +298,68 @@ cp main.pdf main_round2.pdf
 
 ### Step 8: Format Check
 
-After the final recompilation, run a format compliance check:
+After the final recompilation, run a **location-aware** format compliance check.
+
+```bash
+# If the log lacks file/line data, rerun the final compile once with -file-line-error.
+cd paper && latexmk -pdf -file-line-error -interaction=nonstopmode -halt-on-error main.tex
+```
 
 ```bash
 # 1. Page count vs venue limit
 PAGES=$(pdfinfo paper/main.pdf | grep Pages | awk '{print $2}')
 echo "Pages: $PAGES (limit: 9 main body for ICLR/NeurIPS)"
 
-# 2. Overfull hbox warnings (content exceeding margins)
-OVERFULL=$(grep -c "Overfull" paper/main.log 2>/dev/null || echo 0)
-echo "Overfull hbox warnings: $OVERFULL"
-grep "Overfull" paper/main.log 2>/dev/null | head -10
+# 2. Duplicate labels: HARD BLOCK
+DUP_LABELS=$(grep -Rho "\\\\label{[^}]*}" paper/main.tex paper/sections 2>/dev/null | sort | uniq -d || true)
+if [ -n "$DUP_LABELS" ]; then
+    echo "Duplicate labels found (BLOCKING):"
+    echo "$DUP_LABELS"
+fi
 
-# 3. Underfull hbox warnings (loose spacing)
-UNDERFULL=$(grep -c "Underfull" paper/main.log 2>/dev/null || echo 0)
-echo "Underfull hbox warnings: $UNDERFULL"
+# 3. Overfull warnings with location classification
+OVERFULLS=$(grep -n "Overfull \\\\hbox" paper/main.log 2>/dev/null || true)
 
-# 4. Bad boxes summary
-grep -c "badness" paper/main.log 2>/dev/null || echo "0 badness warnings"
+# Main body = source files before \appendix in main.tex.
+# Appendix = source files after \appendix, or files whose path contains "appendix".
+# Bibliography = paper.bbl, references.bib, or bibliography-generated output.
+MAIN_BODY_OVERFULL=$(echo "$OVERFULLS" | grep -v -E 'appendix|paper\.bbl|references\.bib' || true)
+APPENDIX_OVERFULL=$(echo "$OVERFULLS" | grep -E 'appendix' || true)
+BIB_OVERFULL=$(echo "$OVERFULLS" | grep -E 'paper\.bbl|references\.bib' || true)
+
+echo "Main-body overfulls (any size BLOCKS):"
+echo "$MAIN_BODY_OVERFULL"
+echo "Appendix overfulls (>10pt blocks):"
+echo "$APPENDIX_OVERFULL"
+echo "Bibliography overfulls (>20pt blocks):"
+echo "$BIB_OVERFULL"
 ```
 
-**Auto-fix patterns:**
+**Stop criteria:**
+- Any duplicate label blocks completion.
+- Any overfull in the main body blocks completion, regardless of size.
+- Appendix overfulls block completion only if they exceed 10pt or are visibly clipping.
+- Bibliography overfulls block completion only if they exceed 20pt or are visibly clipping.
+- Underfull hboxes remain warnings unless they create obvious layout damage.
+
+**Auto-fix patterns (location-aware):**
 
 | Issue | Fix |
 |-------|-----|
-| Overfull hbox in equation | Wrap in `\resizebox` or split with `\split`/`aligned` |
-| Overfull hbox in table | Reduce font (`\small`/`\footnotesize`) or use `\resizebox{\linewidth}{!}{...}` |
-| Overfull hbox in text | Rephrase sentence or add `\allowbreak` / `\-` hints |
+| Main-body overfull in equation | Split with `aligned` / `split` / `multline`, or shorten notation |
+| Main-body overfull in table | Reduce font, resize table, or break table across rows |
+| Main-body overfull in text | Rephrase; do not hide it with global `\sloppy` |
+| Appendix overfull ≤ 10pt | Warn only unless visibly clipping |
+| Appendix overfull > 10pt | Apply the same fix if the spill is visible |
+| Bibliography overfull ≤ 20pt | Warn only unless caused by malformed entry or clipping |
+| Bibliography overfull > 20pt | Fix malformed entry, URL, or DOI formatting |
 | Over page limit | Move content to appendix, compress tables, reduce figure sizes |
-| Underfull hbox (loose) | Rephrase for better line filling or add `\looseness=-1` |
 
-If any overfull hbox > 10pt is found, fix it and recompile before documenting.
+**Location-aware interpretation:**
+- Classify by the source file reported in the `-file-line-error` log.
+- If a warning cannot be classified, treat it as main body and fix it.
+
+**Empirical motivation:** in our April 2026 NeurIPS run, 28+ overfull hbox warnings (largest 160pt in the appendix bridge proof) survived 5 improvement rounds because the previous blanket "overfull > 10pt blocks" rule was too lax and treated all locations equally.
 
 ### Step 9: Document Results
 
@@ -300,7 +442,7 @@ paper/
 
 - **Preserve all PDF versions** — user needs to compare progression
 - **Save FULL raw review text** — do not summarize or truncate GPT-5.4 responses
-- **Use `send_input`** for Round 2 to maintain conversation context
+- **Reviewer independence (Round 2+)**: when `REVIEWER_BIAS_GUARD = true` (default), use a **fresh** `spawn_agent` reviewer for every review round; never use stale reviewer continuation and never include "since last round" / fix summaries in the prompt. See the Reviewer Independence Protocol section above.
 - **Always recompile after fixes** — verify 0 errors before proceeding
 - **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
 - **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
@@ -319,3 +461,6 @@ Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
 
 **+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final: 8 pages main body, 0 overfull hbox, ICLR-compliant.
 
+## Review Tracing
+
+After each `spawn_agent`, `send_input`, or adversarial reviewer call, save the trace following `../shared-references/review-tracing.md`. Write files directly to `.aris/traces/auto-paper-improvement-loop/<date>_run<NN>/`. Respect the `--- trace:` parameter when present (default: `full`).

--- a/skills/skills-codex/auto-review-loop/SKILL.md
+++ b/skills/skills-codex/auto-review-loop/SKILL.md
@@ -16,10 +16,33 @@ Autonomously iterate: review → implement fixes → re-review, until the extern
 - REVIEW_DOC: `review-stage/AUTO_REVIEW.md` (cumulative log) *(fall back to `./AUTO_REVIEW.md` for legacy projects)*
 - **OUTPUT_DIR = `review-stage/`** — All review-stage outputs go here. Create the directory if it doesn't exist.
 - REVIEWER_MODEL = `gpt-5.4` — Model used via a secondary Codex agent. Must be an OpenAI model (e.g., `gpt-5.4`, `o3`, `gpt-4o`)
+- **REVIEWER_BACKEND = `codex`** — Default: Codex reviewer agent at xhigh reasoning. Override with `--reviewer: oracle-pro` only when the user explicitly requests Oracle; if Oracle is unavailable, warn and fall back to Codex xhigh.
 - **HUMAN_CHECKPOINT = false** — When `true`, pause after each round's review (Phase B) and present the score + weaknesses to the user. Wait for user input before proceeding to Phase C. The user can: approve the suggested fixes, provide custom modification instructions, skip specific fixes, or stop the loop early. When `false` (default), the loop runs fully autonomously.
 - **COMPACT = false** — When `true`, (1) read `EXPERIMENT_LOG.md` and `findings.md` instead of parsing full logs on session recovery, (2) append key findings to `findings.md` after each round.
+- **REVIEWER_DIFFICULTY = medium** — Controls adversarial depth: `medium` uses normal Codex xhigh review through `spawn_agent` / `send_input`; `hard` adds Reviewer Memory and Debate Protocol; `nightmare` adds direct repository-reading adversarial verification by an independent reviewer.
 
-> 💡 Override: `/auto-review-loop "topic" — compact: true, human checkpoint: true`
+> 💡 Override: `/auto-review-loop "topic" — compact: true, human checkpoint: true, difficulty: hard`
+
+## Claude-Aligned Reviewer Memory and Debate
+
+For `difficulty: hard` and `difficulty: nightmare`, maintain `review-stage/REVIEWER_MEMORY.md`.
+
+- Before each reviewer call, prepend the full `REVIEWER_MEMORY.md` contents under `## Your Reviewer Memory (persistent across rounds)`.
+- Tell the reviewer to check whether prior suspicions were genuinely addressed or merely sidestepped.
+- Require a `Memory update` section in the reviewer response.
+- After Phase B, copy the `Memory update` into `REVIEWER_MEMORY.md` before writing `REVIEW_STATE.json`.
+- In `nightmare`, launch an additional fresh adversarial reviewer with direct repository/file-reading instructions. It should read `NARRATIVE_REPORT.md` or `review-stage/AUTO_REVIEW.md` for the author's claims, then verify those claims against code, logs, result files, and paper drafts instead of trusting executor summaries.
+
+## Instructions
+
+In hard and nightmare modes, the reviewer must actively look for omissions, unsupported claims, cherry-picked evidence, metric mistakes, and weaknesses the executor may have downplayed.
+
+For `difficulty: hard` and `nightmare`, use the **Debate Protocol** after a critical review:
+
+1. Codex writes a concise rebuttal with evidence, not spin.
+2. Send the rebuttal to the same reviewer via `send_input`.
+3. The reviewer rules which objections are resolved, unresolved, or newly discovered.
+4. Only mark a concern resolved when the reviewer accepts the rebuttal.
 
 ## State Persistence (Compact Recovery)
 
@@ -65,6 +88,10 @@ Long-running loops may hit the context window limit, triggering automatic compac
 
 #### Phase A: Review
 
+**Route by REVIEWER_DIFFICULTY:**
+
+##### Medium (default) — Codex Review
+
 Send comprehensive context to the external reviewer:
 
 ```
@@ -88,6 +115,14 @@ spawn_agent:
 
 If this is round 2+, use `send_input` with the saved agent id to maintain continuity.
 
+##### Hard — Codex Review + Reviewer Memory
+
+Use the same `spawn_agent` / `send_input` route as medium, but prepend the full `review-stage/REVIEWER_MEMORY.md` contents under `## Your Reviewer Memory (persistent across rounds)` and require a `Memory update` section in the reviewer response.
+
+##### Nightmare — Independent Repository Review
+
+Use everything in hard mode, then ask an additional fresh adversarial reviewer to verify claims against repository files, logs, result files, and paper drafts instead of trusting executor summaries. Preserve the fresh review as a separate raw response and trace.
+
 #### Phase B: Parse Assessment
 
 **CRITICAL: Save the FULL raw response** from the external reviewer verbatim (store in a variable for Phase E). Do NOT discard or summarize — the raw text is the primary record.
@@ -98,6 +133,67 @@ Then extract structured fields:
 - **Action items** (ranked list of fixes)
 
 **STOP CONDITION**: If score >= 6 AND verdict contains "ready" or "almost" → stop loop, document final state.
+
+#### Phase B.5: Reviewer Memory Update (hard + nightmare only)
+
+Skip entirely if `REVIEWER_DIFFICULTY = medium`.
+
+After parsing the assessment, update `review-stage/REVIEWER_MEMORY.md`:
+
+## Your Reviewer Memory (persistent across rounds)
+
+Pass this file back to the reviewer in the next round so it can track its own suspicions.
+
+```markdown
+# Reviewer Memory
+
+## Round 1 — Score: X/10
+- **Suspicion**: [what the reviewer flagged]
+- **Unresolved**: [concerns not yet addressed]
+- **Patterns**: [recurring issues the reviewer noticed]
+
+## Round 2 — Score: X/10
+- **Previous suspicions addressed?**: [yes/no for each, with reviewer judgment]
+- **New suspicions**: [...]
+- **Unresolved**: [carried forward + new]
+```
+
+Rules:
+- Append each round; never delete prior rounds.
+- If the reviewer response includes a `Memory update` section, copy it verbatim.
+- This file is passed back to the reviewer in the next round's Phase A.
+
+#### Phase B.6: Debate Protocol (hard + nightmare only)
+
+Skip entirely if `REVIEWER_DIFFICULTY = medium`.
+
+After parsing the review, Codex writes a structured rebuttal for up to three high-impact weaknesses:
+
+```markdown
+### Rebuttal to Weakness #1: [title]
+- **Accept / Partially Accept / Reject**
+- **Argument**: [why this criticism is valid, invalid, already addressed, or out of scope]
+- **Evidence**: [specific code, result file, log, prior-round fix, or paper section]
+```
+
+Send the rebuttal to the same reviewer via `send_input`:
+
+```text
+send_input:
+  target: [saved reviewer id]
+  message: |
+    Please rule on the author's rebuttal below.
+    For each contested weakness, decide: accepted / partially accepted / rejected.
+    If rejected, state the minimum evidence or change required.
+
+    [paste rebuttal + evidence]
+```
+
+Record a `### Debate Transcript (hard + nightmare only)` section in `review-stage/AUTO_REVIEW.md`. Only mark a weakness resolved if the reviewer accepts the rebuttal.
+
+### Debate Transcript (hard + nightmare only)
+
+In the round log, preserve the rebuttal, reviewer ruling, accepted objections, rejected objections, and any required follow-up evidence.
 
 #### Human Checkpoint (if enabled)
 
@@ -202,6 +298,12 @@ This is the authoritative record. Do NOT truncate or paraphrase.]
 ```
 
 Increment round counter → back to Phase A.
+
+#### Review Tracing
+
+## Review Tracing
+
+After every `spawn_agent`, `send_input`, `oracle-pro`, or nightmare adversarial verification call, save a trace following `../shared-references/review-tracing.md`. Include prompt summary, reviewer route, saved agent id, raw response path, score/verdict, accepted fixes, rejected rebuttals, and the `Reviewer Memory` update if present.
 
 ### Termination
 

--- a/skills/skills-codex/citation-audit/SKILL.md
+++ b/skills/skills-codex/citation-audit/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: citation-audit
+description: "Zero-context verification that every bibliographic entry in the paper is real, correctly attributed, and used in a context the cited paper actually supports. Uses a fresh cross-model reviewer with web/DBLP/arXiv lookup to catch hallucinated authors, wrong years, fabricated venues, version mismatches, and wrong-context citations (cite present but the cited paper does not establish the claim). Use when user says \"审查引用\", \"check citations\", \"citation audit\", \"verify references\", \"引用核对\", or before submission to ensure bibliography integrity."
+argument-hint: [paper-directory-or-bib-file]
+allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent, WebSearch, WebFetch
+---
+
+# Citation Audit
+
+Verify every `\cite{...}` in a paper against three independent layers:
+
+1. **Existence** — the cited paper actually exists at the claimed arXiv ID / DOI / venue.
+2. **Metadata correctness** — author names, year, venue, and title match canonical sources (DBLP, arXiv, ACL Anthology, Nature, OpenReview, etc.).
+3. **Context appropriateness** — the cited paper actually supports the claim it is being used to support in the manuscript.
+
+This skill is the fourth layer of \aris{}'s evidence-and-claim assurance, complementing `experiment-audit` (code), `result-to-claim` (science verdict), and `paper-claim-audit` (numerical claims). Together they form a bottom-up integrity stack from raw evaluation code to manuscript bibliography.
+
+## When to Use This Skill
+
+**Run before submission.** The right gating point is:
+- After `paper-write` has produced the LaTeX draft and bib file
+- After `paper-claim-audit` has verified numerical claims
+- Before final `paper-compile` for submission
+
+**Do not** run this on a half-written draft — most of the work is in cross-checking each `\cite` against context, which is wasted on placeholder text.
+
+## What This Skill Catches
+
+The dangerous citation problems are **not** wildly fake citations — those are easy to spot. The dangerous ones are:
+
+- **Wrong-context citations**: real paper, but the cited claim is not what that paper actually establishes (e.g., citing Self-Refine to support "self-feedback produces correlated errors" — Self-Refine actually argues the opposite).
+- **Author hallucinations**: anonymous-author placeholders that slipped through, missing co-authors, wrong order.
+- **Title drift**: arXiv v1 vs v3 with different titles silently merged.
+- **Venue confusion**: arXiv preprint cited but the official venue is now CVPR/ICML/NeurIPS — using the wrong record.
+- **Year mismatch**: arXiv 2023 preprint with 2024 conference acceptance, year reported inconsistently.
+- **Phantom DOIs**: DOI looks real but does not resolve.
+- **Self-citation drift**: your own prior work cited with year off by one.
+
+## Constants
+
+- **REVIEWER_MODEL = `gpt-5.4`** — Used via Codex MCP. Default for cross-model review with web access.
+- **CONTEXT_POLICY = `fresh`** — Each audit run uses a new reviewer thread (REVIEWER_BIAS_GUARD). Never `codex-reply`.
+- **WEB_SEARCH = required** — The reviewer must perform real web/DBLP/arXiv lookups, not pattern-match from memory.
+- **OUTPUT = `CITATION_AUDIT.md`** — Human-readable per-entry verdict report.
+- **STATE = `CITATION_AUDIT.json`** — Machine-readable verdict ledger consumable by downstream tools.
+
+## Workflow
+
+### Step 1: Discover bib file and section files
+
+Locate:
+- `references.bib` (or `paper.bib` / similar) under the paper directory
+- All `*.tex` files containing `\cite{...}` calls (typically `sec/` or `sections/`)
+
+If multiple bib files exist, audit each separately.
+
+### Step 2: Extract all (cite-key, context) pairs
+
+For each `\cite{key1,key2,...}` invocation in the paper:
+- Record the cite key
+- Record the file + line number
+- Record the surrounding sentence (≥ 1 full sentence around the cite, for context check)
+
+Output a flat list of `(key, file, line, surrounding_sentence)` tuples.
+
+Also build the inverse: for each bib entry, the list of all places it is cited.
+
+Save the extracted contexts to `paper/.aris/citation-audit/contexts.txt` so the reviewer can read it directly. Use the paper-dir-relative path `.aris/citation-audit/contexts.txt` when recording the file in `audited_input_hashes`; do not stage under `/tmp` or other transient locations that the verifier cannot rehash later.
+
+### Step 3: Send each entry to fresh cross-model reviewer
+
+For each bib entry, launch a fresh Codex reviewer agent. Do not reuse the same reviewer across entries.
+
+```
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are auditing a bibliographic entry. Use web/DBLP/arXiv search.
+
+    ## Bib entry
+    @article{key2024example,
+      author = {...}, title = {...}, journal = {...}, year = {...}, ...
+    }
+
+    ## Where this entry is cited in the paper
+    [paste extracted contexts]
+
+    For this entry, verify:
+    1. EXISTENCE: does this paper exist at the claimed arXiv ID / DOI / venue?
+       Output: YES / NO / UNCERTAIN, with the verifying URL.
+    2. METADATA: are author names, year, venue, title correct?
+       For each, output: correct / wrong: should be ... / typo: ...
+    3. CONTEXT: for each use, does the cited paper actually support the surrounding claim?
+       Output per-use: SUPPORTS / WEAK / WRONG, with one-sentence reasoning.
+
+    VERDICT: KEEP / FIX / REPLACE / REMOVE
+    - KEEP: entry is clean, all uses are appropriate
+    - FIX: metadata needs correction; uses are appropriate
+    - REPLACE: cite is wrong-context, find a different paper that actually supports the claim
+    - REMOVE: entry is hallucinated or unsupportable
+
+    Be honest. If you cannot verify online, say UNCERTAIN; do not guess.
+```
+
+Save the response to `.aris/traces/citation-audit/<date>_runNN/<key>.md` per the review-tracing protocol.
+
+### Step 4: Aggregate verdicts
+
+Build `CITATION_AUDIT.json` following the schema defined in **"Submission
+Artifact Emission"** below (single authoritative schema for this file).
+Per-entry ledger data goes under `details.per_entry`, not under a
+top-level `entries` field. The top-level `verdict` is a single overall
+value (PASS / WARN / FAIL / NOT_APPLICABLE / BLOCKED / ERROR) derived
+from per-entry verdicts per the decision table in "Submission Artifact
+Emission"; the top-level `summary` is a one-line human-readable string.
+
+Concretely, `details` carries the per-entry ledger:
+
+```json
+"details": {
+  "total_entries": 29,
+  "counts": { "KEEP": 11, "FIX": 14, "REPLACE": 3, "REMOVE": 1 },
+  "per_entry": [
+    {
+      "key": "lu2024aiscientist",
+      "verdict": "KEEP",
+      "axis_failures": [],
+      "uses": [
+        {"file": "sections/1.intro.tex", "line": 11, "verdict": "SUPPORTS"},
+        {"file": "sections/6.related.tex", "line": 8, "verdict": "SUPPORTS"}
+      ]
+    },
+    {
+      "key": "madaan2023selfrefine",
+      "verdict": "FIX",
+      "axis_failures": ["CONTEXT"],
+      "uses": [
+        {"file": "sections/2.overview.tex", "line": 42, "verdict": "WRONG",
+         "note": "Self-Refine demonstrates iterative improvement, not correlated errors"},
+        {"file": "sections/6.related.tex", "line": 13, "verdict": "SUPPORTS"}
+      ]
+    }
+  ]
+}
+```
+
+See "Submission Artifact Emission" for the full artifact (top-level
+fields `audit_skill`, `verdict`, `reason_code`, `summary`,
+`audited_input_hashes`, `trace_path`, `thread_id`, `reviewer_model`,
+`reviewer_reasoning`, `generated_at`, `details`).
+
+### Step 5: Generate human-readable report
+
+Write `CITATION_AUDIT.md`:
+
+```markdown
+# Citation Audit Report
+
+**Date**: 2026-04-19
+**Bib file**: references.bib
+**Total entries**: 29
+
+## Summary
+| Verdict | Count |
+|---------|------|
+| KEEP    | 11   |
+| FIX     | 14   |
+| REPLACE | 3    |
+| REMOVE  | 1    |
+
+## Priority Fixes (CRITICAL — apply before submission)
+
+### REMOVE: hidden2025aiscientistpitfalls
+- Author listed as "Anonymous" — actual authors are Luo, Kasirzadeh, Shah
+- Title is incomplete
+- ACTION: Replace key with `luo2025aiscientistpitfalls`, update authors and title
+
+### REPLACE-CONTEXT: madaan2023selfrefine in sec/2.overview.tex:42
+- Cited to support: "single-model self-refinement can produce correlated errors"
+- Self-Refine paper actually demonstrates iterative IMPROVEMENT, not correlated errors
+- ACTION: Rewrite the sentence; cite Self-Refine for "self-feedback loop" framing instead
+
+[... continues for each entry ...]
+
+## All-Clean Entries (no action needed)
+
+[list of KEEP keys]
+```
+
+### Step 6: Apply fixes (interactive)
+
+For each FIX/REPLACE/REMOVE verdict, prompt the user:
+
+```
+Fix [key]?
+  Change: <description of change>
+  Files affected: references.bib + sec/X.tex:Y
+[Apply / Skip / Defer]
+```
+
+If `AUTO_APPLY = true`, apply all FIX-level changes (metadata corrections only). REPLACE and REMOVE always require human approval — they involve content changes.
+
+### Step 7: Recompile and verify
+
+```bash
+latexmk -C && latexmk -pdf -interaction=nonstopmode main.tex
+```
+
+Confirm:
+- No new `Citation undefined` warnings
+- No `Reference undefined` warnings
+- Page count unchanged or only minimally affected by metadata fixes
+
+## Key Rules
+
+- **Fresh reviewer thread per audit run** — never reuse prior review context
+- **Web access required** — the reviewer must do real lookups, not memory pattern-match
+- **Wrong-context > metadata** — a real paper used to support a wrong claim is more dangerous than a typo in author name
+- **REPLACE/REMOVE require human approval** — never auto-modify content claims
+- **Always emit, never block** — this skill always writes `CITATION_AUDIT.json` with a verdict; the decision to block finalization lives in `paper-writing` Phase 6 + `tools/verify_paper_audits.sh`, driven by the `assurance` level. See "Submission Artifact Emission" below.
+- **Run once per submission** — the audit is wall-clock expensive (web lookups for each entry); not for every save
+
+## Comparison with Other Audit Skills
+
+| Skill | What it audits | What it catches |
+|-------|---------------|-----------------|
+| `/experiment-audit` | Evaluation code | Fake ground truth, self-normalized scores, phantom results |
+| `/result-to-claim` | Result-to-claim mapping | Claims unsupported by evidence |
+| `/paper-claim-audit` | Numerical claims in manuscript | Number inflation, best-seed cherry-pick, config mismatch |
+| `/citation-audit` | Bibliographic entries | Hallucinated refs, wrong-context citations, metadata errors |
+
+Together: code → result → numerical claim → cited claim. Each layer has cross-family review with no executor in the validator path.
+
+## Known Limitations
+
+- **DBLP coverage gap**: very recent papers (< 2 weeks) may not yet be in DBLP. Reviewer should fall back to arXiv.
+- **Pre-print vs published**: when both exist, reviewer should prefer the published venue (ICML 2024 over arXiv 2401.xxxxx) but flag both.
+- **Anthology vs OpenReview**: NeurIPS/ICLR papers have OpenReview entries before official proceedings; both are valid sources.
+- **Multi-author truncation**: bib entries with 6+ authors using `and others` are conventional and not flagged unless the truncation hides a co-author the user explicitly cares about.
+
+## Review Tracing
+
+After each reviewer agent call, save the trace following `shared-references/review-tracing.md`. Use `tools/save_trace.sh` or write files directly to `.aris/traces/citation-audit/<date>_run<NN>/`. Respect the `--- trace:` parameter (default: `full`).
+
+## Output Contract
+
+- `CITATION_AUDIT.md` (human-readable report) at paper root
+- `CITATION_AUDIT.json` (machine-readable ledger; schema below) at paper root
+- `.aris/traces/citation-audit/<date>_runNN/` (per-entry review traces)
+- Optional: applied fixes to `references.bib` + `sec/*.tex` (with --apply flag)
+
+## Submission Artifact Emission
+
+This skill **always** writes `paper/CITATION_AUDIT.json`, regardless of
+caller or detector outcome. A paper with no `.bib` file or no `\cite{...}`
+usage emits verdict `NOT_APPLICABLE`; silent skip is forbidden.
+`paper-writing` Phase 6 and `tools/verify_paper_audits.sh` both rely on
+this artifact existing at a predictable path.
+
+The artifact conforms to the schema in `shared-references/assurance-contract.md`:
+
+```json
+{
+  "audit_skill":      "citation-audit",
+  "verdict":          "PASS | WARN | FAIL | NOT_APPLICABLE | BLOCKED | ERROR",
+  "reason_code":      "all_entries_keep | metadata_drift | wrong_context | hallucinated | ...",
+  "summary":          "One-line human-readable verdict summary.",
+  "audited_input_hashes": {
+    "references.bib":             "sha256:...",
+    "main.tex":                   "sha256:...",
+    "sections/3.related.tex":     "sha256:..."
+  },
+  "trace_path":       ".aris/traces/citation-audit/<date>_run<NN>/",
+  "thread_id":        "<codex mcp thread id>",
+  "reviewer_model":   "gpt-5.4",
+  "reviewer_reasoning": "xhigh",
+  "generated_at":     "<UTC ISO-8601>",
+  "details": {
+    "total_entries":  <int>,
+    "per_entry":      [ { "key": "madaan2023selfrefine",
+                          "verdict": "KEEP | FIX | REPLACE | REMOVE",
+                          "axis_failures": [ "CONTEXT" | "METADATA" | "EXISTENCE" ],
+                          "note": "..." }, ... ]
+  }
+}
+```
+
+### `audited_input_hashes` scope
+
+Hash the **declared input set** actually passed to this audit: the `.bib`
+file, `main.tex`, and every `sections/*.tex` file that supplied citation
+contexts. Do NOT hash extracted contexts from `/tmp` or other transient
+paths — if you need to stage extracted contexts, materialize them under
+`paper/.aris/` so the verifier can rehash reproducibly. Do NOT hash
+repo-wide unions or the reviewer's self-reported opened subset.
+
+**Path convention** (must match `tools/verify_paper_audits.sh`): keys are
+**paths relative to the paper directory** (no `paper/` prefix — the
+verifier already resolves relative to the paper dir; prefixing produces
+`paper/paper/...` and false-fails as STALE). Use **absolute paths** for
+any file outside the paper dir.
+
+### Verdict decision table
+
+| Input state                                                    | Verdict          | `reason_code` example |
+|----------------------------------------------------------------|------------------|-----------------------|
+| No `.bib` file or no `\cite{...}` usage                        | `NOT_APPLICABLE` | `no_citations`        |
+| `.bib` file referenced but unreadable / missing                | `BLOCKED`        | `bib_unreadable`      |
+| Every entry KEEP, all three axes green                         | `PASS`           | `all_entries_keep`    |
+| Only FIX verdicts (metadata drift, no context errors)          | `WARN`           | `metadata_drift`      |
+| Any REPLACE or REMOVE (wrong-context or hallucinated entry)    | `FAIL`           | `wrong_context`       |
+| Web lookups timed out / reviewer invocation failed             | `ERROR`          | `reviewer_error`      |
+
+### Thread independence
+
+Every invocation uses a fresh reviewer agent. Never reuse `send_input` across
+different bibliography entries. Do not accept prior audit outputs (PROOF_AUDIT,
+PAPER_CLAIM_AUDIT, EXPERIMENT_LOG) as input — the fresh thread preserves
+reviewer independence per `shared-references/reviewer-independence.md`.
+
+This skill never blocks by itself; `paper-writing` Phase 6 plus the
+verifier decide whether the verdict blocks finalization based on the
+`assurance` level.
+
+## See Also
+
+- `/paper-claim-audit` — sibling skill for numerical claim verification
+- `/experiment-audit` — sibling skill for evaluation code integrity
+- `/result-to-claim` — claim verdict assignment from results
+- `shared-references/citation-discipline.md` — protocol document for citation hygiene
+- `shared-references/reviewer-independence.md` — cross-model review constraints

--- a/skills/skills-codex/claims-drafting/SKILL.md
+++ b/skills/skills-codex/claims-drafting/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: claims-drafting
+description: "Draft patent claims for an invention. Use when user says \"撰写权利要求\", \"draft claims\", \"写权利要求书\", \"claim drafting\", or wants to create patent claims. The core skill of the patent pipeline."
+argument-hint: [invention-disclosure-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch
+---
+
+# Claims Drafting: The Core Patent Skill
+
+Draft patent claims based on: **$ARGUMENTS**
+
+This is the most critical skill in the patent pipeline. Claims define the legal scope of protection -- everything else (specification, figures, abstract) exists to support and enable the claims.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — External examiner for claim quality review
+- `MAX_CLAIM_REVISION_ROUNDS = 3` — Maximum revision iterations
+- `CLAIM_STYLE = "auto"` — `US` (Jepson or open), `EP` (two-part mandatory), `CN` (two-part), `auto` (detect from jurisdiction)
+- `MIN_INDEPENDENT_CLAIMS = 2` — Typically method + system. For utility model (实用新型): apparatus/device only, NO method claims.
+- `MAX_TOTAL_CLAIMS = 20` — Practical limit (USPTO includes 20 in base fee)
+- `PATENT_TYPE = "invention"` — `invention` (发明专利) or `utility_model` (实用新型, apparatus claims only)
+
+## Inputs
+
+1. `patent/INVENTION_DISCLOSURE.md` — structured invention with core/supporting/optional features
+2. `patent/PRIOR_ART_REPORT.md` — prior art to avoid
+3. `patent/NOVELTY_ASSESSMENT.md` — novelty analysis with suggested amendments
+4. Target jurisdiction from invention disclosure or `$ARGUMENTS`
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for claim drafting principles, antecedent basis rules, and common pitfalls.
+Load `../shared-references/patent-format-cn.md` for CN claim format (其特征在于).
+Load `../shared-references/patent-format-us.md` for US claim format (comprising, means-plus-function).
+Load `../shared-references/patent-format-ep.md` for EP two-part form (characterised in that).
+
+## Workflow
+
+### Step 1: Determine Claim Style and Patent Type
+
+Based on patent type and jurisdiction:
+
+**If `PATENT_TYPE = utility_model` (实用新型)**:
+- CN jurisdiction ONLY
+- Apparatus/device claims ONLY — no method, no product-by-process
+- `MIN_INDEPENDENT_CLAIMS = 1` (single apparatus claim is sufficient)
+- Claim format: "1. 一种[主题]，其特征在于，包括：[组件描述]。"
+
+Based on target jurisdiction:
+
+| Jurisdiction | Claim Style | Characterising Phrase | Preamble Format |
+|-------------|------------|----------------------|-----------------|
+| CN | Two-part (两部式) | 其特征在于 | 一种...的方法/装置，包括： |
+| US | Open (preferred) | comprising | A method for..., comprising: |
+| EP | Two-part (mandatory) | characterised in that | A method for..., comprising [known], characterised in that [inventive] |
+| ALL | Draft CN + US + EP | All of the above | All of the above |
+
+### Step 2: Draft Independent Claims
+
+**CRITICAL — Claims numbering (CN format):**
+- Claims must be numbered 1, 2, 3, ... continuously without gaps
+- Independent and dependent claims are INTERMIXED in final numbering
+- Do NOT group independent claims separately from dependent claims
+- Example correct: Claim 1 (independent, product), Claim 2 (depends on 1), Claim 3 (depends on 1), Claim 4 (independent, method), Claim 5 (depends on 4)...
+- Example WRONG: Claim 1 (independent), Claim 5 (independent), Claim 8 (independent), then Claim 2, 3, 4, 6, 7, 9, 10 as dependents
+
+**CRITICAL — No empirical content in claims:**
+- Claims describe ONLY structural features or method steps
+- Do NOT include signal characteristics, detection principles, measurement results
+- WRONG: "产生负脉冲信号" / "谐振频率下降" — these are results, not features
+- RIGHT: "所述开口谐振环的开口处形成用于检测通过流体中颗粒物的间隙传感区域"
+
+For each claim category identified in INVENTION_DISCLOSURE.md:
+
+**Method Claim (broadest)**:
+1. Start with preamble identifying the category and purpose
+2. List the core inventive features (from the "Core Inventive Concept" section)
+3. Include enough known features for context (but not more than necessary)
+4. Use open transition ("comprising" / "包括")
+5. Each element should be separated by semicolons or on separate lines
+6. Apply jurisdiction-specific format:
+   - CN: 前序部分 + "其特征在于" + 特征部分
+   - US: Preamble + "comprising:" + elements
+   - EP: Preamble + known features + "characterised in that" + inventive features
+
+**System/Apparatus Claim**:
+1. Mirror the method claim in structural form
+2. Each method step becomes a "module configured to..." or "component for..."
+3. Same hierarchy of known vs. inventive features
+
+**Quality checks for each independent claim**:
+- [ ] Single sentence (US/EP) or properly structured (CN)
+- [ ] Antecedent basis: "a" first, "the" thereafter for each element
+- [ ] No relative terms without definition
+- [ ] No result-to-be-achieved limitations
+- [ ] Transitional phrase is appropriate (open preferred)
+- [ ] Preamble does not import unnecessary limitations
+- [ ] Each element is necessary for patentability
+- [ ] Claim scope is broadest defensible over prior art
+
+### Step 3: Draft Dependent Claims
+
+For each independent claim, draft 5-10 dependent claims that:
+
+1. **Narrow the core inventive features**: Specific implementations, parameters, ranges
+2. **Cover preferred embodiments**: Features from the specification's detailed description
+3. **Provide fallback positions**: If the independent claim is rejected, these narrower claims may survive
+4. **Cover alternatives**: Different ways to achieve the same inventive result
+
+**Dependent claim format**:
+- CN: "根据权利要求X所述的[主题]，其特征在于，所述[特征]具体为..."
+- US: "The [method/system] of claim X, wherein the [element] comprises [limitation]."
+- EP: "The [method/system] according to claim X, characterised in that [limitation]."
+
+**Rules for dependent claims**:
+- Each must add at least one meaningful limitation
+- Must reference a prior claim by number
+- Must not merely repeat the parent claim
+- Should not be cumulative (each claim should be independently useful as a fallback)
+- Multiple dependent claims (US: only "or" references, not "and")
+
+### Step 4: Claim-to-Specification Mapping
+
+Create a preliminary mapping to verify enablement:
+
+| Claim Element | Must be described in specification | Reference numeral |
+|---------------|-----------------------------------|-------------------|
+| [element 1] | Yes/No | [numeral] |
+| [element 2] | Yes/No | [numeral] |
+
+If any element lacks specification support, add it to the specification requirements.
+
+### Step 5: Cross-Model Examiner Review
+
+Start the examiner review with a dedicated Codex reviewer agent at xhigh reasoning:
+
+```
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are a senior patent examiner at the [USPTO/CNIPA/EPO].
+    Review the following patent claims for quality and patentability.
+
+    CLAIMS: [all claims]
+
+    PRIOR ART: [prior art references from PRIOR_ART_REPORT.md]
+
+    INVENTION: [summary from INVENTION_DISCLOSURE.md]
+
+    Analyze each claim for:
+    1. Clarity (35 USC 112(b) / Art 84 EPC): Are terms definite?
+    2. Written description support: Does the spec support all claim scope?
+    3. Anticipation (102/Art 54): Would any single reference anticipate?
+    4. Obviousness (103/Art 56): Would any combination render obvious?
+    5. Claim scope: Are independent claims broad enough to be valuable?
+    6. Dependent claims: Do they provide meaningful fallback positions?
+    7. Antecedent basis: Any issues with "a"/"the" usage?
+    8. Indefinite terms: Any functional/result language issues?
+
+    For each issue found, provide:
+    - The specific claim number and element
+    - The problem (cite statute/rule)
+    - A suggested fix
+
+    Provide an overall PATENTABILITY SCORE: 1-10.
+```
+
+### Step 6: Revision Loop
+
+If the examiner review identifies issues:
+
+1. Address all CRITICAL issues (anticipation, obviousness, indefiniteness)
+2. Address MAJOR issues (scope too narrow, missing support, weak fallbacks)
+3. Consider MINOR issues (antecedent basis, formatting)
+4. Re-submit to the same examiner via `send_input` using the saved reviewer id
+5. Repeat up to `MAX_CLAIM_REVISION_ROUNDS` times
+
+```text
+send_input:
+  target: [saved reviewer id from Step 5]
+  message: |
+    Here is the revised claim set after addressing the previous office action.
+
+    Revised claims:
+    [full revised claims]
+
+    Focus only on unresolved or newly introduced issues.
+```
+
+### Step 7: Output
+
+Write `patent/CLAIMS.md`:
+
+```markdown
+## Patent Claims
+
+### Independent Claims
+
+#### Claim 1 — Method
+[formatted claim text]
+
+#### Claim X — System/Apparatus
+[formatted claim text]
+
+### Dependent Claims
+
+#### Claim 2 (depends on 1)
+[formatted claim text]
+
+#### Claim 3 (depends on 1)
+[formatted claim text]
+...
+
+### Claims Summary Table
+
+| Claim | Type | Depends On | Key Limitation | Prior Art Avoidance |
+|-------|------|-----------|----------------|---------------------|
+| 1 | Method | — | [core inventive features] | [what makes it novel over prior art] |
+| 2 | Method | 1 | [narrowing] | [additional distinguishing] |
+| X | System | — | [mirrors claim 1] | [same as claim 1] |
+...
+
+### Examiner Review Summary
+[Key findings and how they were addressed]
+```
+
+## Key Rules
+
+- Claims are the single most important part of the patent. Everything else supports them.
+- Draft independent claims first, then dependent claims.
+- Independent claims must be broadest defensible scope over prior art -- not broader, not narrower.
+- Each dependent claim should be independently useful as a fallback position.
+- Antecedent basis is mandatory: "a processor" first, "the processor" thereafter.
+- Use "comprising" (open) unless there is a specific reason for "consisting of" (closed).
+- Never include result-to-be-achieved language in claims ("configured to achieve high accuracy").
+- Never fabricate claim language -- every element must come from the actual invention.
+- If drafting for ALL jurisdictions, produce separate claim sets for CN, US, and EP.
+- If reviewer delegation is unavailable in the current Codex host, stop and ask the user to enable Codex agent support before continuing the examiner loop.

--- a/skills/skills-codex/comm-lit-review/SKILL.md
+++ b/skills/skills-codex/comm-lit-review/SKILL.md
@@ -1,92 +1,218 @@
 ---
 name: comm-lit-review
-description: Communications-domain literature review and related-work search with database-aware source control. Use when the task is about communications, wireless, networking, satellite/NTN, Wi-Fi, cellular, transport protocols, congestion control, routing, scheduling, MAC/PHY, rate adaptation, channel estimation, beamforming, or communication-system research and the user wants papers, prior art, a survey, related work, or a landscape summary. Prioritize IEEE Xplore and ScienceDirect, prefer formal publications over preprints, and separate foundational work from recent progress.
+description: Communications-domain literature review with Claude-style knowledge-base-first retrieval. Use when the task is about communications, wireless, networking, satellite/NTN, Wi-Fi, cellular, transport protocols, congestion control, routing, scheduling, MAC/PHY, rate adaptation, channel estimation, beamforming, or communication-system research and the user wants papers, related work, a survey, or a landscape summary. Search Zotero, Obsidian, and local paper folders first when available, then search IEEE Xplore, ScienceDirect, ACM Digital Library, and broader web in that order.
+allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write, Agent, mcp__zotero__*, mcp__obsidian-vault__*
 ---
 
-# Comm Lit Review
+# Comm Lit Review Claude Single
 
-## Overview
+Research topic: $ARGUMENTS
 
-Run communications-focused paper search with tighter source policy than a generic literature review. Default to formal publications, prioritize `IEEE Xplore` and `ScienceDirect`, then `ACM Digital Library`, and output a review that is structured for research use rather than casual browsing.
+## Purpose
 
-Read [references/source-policy.md](references/source-policy.md) before searching. Use [references/domain-taxonomy.md](references/domain-taxonomy.md) to classify the topic, [references/venue-tiering.md](references/venue-tiering.md) to rank venues, and [references/output-template.md](references/output-template.md) to format the final answer.
+Use this skill for communications-domain literature review when the topic is about:
+
+- wireless communications
+- cellular systems, `4G/5G/6G`, `NR`, `NTN`
+- satellite, `LEO`, `GEO`, integrated space-air-ground systems
+- Wi-Fi, WLAN, mesh, ad hoc, sidelink, V2X
+- routing, scheduling, resource allocation, beamforming
+- rate adaptation, link adaptation, `ACM`, `HARQ`, `CSI` feedback
+- transport protocols and congestion control in communication networks
+- cross-layer optimization for communication systems
+
+If the center of gravity is generic ML architecture research, pure control theory without communications literature, or software/API documentation rather than papers, fall back to a general literature skill.
+
+## Constants
+
+- **PAPER_LIBRARY**: Check local PDFs in this order:
+  1. `papers/` in the current project
+  2. `literature/` in the current project
+  3. Custom path specified by the user in `AGENTS.md` under `## Paper Library`
+- **MAX_LOCAL_PAPERS = 20**: Maximum number of local PDFs to scan. If there are more, prioritize by filename and first-page relevance.
+
+## Source Selection
+
+Parse `$ARGUMENTS` for a `— sources:` directive.
+
+- If `— sources:` is specified, only search the listed sources.
+- If not specified, default to:
+  - `zotero`
+  - `obsidian`
+  - `local`
+  - `ieee`
+  - `sciencedirect`
+  - `acm`
+  - `web`
+
+Valid source values:
+
+- `zotero`
+- `obsidian`
+- `local`
+- `ieee`
+- `sciencedirect`
+- `acm`
+- `web`
+- `all`
+
+If `all` is specified, interpret it as the full default source set.
+
+## Retrieval Order
+
+This is a knowledge-base-first skill. Search in this order unless the user overrides it:
+
+1. `Zotero`
+2. `Obsidian`
+3. local `papers/` and `literature/`
+4. `IEEE Xplore`
+5. `ScienceDirect`
+6. `ACM Digital Library`
+7. broader web
+
+Graceful degradation rules:
+
+- If an unrequested source is unavailable, do not fail.
+- Skip it silently and continue to the next source.
+- If the user explicitly requested a source and it is unavailable, stop and tell the user what must be configured. Do not silently downgrade an explicitly requested source policy.
+
+## External Search Policy
+
+For external search:
+
+- prefer `IEEE Xplore` first
+- then `ScienceDirect`
+- then `ACM`
+- then broader web only when needed
+
+Publication policy:
+
+- prefer peer-reviewed journals and major conferences
+- label workshop papers as `workshop`
+- label arXiv-only or author-hosted versions as `preprint`
+- if both preprint and formal version exist, cite the formal version first
+
+Time-window policy:
+
+- if the user does not specify a year range, include both a short foundational set and a recent set
+- recommended split:
+  - `foundational`: before 2022
+  - `recent`: 2022 to present
+
+## Venue Priority
+
+Within each database tier, search venue tiers in this order.
+
+### Tier A
+
+Journals:
+
+- `IEEE Journal on Selected Areas in Communications (JSAC)`
+- `IEEE/ACM Transactions on Networking (ToN)`
+- `IEEE Transactions on Wireless Communications (TWC)`
+- `IEEE Transactions on Communications (TCOM)`
+
+Conferences:
+
+- `ACM SIGCOMM`
+- `USENIX NSDI`
+- `ACM MobiCom`
+- `ACM CoNEXT`
+- `IEEE INFOCOM`
+
+### Tier B
+
+Journals:
+
+- `IEEE Transactions on Vehicular Technology (TVT)`
+- `IEEE Wireless Communications Letters (WCL)`
+- `IEEE Communications Letters`
+- `Computer Networks`
+- `Computer Communications`
+- `Ad Hoc Networks`
+- `Physical Communication`
+
+Conferences:
+
+- `IEEE ICC`
+- `IEEE GLOBECOM`
+- `IEEE WCNC`
+- `IEEE PIMRC`
+- `ACM MobiHoc`
+
+### Tier C
+
+- other relevant IEEE journals and transactions
+- other relevant Elsevier journals
+- other clearly relevant ACM conferences and workshops
+- topic-specific satellite, optical, vehicular, IoT, aerial, or edge communications venues
+
+Usage rules:
+
+- start from Tier A
+- widen to Tier B if needed
+- widen to Tier C if still sparse
+- only then broaden to full web search
+- by default this is a soft priority, not a hard whitelist
+- if the user says `only top venues`, `top journals only`, or `top conferences only`, treat Tier A as a hard filter
 
 ## Workflow
 
-### 1. Classify the request
+### Step 0a: Search Zotero Library
 
-Decide whether the request is primarily about:
+Skip this step if Zotero MCP is not configured or `zotero` is not enabled.
 
-- Wireless PHY/MAC
-- Networking / transport / congestion control
-- Satellite / NTN / integrated space-air-ground systems
-- Cross-layer optimization / scheduling / resource allocation
-- Sensing / MEC / edge intelligence within communications systems
+If available:
 
-If the request is not clearly in communications systems research, fall back to a more general literature skill.
+1. search by topic
+2. capture title, authors, year, venue
+3. pull user annotations, tags, or collections when present
+4. treat these as high-priority evidence because they reflect the user's existing library
 
-### 2. Lock the search policy
+### Step 0b: Search Obsidian Vault
 
-Apply these defaults unless the user overrides them:
+Skip this step if Obsidian MCP is not configured or `obsidian` is not enabled.
 
-- Databases first: `IEEE Xplore`, `ScienceDirect`, then `ACM Digital Library`, then broader web
-- Publication bias: formal publications first, preprints second
-- Time window: cover both foundational and recent work
-  - Default split: foundational before 2022, recent from 2022 onward
-- Output goal: research note, related-work summary, or comparison table rather than a raw search dump
+If available:
 
-If the user explicitly narrows scope, obey the narrower scope:
+1. search topic-related notes
+2. collect summaries, wikilinks, tags, and paper references
+3. treat these notes as the user's processed understanding of the topic
 
-- only journals
-- only IEEE / only ScienceDirect
-- only top venues
-- only LEO / only Wi-Fi / only transport
-- exclude arXiv
-- only papers after a certain year
+### Step 0c: Scan Local Paper Library
 
-### 3. Search primary sources first
+Run this step if `local` is enabled.
 
-Use a layered search strategy. For communications topics, do not build the review from random blog posts or derivative summaries.
+1. locate PDFs from `papers/**/*.pdf` and `literature/**/*.pdf`
+2. de-duplicate against Zotero hits when possible
+3. read the first pages of relevant PDFs
+4. extract title, authors, year, problem, method, and relevance
+5. use local hits to guide and de-duplicate later external search
 
-#### Database ladder
+### Step 1: Search External Primary Sources
 
-Search in this order by default:
+Use a layered search strategy. For communications topics, avoid random blog posts or tertiary summaries.
+
+Database ladder:
 
 1. `ieeexplore.ieee.org`
 2. `sciencedirect.com`
 3. `dl.acm.org`
 4. broader web using primary publisher pages, official conference sites, DOI pages, and author-hosted copies of already-identified formal papers
 
-Only move to the next database tier when one of these is true:
+Move to the next database tier only when:
 
-- the higher-priority tiers are too sparse for the topic
-- the topic is known to publish heavily outside the higher tier
+- the higher-priority tier is too sparse
+- the topic clearly publishes elsewhere
 - the user explicitly asks for broader coverage
 
-#### Venue ladder
+Within each database tier:
 
-Within each database tier, search venue tiers in this order:
+1. start from Tier A venues
+2. widen to Tier B if needed
+3. widen to Tier C if still sparse
 
-1. top communications and networking journals / top conferences
-2. mainstream strong journals / flagship broader conferences
-3. all remaining relevant formal venues
-
-Follow the concrete tier lists in [references/venue-tiering.md](references/venue-tiering.md).
-
-By default this venue tiering is a soft priority, not a hard whitelist.
-
-- Default behavior: start from Tier A, then widen if needed
-- If the user says `only top venues`, `top journals only`, `top conferences only`, or equivalent, switch to hard constraint mode and do not auto-expand beyond Tier A unless the user later relaxes the constraint
-
-Use preprints only when:
-
-- the user explicitly asks for them
-- the area is very recent and formal versions are missing
-- a paper is clearly influential but only publicly accessible as a preprint
-
-When a preprint is used, label it clearly as `preprint`.
-
-### 4. Extract paper-level facts
+### Step 2: Extract Paper-Level Facts
 
 For each relevant paper, capture:
 
@@ -101,45 +227,73 @@ For each relevant paper, capture:
 - Limitation
 - Relevance to the user's topic
 - Source URL
+- Source origin: `zotero`, `obsidian`, `local`, `ieee`, `sciencedirect`, `acm`, or `web`
 
-Favor numbers, assumptions, and actual problem statements over generic summaries.
+Favor concrete numbers, assumptions, and problem definitions over generic paraphrases.
 
-### 5. Synthesize as a communications review
+Do not collapse transport-layer rate control and PHY/MAC rate adaptation into one bucket without saying so explicitly.
 
-Group papers by technical axis, not by search order. Common groupings:
+## Synthesis Rules
 
-- PHY/MAC adaptation
-- Transport / congestion control
-- NTN / satellite resource management
-- Cross-layer or learning-based control
-- Measurement / empirical studies
+Group papers by technical axis rather than by search order. Common groupings:
 
-Explicitly separate:
+- `PHY/MAC` adaptation
+- transport and congestion control
+- `NTN` and satellite resource management
+- cross-layer or learning-based control
+- measurement and empirical studies
 
-- foundational vs recent papers
+When useful, explicitly separate:
+
+- foundational vs recent work
 - formal publications vs preprints
-- top-tier vs lower-tier venues when that distinction matters
-- single-link vs multi-user / network-wide formulations
-- simulation-only vs measurement / deployment-backed work
+- top-tier vs lower-tier venues
+- single-link vs multi-user formulations
+- simulation-only vs deployment-backed work
+- user-owned sources vs newly surfaced external papers
 
-### 6. Produce a research-useful output
+If evidence is weak, say so instead of smoothing it over.
 
-Follow the templates in [references/output-template.md](references/output-template.md).
+## Output
 
-The default output should include:
+Use a literature table with these columns:
 
-- a compact literature table
-- a short narrative on where the field stands
-- disagreements or unresolved assumptions
-- likely research gaps
+| Paper | Venue | Year | Layer | Scenario | Method | Key Result | Limitation | Relevance | Source |
+|---|---|---:|---|---|---|---|---|---|---|
 
-## Rules
+`Source` should indicate where the paper came from first:
 
-- Prefer primary sources over summaries or tertiary commentary.
-- Prefer IEEE and ScienceDirect first, ACM second, and only then broader web search unless the user asks otherwise.
+- `zotero`
+- `obsidian`
+- `local`
+- `ieee`
+- `sciencedirect`
+- `acm`
+- `web`
+
+After the table, summarize in this order:
+
+1. what the field is mostly trying to solve
+2. how papers cluster into `2-4` approaches
+3. what the user already had vs what was newly surfaced
+4. where the evidence is strong vs weak
+5. what research gap remains
+
+End with `Practical Takeaway`:
+
+- dominant current approach
+- likely saturated direction
+- promising open direction
+
+## Key Rules
+
+- Do not silently downgrade explicitly requested sources, account-backed databases, or primary-database constraints. Report the missing configuration instead.
+
+- Never fail because Zotero or Obsidian MCP is missing.
+- Prefer user-owned sources first when available, but do not let them replace external validation.
+- Prefer primary formal sources over summaries or tertiary commentary.
+- Prefer `IEEE` and `ScienceDirect` first, `ACM` second, and only then broader web search unless the user asks otherwise.
 - Search venue tiers from top to broad within each database tier.
 - Treat venue tiers as soft ranking by default and hard constraint only when the user explicitly asks for top-only search.
 - Do not pretend a preprint is peer reviewed.
-- Do not collapse transport-layer rate control and PHY/MAC rate adaptation into one bucket without saying so explicitly.
 - If the topic spans multiple layers, say that the literature itself is split across layers.
-- If evidence is weak, say so instead of smoothing it over.

--- a/skills/skills-codex/deepxiv/SKILL.md
+++ b/skills/skills-codex/deepxiv/SKILL.md
@@ -14,13 +14,14 @@ DeepXiv is the progressive-reading literature source:
 | Skill | Best for |
 |------|----------|
 | `/arxiv` | Direct preprint search and PDF download |
-| `/deepxiv` | Layered reading: search → brief → head → section |
+| `/semantic-scholar` | Published venue metadata, citation counts, DOI links |
+| `/deepxiv` | Layered reading: search → brief → head → section, plus trending and web search |
 
 Use DeepXiv when you want to inspect papers incrementally instead of loading the full text immediately.
 
 ## Constants
 
-- **FETCH_SCRIPT** — `tools/deepxiv_fetch.py` relative to the current project. If unavailable, fall back to the raw `deepxiv` CLI.
+- **FETCH_SCRIPT** — `$ARIS_REPO/tools/deepxiv_fetch.py` from the ARIS repo recorded by the Codex install manifest. If unavailable, fall back to the raw `deepxiv` CLI.
 - **MAX_RESULTS = 10** — Default number of search results.
 
 > Overrides (append to arguments):
@@ -60,10 +61,17 @@ Parse `$ARGUMENTS` for:
 
 If the input looks like an arXiv ID and no explicit mode is provided, default to `brief`.
 
-### Step 2: Prefer the Adapter
+### Step 2: Locate the Adapter
+
+Locate the adapter. Prefer the Codex managed install manifest when present, then fall back to the same project/global copy-install lookup style as the Claude skill:
 
 ```bash
-python3 tools/deepxiv_fetch.py --help
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/deepxiv_fetch.py" ] && SCRIPT="$ARIS_REPO/tools/deepxiv_fetch.py"
+[ -z "$SCRIPT" ] && [ -f tools/deepxiv_fetch.py ] && SCRIPT="tools/deepxiv_fetch.py"
+[ -z "$SCRIPT" ] && [ -f ~/.codex/skills/deepxiv/deepxiv_fetch.py ] && SCRIPT="$HOME/.codex/skills/deepxiv/deepxiv_fetch.py"
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" --help
 ```
 
 If the adapter is unavailable, fall back to raw `deepxiv` commands.
@@ -71,13 +79,13 @@ If the adapter is unavailable, fall back to raw `deepxiv` commands.
 ### Step 3: Execute the Minimal Command
 
 ```bash
-python3 tools/deepxiv_fetch.py search "QUERY" --max MAX_RESULTS
-python3 tools/deepxiv_fetch.py paper-brief ARXIV_ID
-python3 tools/deepxiv_fetch.py paper-head ARXIV_ID
-python3 tools/deepxiv_fetch.py paper-section ARXIV_ID "SECTION_NAME"
-python3 tools/deepxiv_fetch.py trending --days 7 --max MAX_RESULTS
-python3 tools/deepxiv_fetch.py wsearch "QUERY"
-python3 tools/deepxiv_fetch.py sc "SEMANTIC_SCHOLAR_ID"
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" search "QUERY" --max MAX_RESULTS
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" paper-brief ARXIV_ID
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" paper-head ARXIV_ID
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" paper-section ARXIV_ID "SECTION_NAME"
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" trending --days 7 --max MAX_RESULTS
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" wsearch "QUERY"
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" sc "SEMANTIC_SCHOLAR_ID"
 ```
 
 Fallbacks:
@@ -107,8 +115,15 @@ Use the progression:
 
 Only read the full paper when the user explicitly needs it.
 
+### Step 6: Update Research Wiki (if active)
+
+If the project has an active research wiki and the user is building a literature set, add DeepXiv findings as source-backed entries with arXiv/Semantic Scholar IDs, retrieved sections, and the recommended next depth step.
+
+Follow [`shared-references/integration-contract.md`](../shared-references/integration-contract.md). If the wiki path or schema is unclear, ask before writing.
+
 ## Key Rules
 
 - Prefer the adapter script over raw `deepxiv` commands when available.
 - If DeepXiv is missing, give the install command and suggest `/arxiv` or `/research-lit "topic" - sources: web`.
 - Use DeepXiv as an additive source, not a replacement for existing ARIS literature tooling.
+- If the result overlaps with a published venue paper from Semantic Scholar, keep the richer venue metadata in the final summary.

--- a/skills/skills-codex/embodiment-description/SKILL.md
+++ b/skills/skills-codex/embodiment-description/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: embodiment-description
+description: "Write detailed embodiment descriptions for patent specifications. Use when user says \"撰写实施例\", \"write embodiment\", \"实施例描述\", \"detailed description\", or wants to describe how to practice an invention."
+argument-hint: [claims-path-or-embodiment-details]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
+---
+
+# Embodiment Description
+
+Write detailed embodiments for: **$ARGUMENTS**
+
+Embodiments describe HOW to make and use the invention -- they are the patent equivalent of experiment sections, but describe the invention rather than evaluating it empirically.
+
+## Constants
+
+- `MIN_EMBODIMENTS = 1` — At least one complete embodiment required
+- `MAX_EMBODIMENTS = 3` — Practical limit; more embodiments strengthen enablement
+- `EMBODIMENT_STYLE = detailed` — `detailed` (full working example) or `outline` (sketch)
+- `REFERENCE_NUMERAL_PREFIX = 100` — Starting reference numeral for first figure's components
+
+## Inputs
+
+1. `patent/INVENTION_DISCLOSURE.md` — invention decomposition (core/supporting/optional features)
+2. `patent/CLAIMS.md` — drafted claims that the embodiments must support
+3. User-provided figures (if any) in any directory
+4. `patent/figures/numeral_index.md` if it exists (from `/figure-description`)
+
+## Workflow
+
+### Step 1: Plan Embodiments
+
+For each claim category (method, system, etc.), plan at least one embodiment:
+
+| Embodiment | Covers Claims | Type | Key Variations |
+|-----------|--------------|------|----------------|
+| 1 | Claims 1, X | Best mode / preferred | [primary implementation] |
+| 2 | Claims 2, 3 | Alternative | [different parameters/materials] |
+| 3 | Claims 4, 5 | Additional alternative | [different configuration] |
+
+### Step 2: Write Each Embodiment
+
+For each embodiment, write a detailed description following this structure:
+
+**Opening paragraph**:
+"In one embodiment, [invention summary with reference to what is being described]."
+
+**Component/step-by-step description**:
+
+For method embodiments:
+- Describe each step in order
+- Reference figure numerals: "As shown in FIG. 1, at step 202, the processor 102 receives the input data 104..."
+- Include specific parameters, ranges, and conditions
+- Describe what happens at each decision point
+
+For system/apparatus embodiments:
+- Describe each component
+- Reference figure numerals: "Referring to FIG. 1, the system 100 comprises a processor 102, a memory 104, and a communication interface 106..."
+- Describe interconnections between components
+- Describe operation of the system step-by-step
+
+**Variations and alternatives**:
+- "In some embodiments, the processor 102 may be a GPU, an FPGA, or an ASIC."
+- "In another embodiment, the memory 104 may be replaced with a distributed storage system."
+- "The parameters described above are exemplary; other values within the range [X, Y] are also contemplated."
+
+These variations are critical -- they support broader claim interpretation.
+
+### Step 3: Reference Numeral Integration
+
+Ensure consistent reference numeral usage:
+
+1. Every component mentioned must have a numeral
+2. Numeral must appear first in parentheses after the component name: "the processor (102)"
+3. Subsequent references: "the processor 102" (no parentheses)
+4. Numbering follows figure series: 100-series for FIG. 1, 200-series for FIG. 2
+
+**Format**:
+- First mention: "the processor (102)"
+- Later in same embodiment: "the processor 102"
+- Cross-figure: "the processor 102 (shown in both FIG. 1 and FIG. 2)"
+
+### Step 4: Claim Support Verification
+
+For each claim element, verify it appears in at least one embodiment:
+
+| Claim Element | Embodiment | Reference Numeral | Description Paragraph |
+|---------------|-----------|-------------------|----------------------|
+| [element] | [which] | [numeral] | [paragraph reference] |
+
+If any claim element lacks embodiment support, add the necessary description.
+
+### Step 5: Software/Algorithm Embodiments (if applicable)
+
+For method/software inventions, include:
+- Pseudocode or algorithmic description (NOT actual code)
+- Flowchart description tied to figures
+- Data structure descriptions
+- Interface specifications
+
+Example:
+```
+In one embodiment, the method comprises the following steps:
+At step 202, the processor 102 receives input data from the input device 108.
+At step 204, the processor 102 extracts feature vectors from the input data using a convolutional neural network.
+At step 206, the processor 102 applies the attention mechanism 110 to the feature vectors...
+```
+
+### Step 6: Output
+
+Embodiment sections are written to `patent/specification/detailed_description.md` (or appended to the specification structure).
+
+Each embodiment section should be self-contained but cross-reference other embodiments when describing alternatives.
+
+## Key Rules
+
+- Embodiments must teach a POSITA to make and use the invention without undue experimentation.
+- Include at least one "best mode" embodiment (US requirement).
+- Multiple embodiments strengthen the specification against enablement challenges.
+- Describe the invention, do NOT evaluate it empirically ("The embodiment achieves 95% accuracy" is wrong; "The processor classifies the input data" is correct).
+- **CRITICAL — NO experimental data, test results, accuracy percentages, detection rates, precision values, or comparative performance data.** These belong in papers, not patents. The embodiment teaches HOW to make and use, not HOW WELL it performs.
+- WRONG: "传感器对直径超过150μm的金属颗粒实现了100%的检测精度，即使在检测限处仍保持94%的高精度。"
+- RIGHT: "当不锈钢颗粒通过间隙传感区域时，谐振频率下降。颗粒直径越大，频率偏移幅度越大。"
+- Do NOT include tables of experimental results, graphs of measurement data, or comparisons with prior art performance.
+- **CRITICAL — An embodiment is NOT an experiment.** Do NOT describe "repeated experiments", "accuracy evaluation", "precision testing", "calibration experiments", or "comparison with reference methods". An embodiment describes ONE way to make and use the invention — it is a recipe, not a test report.
+- Do NOT copy experimental sections from source papers verbatim. Transform the experimental setup into a manufacturing/operation description.
+- If the source material is a paper, extract ONLY: (1) what was built, (2) what materials/parameters were used, (3) how it operates. Ignore all test methodology, results, and performance metrics.
+- Include specific parameters where possible, but frame them as exemplary, not limiting.
+- Reference numerals must be consistent with the figures.
+- Do NOT use subjective language ("excellent", "surprising", "superior").

--- a/skills/skills-codex/exa-search/SKILL.md
+++ b/skills/skills-codex/exa-search/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: exa-search
+description: AI-powered web search via Exa with content extraction. Use when user says "exa search", "web search with content", "find similar pages", or needs broad web results beyond academic databases (arXiv, Semantic Scholar).
+argument-hint: [search-query-or-url]
+allowed-tools: Bash(*), Read, Write
+---
+
+# Exa AI-Powered Web Search
+
+Search query: $ARGUMENTS
+
+## Role & Positioning
+
+Exa is the **broad web search** source with built-in content extraction:
+
+| Skill | Best for |
+|------|----------|
+| `/arxiv` | Direct preprint search and PDF download |
+| `/semantic-scholar` | Published venue papers (IEEE, ACM, Springer), citation counts |
+| `/deepxiv` | Layered reading: search, brief, section map, section reads |
+| `/exa-search` | Broad web search: blogs, docs, news, companies, research papers — with content extraction |
+
+Use Exa when you need results beyond academic databases, or when you want content (highlights, full text, summaries) extracted alongside search results.
+
+## Constants
+
+- **FETCH_SCRIPT** — `$ARIS_REPO/tools/exa_search.py` from the ARIS repo recorded by the Codex install manifest.
+- **MAX_RESULTS = 10** — Default number of results to return.
+
+> Overrides (append to arguments):
+> - `/exa-search "RAG pipelines" — max: 5` — top 5 results
+> - `/exa-search "diffusion models" — category: research paper` — research papers only
+> - `/exa-search "startup funding" — category: news, start date: 2025-01-01` — recent news
+> - `/exa-search "transformer" — content: text, max chars: 8000` — full text mode
+> - `/exa-search "transformer" — content: summary` — LLM-generated summaries
+> - `/exa-search "transformer" — domains: arxiv.org,huggingface.co` — domain filter
+> - `/exa-search "https://arxiv.org/abs/2301.07041" — similar` — find similar pages
+
+## Setup
+
+Exa requires the `exa-py` SDK and an API key:
+
+```bash
+pip install exa-py
+```
+
+Set your API key:
+```bash
+export EXA_API_KEY=your-key-here
+```
+
+Get a key from [exa.ai](https://exa.ai).
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **query**: The search query (required) or a URL (for `find-similar` mode)
+- **similar**: If present, use `find-similar` mode instead of search
+- **max**: Override MAX_RESULTS
+- **category**: `research paper`, `news`, `company`, `personal site`, `financial report`, `people`
+- **content**: `highlights` (default), `text`, `summary`, `none`
+- **max chars**: Max characters for content extraction
+- **type**: Search type — `auto` (default), `neural`, `fast`, `instant`
+- **domains**: Comma-separated include domains
+- **exclude domains**: Comma-separated exclude domains
+- **include text**: Phrase that must appear in results
+- **exclude text**: Phrase to exclude from results
+- **start date**: ISO 8601 date — only results after this
+- **end date**: ISO 8601 date — only results before this
+- **location**: Two-letter ISO country code
+
+### Step 2: Locate Script
+
+```bash
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/exa_search.py" ] && SCRIPT="$ARIS_REPO/tools/exa_search.py"
+[ -z "$SCRIPT" ] && SCRIPT=$(find tools/ -name "exa_search.py" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find ~/.codex/skills/exa-search/ -name "exa_search.py" 2>/dev/null | head -1)
+```
+
+If not found, tell the user:
+```
+exa_search.py not found. Run install_aris_codex.sh, set ARIS_REPO to your ARIS repo root, or install/copy the helper into the project/global Codex skill path; then install exa-py:
+pip install exa-py
+```
+
+### Step 3: Execute Search
+
+**Standard search:**
+```bash
+python3 "$SCRIPT" search "QUERY" --max 10 --content highlights
+```
+
+**With filters:**
+```bash
+python3 "$SCRIPT" search "QUERY" --max 10 \
+  --category "research paper" \
+  --start-date 2025-01-01 \
+  --content text --max-chars 8000
+```
+
+**Find similar pages:**
+```bash
+python3 "$SCRIPT" find-similar "URL" --max 5 --content highlights
+```
+
+**Get content for known URLs:**
+```bash
+python3 "$SCRIPT" get-contents "URL1" "URL2" --content text
+```
+
+### Step 4: Present Results
+
+Format results as a structured table:
+
+```
+| # | Title | Authors | Venue/Publisher | URL | Date | Key Content |
+|---|-------|---------|-----------------|-----|------|-------------|
+```
+
+For each result:
+- Show title and URL
+- Show published date if available
+- Show highlights, text excerpt, or summary depending on content mode
+- Flag particularly relevant results
+- **For `category: "research paper"` hits only** — also record authors
+  (from Exa's `author`/`authors` fields, or fallback: parse from the
+  result snippet) and venue/publisher (from `publisher`, `source`, or
+  the domain hosting the paper). These are needed by Step 6's wiki
+  hook; if either is unavailable for a given hit, skip wiki ingest
+  for that one hit and log a note.
+
+### Step 5: Offer Follow-up
+
+After presenting results, suggest:
+- **Deepen**: "I can fetch full text for any of these results"
+- **Find similar**: "I can find pages similar to any result"
+- **Narrow**: "I can re-search with domain/date/text filters"
+
+### Step 6: Update Research Wiki (if active, research-paper results only)
+
+**Required when `research-wiki/` exists AND the search returned
+results of `category: "research paper"`**; skip silently otherwise.
+General web results (blog posts, docs, news) are **not** ingested —
+the wiki is for papers only.
+
+For each research paper hit, try to recover an arXiv ID from the URL
+(`arxiv.org/abs/<id>`); if present, use `--arxiv-id`. Otherwise fall
+back to manual metadata:
+
+```
+if [ -d research-wiki/ ] and query category was "research paper":
+    WIKI_SCRIPT=""
+    [ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+    for each research-paper hit in results:
+        if URL matches arxiv.org/abs/<id>:
+            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+                --arxiv-id "<id>"
+        else:
+            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+                --title "<title>" --authors "<authors joined by , >" \
+                --year <year> --venue "<venue or publisher>"
+```
+
+The helper handles slug / dedup / page / index / log — **do not
+handwrite `papers/<slug>.md`**. See
+[`shared-references/integration-contract.md`](../shared-references/integration-contract.md).
+
+## Key Rules
+- Always check that `EXA_API_KEY` is set before searching
+- Default to `highlights` content mode for a good balance of speed and context
+- Use `category: "research paper"` when the user is clearly looking for academic content
+- Use `text` content mode when the user needs full page content
+- Combine with `/arxiv` or `/semantic-scholar` for comprehensive literature coverage

--- a/skills/skills-codex/experiment-audit/SKILL.md
+++ b/skills/skills-codex/experiment-audit/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: experiment-audit
+description: "Audit experiment integrity before claiming results. Uses cross-model review (GPT-5.4) to check for fake ground truth, score normalization fraud, phantom results, and insufficient scope. Use when user says \"审计实验\", \"check experiment integrity\", \"audit results\", \"实验诚实度\", or after experiments complete before writing claims."
+argument-hint: [experiment-dir-or-results-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
+---
+
+# Experiment Audit: Cross-Model Integrity Verification
+
+Audit experiment integrity for: **$ARGUMENTS**
+
+## Why This Exists
+
+LLM agents can produce fraudulent experimental results through:
+1. **Fake ground truth** — creating synthetic "reference" from model outputs, then reporting high agreement as performance
+2. **Score normalization** — dividing metrics by the model's own max to get 0.99+
+3. **Phantom results** — claiming numbers from files that don't exist or functions never called
+4. **Insufficient scope** — reporting 2-scene pilots as "comprehensive evaluation"
+
+These are NOT intentional deception — they are failure modes of optimizing agents that lack integrity constraints. This skill adds that constraint.
+
+## Core Principle
+
+**The executor (Claude) collects file paths. The reviewer (GPT-5.4) reads code and judges integrity. The executor does NOT participate in integrity judgment.**
+
+This follows `shared-references/reviewer-independence.md` and `shared-references/experiment-integrity.md`.
+
+## Constants
+
+- **REVIEWER_BACKEND = `codex`** — Default: Codex reviewer agent (`spawn_agent`, xhigh). Override with `— reviewer: oracle-pro` for GPT-5.4 Pro via Oracle MCP. See `shared-references/reviewer-routing.md`.
+
+## Workflow
+
+### Step 1: Collect Artifacts (Executor — Claude)
+
+Locate and list these files WITHOUT reading or summarizing their content:
+
+```
+Scan project directory for:
+1. Evaluation scripts:    *eval*.py, *metric*.py, *test*.py, *benchmark*.py
+2. Result files:          *.json, *.csv in results/, outputs/, logs/
+3. Ground truth paths:    look in eval scripts for data loading (dataset paths, GT references)
+4. Experiment tracker:    EXPERIMENT_TRACKER.md, EXPERIMENT_LOG.md
+5. Paper claims:          NARRATIVE_REPORT.md, paper/sections/*.tex, PAPER_PLAN.md
+6. Config files:          *.yaml, *.toml, *.json configs with metric definitions
+```
+
+**DO NOT summarize, interpret, or explain any file content.** Only collect paths.
+
+### Step 2: Send to Reviewer (GPT-5.4 via Codex MCP)
+
+Pass ONLY file paths and the audit checklist to the reviewer. The reviewer reads everything directly.
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are an experiment integrity auditor. Read ALL files listed below
+    and check for the following fraud patterns.
+
+    Files to read:
+    - Evaluation scripts: [list paths]
+    - Result files: [list paths]
+    - Experiment tracker: [list paths]
+    - Paper claims: [list paths]
+    - Config files: [list paths]
+
+    ## Audit Checklist
+
+    ### A. Ground Truth Provenance
+    For each evaluation script:
+    1. Where does "ground truth" / "reference" / "target" come from?
+    2. Is it loaded from the DATASET, or generated/derived from MODEL OUTPUTS?
+    3. If derived: is it explicitly labeled as proxy evaluation?
+    4. Are official eval scripts used when available for this benchmark?
+    FAIL if: GT is derived from model outputs without explicit proxy labeling.
+
+    ### B. Score Normalization
+    For each metric computation:
+    1. Is any metric divided by max/min/mean of the model's OWN output?
+    2. Are raw scores reported alongside any normalized scores?
+    3. Are any scores suspiciously close to 1.0 or 100%?
+    FAIL if: Normalization denominator comes from prediction statistics.
+
+    ### C. Result File Existence
+    For each claim in the paper/narrative:
+    1. Does the referenced result file actually exist?
+    2. Does the claimed metric key exist in that file?
+    3. Does the claimed NUMBER match what's in the file?
+    4. Is the experiment tracker status DONE (not TODO/IN_PROGRESS)?
+    FAIL if: Claimed results reference nonexistent files or mismatched numbers.
+
+    ### D. Dead Code Detection
+    For each metric function defined in eval scripts:
+    1. Is it actually CALLED in any evaluation pipeline?
+    2. Does its output appear in any result file?
+    WARN if: Metric functions exist but are never called.
+
+    ### E. Scope Assessment
+    1. How many scenes/datasets/configurations were actually tested?
+    2. How many seeds/runs per configuration?
+    3. Does the paper use words like "comprehensive", "extensive", "robust"?
+    4. Is the actual scope sufficient for those claims?
+    WARN if: Scope language exceeds actual evidence.
+
+    ### F. Evaluation Type Classification
+    Classify each evaluation as:
+    - real_gt: uses dataset-provided ground truth
+    - synthetic_proxy: uses model-generated reference
+    - self_supervised_proxy: no GT by design
+    - simulation_only: simulated environment
+    - human_eval: human judges
+
+    ## Output Format
+
+    For each check (A-F), report:
+    - Status: PASS | WARN | FAIL
+    - Evidence: exact file:line references
+    - Details: what specifically was found
+
+    Overall verdict: PASS | WARN | FAIL
+    
+    Be thorough. Read every eval script line by line.
+```
+
+### Step 3: Parse and Write Report (Executor — Claude)
+
+Parse the reviewer's response and write `EXPERIMENT_AUDIT.md`:
+
+```markdown
+# Experiment Audit Report
+
+**Date**: [today]
+**Auditor**: GPT-5.4 xhigh (cross-model, read-only)
+**Project**: [project name]
+
+## Overall Verdict: [PASS | WARN | FAIL]
+
+## Integrity Status: [pass | warn | fail]
+
+## Checks
+
+### A. Ground Truth Provenance: [PASS|WARN|FAIL]
+[details + file:line evidence]
+
+### B. Score Normalization: [PASS|WARN|FAIL]
+[details]
+
+### C. Result File Existence: [PASS|WARN|FAIL]
+[details]
+
+### D. Dead Code Detection: [PASS|WARN|FAIL]
+[details]
+
+### E. Scope Assessment: [PASS|WARN|FAIL]
+[details]
+
+### F. Evaluation Type: [real_gt | synthetic_proxy | ...]
+[classification + evidence]
+
+## Action Items
+- [specific fixes if WARN or FAIL]
+
+## Claim Impact
+- Claim 1: [supported | needs qualifier | unsupported]
+- Claim 2: ...
+```
+
+Also write `EXPERIMENT_AUDIT.json` for machine consumption:
+
+```json
+{
+  "date": "2026-04-10",
+  "auditor": "gpt-5.4-xhigh",
+  "overall_verdict": "warn",
+  "integrity_status": "warn",
+  "checks": {
+    "gt_provenance": {"status": "pass", "details": "..."},
+    "score_normalization": {"status": "warn", "details": "..."},
+    "result_existence": {"status": "pass", "details": "..."},
+    "dead_code": {"status": "pass", "details": "..."},
+    "scope": {"status": "warn", "details": "..."},
+    "eval_type": "real_gt"
+  },
+  "claims": [
+    {"id": "C1", "impact": "supported"},
+    {"id": "C2", "impact": "needs_qualifier"}
+  ]
+}
+```
+
+### Step 4: Print Summary
+
+```
+🔬 Experiment Audit Complete
+
+  GT Provenance:      ✅ PASS — real dataset GT used
+  Score Normalization: ⚠️ WARN — boundary metric uses self-reference
+  Result Existence:    ✅ PASS — all files exist, numbers match
+  Dead Code:           ✅ PASS — all metric functions called
+  Scope:               ⚠️ WARN — 2 scenes, paper says "comprehensive"
+
+  Overall: ⚠️ WARN
+  
+  See EXPERIMENT_AUDIT.md for details.
+```
+
+## Integration with Other Skills
+
+### Automatic in /research-pipeline (advisory, never blocks)
+
+When integrated into the pipeline, this skill runs automatically after `/experiment-bridge` and before `/auto-review-loop`:
+
+```
+/experiment-bridge → results ready
+    ↓
+/experiment-audit (automatic, advisory)
+    ├── PASS  → continue normally
+    ├── WARN  → print ⚠️ warning, continue, tag claims as [INTEGRITY: WARN]
+    └── FAIL  → print 🔴 alert, continue, tag claims as [INTEGRITY CONCERN]
+    ↓
+/auto-review-loop → proceeds with integrity tags visible to reviewer
+```
+
+**Never blocks the pipeline.** Even on FAIL, the pipeline continues — but claims carry visible integrity tags.
+
+### Read by /result-to-claim (if exists)
+
+```
+if EXPERIMENT_AUDIT.json exists:
+    read integrity_status
+    attach to verdict: {claim_supported: "yes", integrity_status: "warn"}
+    if integrity_status == "fail":
+        downgrade verdict display: "yes [INTEGRITY CONCERN]"
+else:
+    verdict as normal, integrity_status = "unavailable"
+    mark as "provisional — no integrity audit"
+```
+
+### Read by /paper-write (if exists)
+
+```
+if EXPERIMENT_AUDIT.json exists AND integrity_status == "fail":
+    add footnote to affected claims: "Note: integrity audit flagged concerns with this evaluation"
+```
+
+## Key Rules
+
+- **Reviewer independence**: executor collects paths, reviewer judges. Period.
+- **Never block**: warn loudly, never halt the pipeline.
+- **File-as-switch**: no EXPERIMENT_AUDIT.md = skill was never run = zero impact on existing behavior.
+- **Cross-model**: the reviewer MUST be a different model family from the executor.
+- **Honest about limits**: the audit catches common patterns, not all possible fraud. It is a safety net, not a guarantee.
+
+## Acknowledgements
+
+Motivated by community-reported integrity issues (#57, #131) where executor agents created fake ground truth and self-normalized scores.
+
+## Review Tracing
+
+After each reviewer agent call, save the trace following `shared-references/review-tracing.md`. Use `tools/save_trace.sh` or write files directly to `.aris/traces/<skill>/<date>_run<NN>/`. Respect the `--- trace:` parameter (default: `full`).

--- a/skills/skills-codex/experiment-bridge/SKILL.md
+++ b/skills/skills-codex/experiment-bridge/SKILL.md
@@ -21,10 +21,13 @@ refine-logs/FINAL_PROPOSAL.md
 ## Constants
 
 - **AUTO_DEPLOY = true** — Automatically deploy experiments after implementation. Set `false` to review code before deploying.
+- **CODE_REVIEW = true** — Secondary Codex reviewer with xhigh reasoning reviews experiment code before deployment. Catches logic bugs before wasting GPU hours. Set `false` to skip.
 - **SANITY_FIRST = true** — Run the sanity-stage experiment first (smallest, fastest) before launching the rest. Catches setup bugs early.
 - **MAX_PARALLEL_RUNS = 4** — Maximum number of experiments to deploy in parallel (limited by available GPUs).
 - **BASE_REPO = false** — GitHub repo URL to use as a base codebase. When set, clone it first and implement experiments on top of it.
 - **COMPACT = false** — When `true`, prefer `idea-stage/IDEA_CANDIDATES.md` over the full `idea-stage/IDEA_REPORT.md`, and append completed runs to `EXPERIMENT_LOG.md`.
+- **BACKENDS = local | ssh | vast | modal** — Preserve the Claude mainline backend lifecycle. Vast.ai and Modal routes are first-class when configured; do not silently fall back to local execution if the user requested either backend.
+- **RESCUE_ON_FAILURE = true** — If sanity or deployment fails, run a Codex-native rescue / second opinion review before abandoning the experiment plan.
 
 > Override: `/experiment-bridge "EXPERIMENT_PLAN.md" — compact: true, base repo: https://github.com/org/project`
 
@@ -99,6 +102,42 @@ For each milestone (in order), write the experiment scripts:
    - Does the code match FINAL_PROPOSAL.md's method description?
    - **CRITICAL**: does evaluation compare predictions against dataset ground truth, never another model's output?
 
+### Phase 2.5: Cross-Model Code Review (when CODE_REVIEW = true)
+
+Skip this step if `CODE_REVIEW` is `false`.
+
+Before deploying, send the experiment code to a secondary Codex reviewer with xhigh reasoning:
+
+```text
+spawn_agent:
+  reasoning_effort: xhigh
+  message: |
+    Review the following experiment implementation for correctness.
+
+    ## Experiment Plan
+    [paste key sections from EXPERIMENT_PLAN.md]
+
+    ## Method Description
+    [paste from FINAL_PROPOSAL.md]
+
+    ## Implementation
+    [paste the experiment scripts or exact file paths plus relevant snippets]
+
+    Check for:
+    1. Does the code correctly implement the method described in the proposal?
+    2. Are all hyperparameters from the plan reflected in the code?
+    3. Are there logic bugs: wrong loss, wrong data split, missing eval, leakage, metric mismatch?
+    4. Is the evaluation metric computed against ground truth, not another model's output?
+    5. Are seeds, result paths, logging, and failure handling sufficient for reproducible experiments?
+
+    Output:
+    - BLOCKING issues that must be fixed before deployment
+    - NON-BLOCKING issues that can wait
+    - Suggested patches or checks
+```
+
+If BLOCKING issues are found, fix them and re-run this review once before Phase 3. Save the reviewer response and any fixes in `refine-logs/EXPERIMENT_CODE_REVIEW.md`. If reviewer delegation is unavailable, run the same checklist locally and mark the review `[local-only]`.
+
 ### Phase 3: Sanity Check (if SANITY_FIRST = true)
 
 Before deploying the full experiment suite, run the sanity-stage experiment:
@@ -115,18 +154,34 @@ Wait for completion. Verify:
 
 If sanity fails → fix the code, re-run. Do not proceed to full deployment with broken code.
 
+If the same sanity failure repeats, trigger a second opinion: summarize the plan, code diff, command, logs, backend, and failure, then ask a fresh Codex reviewer agent for a rescue diagnosis. Apply only concrete fixes grounded in the logs.
+
 ### Phase 4: Deploy Full Experiments
 
-Deploy experiments following the plan's milestone order:
+Deploy experiments following the plan's milestone order. Route by job count and dependencies:
 
 ```
 /run-experiment [experiment commands]
 ```
 
+For large batches (≥10 jobs), multi-seed sweeps, or teacher→student phase dependencies, use the queue scheduler:
+
+```
+/experiment-queue [grid spec or manifest]
+```
+
+Auto-routing rule: if any milestone in `EXPERIMENT_PLAN.md` declares ≥10 jobs or declares phase dependencies, route that milestone to `/experiment-queue`; otherwise use `/run-experiment`. `/experiment-queue` adds OOM-aware retry with backoff, stale-screen cleanup, wave-transition race prevention, phase dependency enforcement, and crash-safe state persistence in `queue_state.json`.
+
 For each milestone:
-1. Deploy experiments in parallel (up to MAX_PARALLEL_RUNS)
-2. Use `/monitor-experiment` to track progress
+1. Deploy experiments in parallel (up to MAX_PARALLEL_RUNS for `/run-experiment`, or `max_parallel` from the queue manifest for `/experiment-queue`)
+2. Use `/monitor-experiment` to track progress; if `/experiment-queue` is active, monitor `queue_state.json`
 3. Collect results as experiments complete
+
+Backend lifecycle rules:
+- **Vast.ai**: record instance id, SSH endpoint, mounted data/checkpoints, estimated hourly cost, and cleanup policy. If `auto_destroy` is configured, write the exact cleanup command before launch.
+- **Modal**: verify app/function, image/dependencies, secrets, volumes, and output persistence before launch.
+- **Local/SSH**: verify GPU availability, environment activation, log path, and result path before launching.
+- If a backend is unreachable or misconfigured, stop with a configuration issue instead of silently switching backend.
 
 **🚦 Checkpoint (if AUTO_DEPLOY = false):**
 

--- a/skills/skills-codex/experiment-queue/SKILL.md
+++ b/skills/skills-codex/experiment-queue/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: experiment-queue
+description: SSH job queue for multi-seed/multi-config ML experiments with OOM-aware retry, stale-screen cleanup, and wave-transition race prevention. Use when user says "batch experiments", "队列实验", "run grid", "multi-seed sweep", "auto-chain experiments", or when /run-experiment is insufficient for 10+ jobs that need orchestration.
+argument-hint: [manifest-or-grid-spec]
+allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent, Skill(run-experiment), Skill(monitor-experiment)
+---
+
+# Experiment Queue
+
+Orchestrate large batches of ML experiments on SSH remote GPU servers with proper state tracking, OOM retry, stale cleanup, and wave transitions.
+
+## When to Use This Skill
+
+Use when `/run-experiment` is insufficient:
+- **≥10 jobs** that need batching across GPUs
+- **Multi-seed sweeps** (e.g., 21 seeds × 12 cells)
+- **Wave transitions** (run wave 1, wait, run wave 2, wait, run wave 3...)
+- **Teacher+student chains** (train teacher then distill; auto-trigger student after teacher done)
+- **OOM-prone configs** where you need to retry with different GPU or wait
+- **Mixed seed grids** where failed cells need re-running
+
+Do NOT use for:
+- Single ad-hoc experiment (use `/run-experiment`)
+- Modal/Vast.ai deployments (those have their own orchestration)
+- Experiments that need manual inspection between runs
+
+## Why This Exists
+
+Based on session audit (2026-04-16), the major wall-clock sinks in multi-seed grid experiments are:
+
+1. **Stale screens** — python finishes, wandb uploads, screen hangs, next wave blocked
+2. **OOM on shared GPU** — previous job's memory not yet released
+3. **Wave race** — new wave launches before previous wave fully settles
+4. **Missing checkpoints** — student launches before teacher saved
+5. **Parser duplication** — rewriting multi-seed analysis python every batch
+
+All of these are pure engineering friction that can be orchestrated.
+
+## Core Concepts
+
+### Job Manifest
+
+A manifest lists jobs with explicit state:
+
+```yaml
+project: dllm_distill
+cwd: /home/rfyang/rfyang_code/dllm_experiments_torch
+conda: dllm
+# Optional: override conda hook path if conda is not at a standard location.
+# Can be a bare path (wrapped automatically) or a full `eval "$(... shell.bash hook)"` string.
+# Falls back to auto-detect of ~/anaconda3, ~/miniconda3, /opt/anaconda3, etc.,
+# or the ARIS_CONDA_HOOK environment variable.
+# conda_hook: /custom/path/to/conda
+ssh: SJTUServer5
+default_cmd: >
+  python run_pc_distill_exp.py --backbone softmax --lam 0.5
+  --K 500 --L 96 --W 16 --n_steps 30000 --batch_size 128 --lr 1e-4
+
+preconditions:
+  - type: checkpoint_exists
+    path: checkpoints/transformer/pcc_softmax_L96_K500_N{N}_wikitext103.pt
+
+gpus: [0, 1, 2, 3, 4, 5, 6, 7]
+max_parallel: 8
+gpu_free_threshold_mib: 500  # optional, default 500; raise for shared servers, lower for tight packing
+oom_retry:
+  delay: 120
+  max_attempts: 3
+
+jobs:
+  - id: s200_N64_n50K
+    args: {seed: 200, n_hidden: 64, n_train_subset: 50000, subset_seed: 2024}
+  - id: s200_N128_n50K
+    args: {seed: 200, n_hidden: 128, n_train_subset: 50000, subset_seed: 2024}
+  # ... 14 more
+```
+
+### Job State Machine
+
+```
+pending → running → completed
+                 ↘ failed_oom → pending (after delay) [retry up to N]
+                 ↘ failed_other → stuck (needs manual inspection)
+stale_screen_detected → cleaned → pending
+```
+
+### Wave Orchestration
+
+A "wave" is a batch of jobs that fit available GPUs. Next wave only starts when:
+1. All current-wave python processes have exited
+2. No stale screens remain for current-wave tags
+3. GPU memory has dropped below threshold (≤500 MiB)
+4. Precondition checks pass for next-wave jobs
+
+## Workflow
+
+### Step 1: Parse Manifest / Build from Grid
+
+Input can be:
+- **YAML manifest** (explicit job list, recommended for complex cases)
+- **Grid spec** (Cartesian product of param values, e.g., `N=[64,128,256] × n=[50K,150K,500K,652K]`)
+- **Natural language description** (Claude parses into manifest)
+
+Save the built manifest to `<project>/experiment_queue/<timestamp>/manifest.json` for reproducibility.
+
+### Step 2: Pre-flight
+
+- Check SSH connection works
+- Check conda env exists on remote
+- Check `cwd` exists on remote
+- Check all preconditions (checkpoints, input files)
+- Check GPU availability (at least `max_parallel` free GPUs)
+
+If any precondition fails, show user which jobs are blocked and why.
+
+### Step 3: Launch Scheduler
+
+Resolve the bundled helper directory from the managed Codex install manifest or from `ARIS_REPO`, then copy the helpers to the SSH host:
+
+```bash
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+[ -n "$ARIS_REPO" ] || { echo "ERROR: ARIS_REPO not set. Use install_aris_codex.sh managed install or export ARIS_REPO=/path/to/ARIS."; exit 1; }
+QUEUE_TOOLS="$ARIS_REPO/tools/experiment_queue"
+[ -f "$QUEUE_TOOLS/queue_manager.py" ] || { echo "ERROR: queue_manager.py not found under $QUEUE_TOOLS"; exit 1; }
+ssh <server> 'mkdir -p ~/.aris_queue'
+scp "$QUEUE_TOOLS/queue_manager.py" "$QUEUE_TOOLS/build_manifest.py" <server>:~/.aris_queue/
+```
+
+Run `tools/experiment_queue/queue_manager.py` as a detached `nohup` process on the SSH host:
+
+```bash
+ssh <server> 'nohup python3 ~/.aris_queue/queue_manager.py \
+  --manifest /tmp/manifest.json \
+  --state /tmp/queue_state.json \
+  --log /tmp/queue.log \
+  > /tmp/queue_mgr.log 2>&1 &'
+```
+
+The scheduler:
+- Reads manifest
+- Loops: for each pending job, assign to free GPU, launch via `screen`
+- Polls job status (every 60s)
+- Detects stale screens (python exited but screen detached → kill)
+- Detects OOM (CUDA OOM in log → mark failed_oom → retry after delay)
+- Detects completion (expected output JSON/file exists) → mark completed
+- Launches next wave when current wave settles
+- Writes state to `queue_state.json` continuously
+
+### Step 4: Monitoring
+
+User can check state anytime:
+
+```bash
+ssh <server> cat /tmp/queue_state.json | jq '.jobs | group_by(.status) | map({(.[0].status): length}) | add'
+```
+
+Or invoke `/monitor-experiment` which reads the state file.
+
+### Step 5: Post-completion
+
+When all jobs in `manifest.json` are `completed` or `stuck`:
+- Scheduler exits cleanly
+- Write final summary to `<project>/experiment_queue/<timestamp>/summary.md`
+- Invoke `/analyze-results` if `analyze_on_complete: true`
+
+## Grid Spec Syntax
+
+Instead of writing 24 job entries manually:
+
+```yaml
+grid:
+  N: [64, 128, 256]
+  n: [50000, 150000, 500000, 652000]
+  seed: [42, 200, 201]
+template:
+  id: "s${seed}_N${N}_n${n}"
+  args: {seed: ${seed}, n_hidden: ${N}, n_train_subset: ${n}}
+```
+
+Expands to 36 jobs automatically.
+
+## Wave Chaining
+
+For sequential phases (teacher → student):
+
+```yaml
+phases:
+  - name: train_teachers
+    grid:
+      N: [384, 512]
+    template:
+      cmd: python run_pc_exp.py --direction c --backbone softmax --n_hidden ${N} ...
+      output_check: checkpoints/transformer/pcc_softmax_L96_K500_N${N}_wikitext103.pt
+  
+  - name: distill_students
+    depends_on: train_teachers
+    grid:
+      N: [384, 512]
+      seed: [42, 200, 201]
+    template:
+      cmd: python run_pc_distill_exp.py --n_hidden ${N} --seed ${seed} ...
+      output_check: figures/pcdistill_sw_N${N}_*_seed${seed}.json
+```
+
+Scheduler enforces `depends_on`: `distill_students` jobs stay `pending` until all
+`train_teachers` jobs are `completed`.
+
+## OOM Handling
+
+Detect OOM from stdout:
+```regex
+torch\.OutOfMemoryError: CUDA out of memory
+```
+
+On detection:
+1. Mark job `failed_oom`
+2. Kill screen
+3. Wait `oom_retry.delay` seconds
+4. Check if current GPU is free; if not, try another free GPU
+5. Requeue as `pending`
+6. Max `oom_retry.max_attempts` before marking `stuck`
+
+## Stale Screen Detection
+
+Every 60s, for each running screen:
+1. Check screen exists (`screen -ls`)
+2. Check python PID still running (`ps -p`)
+3. If screen exists but python exited:
+   - If expected output file exists → mark `completed`, kill stale screen
+   - If no output file → mark `failed_other`, kill screen
+
+## Resume-on-restart
+
+If scheduler crashes / is killed:
+1. Read `queue_state.json`
+2. For each `running` job: check screen; if still alive, keep; if not, re-evaluate state
+3. For each `pending`: continue normally
+4. Idempotent: safe to restart scheduler without losing state
+
+## Output: Summary Report
+
+```markdown
+# Experiment Queue Summary
+
+**Project**: dllm_distill
+**Started**: 2026-04-16 11:36:29
+**Completed**: 2026-04-16 18:02:14
+**Total wall-clock**: 6h 25m
+**Jobs**: 40 completed, 2 OOM-retried then completed, 0 stuck
+
+## Phases
+| Phase | Jobs | Success | OOM retries | Duration |
+| --- | --- | --- | --- | --- |
+| train_teachers | 2 | 2 | 0 | 58m |
+| distill_students | 24 | 24 | 2 | 4h 02m |
+| multi_seed_validation | 16 | 16 | 0 | 1h 25m |
+
+## Results Files
+- 42 JSON files in `figures/pcdistill_sw_*.json`
+
+## Next Steps
+- Run `/analyze-results` on output JSONs
+- Figures auto-regen via `artifact-sync` (if configured)
+```
+
+## Comparison with `/run-experiment`
+
+| Feature | `/run-experiment` | `experiment-queue` |
+| --- | --- | --- |
+| Single-shot experiment | ✅ | ✅ (overkill) |
+| Multi-GPU parallel | Basic | Proper scheduling |
+| Wave transitions | Manual | Automatic |
+| OOM retry | Manual | Automatic |
+| Stale screen cleanup | Manual | Automatic |
+| Teacher→student chain | Manual | Built-in |
+| State persistence | No | Yes (JSON) |
+| Resume on crash | No | Yes |
+| Grid expansion | Manual | Declarative |
+
+**Rule**: Use `/run-experiment` for ≤5 jobs. Use `experiment-queue` for ≥10 jobs or anything with phases.
+
+## Key Rules
+
+- **Never overlap screens on the same GPU** — always wait for `memory.used < 500 MiB` before launching new job
+- **Always write state to disk** — every state change flushed to `queue_state.json`
+- **Idempotent scheduler** — safe to restart; picks up from state file
+- **Expected-output-based completion** — don't trust screen state alone; verify output file exists
+- **Bounded retry** — max N OOM retries, then mark `stuck` and alert
+- **Dependencies enforced at launch** — never launch student before teacher checkpoint exists
+
+## Known Failure Modes
+
+- **SSH connection drop during scheduling**: scheduler keeps running on remote (nohup), just reconnect and check
+- **GPU reservation by another user**: scheduler waits, does not pre-empt
+- **Disk full on remote**: scheduler detects write failure, marks all pending `stuck`, alerts
+
+## Example Session
+
+User: "跑 T5+T6 全部实验：T5 = N∈{80,192} × n 4 values × seed {200,201}, T6 = N∈{384,512} × n 4 values × seed {42,200,201}; T6 需要先 train teacher"
+
+Claude invokes `/experiment-queue`:
+1. Parses description into 2-phase manifest
+2. Phase 1: T5 (16 jobs, no teacher dependency) + T6 teacher training (2 jobs)
+3. Phase 2: T6 distillation (24 jobs, depends on teachers)
+4. Deploys scheduler via nohup
+5. Reports: "Scheduler PID 93534, total 42 jobs, estimated 6-7h wall-clock"
+
+Then user can check anytime or wait for summary report.
+
+## See Also
+
+- `/run-experiment` — single experiment deployment
+- `/monitor-experiment` — check progress (now reads from queue_state.json)
+- `/analyze-results` — post-hoc analysis
+- `tools/experiment_queue/queue_manager.py` (bundled) — the scheduler implementation
+- `tools/experiment_queue/build_manifest.py` (bundled) — build manifest from grid spec
+
+## Rationale / Source
+
+Identified via 2026-04-16 post-mortem analysis (Codex GPT-5.4 xhigh) of a 1.5-day
+multi-seed paper experiment session:
+
+- Wall-clock sink: stale screens, OOM, wave transitions, manual parser
+- Token sink: re-writing orchestration code each session
+- Cognitive sink: tracking which cells succeeded, which failed, which to retry
+
+This skill targets the wall-clock sink specifically; see `artifact-sync` and
+`paper-fix-auto-apply` for the other two.

--- a/skills/skills-codex/figure-description/SKILL.md
+++ b/skills/skills-codex/figure-description/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: figure-description
+description: "Process user-provided patent figures and generate formal drawing descriptions. Use when user says \"附图处理\", \"figure description\", \"附图说明\", \"drawings description\", or wants to describe patent figures with reference numerals."
+argument-hint: [figure-directory-or-figure-list]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
+---
+
+# Figure Description for Patents
+
+Process patent figures and generate drawing descriptions based on: **$ARGUMENTS**
+
+Unlike `/paper-figure` which generates data plots, this skill processes user-provided technical diagrams and assigns reference numerals.
+
+## Constants
+
+- `FIGURE_DIR = "patent/figures/"` — Output directory for figure descriptions
+- `REFERENCE_NUMERAL_PREFIX = 100` — Starting numeral for first figure's components
+- `NUMERAL_SERIES = 100` — Each figure uses a separate 100-series (Fig 1: 100-199, Fig 2: 200-299, etc.)
+
+## Inputs
+
+1. User-provided figures (PNG, JPG, SVG, PDF) — search for them in the project directory
+2. `patent/INVENTION_DISCLOSURE.md` — for understanding what components to identify
+3. `patent/CLAIMS.md` — for mapping numerals to claim elements
+
+## Workflow
+
+### Step 1: Discover Figures
+
+1. Search the project directory for figure files:
+   - Check `patent/figures/`, `figures/`, root directory
+   - Look for PNG, JPG, SVG, PDF files
+   - Check INVENTION_BRIEF.md or INVENTION_DISCLOSURE.md for figure references
+2. List all discovered figures with their paths
+3. If figures are missing that claims require, note them as `[MISSING: description needed]`
+
+### Step 2: Analyze Each Figure
+
+For each figure found:
+
+1. **Read the image** using the Read tool (supports image files)
+2. **Identify components**: What labeled or visually distinct components are shown?
+3. **Identify connections**: How do components relate to each other?
+4. **Identify flow**: If it's a flowchart or sequence, what is the step order?
+
+### Step 3: Assign Reference Numerals
+
+For each figure, assign numerals using the series convention:
+
+| Figure | Numeral Range |
+|--------|-------------|
+| FIG. 1 | 100-199 |
+| FIG. 2 | 200-299 |
+| FIG. 3 | 300-399 |
+
+For each identified component:
+- Assign the next available numeral in the series
+- Cross-reference to the claim elements it supports
+- Note if a component appears in multiple figures (use same numeral across figures)
+
+### Step 4: Generate Drawing Descriptions
+
+Write formal drawing descriptions (附图说明):
+
+**For CN jurisdiction (Chinese)**:
+```
+图1是[发明名称]的系统结构示意图；
+图2是[发明名称]的方法流程图；
+图3是[具体组件]的详细结构示意图；
+```
+
+**For US/EP jurisdiction (English)**:
+```
+FIG. 1 is a block diagram illustrating the system architecture according to one embodiment;
+FIG. 2 is a flowchart illustrating the method steps according to one embodiment;
+FIG. 3 is a detailed view of the processing module of FIG. 1;
+```
+
+### Step 5: Generate Reference Numeral Index
+
+Create a complete mapping:
+
+```markdown
+## Reference Numeral Index
+
+| Numeral | Component Name | Figure(s) | Claim Element |
+|---------|---------------|-----------|---------------|
+| 100 | System | FIG. 1 | Claim X preamble |
+| 102 | Processor | FIG. 1 | Claim X, element 1 |
+| 104 | Memory | FIG. 1 | Claim X, element 2 |
+| 106 | Communication bus | FIG. 1 | Claim X, element 3 |
+| 200 | Method | FIG. 2 | Claim 1 preamble |
+| 202 | Receiving step | FIG. 2 | Claim 1, step 1 |
+| 204 | Processing step | FIG. 2 | Claim 1, step 2 |
+```
+
+### Step 6: Cross-Reference to Claims
+
+Verify that every claim element has at least one reference numeral:
+
+| Claim Element | Figure | Numeral | Status |
+|---------------|--------|---------|--------|
+| [element] | [which fig] | [numeral] | Covered / [MISSING] |
+
+If any claim element has no corresponding figure or numeral, flag it:
+- `[MISSING FIGURE: Need a diagram showing {element description}]`
+- `[MISSING NUMERAL: Component {name} in figure {X} needs a numeral]`
+
+### Step 7: Output
+
+Write `patent/figures/figure_descriptions.md`:
+```markdown
+## Figure Descriptions
+
+### FIG. 1 — [Description]
+[Formal one-paragraph description with all reference numerals]
+
+### FIG. 2 — [Description]
+[Formal one-paragraph description with all reference numerals]
+...
+```
+
+Write `patent/figures/numeral_index.md`:
+```markdown
+## Reference Numeral Index
+
+[Complete table of all numerals, components, figures, and claim mappings]
+```
+
+## Key Rules
+
+- Every component in every figure must have a reference numeral.
+- Every reference numeral must be explained in the specification.
+- Numeral series must be consistent: 100-series for FIG. 1, 200-series for FIG. 2.
+- If the same component appears in multiple figures, use the SAME numeral.
+- Do NOT modify user-provided figures -- only describe them.
+- Flag missing figures that the claims require but the user has not provided.
+- Drawing descriptions are one sentence each, in a consistent format.

--- a/skills/skills-codex/figure-spec/SKILL.md
+++ b/skills/skills-codex/figure-spec/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: figure-spec
+description: "Generate deterministic publication-quality architecture, workflow, and pipeline diagrams from structured JSON (FigureSpec) into editable SVG. Use when user says \"架构图\", \"workflow 图\", \"pipeline 图\", \"确定性矢量图\", \"figure spec\", \"draw architecture\", or needs precise, editable, publication-ready vector diagrams. Preferred over AI illustration for formal architecture/workflow figures."
+argument-hint: [description-of-diagram]
+allowed-tools: Bash(*), Read, Write, Edit, Agent
+---
+
+# FigureSpec: Deterministic JSON → SVG Figure Generation
+
+Generate publication-quality **architecture diagrams**, **workflow pipelines**, **audit cascades**, and **system topology** figures as editable SVG vector graphics using a deterministic JSON → SVG renderer.
+
+## When to Use This Skill
+
+**Use `figure-spec`** for:
+- System architecture diagrams (layered, hub-and-spoke, multi-plane)
+- Workflow / pipeline figures
+- Audit cascade / flow-control diagrams
+- Any structured diagram where node positions, connections, and groupings are semantically important
+- Figures that need to be edited/tweaked later (SVG is plain text)
+- Figures where determinism matters (same spec → same SVG)
+
+**Do NOT use for:**
+- Data plots (bar/line/scatter) — use `/paper-figure`
+- Natural/qualitative illustrations — use `/paper-illustration`
+- Quick state-machine / flowchart — use `/mermaid-diagram` (lighter syntax)
+
+## Core Properties
+
+- **Deterministic**: identical FigureSpec JSON always produces identical SVG output (for a fixed renderer version + fonts)
+- **Editable**: SVG output is plain-text, can be post-edited by hand or programmatically
+- **Validated**: renderer enforces schema, rejects malformed specs with clear error messages
+- **Shape-aware**: edge clipping works correctly for rect/rounded/circle/ellipse/diamond
+- **CJK support**: multi-line labels with proper Chinese character width estimation
+- **No external API**: runs fully local, no network, no API keys
+
+## Tool Location
+
+Locate `figure_renderer.py` using the Codex managed install manifest first, then project/global copy-install fallbacks. Invoke via:
+
+```bash
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+FIGURE_RENDERER=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/figure_renderer.py" ] && FIGURE_RENDERER="$ARIS_REPO/tools/figure_renderer.py"
+[ -z "$FIGURE_RENDERER" ] && [ -f tools/figure_renderer.py ] && FIGURE_RENDERER="tools/figure_renderer.py"
+[ -z "$FIGURE_RENDERER" ] && [ -f ~/.codex/skills/figure-spec/figure_renderer.py ] && FIGURE_RENDERER="$HOME/.codex/skills/figure-spec/figure_renderer.py"
+[ -n "$FIGURE_RENDERER" ] || { echo "ERROR: figure_renderer.py not found. Set ARIS_REPO, use install_aris_codex.sh managed install, or copy tools/figure_renderer.py next to this skill."; exit 1; }
+python3 "$FIGURE_RENDERER" render <spec.json> --output <out.svg>
+python3 "$FIGURE_RENDERER" validate <spec.json>
+python3 "$FIGURE_RENDERER" schema
+```
+
+## Workflow
+
+### Step 1: Understand the Diagram Goal
+
+From `$ARGUMENTS` (description or path to `PAPER_PLAN.md` / `NARRATIVE_REPORT.md`), identify:
+- **Purpose**: architecture, workflow, pipeline, audit cascade, topology?
+- **Main entities**: what are the boxes?
+- **Relationships**: how do they connect? (uses, produces, calls, verifies, chains)
+- **Grouping**: do entities cluster into named regions?
+- **Hierarchy vs network**: stacked layers, left-to-right flow, or central hub?
+
+### Step 2: Draft the FigureSpec JSON
+
+Canvas sizing guide:
+- Single-column figure: ~500×350 px
+- Two-column (full-width): ~900×500 px
+- Tall topology: ~700×700 px
+
+Start from a template based on the diagram type:
+
+**Architecture (stacked rows)**:
+```json
+{
+  "canvas": {"width": 900, "height": 520},
+  "nodes": [
+    {"id": "layer1_label", "label": "Layer 1", "x": 450, "y": 60, ...},
+    {"id": "node_a", "label": "A", "x": 180, "y": 120, ...},
+    {"id": "node_b", "label": "B", "x": 350, "y": 120, ...}
+  ],
+  "edges": [...],
+  "groups": [
+    {"label": "Layer 1", "node_ids": ["node_a", "node_b"], "fill": "#F0F9FF", "stroke": "#BAE6FD"}
+  ]
+}
+```
+
+**Workflow (left-to-right chain)**:
+```json
+{
+  "canvas": {"width": 900, "height": 300},
+  "nodes": [
+    {"id": "step1", "label": "Step 1", "x": 100, "y": 150, "shape": "rounded"},
+    {"id": "step2", "label": "Step 2", "x": 280, "y": 150, "shape": "rounded"}
+  ],
+  "edges": [
+    {"from": "step1", "to": "step2", "label": "produces"}
+  ]
+}
+```
+
+**Decision diamond**:
+```json
+{"id": "check", "label": "Passes?", "shape": "diamond", "x": 450, "y": 200}
+```
+
+### Step 3: Render and Validate
+
+```bash
+# Validate first
+python3 "$FIGURE_RENDERER" validate /tmp/spec.json
+
+# Render to SVG
+python3 "$FIGURE_RENDERER" render /tmp/spec.json --output figures/fig_arch.svg
+
+# Convert to PDF for LaTeX inclusion
+rsvg-convert -f pdf figures/fig_arch.svg -o figures/fig_arch.pdf
+```
+
+If validation fails, inspect the error (missing field, duplicate ID, overlap warning, invalid hex color) and fix the JSON.
+
+### Step 4: Visual Review
+
+Open the SVG/PDF and check:
+- **No overlaps**: nodes don't collide with each other or group boundaries
+- **Readability**: font sizes are consistent, labels aren't clipped
+- **Edge clarity**: arrows hit nodes at clean angles, labels near edges are legible
+- **Group alignment**: background rectangles frame their members cleanly
+- **Color distinction**: categories are visually distinct in both color and grayscale
+
+If issues found, edit the JSON spec (never the generated SVG) and re-render.
+
+### Step 5: Iterate with Codex Review (Optional, for High-Stakes Figures)
+
+For paper architecture figures, invoke cross-model review:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    Review this SVG figure for a technical paper (architecture / workflow diagram).
+
+    Spec file: /path/to/spec.json
+    Rendered: /path/to/fig.svg
+
+    Evaluate:
+    1. Clarity (C): can a reader understand the system from this figure alone?
+    2. Readability (R): font sizes, label placement, visual hierarchy
+    3. Semantic accuracy (S): do relationships match the described system?
+
+    Score each axis 1-10 and list specific issues to fix.
+```
+
+Iterate until all three axes ≥ 7/10. The ARIS tech report figures went through 5 rounds of this loop to reach C:7/R:7/S:8.
+
+## Schema Quick Reference
+
+Run `python3 "$FIGURE_RENDERER" schema` for the authoritative schema.
+
+### Nodes
+
+| Field | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `id` | ✓ | — | Unique |
+| `label` | ✓ | — | `\n` for multi-line |
+| `x`, `y` | ✓ | — | Center coordinates |
+| `width`, `height` | | 120, 50 | |
+| `shape` | | `rounded` | `rect` / `rounded` / `circle` / `ellipse` / `diamond` |
+| `fill`, `stroke` | | auto from palette | `#RRGGBB` |
+| `text_color` | | `#333333` | |
+| `font_size` | | 14 | Override style default |
+
+### Edges
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `from`, `to` | required | Same = self-loop |
+| `label` | — | Short edge label |
+| `style` | `solid` | `solid` / `dashed` / `dotted` |
+| `color` | `#555555` | |
+| `curve` | `false` | Curved path |
+
+### Groups
+
+Rectangular background regions framing a set of nodes:
+```json
+{"label": "Layer Name", "node_ids": ["a", "b", "c"], "fill": "#EFF6FF", "stroke": "#BFDBFE"}
+```
+
+## Design Patterns
+
+### Pattern 1: Layered Architecture
+Stack rows of related nodes, each row is a group, add inter-layer arrows with semantic labels (`uses↓`, `produces↑`, `checks↓`).
+
+### Pattern 2: Hub-and-Spoke
+Central node (e.g., Executor), peripheral nodes (skills, tools), solid arrows for primary relations, dashed for feedback.
+
+### Pattern 3: Pipeline with Feedback
+Left-to-right main flow, feedback arrows curve below with `curve: true`.
+
+### Pattern 4: Audit Cascade
+Three-stage horizontal cascade with inputs feeding in from top, outputs exiting right, each stage in its own group.
+
+## Anti-Patterns
+
+- **Don't use groups as hierarchy**: groups frame peer nodes, not containment
+- **Don't nest groups**: renderer draws them as background rectangles; nested groups look like Russian dolls
+- **Don't cross-draw long diagonals**: if an arrow crosses 3+ rows, rethink the layout
+- **Don't mix font sizes for same role**: keep one size per node category
+
+## Output Contract
+
+- SVG file in `figures/` (vector, editable, hand-tweakable)
+- Source FigureSpec JSON saved in `figures/specs/` for reproducibility
+- PDF version via `rsvg-convert` for LaTeX inclusion
+
+## Integration with Other Skills
+
+- **`/paper-writing`** (Workflow 3): when `illustration: figurespec` (default for architecture figures), this skill handles Phase 2b
+- **`/paper-figure`**: handles data plots; they complement each other (data + architecture = complete figure set)
+- **`/paper-illustration`**: fallback for figures that need natural/qualitative style (method illustrations with photos, qualitative result grids)
+- **`/mermaid-diagram`**: lighter alternative for simple flowcharts
+
+## Review Tracing
+
+After each reviewer agent call, save the trace following `shared-references/review-tracing.md`. Use `tools/save_trace.sh` or write files directly to `.aris/traces/<skill>/<date>_run<NN>/`. Respect the `--- trace:` parameter (default: `full`).

--- a/skills/skills-codex/formula-derivation/SKILL.md
+++ b/skills/skills-codex/formula-derivation/SKILL.md
@@ -1,207 +1,280 @@
 ---
-name: "formula-derivation"
-description: "Structure and derive research formulas when the user wants to 推导公式, derive a theory line, build equations from a problem statement, clarify assumptions, separate formal derivation from remarks, or turn messy theory notes into a paper-ready derivation skeleton. Use for research-style formula development, not for fully rigorous theorem proving once the claim is already fixed."
+name: formula-derivation
+description: Structures and derives research formulas when the user wants to 推导公式, build a theory line, organize assumptions, turn scattered equations into a coherent derivation, or rewrite theory notes into a paper-ready formula document. Use when the derivation target is not yet fully fixed, the main object still needs to be chosen, or the user needs a coherent derivation package rather than a finished theorem proof.
+argument-hint: [problem-goal-current-formulas-or-notes]
+allowed-tools: Read, Write, Edit, Grep, Glob
 ---
 
-# Formula Derivation
+# Formula Derivation: Research Theory Line Construction
 
-Use this skill when the task is not merely to prove a finished theorem, but to **build the derivation itself**:
+Build an honest derivation package, not a fake polished theorem story.
 
-- define the right object,
-- decide what should be assumed,
-- determine what is identity vs proposition vs approximation,
-- connect simple and general regimes without splitting into two unrelated stories,
-- and turn messy notes into a derivation line that can later be written into a paper.
+## Constants
 
-Do **not** use this skill as a replacement for strict proof writing once the exact claim is already fixed and the user wants a theorem-proof package. In that case, hand off to `proof-writer`.
+- DEFAULT_DERIVATION_DOC = `DERIVATION_PACKAGE.md` in project root
+- STATUS = `COHERENT AS STATED | COHERENT AFTER REFRAMING / EXTRA ASSUMPTION | NOT YET COHERENT`
 
-## Core Principle
+## Context: $ARGUMENTS
 
-The derivation must be built around **one invariant object**. Do not start from scattered formulas. Start from the object that survives across regimes, then derive proxies, decompositions, and interpretations from it.
+## Goal
 
-## What to Produce
+Produce exactly one of:
+1. a coherent derivation package for the original target
+2. a reframed derivation package with corrected object / assumptions / scope
+3. a blocker report explaining why the current notes cannot yet support a coherent derivation
 
-Prefer one of these outputs:
+## Inputs
 
-1. a **mainline derivation note** for internal alignment;
-2. a **paper-style theory draft** with tighter narrative;
-3. a **blocker report** if the current notes cannot support a coherent derivation.
+Extract and normalize:
+- the target phenomenon, formula, relation, or theory line
+- the intended role of the derivation:
+  - exact identity / algebra
+  - proposition / local theorem
+  - approximation
+  - mechanism interpretation
+- explicit assumptions
+- notation and definitions
+- any user-provided formula chain, sketch, messy notes, or current draft
+- nearby local theory files if the request points to them
+- desired output style if specified:
+  - internal alignment note
+  - paper-style theory draft
+  - blocker report
+
+If the target, object, notation, or assumptions are ambiguous, state the exact interpretation you are using before deriving anything.
 
 ## Workflow
 
-### 1. Freeze the Target
+### Step 1: Gather Derivation Context
+Determine the target derivation file with this priority:
+1. a file path explicitly specified by the user
+2. a derivation draft already referenced in local notes
+3. `DERIVATION_PACKAGE.md` in project root as the default target
 
+Read the relevant local context:
+- the chosen target derivation file, if it already exists
+- any local theory notes, formula drafts, appendix notes, or files explicitly mentioned by the user
+
+Extract:
+- target formula / theory goal
+- current formula chain
+- assumptions
+- notation
+- known blockers
+- desired output mode
+
+### Step 2: Freeze the Target
 State explicitly:
-
-- what phenomenon is being explained;
-- what claim is being supported;
-- whether the goal is:
-  - identity / algebra,
-  - local comparative statics,
-  - approximation,
-  - or mechanism interpretation.
+- what is being explained, derived, or supported
+- whether the immediate goal is:
+  - identity / algebra
+  - proposition
+  - approximation
+  - interpretation
+- what the derivation is expected to output in the end
 
 Do not start symbolic manipulation before this is fixed.
 
-### 2. Choose the Invariant Object
+### Step 3: Choose the Invariant Object
+Identify the single quantity or conceptual object that should organize the derivation.
 
-Find the single quantity that should remain meaningful across regimes.
+Typical possibilities include:
+- objective / utility / loss
+- total cost / energy / welfare
+- conserved quantity / state variable
+- expected metric / effective rate / effective cost
 
-Examples:
+If the current notes start from a narrower quantity, decide explicitly whether it is:
+- the true top-level object
+- a proxy
+- a local slice
+- an approximation
 
-- objective / loss / utility
-- total energy / cost / welfare
-- state variable / conserved quantity / effective rate
-- expected performance metric
+Do not let a convenient proxy silently replace the actual conceptual object.
 
-If the current notes use a narrower quantity (`c_i`, throughput, delay, CW, etc.), decide whether it is:
+### Step 4: Normalize Assumptions and Notation
+Restate:
+- all assumptions
+- all symbols
+- regime boundaries or special cases
+- which quantities are fixed, adaptive, or state dependent
 
-- the true top-level object,
-- or only a proxy / slice / approximation.
+Identify:
+- hidden assumptions
+- undefined notation
+- scope ambiguities
+- whether the current formula chain already mixes exact steps with approximations
 
-### 3. Put Assumptions and Notation First
+Preserve the user's original notation unless a cleanup is necessary for coherence.
+If you adopt a cleaner internal formulation, keep that as a derivation device rather than silently replacing the user's target.
 
-Before deriving, list:
+### Step 5: Classify the Derivation Steps
+For every nontrivial step, determine whether it is:
+- **identity**: exact algebraic reformulation
+- **proposition**: a claim requiring conditions
+- **approximation**: model simplification or surrogate
+- **interpretation**: prose-level meaning of a formula
 
-- assumptions;
-- notation;
-- regime boundaries;
-- which quantities are fixed and which are state dependent.
+Never merge these categories without signaling the transition.
+If one part is only interpretive, do not present it as if it were mathematically proved.
 
-Do not introduce hidden assumptions mid-derivation unless they are clearly marked as extra local assumptions.
+### Step 6: Build a Derivation Map
+Choose a derivation strategy, for example:
+- definition -> substitution -> simplification
+- primitive law -> intermediate variable -> target expression
+- global quantity -> perturbation -> decomposition
+- exact model -> approximation -> interpretable closed form
+- general dynamic object -> simplified slice -> local theorem -> return to general case
 
-### 4. Classify Every Step
+Then write a derivation map:
+- target formula or theory line
+- required intermediate identities or lemmas
+- which assumptions each nontrivial step uses
+- where approximations enter
+- where special-case and general-case regimes diverge or collapse
 
-Every nontrivial part of the derivation must be labeled mentally as one of:
+If the derivation needs a decomposition, derive it from the chosen global quantity.
+Do not make a split appear magically from one local variable itself.
 
-- **identity**: exact algebraic reformulation;
-- **proposition**: a claim requiring conditions;
-- **approximation**: model simplification or surrogate;
-- **interpretation**: prose-level explanation of what the formula means.
+### Step 7: Write the Derivation Document
+Write to the chosen target derivation file.
 
-Never mix these without signaling the change.
+If the target derivation file already exists:
+- read it first
+- update the relevant section
+- do not blindly duplicate prior content
 
-### 5. Derive from the Global Quantity When Splitting Costs
+If the user does not specify a target, default to `DERIVATION_PACKAGE.md` in project root.
 
-If the goal is to split a quantity into components, start from the **global quantity** and then differentiate / decompose.
+Do NOT write directly into paper sections or appendix `.tex` files unless the user explicitly asks for that target.
 
-Pattern:
+The derivation package must include:
+- target
+- status
+- invariant object
+- assumptions
+- notation
+- derivation strategy
+- derivation map
+- main derivation steps
+- remarks / interpretations
+- boundaries and non-claims
 
-1. define the global quantity, e.g. `W = \sum_j \Gamma_j`;
-2. perturb one local variable, e.g. `c_i`;
-3. compute the marginal social effect;
-4. split the result into:
-   - direct term,
-   - indirect term,
-   - or private / external terms if that distinction is part of the model.
+Writing rules:
+- do not hide gaps with words like "clearly", "obviously", or "similarly"
+- define every symbol before use
+- mark approximations explicitly
+- separate derivation body from remarks
+- if the true object is dynamic or state dependent but a simpler slice is analyzed, say so explicitly
+- if a formula line is only heuristic, label it honestly
 
-Do **not** present the decomposition as if it appeared magically from one local variable itself. The split must come from the effect of changing that variable on the chosen global quantity.
+### Step 8: Final Verification
+Before finishing the target derivation file, verify:
+- the target is explicit
+- the invariant object is stable across the derivation
+- every assumption used is stated
+- each formula step is correctly labeled as identity / proposition / approximation / interpretation
+- the derivation does not silently switch objects
+- special cases and general cases still belong to one theory line
+- boundaries and non-claims are stated
 
-### 6. Keep Special Cases and General Cases in One Line
+If the derivation still lacks a coherent object, stable assumptions, or an honest path from premises to result, downgrade the status and write a blocker report instead of forcing a clean story.
 
-If the theory must cover both a simplified regime and a more general regime, do not write two unrelated stories.
+## Required File Structure
 
-Use this pattern:
+Write the target derivation file using this structure:
 
-- same invariant object across all regimes;
-- special case: some terms vanish or collapse;
-- general case: the same object gains extra structure.
+```md
+# Derivation Package
 
-This prevents the simple case from looking like an exception and the general case from looking like a different theory.
+## Target
+[what is being derived or explained]
 
-### 7. Treat Simplified Parameters as Analysis Slices
+## Status
+COHERENT AS STATED / COHERENT AFTER REFRAMING / NOT YET COHERENT
 
-If the true object is state dependent, adaptive, vector-valued, or otherwise complicated, but a theorem needs a simpler parameterization, write:
+## Invariant Object
+[top-level quantity organizing the derivation]
 
-- the general object first;
-- then define the simpler case as a **tractable slice**.
+## Assumptions
+- ...
 
-Use language such as:
+## Notation
+- ...
 
-- frozen-parameter approximation;
-- constant-coefficient slice;
-- local linearization;
-- reduced-order case.
+## Derivation Strategy
+[chosen route and why]
 
-Do not let the simplified case silently replace the real conceptual object.
+## Derivation Map
+1. Target depends on ...
+2. Intermediate step A uses ...
+3. Approximation enters at ...
 
-### 8. Separate Main Text from Remarks
+## Main Derivation
+Step 1. ...
+Step 2. ...
+...
 
-For derivations intended for papers:
+## Remarks and Interpretation
+- ...
 
-- the **main derivation** should contain only equations and immediate mathematical consequences;
-- explanatory prose, intuition, scenario reading, and caveats should be moved to **Remark / Discussion / Scope** paragraphs.
+## Boundaries and Non-Claims
+- ...
 
-If a section starts to read like an internal lecture note, split it into:
+## Open Risks
+- ...
+```
 
-- derivation body;
-- remark.
+## Output Modes
 
-### 9. Write Boundaries Explicitly
+### If the derivation is coherent as stated
+Write the full structure above with a clean derivation package.
 
-At the end, state:
+### If the notes are close but not coherent yet
+Write:
+- the exact mismatch
+- the corrected invariant object, assumption, or scope
+- the reframed derivation package
 
-- what the derivation actually proves;
-- what remains approximation;
-- what should **not** be claimed.
-
-Especially guard against:
-
-- turning a local proposition into a universal theorem;
-- letting an interpretation sound like a proof;
-- hiding a proxy as if it were the true quantity.
-
-## Common Derivation Patterns
-
-When the user is unsure how to start, try one of these common patterns:
-
-1. **Definition -> substitution -> simplification**
-   Use when the target formula is mostly algebraic.
-
-2. **Global quantity -> perturbation -> decomposition**
-   Use when the target needs direct / indirect, private / external, or local / global splitting.
-
-3. **Primitive law -> intermediate variable -> target expression**
-   Use when deriving from a physical principle, conservation law, or probabilistic identity.
-
-4. **Exact model -> approximation -> interpretable closed form**
-   Use when the exact formula is too heavy and a paper needs a usable surrogate.
-
-5. **General dynamic object -> frozen slice -> theorem -> return to general case**
-   Use when the real system is adaptive or state dependent, but the proof needs a simpler slice.
-
-## Recommended Output Structure
-
-For an internal derivation note:
-
-1. Target
-2. Invariant object
-3. Assumptions and notation
-4. Main derivation
-5. Regime interpretation
-6. Approximations and open risks
-
-For a paper-style theory section:
-
-1. Unified object
-2. Formal proxy and assumptions
-3. Special-case to general-case decomposition
-4. Reward / objective reformulation
-5. Local theorem or proposition
-6. State-dependent extension
-7. Scope and non-claims
+### If the derivation cannot be made coherent honestly
+Write:
+- `Status: NOT YET COHERENT`
+- the exact blocker:
+  - missing object
+  - unstable assumptions
+  - notation conflict
+  - unsupported approximation
+  - theorem-level claim without enough conditions
+- what extra assumption, reframe, or intermediate derivation would be needed
 
 ## Relationship to `proof-writer`
 
 Use `formula-derivation` when the user says things like:
-
 - “我不知道怎么起这条推导主线”
 - “这个公式到底该从哪个量出发”
 - “帮我把理论搭顺”
 - “把说明文档变成可写进论文的公式文档”
+- “这几段公式之间逻辑不通”
 
 Use `proof-writer` only after:
+- the exact claim is fixed
+- the assumptions are stable
+- the notation is settled
+- and the task is now to prove or refute that claim rigorously
 
-- the exact claim is already fixed,
-- the assumptions are stable,
-- and the task is now to prove or refute that claim rigorously.
+## Chat Response
+
+After writing the target derivation file, respond briefly with:
+- status
+- whether the target survived unchanged or had to be reframed
+- what file was updated
+
+## Key Rules
+
+- Never fabricate a coherent derivation if the object, assumptions, or scope do not support one.
+- Prefer reframing the derivation over overclaiming.
+- Separate assumptions, identities, propositions, approximations, and interpretations.
+- Keep one invariant object across special and general cases whenever possible.
+- Treat simplified constant-parameter cases as analysis slices, not as the conceptual main object.
+- If uncertainty remains, mark it explicitly in `Open Risks`; do not hide it in polished prose.
+- Coherence matters more than elegance.

--- a/skills/skills-codex/idea-creator/SKILL.md
+++ b/skills/skills-codex/idea-creator/SKILL.md
@@ -18,11 +18,34 @@ Given a broad research direction from the user, systematically generate, validat
 - **MAX_PILOT_IDEAS = 3** — Pilot at most 3 ideas in parallel. Additional ideas are validated on paper only.
 - **MAX_TOTAL_GPU_HOURS = 8** — Total GPU budget for all pilots combined.
 - **REVIEWER_MODEL = `gpt-5.4`** — Model used via a secondary Codex agent for brainstorming and review. Must be an OpenAI model (e.g., `gpt-5.4`, `o3`, `gpt-4o`).
+- **REVIEWER_BACKEND = `codex`** — Default: Codex xhigh reviewer through `spawn_agent` / `send_input`. Use `--reviewer: oracle-pro` only when explicitly requested; if Oracle is unavailable, warn and fall back to Codex xhigh.
 - **OUTPUT_DIR = `idea-stage/`** — All idea-stage outputs go here. Create the directory if it doesn't exist.
 
 > 💡 Override via argument, e.g., `/idea-creator "topic" — pilot budget: 4h per idea, 20h total`.
 
 ## Workflow
+
+### Phase 0: Load Research Wiki (if active)
+
+Skip this phase entirely if `research-wiki/` does not exist.
+
+Resolve the wiki helper from the Codex install manifest when available:
+
+```bash
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+WIKI_SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+[ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+```
+
+If `research-wiki/query_pack.md` exists and is less than 7 days old, read it as initial landscape context:
+
+- treat listed gaps as priority search seeds
+- treat failed ideas as a banlist
+- treat top papers as known prior work
+- still run Phase 1 for papers from the last 3-6 months because the wiki may be stale
+
+If `research-wiki/` exists but `query_pack.md` is stale or missing, rebuild it only when `WIKI_SCRIPT` is available. If the helper is unavailable, continue without rebuilding and report that wiki refresh was skipped.
 
 ### Phase 1: Landscape Survey (5-10 min)
 
@@ -87,6 +110,8 @@ spawn_agent:
 
 Save the agent id for follow-up.
 
+Save a Review Tracing record for this `spawn_agent` call following `../shared-references/review-tracing.md`, including the landscape summary, prompt summary, raw idea list path, reviewer route, and saved agent id.
+
 ### Phase 3: First-Pass Filtering
 
 For each generated idea, quickly evaluate:
@@ -112,15 +137,18 @@ For each surviving idea, run a deeper evaluation:
 1. **Novelty check**: Use the `/novelty-check` workflow (multi-source search + GPT-5.4 cross-verification) for each idea
 
 2. **Critical review**: Use GPT-5.4 via `send_input` (same agent):
-   ```
-   Here are our top ideas after filtering:
-   [paste surviving ideas with novelty check results]
+   ```text
+   send_input:
+     target: [saved reviewer id from the earlier idea review]
+     message: |
+       Here are our top ideas after filtering:
+       [paste surviving ideas with novelty check results]
 
-   For each, play devil's advocate:
-   - What's the strongest objection a reviewer would raise?
-   - What's the most likely failure mode?
-   - How would you rank these for a top venue submission?
-   - Which 2-3 would you actually work on?
+       For each, play devil's advocate:
+       - What's the strongest objection a reviewer would raise?
+       - What's the most likely failure mode?
+       - How would you rank these for a top venue submission?
+       - Which 2-3 would you actually work on?
    ```
 
 3. **Combine rankings**: Merge your assessment with GPT-5.4's ranking. Select top 2-3 ideas for pilot experiments.
@@ -208,6 +236,28 @@ Write a structured report to `idea-stage/IDEA_REPORT.md`:
 - [ ] If confirmed, invoke /auto-review-loop for full iteration
 ```
 
+## Phase 7: Write Ideas to Research Wiki (if active)
+
+Skip this phase entirely if `research-wiki/` does not exist.
+
+This is critical for spiral learning: without it, `ideas/` stays empty and re-ideation has no memory.
+
+For each recommended and eliminated idea:
+
+1. Create or update `research-wiki/ideas/<idea_id>.md`.
+2. Include `node_id`, `stage`, `outcome`, `based_on`, `target_gaps`, hypothesis, proposed method, expected outcome, and pilot results when available.
+3. If `WIKI_SCRIPT` is available, add edges from idea to source papers and target gaps, then rebuild `query_pack.md`.
+4. If `WIKI_SCRIPT` is unavailable, write the idea pages and report that graph edges/query-pack rebuild require ARIS `research_wiki.py`.
+
+Required edge semantics when helper support exists:
+
+```text
+idea:<id> --inspired_by--> paper:<slug>
+idea:<id> --addresses_gap--> gap:<id>
+```
+
+Log the update as: `idea-creator wrote N ideas (M recommended, K eliminated)`.
+
 ## Output Protocols
 
 > Follow these shared protocols for all output files:
@@ -240,3 +290,6 @@ implement                     → write code
 /auto-review-loop             → iterate until submission-ready
 ```
 
+## Review Tracing
+
+After each `spawn_agent` or `send_input` reviewer call, save the trace following `../shared-references/review-tracing.md`. Include the reviewer route, saved agent id, prompt summary, raw output path, selected ideas, and rejected ideas.

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -35,6 +35,46 @@ Each phase builds on the previous one's output. The final deliverables are a val
 
 ## Pipeline
 
+### Phase 0: Load Research Brief (if available)
+
+Before starting any other phase, check for a detailed research brief in the project:
+
+1. Look for `RESEARCH_BRIEF.md` in the project root or a path passed in `$ARGUMENTS`.
+2. If found, read it and extract:
+   - problem statement and context
+   - constraints: compute, data, timeline, venue
+   - what the user already tried and what did not work
+   - domain knowledge and non-goals
+   - existing results, if any
+3. Use this as the primary context for all subsequent phases; it replaces the one-line prompt when more specific.
+4. If both `RESEARCH_BRIEF.md` and one-line `$ARGUMENTS` exist, merge them: the brief has priority for details, and the argument sets the direction.
+
+If no brief exists, proceed normally with `$ARGUMENTS` as the research direction.
+
+Recommended template:
+
+```markdown
+# Research Brief
+
+## Problem Statement
+[What problem are we trying to solve?]
+
+## Context
+[Relevant field, current approach, why this matters]
+
+## Constraints
+- Compute:
+- Data:
+- Timeline:
+- Target venue:
+
+## What We Already Tried
+- [attempt] -> [outcome]
+
+## Non-Goals
+- [what not to pursue]
+```
+
 ### Phase 0.5: Reference Paper Summary (when REF_PAPER is set)
 
 **Skip entirely if `REF_PAPER` is `false`.**
@@ -44,7 +84,26 @@ Summarize the reference paper before searching the literature:
 1. **If arXiv URL** — invoke `/arxiv "ARXIV_ID" — download` to fetch the PDF, then read the first 5 pages.
 2. **If local PDF path** — read the PDF directly, focusing on the title, abstract, introduction, and method overview.
 3. **If other URL** — fetch the content and extract the method, results, and limitations.
-4. **Generate `idea-stage/REF_PAPER_SUMMARY.md`** with: what the paper did, key results, limitations/open questions, and plausible improvement directions.
+4. **Generate `idea-stage/REF_PAPER_SUMMARY.md`** using this template:
+
+```markdown
+# Reference Paper Summary
+
+## What They Did
+[2-3 sentences: core method and contribution]
+
+## Key Results
+[Main quantitative findings]
+
+## Limitations & Open Questions
+[Acknowledged weaknesses, missing experiments, future work]
+
+## Potential Improvement Directions
+[Concrete ways to extend, challenge, or improve the paper]
+
+## Codebase
+[If `base repo` is set: link to the repo and identify relevant entry points]
+```
 
 Use `idea-stage/REF_PAPER_SUMMARY.md` as additional context in both Phase 1 and Phase 2.
 

--- a/skills/skills-codex/invention-structuring/SKILL.md
+++ b/skills/skills-codex/invention-structuring/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: invention-structuring
+description: "Structure a raw invention idea into a formal invention disclosure. Use when user says \"构建发明\", \"structure invention\", \"发明构建\", \"invention disclosure\", or wants to formalize a rough idea into a patent-ready structure."
+argument-hint: [invention-description-or-brief-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
+---
+
+# Invention Structuring
+
+Structure the invention into a formal disclosure based on: **$ARGUMENTS**
+
+Adapted from the refinement pattern in `/research-refine` for patent invention decomposition.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — External reviewer for invention decomposition validation
+- `MAX_REFINEMENT_ROUNDS = 3` — Maximum structuring iterations
+
+## Inputs
+
+1. Invention description from `$ARGUMENTS`
+2. `patent/INVENTION_BRIEF.md` if exists
+3. `patent/PRIOR_ART_REPORT.md` — prior art landscape
+4. `patent/NOVELTY_ASSESSMENT.md` — novelty analysis
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for the Problem-Solution-Advantage framework and claimable subject matter guidelines.
+
+## Workflow
+
+### Step 1: Problem-Solution-Advantage Framework
+
+Structure the invention using the universal patent framework:
+
+**Technical Problem (要解决的技术问题)**:
+- Derived from prior art deficiencies identified in NOVELTY_ASSESSMENT.md
+- Must be a specific, technical problem (not a commercial or social problem)
+- Statement format: "The technical problem to be solved is how to [specific technical objective] given [specific technical constraint]."
+
+**Technical Solution (技术方案)**:
+- The invention's specific technical contribution
+- Focus on the mechanism, not the result
+- Must be described at a level that matches the intended claim scope
+- Identify which features are known vs. inventive
+
+**Advantages (有益效果)**:
+- Measurable or quantifiable improvements over prior art
+- Must result from the inventive features, not just good engineering
+- Include specific technical effects if known (e.g., "reduces processing time by 40%")
+
+### Step 2: Invention Decomposition
+
+Break the invention into three layers:
+
+**Core Inventive Concept (核心发明构思)**:
+- The minimal set of features that make the invention patentable
+- This maps to the independent claim scope
+- Test: if you remove this feature, the invention is no longer novel
+
+**Supporting Features (支撑性特征)**:
+- Features that make the invention work well in practice
+- These become dependent claim material
+- They narrow the scope but add practical value
+
+**Optional Features (可选特征)**:
+- Implementation details, preferred parameters, alternatives
+- These become embodiment material
+- They support broader claim interpretation
+
+### Step 3: Claimable Subject Matter Identification
+
+For the core inventive concept, determine what categories of claims to draft:
+
+| Category | Applicability | Content |
+|----------|-------------|---------|
+| Method/process | If invention involves steps | Process flow, algorithm, workflow |
+| System/apparatus | If invention involves components | Hardware structure, modules, connections |
+| Product | If invention is a physical device | Shape, structure, composition |
+| Computer-readable medium | If software invention (US) | Stored instructions, non-transitory medium |
+| Product-by-process | If structure is hard to define | Product defined by how it is made |
+
+### Step 4: Drawing Plan
+
+Plan what figures are needed to support the claims and specification:
+
+| Figure | Type | Shows | Supports Claim Elements |
+|--------|------|-------|------------------------|
+| FIG. 1 | Block diagram | System architecture | System claim components |
+| FIG. 2 | Flowchart | Method steps | Method claim steps |
+| FIG. 3 | Sequence diagram | Interaction between components | Specific implementation details |
+
+If user has provided figures, reference them here. If figures are missing, note what is needed.
+
+### Step 5: Dependency Mapping
+
+Map feature dependencies to plan the claim hierarchy:
+
+```
+Independent Claim 1 (method, broadest scope)
+├── Core inventive feature A
+├── Core inventive feature B
+└── Known feature C (for context)
+
+Dependent Claim 2 → narrows feature A with specific implementation
+Dependent Claim 3 → narrows feature B with specific parameters
+Dependent Claim 4 → depends on 2, adds optional feature D
+Dependent Claim 5 → alternative implementation of feature A
+```
+
+### Step 6: Cross-Model Validation
+
+Call `REVIEWER_MODEL` via a dedicated Codex reviewer agent at xhigh reasoning:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are a patent attorney reviewing an invention disclosure.
+    Evaluate the structuring choices:
+
+    INVENTION: [Problem-Solution-Advantage summary]
+    DECOMPOSITION: [Core/Supporting/Optional features]
+    CLAIM PLAN: [intended claim categories and hierarchy]
+
+    Please assess:
+    1. Is the Problem-Solution-Advantage framework correctly applied?
+    2. Is the core inventive concept correctly identified? Are there features that should be core but are listed as supporting (or vice versa)?
+    3. Are the planned claim categories sufficient to protect the invention?
+    4. Is the drawing plan adequate for enablement?
+    5. Are there any claimable aspects being missed?
+```
+
+### Step 7: Output
+
+Write `patent/INVENTION_DISCLOSURE.md`:
+
+```markdown
+## Invention Disclosure
+
+### Title
+[invention title]
+
+### Technical Problem
+[formal problem statement]
+
+### Technical Solution
+[formal solution description]
+
+### Advantages
+[measurable advantages]
+
+### Feature Decomposition
+
+#### Core Inventive Concept
+[features that define independent claim scope]
+
+#### Supporting Features
+[features for dependent claims]
+
+#### Optional Features
+[features for embodiments]
+
+### Claimable Subject Matter
+[method, system, product, medium claims planned]
+
+### Drawing Plan
+[figures needed, what each shows]
+
+### Dependency Map
+[claim hierarchy plan]
+
+### Inventor Information
+[names, contributions]
+
+### Target Jurisdiction
+[CN/US/EP/ALL]
+```
+
+## Key Rules
+
+- The Problem must come from prior art deficiencies, not from commercial needs.
+- The Solution must describe the technical mechanism, not just the result.
+- The core inventive concept must be the minimum set of features for patentability.
+- Supporting features should be independently valuable -- each should provide a meaningful technical benefit even if other supporting features are removed.
+- Never invent embodiments that do not correspond to the actual invention or user-provided materials.
+- If reviewer delegation is unavailable in the current Codex host, stop and ask the user to enable Codex agent support before continuing.

--- a/skills/skills-codex/jurisdiction-format/SKILL.md
+++ b/skills/skills-codex/jurisdiction-format/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: jurisdiction-format
+description: "Compile patent application into jurisdiction-specific filing format. Use when user says \"格式转换\", \"jurisdiction format\", \"国家格式\", \"compile patent\", or wants formatted patent documents for CN/US/EP filing."
+argument-hint: [patent-directory-or-jurisdiction]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
+---
+
+# Jurisdiction Format: Patent Filing Compilation
+
+Compile the patent application into filing-ready format based on: **$ARGUMENTS**
+
+Analogous to `/paper-compile` but for patent document formatting instead of LaTeX.
+
+## Constants
+
+- `JURISDICTION = "auto"` — From pipeline or args: `CN`, `US`, `EP`, `ALL`
+- `PATENT_TYPE = "invention"` — `invention` (发明专利) or `utility_model` (实用新型, CN only)
+- `OUTPUT_FORMAT = "markdown"` — `markdown` (for review) or `docx` (for filing, requires python-docx)
+- `OUTPUT_DIR = "patent/output/"` — Base output directory
+
+## Inputs
+
+1. `patent/CLAIMS.md` — drafted claims
+2. `patent/specification/` — all specification sections (title, technical_field, background, summary, drawings_description, detailed_description, abstract)
+3. `patent/figures/` — figure descriptions and numeral index
+4. `patent/INVENTION_DISCLOSURE.md` — for metadata
+
+## Shared References
+
+Load `../shared-references/patent-format-cn.md` for CNIPA document structure and formatting rules.
+Load `../shared-references/patent-format-us.md` for USPTO document structure.
+Load `../shared-references/patent-format-ep.md` for EPO document structure.
+
+## Workflow
+
+### Step 1: Determine Output Jurisdictions
+
+From `$ARGUMENTS` or constant:
+- `CN` -> Generate CNIPA format only
+- `US` -> Generate USPTO format only
+- `EP` -> Generate EPO format only
+- `ALL` -> Generate all three formats
+
+### Step 2: Generate CN Format (if CN or ALL)
+
+Output to `patent/output/CN/`:
+
+#### 权利要求书 (Claims)
+- Extract claims from `patent/CLAIMS.md`
+- Format per CNIPA conventions:
+  - Independent claims: "1. 一种[主题]的方法，...其特征在于..."
+  - Dependent claims: "2. 根据权利要求1所述的方法，其特征在于..."
+- Ensure Chinese terminology is correct (所述, 其特征在于, 包括, 等)
+
+#### 说明书 (Description)
+Combine all specification sections in CNIPA order:
+1. 发明名称 (from title.md)
+2. 技术领域 (from technical_field.md)
+3. 背景技术 (from background.md)
+4. 发明内容 (from summary.md — split into 技术问题/技术方案/有益效果)
+5. 附图说明 (from drawings_description.md)
+6. 具体实施方式 (from detailed_description.md)
+
+#### 说明书摘要 (Abstract)
+- Extract from abstract.md
+- Verify word count <= 300 Chinese characters
+- Include most representative claim
+
+#### Format as markdown or docx
+If `OUTPUT_FORMAT = "markdown"`:
+- Write as separate .md files with clear section headers
+
+If `OUTPUT_FORMAT = "docx"`:
+- Use python-docx to create Word documents matching CNIPA templates
+- Set font to 宋体 (SimSun) for body, 黑体 (SimHei) for headers
+- Standard margins (上下 2.54cm, 左右 3.17cm)
+
+### Step 3: Generate US Format (if US or ALL)
+
+Output to `patent/output/US/`:
+
+#### Claims Section
+- Number all claims sequentially (1, 2, 3, ...)
+- Format per US conventions:
+  - "1. A method for [purpose], comprising:"
+  - "2. The method of claim 1, wherein..."
+- Ensure antecedent basis is correct ("a" -> "the")
+
+#### Specification
+Combine all sections in USPTO order:
+1. Title
+2. Cross-Reference to Related Applications (if any)
+3. Field of the Invention
+4. Background of the Invention
+5. Brief Summary of the Invention
+6. Brief Description of the Drawings
+7. Detailed Description of Preferred Embodiments
+8. Abstract
+
+Format drawings references as "FIG. 1" (not "Figure 1").
+
+#### Abstract
+- Extract from abstract.md
+- Verify word count <= 150 words / 2500 characters
+
+#### Application Data Sheet (ADS) Template
+Generate a skeleton ADS with:
+- Title
+- Inventor information (placeholder)
+- Application type
+- Entity status (small/micro/large)
+
+### Step 4: Generate EP Format (if EP or ALL)
+
+Output to `patent/output/EP/`:
+
+#### Claims Section
+- Format in two-part form per Rule 43(1) EPC:
+  - "1. A method for [purpose], comprising [known features], characterised in that [inventive features]."
+- Ensure the "characterised in that" phrase is present in all independent claims
+
+#### Description
+Combine all sections in EPO Rule 42 order:
+1. Title of the Invention
+2. Technical Field
+3. Background Art
+4. Disclosure of the Invention (problem-solution-advantage)
+5. Description of Embodiments
+6. Brief Description of Drawings
+7. Reference Signs List (mandatory at EPO)
+
+Format drawings references as "FIG. 1" or "Figure 1".
+
+#### Abstract
+- Extract from abstract.md
+- ~150 words limit
+
+### Step 5: Consistency Check
+
+Verify across all generated formats:
+- [ ] All claims are present in every format
+- [ ] Claim numbering is consistent
+- [ ] Reference numerals match specification across all formats
+- [ ] No format-specific requirements are violated
+- [ ] Language is correct for each jurisdiction (Chinese for CN, English for US/EP)
+
+### Step 6: Output Summary
+
+Write `patent/output/OUTPUT_SUMMARY.md`:
+
+```markdown
+## Patent Filing Documents
+
+### Generated Files
+
+#### CN (CNIPA)
+| File | Description | Status |
+|------|-------------|--------|
+| 权利要求书.md | Claims in CN format | Complete |
+| 说明书.md | Description in CN format | Complete |
+| 说明书摘要.md | Abstract (CN) | Complete |
+
+#### US (USPTO)
+| File | Description | Status |
+|------|-------------|--------|
+| claims.md | Claims in US format | Complete |
+| specification.md | Description in US format | Complete |
+| abstract.md | Abstract (US) | Complete |
+| ads_template.md | Application Data Sheet skeleton | Complete |
+
+#### EP (EPO)
+| File | Description | Status |
+|------|-------------|--------|
+| claims.md | Claims in EP format | Complete |
+| description.md | Description in EP format | Complete |
+| abstract.md | Abstract (EP) | Complete |
+
+### Consistency Check
+- [ ] All claims present in all formats
+- [ ] Reference numerals consistent
+- [ ] Language correct per jurisdiction
+```
+
+## Key Rules
+
+- Never mix jurisdiction formats (e.g., do not include "其特征在于" in US claims).
+- Claims must be identical in technical content across jurisdictions, only the format differs.
+- For CN output, verify Chinese patent terminology is correct and consistent.
+- For EP output, the two-part claim form is mandatory -- every independent claim must have "characterised in that."
+- Abstract word limits are jurisdiction-specific and must be verified.
+- The jurisdiction-format skill does NOT modify claim content -- it reformats existing content only.
+- If `OUTPUT_FORMAT = "docx"`, check that python-docx is available; if not, fall back to markdown.

--- a/skills/skills-codex/mermaid-diagram/SKILL.md
+++ b/skills/skills-codex/mermaid-diagram/SKILL.md
@@ -16,6 +16,8 @@ Generate high-quality Mermaid diagram code based on user requirements, with file
 
 ### Step 0: Pre-flight Check
 
+# Create output directory
+
 ```bash
 mkdir -p figures
 ```
@@ -33,6 +35,10 @@ Parse the input: **$ARGUMENTS**
 ### Step 2: Read Documentation
 
 Select the appropriate diagram type. Use built-in Mermaid knowledge first; if external documentation is needed and your environment provides it, fetch the up-to-date syntax reference.
+
+### Configuration & Themes
+
+Choose theme, colors, and layout before writing code. For academic diagrams, prefer clean white backgrounds, restrained colors, and readable labels over decorative styling.
 
 | Type | Use Cases |
 | ---- | --------- |
@@ -64,19 +70,25 @@ Select the appropriate diagram type. Use built-in Mermaid knowledge first; if ex
 
 Generate the Mermaid code and save **two** files:
 
-#### File 1: `figures/<diagram-name>.mmd`
+#### File 1: `figures/<diagram-name>.mmd` — Raw Mermaid source
 
 The `.mmd` file contains only raw Mermaid code, no markdown fences.
 
-#### File 2: `figures/<diagram-name>.md`
+#### File 2: `figures/<diagram-name>.md` — Markdown with embedded Mermaid
 
 The `.md` file wraps the same Mermaid code in a mermaid code block for preview rendering, plus a short title and description.
+
+# Diagram Title
+
+Use a concise title in the `.md` wrapper that matches the generated diagram name.
 
 **Naming convention**: use a descriptive kebab-case name derived from the request, such as `auth-flow`, `system-architecture`, or `database-er`.
 
 ### Step 4: Verify Mermaid Syntax (MANDATORY)
 
 Codex MUST verify the generated Mermaid code by running the Mermaid CLI (`mmdc`).
+
+# Check if mermaid-cli is available
 
 ```bash
 if command -v mmdc >/dev/null 2>&1; then
@@ -110,7 +122,9 @@ After successful rendering, Codex MUST read the generated PNG and perform a stri
 - `figures/<diagram-name>.md`
 - `figures/<diagram-name>.png`
 
-### STRICT VERIFICATION CHECKLIST
+### ═══════════════════════════════════════════════════════════════
+### STRICT VERIFICATION CHECKLIST (ALL must pass for score ≥ 9)
+### ═══════════════════════════════════════════════════════════════
 
 #### A. File Correctness
 - [ ] `.mmd` contains valid Mermaid syntax
@@ -118,10 +132,16 @@ After successful rendering, Codex MUST read the generated PNG and perform a stri
 - [ ] `.mmd` and `.md` contain identical Mermaid code
 - [ ] Diagram renders without errors
 
-#### B. Arrow Correctness Verification
+ASCII alias for automated checks: score >= 9.
+
+#### B. Arrow Correctness Verification (CRITICAL - any failure = score ≤ 6)
+ASCII alias for automated checks: CRITICAL - any failure = score <= 6.
+
 - [ ] Every arrow points to the correct target
 
-#### C. Block Content Verification
+#### C. Block Content Verification (any failure = score ≤ 7)
+ASCII alias for automated checks: any failure = score <= 7.
+
 - [ ] Every block label is correct
 - [ ] Every block contains the intended content
 
@@ -137,10 +157,18 @@ After successful rendering, Codex MUST read the generated PNG and perform a stri
 - [ ] Spacing is balanced
 - [ ] Data flow is understandable within 5 seconds
 
-### Issues Found
+### ═══════════════════════════════════════════════════════════════
+### Issues Found (BE SPECIFIC)
 1. [issue] -> [fix]
 
 ### Score: X/10
+
+### Score Breakdown Guide:
+- 10: correct, readable, publication-ready
+- 9: minor polish only
+- 8: usable but one visual/layout weakness remains
+- 7: one content or block-label weakness remains
+- 6 or below: arrow direction, missing component, syntax, or semantic error
 
 ### Verdict
 - [ ] ACCEPT
@@ -234,7 +262,7 @@ When the diagram is intended for academic papers, apply these style standards:
 - **Arrows**: Dark gray (`#333333` / `#1F2937`)
 - **Background**: White (`#FFFFFF`)
 
-### What to Avoid
+### What to AVOID
 
 - Rainbow color schemes
 - Thin hairline arrows
@@ -266,7 +294,7 @@ Math rendering with `$$...$$` is supported in:
 3. Mix text and math by placing `$$` only around the math portion
 4. Use `\text{}` for non-math text inside `$$`
 
-### Common Math Patterns
+### Common Math Patterns for ML/Science Diagrams
 
 | Concept | KaTeX Syntax |
 | ------- | ------------ |

--- a/skills/skills-codex/meta-optimize/SKILL.md
+++ b/skills/skills-codex/meta-optimize/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: meta-optimize
+description: "Analyze ARIS usage logs and propose optimizations to SKILL.md files, reviewer prompts, and workflow defaults. Outer-loop harness optimization inspired by Meta-Harness (Lee et al., 2026). Use when user says \"优化技能\", \"meta optimize\", \"improve skills\", \"分析使用记录\", or wants to optimize ARIS's own harness components based on accumulated experience."
+argument-hint: [target-skill-or-all]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
+---
+
+# Meta-Optimize: Outer-Loop Harness Optimization for ARIS
+
+Analyze accumulated usage logs and propose optimizations for: **$ARGUMENTS**
+
+## Context
+
+ARIS is a **research harness** — a system of skills, bridges, workflows, and artifact contracts that wraps around LLMs to orchestrate research. This skill implements a prototype **outer loop** that observes how the harness is used and proposes improvements to the harness itself (not to the research artifacts it produces).
+
+Inspired by Meta-Harness (Lee et al., 2026): the key insight is that harness design matters as much as model weights, and harness engineering can be partially automated by logging execution traces and using them to guide improvements.
+
+## What This Skill Optimizes (Harness Components)
+
+| Component | Example | Optimizable? |
+|-----------|---------|:---:|
+| SKILL.md prompts | Reviewer instructions, quality gates, step descriptions | Yes |
+| Default parameters | `difficulty: medium`, `MAX_ROUNDS: 4`, `threshold: 6/10` | Yes |
+| Convergence rules | When to stop the review loop, retry counts | Yes |
+| Workflow ordering | Skill chain sequence within a workflow | Yes |
+| Artifact schemas | What fields go in EXPERIMENT_LOG.md, idea-stage/IDEA_REPORT.md | Cautious |
+| MCP bridge config | Which reviewer model, routing rules | No (infra) |
+
+**Not optimized**: The research artifacts themselves (papers, code, experiments). That's what the regular workflows do.
+
+## Prerequisites
+
+1. **Logging must be active.** Codex mirror installs do not create Claude Code hooks. Provide `.aris/meta/events.jsonl` from a Codex-compatible event logger, an external wrapper, or a manually exported trace log before running this skill.
+2. **Sufficient data.** At least 5 complete workflow runs logged in `.aris/meta/events.jsonl`. The skill will check and warn if insufficient.
+
+## Workflow
+
+### Step 0: Check Data Availability
+
+```bash
+EVENTS_FILE=".aris/meta/events.jsonl"
+if [ ! -f "$EVENTS_FILE" ]; then
+    echo "ERROR: No event log found at $EVENTS_FILE"
+    echo "Enable Codex-compatible logging first: create .aris/meta/events.jsonl from your Codex wrapper, external event logger, or exported trace log."
+    exit 1
+fi
+
+EVENT_COUNT=$(wc -l < "$EVENTS_FILE")
+SKILL_INVOCATIONS=$(grep -c '"skill_invoke"' "$EVENTS_FILE" || echo 0)
+SESSIONS=$(grep -c '"session_start"' "$EVENTS_FILE" || echo 0)
+
+echo "📊 Event log: $EVENT_COUNT events, $SKILL_INVOCATIONS skill invocations, $SESSIONS sessions"
+
+if [ "$SKILL_INVOCATIONS" -lt 5 ]; then
+    echo "⚠️  Insufficient data (<5 skill invocations). Continue using ARIS normally and re-run later."
+    exit 0
+fi
+```
+
+### Step 1: Analyze Usage Patterns
+
+Read `.aris/meta/events.jsonl` and compute:
+
+**Frequency analysis:**
+- Which skills are invoked most often?
+- Which slash commands do users type most?
+- What parameter overrides are most common? (These suggest bad defaults.)
+
+**Failure analysis:**
+- Which tools fail most often? In which skills?
+- What error patterns repeat? (OOM, import, compilation, timeout)
+- How many auto-debug retries per workflow run?
+
+**Convergence analysis (for auto-review-loop):**
+- Average rounds to reach threshold
+- Score trajectory shape (fast improvement? plateau? oscillation?)
+- Which review round catches the most critical issues?
+- Do users override difficulty mid-run?
+
+**Human intervention analysis:**
+- Where do users interrupt with manual prompts during workflows?
+- What manual corrections do users make most? (These indicate skill gaps.)
+
+Present findings as a structured summary table.
+
+### Step 2: Identify Optimization Targets
+
+Based on Step 1, rank optimization opportunities by expected impact:
+
+```markdown
+## Optimization Opportunities (ranked)
+
+| # | Target | Signal | Proposed Change | Expected Impact |
+|---|--------|--------|-----------------|-----------------|
+| 1 | auto-review-loop default threshold | Users override to 7/10 in 60% of runs | Change default from 6/10 to 7/10 | Fewer manual overrides |
+| 2 | experiment-bridge retry count | 40% of runs hit max retries on OOM | Add OOM-specific recovery (reduce batch size) | Fewer failed experiments |
+| 3 | paper-write de-AI patterns | Users manually fix "delve" in 80% of runs | Add "delve" to default watchword list | Fewer manual edits |
+```
+
+If `$ARGUMENTS` specifies a target skill, focus analysis on that skill only.
+If `$ARGUMENTS` is empty or "all", analyze all skills with sufficient data.
+
+### Step 3: Generate Patch Proposals
+
+For each optimization target, generate a concrete diff:
+
+```diff
+--- a/skills/auto-review-loop/SKILL.md
++++ b/skills/auto-review-loop/SKILL.md
+@@ -15,7 +15,7 @@
+ ## Constants
+ 
+-- **SCORE_THRESHOLD = 6** — Minimum review score to accept.
++- **SCORE_THRESHOLD = 7** — Minimum review score to accept. (Raised based on usage data: 60% of users overrode to 7+.)
+```
+
+**Rules for patch generation:**
+- One patch per optimization target
+- Each patch must include a comment explaining WHY (with data from the log)
+- Patches must be minimal — change only what the data supports
+- Never change artifact schemas or MCP bridge config in v1
+- Never change behavior that would break existing user workflows
+
+### Step 4: Cross-Model Review of Patches
+
+Send each patch to GPT-5.4 xhigh for adversarial review:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are reviewing a proposed optimization to an ARIS SKILL.md file.
+    
+    ## Original Skill (relevant section)
+    [paste original]
+    
+    ## Proposed Patch
+    [paste diff]
+    
+    ## Evidence from Usage Log
+    [paste summary stats]
+    
+    Review this patch:
+    1. Does the evidence support the change?
+    2. Could this change hurt other use cases?
+    3. Is the change minimal and safe?
+    4. Score 1-10: should this be applied?
+    
+    If score < 7, explain what additional evidence would be needed.
+```
+
+### Step 5: Present Results
+
+Output a structured report:
+
+```markdown
+# ARIS Meta-Optimization Report
+
+**Date**: [today]
+**Data**: [N] events, [M] skill invocations, [K] sessions
+**Target**: [skill name or "all"]
+
+## Proposed Changes
+
+### Change 1: [title]
+- **Target**: [skill/file:line]
+- **Signal**: [what the data shows]
+- **Patch**: [diff]
+- **Reviewer Score**: [X/10]
+- **Reviewer Notes**: [summary]
+- **Status**: ✅ Recommended / ⚠️ Needs more data / ❌ Rejected
+
+### Change 2: ...
+
+## Changes NOT Made (insufficient evidence)
+- [pattern observed but too few samples]
+
+## Recommendations
+- [ ] Apply Change 1 (reviewer approved)
+- [ ] Collect more data for Change 3 (need N more runs)
+- [ ] Consider manual review of Change 2
+
+## Next Steps
+Run `/meta-optimize apply 1` to apply a specific change, or
+`/meta-optimize apply all` to apply all recommended changes.
+```
+
+### Step 6: Apply Changes (if user approves)
+
+If user runs `/meta-optimize apply [N]`:
+1. Back up original SKILL.md to `.aris/meta/backups/`
+2. Apply the patch
+3. Log the change to `.aris/meta/optimizations.jsonl`
+4. Remind user to test the changed skill on their next run
+
+**Never auto-apply without user approval.**
+
+## Key Rules
+
+- **Log-driven, not speculative.** Every proposed change must cite specific data from the event log. No "I think this would be better."
+- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills.
+- **Reviewer-gated.** Every patch goes through cross-model review before recommendation.
+- **Reversible.** Always back up before applying. Always log what changed.
+- **User-approved.** Never auto-apply. Present, explain, let the user decide.
+- **Honest about uncertainty.** If the data is insufficient, say so. Don't optimize on noise.
+- **Portable.** Optimizations should improve the skill for all users, not just one user's style. If a change seems user-specific, flag it.
+
+## Event Schema Reference
+
+The log at `.aris/meta/events.jsonl` contains JSONL records with these shapes:
+
+```jsonl
+{"ts":"...","session":"...","event":"skill_invoke","skill":"auto-review-loop","args":"difficulty: hard"}
+{"ts":"...","session":"...","event":"PostToolUse","tool":"Bash","input_summary":"pdflatex main.tex"}
+{"ts":"...","session":"...","event":"spawn_agent","tool":"spawn_agent","input_summary":"review..."}
+{"ts":"...","session":"...","event":"tool_failure","tool":"Bash","input_summary":"python train.py"}
+{"ts":"...","session":"...","event":"slash_command","command":"/auto-review-loop","args":""}
+{"ts":"...","session":"...","event":"user_prompt","prompt_preview":"change difficulty to hard"}
+{"ts":"...","session":"...","event":"session_start","source":"startup","model":"claude-opus-4-6"}
+{"ts":"...","session":"...","event":"session_end"}
+```
+
+## Triggering
+
+This skill is NOT part of the standard W1→W1.5→W2→W3→W4 pipeline. It is a **maintenance workflow** with three trigger mechanisms:
+
+1. **Passive logging** (always on): Claude Code hooks record events to `.aris/meta/events.jsonl` automatically during normal usage. Zero user effort.
+
+2. **Automatic readiness check** (SessionEnd hook): When a Claude Code session ends, `check_ready.sh` counts skill invocations since the last `/meta-optimize` run. If ≥5 new invocations have accumulated, it prints a reminder:
+   ```
+   📊 ARIS has logged 8 skill runs since last optimization. Run /meta-optimize to check for improvement opportunities.
+   ```
+   This is a **suggestion only** — it does not auto-run optimization.
+
+3. **Manual trigger**: User runs `/meta-optimize` when they see the reminder or whenever they want.
+
+**After each `/meta-optimize` run**, the skill writes the current timestamp to `.aris/meta/.last_optimize` so the readiness check only counts new invocations.
+
+## Acknowledgements
+
+Inspired by [Meta-Harness](https://arxiv.org/abs/2603.28052) (Lee et al., 2026) — end-to-end optimization of model harnesses via filesystem-based experience access and agentic code search.
+
+## Output Protocols
+
+> Follow these shared protocols for all output files:
+> - **[Output Versioning Protocol](../shared-references/output-versioning.md)** — write timestamped file first, then copy to fixed name
+> - **[Output Manifest Protocol](../shared-references/output-manifest.md)** — log every output to MANIFEST.md
+> - **[Output Language Protocol](../shared-references/output-language.md)** — respect the project's language setting
+
+## Review Tracing
+
+After each reviewer agent call, save the trace following `shared-references/review-tracing.md`. Use `tools/save_trace.sh` or write files directly to `.aris/traces/<skill>/<date>_run<NN>/`. Respect the `--- trace:` parameter (default: `full`).

--- a/skills/skills-codex/monitor-experiment/SKILL.md
+++ b/skills/skills-codex/monitor-experiment/SKILL.md
@@ -10,9 +10,14 @@ Monitor: $ARGUMENTS
 ## Workflow
 
 ### Step 1: Check What's Running
+
+First identify the backend from `AGENTS.md`, run notes, or launch summary: local, SSH, Vast.ai, or Modal. Monitor the backend that was actually used; do not assume a plain SSH screen session when the run was launched through Vast.ai or Modal.
+
 ```bash
 ssh <server> "screen -ls"
 ```
+
+For Vast.ai, also check instance state, SSH reachability, hourly cost, and whether `auto_destroy` is pending. For Modal, check the Modal run/app logs, function status, timeout, volume outputs, and cloud cost exposure.
 
 ### Step 2: Collect Output from Each Screen
 For each screen session, capture the last N lines:
@@ -31,6 +36,38 @@ If JSON results exist, fetch and parse them:
 ```bash
 ssh <server> "cat <results_dir>/<latest>.json"
 ```
+
+### Step 3.5: Pull W&B Metrics (when `wandb: true` in AGENTS.md)
+
+If the project enables W&B, pull metrics before interpreting results. Prefer W&B as the source of training curves and recent eval state, while still checking logs for crashes.
+
+List recent runs:
+
+```bash
+python3 - <<'PY'
+import wandb
+api = wandb.Api()
+for run in api.runs("<entity>/<project>", per_page=20):
+    print(run.name, run.state, run.url)
+PY
+```
+
+Pull recent history for a specific run:
+
+```bash
+python3 - <<'PY'
+import wandb
+api = wandb.Api()
+run = api.run("<entity>/<project>/<run_id>")
+for row in run.history(samples=50, keys=["train/loss", "eval/loss", "eval/accuracy", "train/lr"]):
+    print(row)
+print("summary:", dict(run.summary))
+PY
+```
+
+If W&B is configured but unavailable, report the connectivity problem and fall back to screen/log/json evidence. Do not interpret missing W&B data as experiment failure by itself.
+
+Always include W&B dashboard links (`run.url`) when available so later review and paper-writing agents can inspect the exact training curves.
 
 ### Step 4: Summarize Results
 
@@ -58,4 +95,4 @@ After results are collected, check `~/.codex/feishu.json`:
 - Compare against the correct baseline (same config)
 - Note if experiments are still running (check progress bars, iteration counts)
 - If results look wrong, check training logs for errors before concluding
-
+- Include backend cost/risk notes for long-running Vast.ai or Modal jobs

--- a/skills/skills-codex/novelty-check/SKILL.md
+++ b/skills/skills-codex/novelty-check/SKILL.md
@@ -10,6 +10,7 @@ Check whether a proposed method/idea has already been done in the literature: **
 ## Constants
 
 - REVIEWER_MODEL = `gpt-5.4` — Model used via a secondary Codex agent. Must be an OpenAI model (e.g., `gpt-5.4`, `o3`, `gpt-4o`)
+- **REVIEWER_BACKEND = `codex`** — Default: Codex xhigh reviewer. Use `--reviewer: oracle-pro` only when explicitly requested; if Oracle is unavailable, warn and fall back to Codex xhigh.
 
 ## Instructions
 
@@ -83,3 +84,6 @@ Output a structured report:
 - If the method is not novel but the FINDING would be, say so explicitly
 - Always check the most recent 6 months of arXiv — the field moves fast
 
+## Review Tracing
+
+After each `spawn_agent` or optional `oracle-pro` reviewer call, save the trace following `../shared-references/review-tracing.md`. Write files directly to `.aris/traces/novelty-check/<date>_run<NN>/` and record searched claims, closest papers, reviewer route, raw response, and final novelty decision. Respect the `--- trace:` parameter when present (default: `full`).

--- a/skills/skills-codex/overleaf-sync/SKILL.md
+++ b/skills/skills-codex/overleaf-sync/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: overleaf-sync
+description: "Two-way sync between a local paper directory and an Overleaf project via the Overleaf Git bridge (Premium feature). Lets you keep ARIS audit/edit workflows on the local copy while collaborators edit in the Overleaf web UI. Token never touches the agent — user does the one-time auth via macOS Keychain. Use when user says \"同步 overleaf\", \"overleaf sync\", \"推送到 overleaf\", \"connect overleaf\", \"Overleaf 桥接\", \"pull overleaf\", \"push overleaf\", or wants to bridge their ARIS paper directory with an Overleaf project."
+argument-hint: [setup <project-id> | pull | push | status]
+allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write
+---
+
+# Overleaf Sync
+
+Bridge a local paper directory with an Overleaf project so that:
+
+- **You** can keep editing in the Overleaf web UI (or share editing access with collaborators)
+- **ARIS** can read your changes, run audits (`/paper-claim-audit`, `/citation-audit`, `/auto-paper-improvement-loop`), and push fixes back
+
+This uses the official **Overleaf Git bridge** (Premium feature). The agent **never sees your authentication token** — you do the one-time auth manually so the token lives in macOS Keychain, not in chat history or `.git/config`.
+
+## When to Use This Skill
+
+- You want to use Overleaf as the editing surface (better collaboration, shared with team) but still run ARIS pipelines locally
+- You want to take an existing local ARIS paper and push it to Overleaf for a co-author to edit
+- A collaborator made changes in Overleaf and you want to pull + diff them before continuing local work
+
+## Constants
+
+- **CLONE_DIR_DEFAULT** = `paper-overleaf` (sibling of existing `paper/`, NOT inside `paper/`)
+- **CREDENTIAL_HELPER** = `osxkeychain` (macOS) / `manager` (Windows) / `cache` (Linux fallback)
+- **TOKEN_HANDLING** = **NEVER write token to disk, env var, or chat**. User pastes it once into the terminal credential prompt; the OS keychain stores it from then on.
+
+## Architecture
+
+```
+┌─────────────────┐       git pull/push      ┌─────────────────┐
+│  Local paper/   │ ◄─── rsync ──── ►       │ paper-overleaf/ │ ◄──► Overleaf web
+│  (ARIS audits)  │                          │ (git bridge)    │     (collaborators)
+└─────────────────┘                          └─────────────────┘
+```
+
+The `paper-overleaf/` directory is a **git clone of the Overleaf project**. The `paper/` directory is the working copy where ARIS skills run. They are kept in sync via `rsync`.
+
+**Single-source-of-truth rule**: at any given time, treat *one* of them as authoritative for active editing. Switch directions explicitly with `pull` or `push`, and run a `status` check before either to surface unexpected divergence.
+
+## Sub-commands
+
+### `setup <project-id>` — one-time
+
+Sets up the bridge for a new Overleaf project. **The user runs this in their own terminal, never through the agent.** The skill ships with a hardened setup script that:
+
+1. Refuses to run unless stdin/stdout are a TTY (won't run inside an agent harness)
+2. Reads the token from a hidden prompt (no chat history, no shell history)
+3. Strips the token from the remote URL immediately after cloning
+4. Primes the OS keychain so subsequent agent operations are auth-free
+5. **Auto-installs a `pre-commit` hook in `paper-overleaf/.git/hooks/` that refuses to commit any blob containing the token pattern `olp_[A-Za-z0-9]{20,}`** — a hard technical block, not a behavioral rule
+
+The agent's only role here is to print the user instruction:
+
+```
+Run this in your own terminal (NOT through me):
+
+    bash <ARIS_REPO>/tools/overleaf_setup.sh <project-id-or-url>
+
+When it finishes, tell me "setup done" and I'll verify.
+```
+
+After the user reports "setup done", the agent verifies (token-free):
+
+```bash
+cd paper-overleaf
+git remote -v                    # must show URL WITHOUT token
+git config --get credential.helper
+git fetch && git log --oneline -3   # must succeed without prompting
+ls .git/hooks/pre-commit         # must exist
+bash <ARIS_REPO>/tools/overleaf_audit.sh .   # must report "Audit clean"
+```
+
+If `paper-overleaf/` exists but is empty (new Overleaf project), the agent then mirrors local `paper/` into it (see `push` workflow).
+
+### `pull` — before each editing session
+
+```bash
+cd paper-overleaf && git pull --ff-only
+
+# Show what changed since last pull
+LAST=$(git rev-parse HEAD@{1})
+git diff --stat $LAST..HEAD
+git diff $LAST..HEAD -- 'sec/*.tex'        # detailed view for prose changes
+```
+
+**Diff protocol — DO NOT blindly merge into local `paper/`.** Overleaf edits frequently include:
+
+- **Half-finished sentences** (collaborator clicked save mid-thought)
+- **Typos** that aren't in canonical references (`Lrage` for `Large`)
+- **Commented-out blocks** that may be intentional or may be a stash
+- **Number changes** that should re-trigger `/paper-claim-audit`
+- **Cite key changes** that should re-trigger `/citation-audit`
+
+For each diff hunk, decide one of:
+
+| Hunk character | Action |
+|----------------|--------|
+| Clean editorial improvement | Sync into `paper/`, no audit needed |
+| Numerical / claim change | Sync, then re-run `/paper-claim-audit` |
+| New `\cite{...}` | Sync, then re-run `/citation-audit` |
+| Half-sentence / obvious typo | Flag to user, do NOT auto-sync |
+| New section / restructure | Stop, ask user before syncing |
+
+After deciding per-hunk:
+
+```bash
+# Sync only the files the user approved into local paper/
+rsync -av paper-overleaf/sec/0.abstract.tex paper/sec/0.abstract.tex
+# (or use Edit tool for surgical changes that skip half-sentences)
+```
+
+### `push` — after local editing
+
+Use after ARIS skills have edited `paper/` and you want collaborators on Overleaf to see the changes.
+
+```bash
+# 1. Always pull first to surface remote drift
+cd paper-overleaf && git pull --ff-only
+
+# 2. If pull was a no-op, sync local paper → paper-overleaf
+rsync -av --delete \
+  --exclude='.git' --exclude='.DS_Store' \
+  --exclude='*.aux' --exclude='*.log' --exclude='*.bbl' --exclude='*.blg' \
+  --exclude='*.fls' --exclude='*.fdb_latexmk' --exclude='*.out' \
+  --exclude='*.synctex.gz' --exclude='*.toc' \
+  paper/ paper-overleaf/
+
+# 3. Show what would be pushed
+git status --short
+git diff --stat
+
+# 4. Commit + push
+git add -A
+git commit -m "<descriptive message — what ARIS changed and why>"
+git push
+```
+
+**Commit message protocol**: include the ARIS skill that produced the change so collaborators on Overleaf understand provenance. Examples:
+
+- `paper-write: regenerated sec/3.assurance after audit cascade refactor`
+- `citation-audit: fix 14 metadata entries (madaan2023, lee2024, ...)`
+- `paper-claim-audit: correct sec/5 numbers vs results/run_2026_04_19.json`
+
+**Confirmation gate**: `push` writes to a shared resource. ALWAYS show the user `git diff --stat` (and a representative hunk for prose changes) before running `git push`. Wait for explicit confirmation unless the user said `auto: true` upfront.
+
+### `status` — diagnostic
+
+```bash
+cd paper-overleaf
+git fetch
+echo "=== Remote-vs-local divergence ==="
+git log --oneline HEAD..origin/master    # remote ahead
+git log --oneline origin/master..HEAD    # local ahead
+echo "=== paper/ vs paper-overleaf/ divergence ==="
+diff -rq --brief paper/ paper-overleaf/ 2>/dev/null \
+  | grep -v "Only in paper/.*\.\(aux\|log\|out\|fls\|fdb_latexmk\|bbl\|blg\|synctex\|toc\)" \
+  | grep -v "Only in paper-overleaf/.git" \
+  | grep -v "DS_Store"
+```
+
+Three-way state assessment:
+
+| Remote ahead? | paper/ vs paper-overleaf/ differ? | Meaning | Recommended action |
+|:-------------:|:---------------------------------:|---------|--------------------|
+| No  | No  | Clean       | Nothing to do |
+| Yes | No  | Overleaf has new edits | Run `pull`, then re-run status |
+| No  | Yes | Local ARIS edits unsynced | Run `push` |
+| Yes | Yes | Diverged — needs merge | Stop, surface to user, do NOT auto-resolve |
+
+## Conflict Resolution
+
+If `git pull --ff-only` fails because of true divergence:
+
+1. **Do not** run `git pull` (which would auto-merge).
+2. **Do not** run `git reset --hard` or `git push --force` (destructive).
+3. Show the user `git log origin/master ^HEAD` (their Overleaf commits) and `git log HEAD ^origin/master` (local ARIS commits).
+4. Ask the user which side to take per file, or to manually merge in Overleaf and then re-pull.
+
+## Token Security — Defense in Depth
+
+Behavioral rules alone are not enough — the next agent reading this skill might forget them. The skill therefore relies on **technical guards** that hold even if the agent misbehaves:
+
+| Layer | Guard | Where enforced |
+|-------|-------|---------------|
+| 1. Setup | `overleaf_setup.sh` refuses to run without an interactive TTY (agents don't have one) | `tools/overleaf_setup.sh` |
+| 2. Input | Token is read by `read -s` (hidden prompt, no shell history, never enters chat) | `tools/overleaf_setup.sh` |
+| 3. Storage | Token goes straight into OS keychain via `git credential approve`; remote URL is stripped to a token-free form | `tools/overleaf_setup.sh` |
+| 4. Commits | `paper-overleaf/.git/hooks/pre-commit` greps staged content for `olp_[A-Za-z0-9]{20,}` and aborts | auto-installed by setup script |
+| 5. Audit | `overleaf_audit.sh` scans working tree, remote URLs, git history, credential files | `tools/overleaf_audit.sh` |
+
+Behavioral rules (still apply, but secondary):
+
+- **Never** ask the user to paste a token into chat. If they do anyway: (a) acknowledge it, (b) tell them to revoke it at https://www.overleaf.com/user/settings, (c) recover via keychain if already primed.
+- **Never** write a token to a file (`.env`, `.netrc`, `tools/*.sh`, etc.) committed to any repo.
+- **Never** include a token in a `git remote -v` URL — strip it after clone.
+- On `401 Unauthorized` from push/pull, tell the user the keychain entry expired and to re-run `overleaf_setup.sh`. Do **not** ask for a fresh token.
+
+## Mutual-Exclusion Rule
+
+The single biggest source of pain in two-way sync is **simultaneous editing on both sides**.
+
+- If the user is in an active Overleaf editing session, ARIS skills should **read-only** access `paper/` until the user runs `/overleaf-sync pull`.
+- If ARIS is in the middle of `/auto-paper-improvement-loop` or `/paper-write`, the user should pause Overleaf editing until the loop finishes and `/overleaf-sync push` is run.
+
+When in doubt, run `status` first.
+
+## Output Contract
+
+- `paper-overleaf/` directory at repo root, git clone of Overleaf project (origin URL has NO token)
+- `paper/` directory unchanged in role — still the ARIS working copy
+- Each `pull`/`push` operation: a one-line summary back to the user (commits pulled / pushed, file count, link to Overleaf project URL)
+
+## See Also
+
+- `/paper-claim-audit` — re-run after pulling Overleaf changes that touch numbers
+- `/citation-audit` — re-run after pulling Overleaf changes that add/edit `\cite{...}`
+- `/paper-compile` — local LaTeX build; Overleaf compiles independently in the cloud
+- Overleaf Git bridge docs: https://www.overleaf.com/learn/how-to/Using_Git_and_GitHub

--- a/skills/skills-codex/paper-claim-audit/SKILL.md
+++ b/skills/skills-codex/paper-claim-audit/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: paper-claim-audit
+description: "Zero-context verification that every number, comparison, and scope claim in the paper matches raw result files. Uses a fresh cross-model reviewer with NO prior context to prevent confirmation bias. Use when user says \"审查论文数据\", \"check paper claims\", \"verify numbers\", \"论文数字核对\", or before submission to ensure paper-to-evidence fidelity."
+argument-hint: [paper-directory]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
+---
+
+# Paper Claim Audit: Zero-Context Evidence Verification
+
+Verify that every claim in the paper matches raw evidence for: **$ARGUMENTS**
+
+## Why This Exists
+
+The executor writes experiments AND writes the paper. It "knows" what the results should be. This creates confirmation bias:
+- Rounding 84.7% up to 85.3%
+- Reporting best seed instead of average
+- Citing metrics from a different experiment config
+- Claiming "improves by 15%" when the delta is actually 12.8%
+
+A **fresh reviewer with zero prior context** catches these because it has no expectations — it just compares paper text vs raw files.
+
+## How This Differs From Other Audit Skills
+
+| Skill | Question it answers |
+|-------|-------------------|
+| `/experiment-audit` | Is the experiment code honest? (fake GT, normalization fraud) |
+| `/result-to-claim` | Does the data scientifically support this claim? |
+| **`/paper-claim-audit`** | **Does the paper report the data truthfully and precisely?** |
+
+## Core Principle
+
+**Zero-context, fresh reviewer.** The auditor receives ONLY:
+- Paper .tex files (the claims)
+- Raw result files (the evidence)
+
+It does NOT receive:
+- ❌ EXPERIMENT_LOG.md
+- ❌ EXPERIMENT_TRACKER.md
+- ❌ AUTO_REVIEW.md
+- ❌ NARRATIVE_REPORT.md
+- ❌ Any executor summary or interpretation
+- ❌ Any prior audit results
+- ❌ Any conversation history
+
+This is **stricter than reviewer-independence** — it's zero-context evidence audit.
+
+## Workflow
+
+### Step 1: Collect Files (Executor — Claude)
+
+Locate paper and result files WITHOUT reading or interpreting them.
+
+**Paper files** (claims) — paths shown relative to the shell's working
+directory so you can find them with `ls`; when writing them into
+`audited_input_hashes`, use paths relative to the paper dir (no `paper/`
+prefix) per the "Submission Artifact Emission" section below:
+```
+paper/main.tex                # → hash key: main.tex
+paper/sections/*.tex          # → hash key: sections/*.tex
+paper/tables/*.tex (if separate)   # → hash key: tables/*.tex
+```
+
+**Result files** (evidence):
+```
+results/*.json, results/*.jsonl, results/*.csv, results/*.tsv
+outputs/*.json, outputs/*.csv
+wandb-summary.json (if exists)
+**/metrics.json, **/eval_results.json
+**/config.yaml, **/args.json (experiment configs)
+```
+
+**Exclude** (no summaries, no interpretations):
+```
+EXPERIMENT_LOG.md, EXPERIMENT_TRACKER.md, AUTO_REVIEW*.md
+NARRATIVE_REPORT.md, PAPER_PLAN.md, findings.md
+Any .md file that is an executor-written summary
+```
+
+### Step 2: Fresh Reviewer Audit (GPT-5.4 — NEW thread, no reply)
+
+**CRITICAL: Use a fresh reviewer agent every run.** Never reuse an old reviewer context for this audit.
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are a paper-to-evidence auditor. You have ZERO prior context about
+    this research. You will receive only paper source files and raw result
+    files. Your job is to verify that every number in the paper exactly
+    matches the raw evidence.
+
+    Paper files to read:
+    [list .tex file paths]
+
+    Result files to read:
+    [list .json/.csv/.yaml file paths]
+
+    ## Audit Protocol
+
+    ### A. Extract Every Quantitative Claim
+    For each number, percentage, comparison, or scope statement in the paper:
+    - Location (section, table, caption, or inline text)
+    - Exact claim text
+    - The number or comparison being made
+
+    ### B. Trace Each Claim to Evidence
+    For each extracted claim, find the supporting raw data:
+    - Which result file contains this number?
+    - What is the EXACT value in that file?
+    - Match status: exact_match / rounding_ok / mismatch
+
+    ### C. Check These Specific Failure Modes
+
+    1. **Number inflation**: Paper says 85.3%, raw file says 84.7%
+       Rule: only standard rounding to displayed precision is allowed
+
+    2. **Best-seed cherry-pick**: Paper says "achieves 90.2%" but
+       that's the best of 5 seeds; mean is 87.1%
+       Rule: check if paper specifies "average" / "best" / "median"
+
+    3. **Config mismatch**: Paper compares Method A vs Baseline B,
+       but they used different hyperparameters / datasets / splits
+       Rule: verify config files show same settings for compared methods
+
+    4. **Aggregation mismatch**: Paper says "average over 5 seeds"
+       but result files show only 3 runs
+       Rule: count actual runs vs claimed count
+
+    5. **Delta error**: Paper says "improves by 15%" but
+       actual delta is (85.3 - 73.1) / 73.1 = 16.7%
+       Rule: verify arithmetic of all relative improvements
+
+    6. **Caption-table mismatch**: Figure caption describes
+       something different from what the figure/table actually shows
+       Rule: cross-check every caption against its content
+
+    7. **Scope overclaim**: Paper says "consistently outperforms"
+       but only tested on 2 datasets
+       Rule: check if language matches actual evaluation scope
+
+    ## Output Format (per claim)
+    For each claim, report:
+    - claim_id: sequential number
+    - location: section/table/figure
+    - paper_text: exact quote from paper
+    - paper_value: the number claimed
+    - evidence_file: which raw file
+    - evidence_value: the actual number
+    - status: exact_match | rounding_ok | ambiguous_mapping |
+              missing_evidence | config_mismatch | aggregation_mismatch |
+              number_mismatch | scope_overclaim | unsupported_claim
+    - details: explanation if not exact_match
+
+    Overall verdict: PASS | WARN | FAIL
+```
+
+### Step 3: Write Report (Executor — Claude)
+
+Parse the reviewer's response and write `PAPER_CLAIM_AUDIT.md`:
+
+```markdown
+# Paper Claim Audit Report
+
+**Date**: [today]
+**Auditor**: GPT-5.4 xhigh (fresh zero-context thread)
+**Paper**: [paper title from tex]
+
+## Overall Verdict: [PASS | WARN | FAIL]
+
+## Claims Verified: [N total]
+- exact_match: [count]
+- rounding_ok: [count]
+- ambiguous_mapping: [count]
+- missing_evidence: [count]
+- mismatch: [count]
+
+## Issues Found
+
+### [FAIL/WARN] Claim #N: [description]
+- **Location**: Section X / Table Y / Figure Z
+- **Paper says**: "..."
+- **Evidence shows**: ...
+- **Status**: [status]
+- **Fix**: [specific correction needed]
+
+## All Claims (detailed)
+
+| # | Location | Paper Value | Evidence Value | Status |
+|---|----------|-------------|---------------|--------|
+| 1 | Table 2 | 85.3% | 85.28% | rounding_ok |
+| 2 | Abstract | "15% improvement" | 12.8% | number_mismatch |
+| ... |
+```
+
+Also write `PAPER_CLAIM_AUDIT.json` for machine consumption.
+
+### Step 4: Print Summary
+
+```
+📋 Paper Claim Audit Complete
+
+  Claims verified: 24
+  exact_match:     18
+  rounding_ok:      3
+  ambiguous:         1
+  ⚠️ mismatch:      2
+
+  Overall: ⚠️ WARN
+
+  See PAPER_CLAIM_AUDIT.md for details.
+```
+
+## When to Run
+
+1. **After `/paper-write`** — first check before improvement loop
+2. **After `/auto-paper-improvement-loop`** — recheck if improvement loop changed numbers
+3. **Before submission** — final verification
+
+## Integration with Other Skills
+
+### Read by `/auto-paper-improvement-loop` (if exists)
+
+```
+if PAPER_CLAIM_AUDIT.json exists:
+    read mismatched claims
+    fix them as priority items in the improvement round
+```
+
+### Advisory, Never Blocking
+
+Same pattern as `/experiment-audit`:
+- `PASS` → continue normally
+- `WARN` → print warning, continue, flag draft as "check numbers before submission"
+- `FAIL` → print alert, continue, but do NOT mark as submission-ready
+
+## Key Rules
+
+- **Fresh thread EVERY run.** Never use `codex-reply`. Never carry context.
+- **Zero executor interpretation.** Only file paths. No summaries.
+- **Only raw results.** No EXPERIMENT_LOG, no AUTO_REVIEW, no human summaries.
+- **Rounding rule.** Only standard rounding to displayed precision. 84.7% → 84.7% or 85% is OK. 84.7% → 85.3% is NOT OK.
+- **Cross-model.** Reviewer must be a different model family from executor.
+
+## Review Tracing
+
+After each reviewer agent call, save the trace following `shared-references/review-tracing.md`. Use `tools/save_trace.sh` or write files directly to `.aris/traces/<skill>/<date>_run<NN>/`. Respect the `--- trace:` parameter (default: `full`).
+
+## Submission Artifact Emission
+
+This skill **always** writes `paper/PAPER_CLAIM_AUDIT.json`, regardless of
+caller or detector outcome. A detector-negative run (paper has no numeric
+claims) emits verdict `NOT_APPLICABLE`; a paper-with-numeric-claims-but-no-
+raw-results run emits `BLOCKED`. Silent skip is forbidden — `paper-writing`
+Phase 6 and `tools/verify_paper_audits.sh` both rely on this artifact
+existing at a predictable path.
+
+The artifact conforms to the schema in `shared-references/assurance-contract.md`:
+
+```json
+{
+  "audit_skill":      "paper-claim-audit",
+  "verdict":          "PASS | WARN | FAIL | NOT_APPLICABLE | BLOCKED | ERROR",
+  "reason_code":      "all_numbers_match | rounding_drift | missing_raw_results | ...",
+  "summary":          "One-line human-readable verdict summary.",
+  "audited_input_hashes": {
+    "main.tex":                              "sha256:...",
+    "sections/5.evidence.tex":               "sha256:...",
+    "/abs/path/to/results/run_2026_04_19.json": "sha256:..."
+  },
+  "trace_path":       ".aris/traces/paper-claim-audit/<date>_run<NN>/",
+  "thread_id":        "<codex mcp thread id>",
+  "reviewer_model":   "gpt-5.4",
+  "reviewer_reasoning": "xhigh",
+  "generated_at":     "<UTC ISO-8601>",
+  "details": {
+    "total_claims":   <int>,
+    "mismatches":     [ ... per-claim issue records ... ],
+    "result_files":   [ ... raw files consulted ... ]
+  }
+}
+```
+
+### `audited_input_hashes` scope
+
+Hash the **declared input set** passed into this audit invocation — i.e. the
+exact `.tex` files and raw result / config files this run read — not a
+repo-wide union and not the reviewer's self-reported subset. If a caller
+passed only `main.tex` + a single result file, hash those two files and no
+others. The external verifier rehashes these entries; any mismatch flags
+`STALE`.
+
+**Path convention** (must match what `tools/verify_paper_audits.sh`
+expects): keys are **paths relative to the paper directory** (the arg
+passed to the verifier) for in-paper files — so `main.tex`, not
+`paper/main.tex` — and **absolute paths** for out-of-paper files such as
+external `results/` dirs. The verifier resolves relative entries via
+`os.path.join(paper_dir, key)`; prefixing with `paper/` produces
+`paper/paper/main.tex` and false-fails as STALE.
+
+### Verdict decision table
+
+| Input state                                           | Verdict          | `reason_code` example |
+|-------------------------------------------------------|------------------|-----------------------|
+| No numeric claims detected in paper                   | `NOT_APPLICABLE` | `no_numeric_claims`   |
+| Numeric claims detected, no raw result files found    | `BLOCKED`        | `no_raw_evidence`     |
+| All claims reconcile to raw data                      | `PASS`           | `all_numbers_match`   |
+| Minor rounding drift only, no material mismatch       | `WARN`           | `rounding_drift`      |
+| Any material mismatch (wrong number, config mismatch) | `FAIL`           | `claim_mismatch`      |
+| Reviewer invocation failed (network / malformed)      | `ERROR`          | `reviewer_error`      |
+
+### Thread independence
+
+Every invocation uses a fresh reviewer agent. Never continue a prior audit via
+`send_input`. Do not accept prior audit outputs (PROOF_AUDIT, CITATION_AUDIT,
+EXPERIMENT_LOG, AUTO_REVIEW summaries) as input to this audit — the fresh
+thread preserves reviewer independence per
+`shared-references/reviewer-independence.md`.
+
+### Human-readable sibling
+
+`paper/PAPER_CLAIM_AUDIT.md` is written alongside the JSON for readers.
+The JSON is authoritative for `tools/verify_paper_audits.sh`; the Markdown
+is for humans. The parent skill (`paper-writing` Phase 6) plus the verifier
+decide whether the verdict blocks finalization — this skill itself never
+blocks; it only emits.

--- a/skills/skills-codex/paper-compile/SKILL.md
+++ b/skills/skills-codex/paper-compile/SKILL.md
@@ -14,6 +14,7 @@ Compile the LaTeX paper and fix any issues: **$ARGUMENTS**
 - **MAX_COMPILE_ATTEMPTS = 3** — Maximum attempts to fix errors and recompile.
 - **PAPER_DIR = `paper/`** — Directory containing LaTeX source files.
 - **MAX_PAGES** — Page limit. ML conferences: main body to Conclusion end (excluding references & appendix). ICLR=9, NeurIPS=9, ICML=8. **IEEE venues: references ARE included in page count.** IEEE journal ≈ 12-14 pages, IEEE conference ≈ 5-8 pages (all inclusive).
+- **RESCUE_ON_REPEAT_FAILURE = true** — If the same compile class fails after two attempts, preserve `compile.log` and ask for a focused rescue / second opinion before further edits.
 
 ## Workflow
 
@@ -250,4 +251,3 @@ For conference submission, additional checks:
 | ICML 2025 | `icml2025.sty` | `natbib` (`\citep`/`\citet`) | 8 pages (to Conclusion end) | No | OpenReview |
 | IEEE Journal | `IEEEtran.cls` [journal] | `cite` (`\cite{}`, numeric) | ~12-14 pages (Transactions) / ~4-5 (Letters) | **Yes** | IEEE Author Portal / ScholarOne |
 | IEEE Conference | `IEEEtran.cls` [conference] | `cite` (`\cite{}`, numeric) | 5-8 pages (varies by conf) | **Yes** | EDAS / IEEE Author Portal |
-

--- a/skills/skills-codex/paper-poster/SKILL.md
+++ b/skills/skills-codex/paper-poster/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-poster
 description: "Generate a conference poster (article + tcbposter LaTeX → A0/A1 PDF + editable PPTX + SVG) from a compiled paper. Use when user says \"做海报\", \"制作海报\", \"conference poster\", \"make poster\", \"生成poster\", \"poster session\", or wants to create a poster for a conference presentation."
 argument-hint: [paper-directory-or-venue]
-allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
 ---
 
 # Paper Poster: From Paper to Conference Poster
@@ -759,14 +759,15 @@ Append all iteration scores and feedback to `poster/POSTER_VISUAL_REVIEW.md`:
 - Decision: PASS — print-ready
 ```
 
-### Phase 6: Codex MCP Review
+### Phase 6: Codex Reviewer Review
 
 Send the poster content plan + key LaTeX sections to GPT-5.4 xhigh for review.
 
-```
-mcp__codex__codex:
-  config: {"model_reasoning_effort": "xhigh"}
-  prompt: |
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
     Review this academic conference poster for [VENUE].
 
     Evaluate using these criteria (score 1-5 each):
@@ -1077,7 +1078,8 @@ Next steps:
 - **Do NOT hallucinate citations.** Use only references from the paper's bibliography.
 - **Include QR code placeholder** or code link for paper/code repository.
 - **Font size minimums (article class)**: Title ≥84pt, section headers ≥40pt, body ≥34pt, captions ≥26pt, references ≥30pt, stat numbers ≥66pt.
-- **Feishu notifications are optional.** If `~/.claude/feishu.json` exists, send notifications. Otherwise skip.
+- **Feishu notifications are optional.** If `~/.codex/feishu.json` exists, send notifications. Otherwise skip.
+- If poster generation requires local preview, PNG review, or `mcp__illustrator__run` and that capability is missing in the current environment, stop and tell the user what to configure. Do not silently degrade this skill into text-only poster drafting.
 
 ## Parameter Pass-Through
 

--- a/skills/skills-codex/paper-slides/SKILL.md
+++ b/skills/skills-codex/paper-slides/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-slides
 description: "Generate conference presentation slides (beamer LaTeX → PDF + editable PPTX) from a compiled paper, with speaker notes and full talk script. Use when user says \"做PPT\", \"做幻灯片\", \"make slides\", \"conference talk\", \"presentation slides\", \"生成slides\", \"写演讲稿\", or wants beamer slides for a conference talk."
 argument-hint: [paper-directory-or-talk-length]
-allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
 ---
 
 # Paper Slides: From Paper to Conference Talk
@@ -318,10 +318,11 @@ If page count differs significantly from outline (>2 slides off), investigate.
 
 Send the slide outline + selected LaTeX frames to GPT-5.4 xhigh:
 
-```
-mcp__codex__codex:
-  config: {"model_reasoning_effort": "xhigh"}
-  prompt: |
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
     Review this [TALK_TYPE] presentation ([TALK_MINUTES] min) for [VENUE].
 
     Evaluate using these criteria (score 1-5 each):
@@ -348,7 +349,7 @@ mcp__codex__codex:
 
 Apply fixes. Recompile if LaTeX was changed.
 
-> ⚠️ If `mcp__codex__codex` is not available (no OpenAI API key), skip external review and proceed to Phase 6. Note the skip in `SLIDES_STATE.json`.
+> If reviewer delegation is unavailable in the current Codex host, stop and ask the user to enable Codex agent support before continuing Phase 6.
 
 Save review to `slides/SLIDES_REVIEW.md`.
 
@@ -551,7 +552,7 @@ Next steps:
 - **Do NOT hallucinate citations.** Reference only papers cited in the paper.
 - **Opening hook matters**: Never start with "In this paper, we..." — start with the problem or a provocative question.
 - **Font size minimums**: Title ≥28pt, body ≥20pt, footnotes ≥14pt.
-- **Feishu notifications are optional.** If `~/.claude/feishu.json` exists, send notifications. If absent, skip.
+- **Feishu notifications are optional.** If `~/.codex/feishu.json` exists, send notifications. If absent, skip.
 
 ## Parameter Pass-Through
 

--- a/skills/skills-codex/paper-write/SKILL.md
+++ b/skills/skills-codex/paper-write/SKILL.md
@@ -200,6 +200,26 @@ Before drafting the front matter, re-read the one-sentence contribution from `PA
 - Implementation details, hyperparameter tables
 - Additional visualizations
 
+### Step 3.5: Theory Paper Consistency Pass (theory papers only)
+
+Run this pass after drafting all sections and before building the bibliography.
+
+Trigger it when `PAPER_PLAN.md` labels the paper as theory/analysis, or when the drafted sections contain five or more formal result environments (`theorem`, `lemma`, `proposition`, or `corollary`).
+
+**Proof source search:** search the workspace for standalone full-proof sources whose names or contents indicate a canonical proof version (`proof`, `appendix`, `full`, `complete`, `supplement`, `supplementary`). If one exists, ask:
+
+`Inline full proofs from {file}? [Y/n]`
+
+Default to `Y`. If accepted:
+
+- import the full theorem/lemma statement plus proof block into the appendix source;
+- use the main-body theorem statement as the canonical public statement;
+- do not leave placeholders such as "see supplementary proof document" or "proof omitted for brevity";
+- preserve theorem labels, equation labels, and proof structure exactly;
+- keep main-body proof sketches short, but never let the appendix be sketch-only when a full proof source exists.
+
+**Restatement audit:** compare every theorem/lemma/proposition statement restated in the appendix against the main-body version. Audit statements, hypotheses, case splits, quantifiers, domains, notation, variable names, and terminology for defined objects. Resolve all mismatches before Step 4.
+
 ### Step 4: Build Bibliography
 
 **CRITICAL: Only include entries that are actually cited in the paper.**
@@ -258,7 +278,19 @@ This prevents bib bloat (e.g., 948 lines → 215 lines in testing).
 4. Double-check year and venue for every entry
 5. Remove duplicate entries (same paper with different keys)
 
-### Step 5: De-AI Polish (from kgraph57/paper-writer-skill)
+### Step 5: Scientific Writing Quality Pass (5 audit passes)
+
+After drafting all sections, run five sequential audit passes. De-AI polish is included as one part of this quality pass, not a replacement for it.
+
+**Pass 1: Clutter Extraction** — strip sentences to their cleanest components, remove filler, and remove AI-isms.
+
+**Pass 2: Active Voice and Verb Vitality** — identify who did what, convert unnecessary passive voice, and resurrect smothered verbs.
+
+**Pass 3: Sentence Architecture** — flag sentences over 40 words, keep subject and verb close, put familiar context first and new information later, and ensure each paragraph does one job.
+
+**Pass 4: Keyword Consistency** — apply the Banana Rule: do not rename defined technical terms just to avoid repetition. If Methods defines a group, variable, or technique name, Results, Discussion, tables, and captions must use the same term.
+
+**Pass 5: Numerical and Citation Integrity** — check sample sizes, percentages, significant figures, figure/table values, and whether citations support the claims they are attached to.
 
 After drafting all sections, scan for common AI writing patterns and fix them:
 

--- a/skills/skills-codex/paper-writing/SKILL.md
+++ b/skills/skills-codex/paper-writing/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: "paper-writing"
-description: "Workflow 3: Full paper writing pipeline. Orchestrates paper-plan \u2192 paper-figure \u2192 paper-write \u2192 paper-compile \u2192 auto-paper-improvement-loop to go from a narrative report to a polished, submission-ready PDF. Use when user says \\\"\u5199\u8bba\u6587\u5168\u6d41\u7a0b\\\", \\\"write paper pipeline\\\", \\\"\u4ece\u62a5\u544a\u5230PDF\\\", \\\"paper writing\\\", or wants the complete paper generation workflow."
+name: paper-writing
+description: "Workflow 3: Full paper writing pipeline. Orchestrates paper-plan → paper-figure → figure-spec/paper-illustration/mermaid-diagram → paper-write → paper-compile → auto-paper-improvement-loop to go from a narrative report to a polished PDF. At `— effort: max | beast` (or explicit `— assurance: submission`), Phase 6 gates the Final Report on `tools/verify_paper_audits.sh`; the PDF is labelled `submission-ready` only when the external verifier is green. Use when user says \"写论文全流程\", \"write paper pipeline\", \"从报告到PDF\", \"paper writing\", or wants the complete paper generation workflow."
+argument-hint: [narrative-report-path-or-topic]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, Skill
 ---
 
 # Workflow 3: Paper Writing Pipeline
@@ -18,15 +20,18 @@ This skill chains five sub-skills into a single automated pipeline:
 
 Each phase builds on the previous one's output. The final deliverable is a polished, reviewed `paper/` directory with LaTeX source and compiled PDF.
 
+In this hybrid pack, the pipeline itself is unchanged, but `paper-plan` and `paper-write` use Orchestra-adapted shared references for stronger story framing and prose guidance.
+
 ## Constants
 
 - **VENUE = `ICLR`** — Target venue. Options: `ICLR`, `NeurIPS`, `ICML`, `CVPR`, `ACL`, `AAAI`, `ACM`, `IEEE_JOURNAL` (IEEE Transactions / Letters), `IEEE_CONF` (IEEE conferences). Affects style file, page limit, citation format.
 - **MAX_IMPROVEMENT_ROUNDS = 2** — Number of review→fix→recompile rounds in the improvement loop.
-- **REVIEWER_MODEL = `gpt-5.4`** — Model used via a secondary Codex agent for plan review, figure review, writing review, and improvement loop.
+- **REVIEWER_MODEL = `gpt-5.4`** — Model used via Codex MCP for plan review, figure review, writing review, and improvement loop.
 - **AUTO_PROCEED = true** — Auto-continue between phases. Set `false` to pause and wait for user approval after each phase.
 - **HUMAN_CHECKPOINT = false** — When `true`, the improvement loop (Phase 5) pauses after each round's review to let you see the score and provide custom modification instructions. When `false` (default), the loop runs fully autonomously. Passed through to `/auto-paper-improvement-loop`.
+- **ILLUSTRATION = `figurespec`** — Architecture/illustration generator for Phase 2b: `figurespec` (default, deterministic JSON→SVG via `/figure-spec`, best for architecture/workflow/topology), `gemini` (AI-generated via `/paper-illustration`, best for qualitative method illustrations; needs `GEMINI_API_KEY`), `mermaid` (Mermaid syntax via `/mermaid-diagram`, free, best for flowcharts), or `false` (skip Phase 2b, manual only).
 
-> Override inline: `/paper-writing "NARRATIVE_REPORT.md" — venue: NeurIPS, human checkpoint: true`
+> Override inline: `/paper-writing "NARRATIVE_REPORT.md" — venue: NeurIPS, illustration: gemini, human checkpoint: true`
 > IEEE example: `/paper-writing "NARRATIVE_REPORT.md" — venue: IEEE_JOURNAL`
 
 ## Inputs
@@ -40,6 +45,49 @@ This pipeline accepts one of:
 The more detailed the input (especially figure descriptions and quantitative results), the better the output.
 
 ## Pipeline
+
+### Phase 0: Assurance Setup
+
+Resolve the active `assurance` level and persist it so Phase 6's external
+verifier reads the same value. **Run once at pipeline start, before Phase 1.**
+
+**Resolution order** (first match wins):
+
+1. Explicit `— assurance: draft | submission` in `$ARGUMENTS`
+2. Derived from `— effort:`
+   - `lite` / `balanced` → `draft` (default, **zero change from current behavior**)
+   - `max` / `beast` → `submission`
+3. Default: `draft`
+
+**Action:**
+
+```bash
+mkdir -p paper/.aris
+echo "<resolved-level>" > paper/.aris/assurance.txt   # draft or submission
+```
+
+**What each level does downstream:**
+
+- **`draft`** — Existing behavior. Audits run only when their content detector
+  matches (Phase 4.5 / 4.7 / 5.5 / 5.8). Missing artifacts are non-blocking.
+  Silent-skip allowed.
+- **`submission`** — The three mandatory audits (proof-checker,
+  paper-claim-audit, citation-audit) are treated as load-bearing gates. Each
+  sub-audit must emit its JSON artifact (PASS / WARN / FAIL / NOT_APPLICABLE /
+  BLOCKED / ERROR) — never silent-skip. Phase 6 runs
+  `tools/verify_paper_audits.sh`; a non-zero exit blocks the Final Report.
+
+**Escape hatch:** a user wanting the old "beast = depth-only, no audit gate"
+can pass `— effort: beast, assurance: draft` explicitly. Legal but
+discouraged for actual submissions. See
+`shared-references/assurance-contract.md` for the full contract.
+
+**Announce the resolved level in-line before Phase 1:**
+
+```
+📋 Assurance: <level> (derived from effort: <effort>)
+   <either "current behavior, no audit gate" OR "mandatory audits gated by tools/verify_paper_audits.sh">
+```
 
 ### Phase 1: Paper Plan
 
@@ -91,29 +139,57 @@ Invoke `/paper-figure` to generate data-driven plots and tables:
 
 **Output:** `figures/` directory with PDFs, generation scripts, and LaTeX snippets.
 
-#### Phase 2b: AI Illustration Generation (when `illustration: true`)
+> **Scope:** `paper-figure` covers data plots and comparison tables. Architecture diagrams, pipeline figures, and method illustrations are handled in Phase 2b below.
 
-**Skip this step entirely if `illustration` is not set or is `false`.**
+#### Phase 2b: Architecture & Illustration Generation
 
-If the paper plan includes architecture diagrams, pipeline figures, or method illustrations, invoke `/paper-illustration`:
+**Skip this step entirely if `illustration: false`.**
 
+If the paper plan includes architecture diagrams, pipeline figures, audit cascades, or method illustrations, invoke the appropriate generator based on the `illustration` parameter:
+
+**When `illustration: figurespec`** (default) — invoke `/figure-spec`:
+```
+/figure-spec "[architecture/workflow description from PAPER_PLAN.md]"
+```
+- Deterministic JSON → SVG vector rendering (editable, reproducible)
+- Best for: system architecture, workflow pipelines, audit cascades, layered topology
+- Output: `figures/*.svg` + `figures/*.pdf` (via rsvg-convert) + `figures/specs/*.json`
+- No external API, runs fully local
+
+**When `illustration: gemini`** — invoke `/paper-illustration`:
 ```
 /paper-illustration "[method description from PAPER_PLAN.md or NARRATIVE_REPORT.md]"
 ```
-
-**What this does:**
-- Codex plans the layout → Gemini optimizes → Nano Banana Pro renders → Codex reviews (score ≥ 9)
-- Output: `figures/ai_generated/*.png` — publication-quality method diagrams
+- Claude plans → Gemini optimizes → Nano Banana Pro renders → Claude reviews (score ≥ 9)
+- Best for: qualitative method illustrations, natural-style diagrams, result grids
+- Output: `figures/ai_generated/*.png`
 - Requires `GEMINI_API_KEY` environment variable
 
-> **Without `illustration: true`:** Architecture diagrams must still be created manually (draw.io, Figma, TikZ) and placed in `figures/` before proceeding — same as before.
+**When `illustration: mermaid`** — invoke `/mermaid-diagram`:
+```
+/mermaid-diagram "[method description from PAPER_PLAN.md]"
+```
+- Generates Mermaid syntax diagrams (flowchart, sequence, class, state, etc.)
+- Best for: lightweight flowcharts, state machines, simple sequence diagrams
+- Output: `figures/*.mmd` + `figures/*.png`
+- Free, no API key needed
+
+**When `illustration: false`** — skip entirely. All non-data figures must be created manually (draw.io, Figma, TikZ) and placed in `figures/` before Phase 3.
+
+**Choosing the right mode:**
+- Formal architecture / workflow / topology figures → `figurespec` (default)
+- Method concept illustrations with natural style → `gemini`
+- Quick flowchart / state machine → `mermaid`
+- Full manual control → `false`
+
+These are complementary, not mutually exclusive: you can run multiple generators for different figures in the same paper by re-invoking with different `illustration` overrides.
 
 **Checkpoint:** List generated vs manual figures.
 
 ```
 📊 Figures complete:
-- Data plots (auto): [list]
-- AI illustrations (auto): [list, if illustration: true]
+- Data plots (auto, Phase 2): [list]
+- Architecture/illustrations (auto, Phase 2b, mode=<illustration>): [list]
 - Manual (need your input): [list]
 - LaTeX snippets: figures/latex_includes.tex
 
@@ -182,6 +258,46 @@ Invoke `/paper-compile` to build the PDF:
 Shall I proceed with the improvement loop?
 ```
 
+### Phase 4.5: Proof Verification (theory papers only)
+
+**Skip this phase if the paper contains no theorems, lemmas, or proofs.**
+
+```
+if paper contains \begin{theorem} or \begin{lemma} or \begin{proof}:
+    Run /proof-checker "paper/"
+    This invokes GPT-5.4 xhigh to:
+    - Verify all proof steps (hypothesis discharge, interchange justification, etc.)
+    - Check for logic gaps, quantifier errors, missing domination conditions
+    - Attempt counterexamples on key lemmas
+    - Generate PROOF_AUDIT.md with issue list + severity
+
+    If FATAL or CRITICAL issues found:
+        Fix before proceeding to improvement loop
+    If only MAJOR/MINOR:
+        Proceed, improvement loop may address remaining issues
+else:
+    skip — no proofs, no action
+```
+
+### Phase 4.7: Paper Claim Audit
+
+**Skip if no result files exist (e.g., survey/position papers with no experiments).**
+
+```
+if results/*.json or results/*.csv or outputs/*.json exist:
+    Run /paper-claim-audit "paper/"
+    Fresh zero-context reviewer compares every number in the paper
+    against raw result files. Catches rounding inflation, best-seed
+    cherry-pick, config mismatch, delta errors.
+
+    If FAIL:
+        Fix mismatched numbers before improvement loop
+    If WARN:
+        Proceed, but flag for manual verification
+else:
+    skip — no experimental results to verify
+```
+
 ### Phase 5: Auto Improvement Loop
 
 Invoke `/auto-paper-improvement-loop` to polish the paper:
@@ -192,9 +308,9 @@ Invoke `/auto-paper-improvement-loop` to polish the paper:
 
 **What this does (2 rounds):**
 
-**Round 1:** GPT-5.4 xhigh reviews the full paper → identifies CRITICAL/MAJOR/MINOR issues → Codex implements fixes → recompile → save `main_round1.pdf`
+**Round 1:** GPT-5.4 xhigh reviews the full paper → identifies CRITICAL/MAJOR/MINOR issues → Claude Code implements fixes → recompile → save `main_round1.pdf`
 
-**Round 2:** GPT-5.4 xhigh re-reviews with conversation context → identifies remaining issues → Codex implements fixes → recompile → save `main_round2.pdf`
+**Round 2:** GPT-5.4 xhigh re-reviews with conversation context → identifies remaining issues → Claude Code implements fixes → recompile → save `main_round2.pdf`
 
 **Typical improvements:**
 - Fix assumption-model mismatches
@@ -205,26 +321,222 @@ Invoke `/auto-paper-improvement-loop` to polish the paper:
 
 **Output:** Three PDFs for comparison + `PAPER_IMPROVEMENT_LOG.md`.
 
-**Format check** (included in improvement loop Step 8): After final recompilation, auto-detect and fix overfull hboxes (content exceeding margins), verify page count vs venue limit, and ensure compact formatting. Any overfull > 10pt is fixed before generating the final PDF.
+**Format check** (included in improvement loop Step 8): After final recompilation, auto-detect and fix overfull hboxes (content exceeding margins), verify page count vs venue limit, and ensure compact formatting. Location-aware thresholds: any main-body overfull blocks completion regardless of size; appendix overfulls block only if >10pt; bibliography overfulls block only if >20pt.
+
+### Phase 5.5: Final Paper Claim Audit (MANDATORY submission gate)
+
+After `/auto-paper-improvement-loop` finishes, **rerun** `/paper-claim-audit` before the final report whenever the paper contains numeric claims and machine-readable raw result files exist.
+
+Use the same detectors as Phase 4.7:
+- numeric-claim regex over `paper/main.tex` and `paper/sections/*.tex`
+- raw-evidence file search in `results/`, `outputs/`, `experiments/`, and `figures/` for `.json`, `.jsonl`, `.csv`, `.tsv`, `.yaml`, or `.yml`
+
+This phase is **mandatory** if both detectors are positive. It blocks the final report.
+If numeric claims exist but no raw result files are found, stop and warn the user before declaring the paper complete.
+If no numeric claims exist, skip.
+
+```bash
+NUMERIC_CLAIMS=$(rg -n -e '[0-9]+(\.[0-9]+)?\s*(%|\\%|±|\\pm|x|×)' \
+  -e '(accuracy|BLEU|F1|AUC|mAP|top-1|top-5|error|loss|perplexity|speedup|improvement)' \
+  paper/main.tex paper/sections 2>/dev/null || true)
+
+RAW_RESULT_FILES=$(find results outputs experiments figures -type f \
+  \( -name '*.json' -o -name '*.jsonl' -o -name '*.csv' -o -name '*.tsv' -o -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | head -200)
+
+if [ -n "$NUMERIC_CLAIMS" ] && [ -n "$RAW_RESULT_FILES" ]; then
+    Run /paper-claim-audit "paper/"
+    If FAIL:
+        Fix mismatched numbers before the final report
+elif [ -n "$NUMERIC_CLAIMS" ]; then
+    Stop and warn: the paper contains numeric claims but no raw evidence files were found
+fi
+```
+
+**Empirical motivation:** in our April 2026 NeurIPS run, the final paper claimed `w ∈ {0,1,2,3}` for the width-tradeoff experiment but the raw JSON had `w ∈ {0,1,2,3,4,5}`. The crossing-point tolerance was claimed as `0.05%` but the actual relative error was `0.0577%`. Both were caught only after manual `paper-claim-audit` invocation in the final round; the improvement loop did not detect them.
+
+### Phase 5.8: Citation Audit (submission gate)
+
+After the final paper-claim-audit passes, run `/citation-audit` to verify every `\cite{...}` along three axes: existence, metadata correctness, and context appropriateness. This is the fourth and final layer of the evidence-and-claim assurance stack (`experiment-audit` → `result-to-claim` → `paper-claim-audit` → `citation-audit`).
+
+```
+if paper/references.bib (or paper.bib) exists and contains entries cited from sec/*.tex:
+    Run /citation-audit "paper/"
+    Fresh cross-family reviewer (gpt-5.4 via Codex MCP) with web/DBLP/arXiv lookup
+    verifies each entry:
+      (i)   EXISTENCE — paper resolves at claimed arXiv ID / DOI / venue
+      (ii)  METADATA — author names, year, venue, title match canonical sources
+      (iii) CONTEXT — cited paper actually establishes the claim it supports
+
+    Output:
+      - CITATION_AUDIT.md (human-readable per-entry verdict report)
+      - CITATION_AUDIT.json (machine-readable verdict ledger)
+      - Per-entry verdicts: KEEP / FIX / REPLACE / REMOVE
+
+    If any REPLACE or REMOVE verdicts:
+        Surface to user for human approval — never auto-modify content claims
+    If only FIX verdicts (metadata corrections):
+        Apply with user confirmation, then recompile
+    If all KEEP:
+        Pass — bibliography clean for submission
+else:
+    skip — no bib file or no citations
+```
+
+**Why this is the most diagnostic of the four audit layers:** wildly fake citations are easy to spot. The dangerous failure mode is a real paper used to support a claim it does not actually establish (wrong-context citations) — these slip past metadata-only checks and damage submission credibility. Run cost is wall-clock heavy (web lookup per entry); run once per submission, not per save.
+
+**Empirical motivation:** in our April 2026 ARIS technical-report run, two real papers (`madaan2023selfrefine`, `liu2023reviewergpt`) were cited in contexts they did not actually support, and one entry (`hidden2025aiscientistpitfalls`) had `author = "Anonymous"` because the metadata had not been resolved. None were caught by the improvement loop or numeric claim audit; only fresh web-lookup review surfaced them.
 
 ### Phase 6: Final Report
+
+**Phase 6.0 — Submission Gate**
+
+Before writing the Final Report, resolve the active assurance level. This
+uses the **same derivation rule as Phase 0** so a run where Phase 0 was
+skipped or its write failed cannot silently downgrade a `beast` / `max` /
+`— assurance: submission` invocation back to draft.
+
+**Resolution at the gate** (re-derive; do not trust `.aris/assurance.txt`
+alone):
+
+1. Parse `$ARGUMENTS` for an explicit `— assurance: draft | submission` or
+   an `— effort: lite | balanced | max | beast` directive.
+2. Derive the expected level:
+   - explicit `assurance:` wins
+   - else `lite` / `balanced` → `draft`, `max` / `beast` → `submission`
+   - else `draft`
+3. Read `paper/.aris/assurance.txt`. If the file is missing, write it now
+   with the derived level.
+4. If the file's value **disagrees** with the derived level (e.g. file
+   says `draft` but `$ARGUMENTS` says `beast`), **overwrite** the file
+   with the derived level and surface a one-line warning in-chat:
+   `⚠️ .aris/assurance.txt was draft but $ARGUMENTS says submission; overriding.`
+5. Use the re-derived level as authoritative for the rest of Phase 6.
+
+```bash
+# Final authoritative value, written and read from the same source
+ASSURANCE=<derived-from-$ARGUMENTS>        # draft | submission
+mkdir -p paper/.aris
+echo "$ASSURANCE" > paper/.aris/assurance.txt
+```
+
+If `ASSURANCE=draft`, skip directly to the Final Report template below —
+**current behavior, no change** for the default `balanced` user.
+
+If `ASSURANCE=submission`, run the pre-flight checklist below, then the
+verifier. The verifier's exit code is the source of truth — do NOT
+self-declare "audits complete" based on conversation memory.
+
+#### Submission pre-flight checklist
+
+Print this checklist verbatim at the start of Phase 6.0 and confirm each row
+before proceeding. This resists the common failure mode of the model
+skipping audits while claiming to have run them.
+
+```
+📋 Submission audits required before Final Report:
+   [ ] 1. /proof-checker        → paper/PROOF_AUDIT.json
+   [ ] 2. /paper-claim-audit    → paper/PAPER_CLAIM_AUDIT.json
+   [ ] 3. /citation-audit       → paper/CITATION_AUDIT.json
+   [ ] 4. bash <ARIS_REPO>/tools/verify_paper_audits.sh paper/ --assurance submission
+   [ ] 5. Block Final Report iff verifier exit code != 0
+```
+
+> `<ARIS_REPO>` placeholder — replace with the absolute path to your ARIS
+> clone (e.g. `~/Desktop/Auto-claude-code-research-in-sleep`). In a Codex
+> project install, derive it from `.aris/installed-skills-codex.txt`:
+> `ARIS_REPO="$(awk -F '\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt)"`.
+> For an unmanaged flat symlink install, use the skill directory symlink:
+> `ARIS_REPO="$(cd "$(readlink .agents/skills/paper-writing)/../../.." && pwd)"`.
+> The path is stable across runs; store it in a shell variable if you prefer.
+
+#### Invoking the three audits
+
+Each sub-audit runs in a **fresh Codex thread** (never `codex-reply`,
+never pass prior audit output as context — this preserves reviewer
+independence per `shared-references/reviewer-independence.md`).
+
+Each sub-audit **always** emits its JSON artifact, even when the content
+detector is negative. A detector-negative run emits verdict
+`NOT_APPLICABLE`; a silent skip is forbidden. See the "Submission artifact
+emission" section of each audit's SKILL.md.
+
+Order:
+
+1. `/proof-checker "paper/"` → writes `paper/PROOF_AUDIT.json` (emits
+   `NOT_APPLICABLE` if the paper contains no theorems / lemmas / proofs)
+2. `/paper-claim-audit "paper/"` → writes `paper/PAPER_CLAIM_AUDIT.json`
+   (emits `NOT_APPLICABLE` if the paper has no numeric claims; emits
+   `BLOCKED` if numeric claims exist but raw result files are missing)
+3. `/citation-audit "paper/"` → writes `paper/CITATION_AUDIT.json`
+   (emits `NOT_APPLICABLE` if no `.bib` file or no `\cite{...}` usage)
+
+#### Running the verifier
+
+```bash
+bash <ARIS_REPO>/tools/verify_paper_audits.sh paper/ --assurance submission
+```
+
+- **Exit 0** — All mandatory audits present, JSON schema-valid, hashes fresh,
+  no blocking verdicts. Proceed to the Final Report below.
+- **Exit 1** — Surface `paper/.aris/audit-verifier-report.json` to the user
+  verbatim, **refuse to generate the Final Report**, and list the specific
+  remediation for each failing row:
+  - `MISSING` → rerun that audit
+  - `STALE` → paper files edited after the audit ran; rerun the affected audit
+  - `BLOCKING_VERDICT` (FAIL / BLOCKED / ERROR) → fix the underlying issue,
+    then rerun the audit
+  - `SCHEMA_INVALID` → audit artifact malformed; rerun the audit
+
+The verifier is cheap to rerun (< 1 s). After fixing any issue, rerun it
+before claiming green.
+
+#### Optional hardening (not default)
+
+Teams that want hook-level enforcement — i.e., the harness physically
+prevents a Stop event while the verifier is red — can register an equivalent
+Codex stop hook if their local Codex runtime supports hooks:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {"command": "bash <ARIS_REPO>/tools/verify_paper_audits.sh paper/ --assurance submission"}
+    ]
+  }
+}
+```
+
+This is documented here, not required. Phase 6.0's verifier-as-truth
+pattern is the default repo behavior.
+
+---
+
+**Phase 6.1 — Final Report** (runs only after the submission gate is green,
+or directly if `assurance=draft`)
 
 ```markdown
 # Paper Writing Pipeline Report
 
 **Input**: [NARRATIVE_REPORT.md or topic]
-**Venue**: [ICLR/NeurIPS/ICML]
+**Venue**: [ICLR/NeurIPS/ICML/CVPR/ACL/AAAI/ACM/IEEE_JOURNAL/IEEE_CONF]
+**Assurance**: [draft | submission]
+**Submission-ready**: [yes | no]   <!-- yes iff assurance=submission AND verifier exit 0 -->
 **Date**: [today]
 
 ## Pipeline Summary
 
 | Phase | Status | Output |
 |-------|--------|--------|
+| 0. Assurance Setup | ✅ | paper/.aris/assurance.txt = [draft\|submission] |
 | 1. Paper Plan | ✅ | PAPER_PLAN.md |
 | 2. Figures | ✅ | figures/ ([N] auto + [M] manual) |
 | 3. LaTeX Writing | ✅ | paper/sections/*.tex ([N] sections, [M] citations) |
 | 4. Compilation | ✅ | paper/main.pdf ([X] pages) |
 | 5. Improvement | ✅ | [score0]/10 → [score2]/10 |
+| 4.5 Proof Audit | [PASS\|WARN\|FAIL\|NOT_APPLICABLE\|BLOCKED\|ERROR] | PROOF_AUDIT.{md,json} |
+| 5.5 Paper Claim Audit | [PASS\|WARN\|FAIL\|NOT_APPLICABLE\|BLOCKED\|ERROR] | PAPER_CLAIM_AUDIT.{md,json} |
+| 5.8 Citation Audit | [PASS\|WARN\|FAIL\|NOT_APPLICABLE\|BLOCKED\|ERROR] | CITATION_AUDIT.{md,json} |
+| 6.0 Assurance Verifier | [OK\|STALE\|BLOCKING_VERDICT\|HAS_ISSUES\|SCHEMA_INVALID\|MISSING] per audit; exit [0\|1] overall (N/A if draft) | .aris/audit-verifier-report.json |
 
 ## Improvement Scores
 | Round | Score | Key Changes |
@@ -239,6 +551,10 @@ Invoke `/auto-paper-improvement-loop` to polish the paper:
 - paper/main_round1.pdf — After round 1
 - paper/main_round2.pdf — After round 2
 - paper/PAPER_IMPROVEMENT_LOG.md — Full review log
+- paper/PROOF_AUDIT.{md,json} — Proof-obligation verification (always emitted at `assurance=submission`; `NOT_APPLICABLE` when no theorems)
+- paper/PAPER_CLAIM_AUDIT.{md,json} — Numerical claim verification (always emitted at `assurance=submission`; `NOT_APPLICABLE` when no numeric claims; omitted in `draft` mode if Phase 5.5 detector was negative)
+- paper/CITATION_AUDIT.{md,json} — Bibliography verification (always emitted at `assurance=submission`; `NOT_APPLICABLE` when no `.bib` or no `\cite{...}`; omitted in `draft` mode if Phase 5.8 detector was negative)
+- paper/.aris/audit-verifier-report.json — External verifier report (submission only)
 
 ## Remaining Issues (if any)
 - [items from final review that weren't addressed]
@@ -252,14 +568,13 @@ Invoke `/auto-paper-improvement-loop` to polish the paper:
 ## Output Protocols
 
 > Follow these shared protocols for all output files:
-> - **[Output Versioning Protocol](../../shared-references/output-versioning.md)** — write timestamped file first, then copy to fixed name
-> - **[Output Manifest Protocol](../../shared-references/output-manifest.md)** — log every output to MANIFEST.md
-> - **[Output Language Protocol](../../shared-references/output-language.md)** — respect the project's language setting
+> - **[Output Versioning Protocol](../shared-references/output-versioning.md)** — write timestamped file first, then copy to fixed name
+> - **[Output Manifest Protocol](../shared-references/output-manifest.md)** — log every output to MANIFEST.md
+> - **[Output Language Protocol](../shared-references/output-language.md)** — note: paper-writing always outputs English LaTeX for venue submission
 
 ## Key Rules
 
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
-
 - **Don't skip phases.** Each phase builds on the previous one — skipping leads to errors.
 - **Checkpoint between phases** when AUTO_PROCEED=false. Present results and wait for approval.
 - **Manual figures first.** If the paper needs architecture diagrams or qualitative results, the user must provide them before Phase 3.

--- a/skills/skills-codex/patent-novelty-check/SKILL.md
+++ b/skills/skills-codex/patent-novelty-check/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: patent-novelty-check
+description: "Assess patent novelty and non-obviousness against prior art. Use when user says \"专利查新\", \"patent novelty\", \"可专利性评估\", \"patentability check\", or wants to evaluate if an invention is patentable."
+argument-hint: [invention-description-or-brief-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch
+---
+
+# Patent Novelty and Non-Obviousness Check
+
+Assess patentability of: **$ARGUMENTS**
+
+Adapted from `/novelty-check` for patent legal standards. Research novelty is NOT the same as patent novelty.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — Model used via Codex MCP for cross-model examiner verification
+- `NOVELTY_STANDARD = patent` — Always use legal patentability standard, not research contribution standard
+
+## Inputs
+
+1. Invention description from `$ARGUMENTS`
+2. `patent/PRIOR_ART_REPORT.md` (output of `/prior-art-search`)
+3. `patent/INVENTION_BRIEF.md` if exists
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for novelty/non-obviousness standards.
+Load `../shared-references/patent-format-us.md` for 102/103 analysis framework.
+
+## Workflow
+
+### Step 1: Define Claim Elements
+
+From the invention description, extract the key claim elements that would define the invention's scope:
+1. List the technical features that make the invention novel
+2. Identify which features are known from prior art vs. inventive
+3. Draft preliminary claim language for 2-3 independent claims (method + system)
+
+### Step 2: Anticipation Analysis (Novelty)
+
+For each preliminary claim, test against EACH prior art reference in `PRIOR_ART_REPORT.md`:
+
+**Single-reference test**: Does any single reference disclose ALL claim elements?
+
+| Claim Element | Ref 1 | Ref 2 | Ref 3 | ... |
+|--------------|-------|-------|-------|-----|
+| Feature A | Yes/No + evidence | | | |
+| Feature B | Yes/No + evidence | | | |
+| Feature C | Yes/No + evidence | | | |
+| Feature D | Yes/No + evidence | | | |
+
+**Verdict per reference**:
+- ANTICIPATED: One reference discloses every element → claim is not novel
+- NOT ANTICIPATED: At least one element missing from every single reference → claim is novel
+
+### Step 3: Obviousness Analysis (Inventive Step)
+
+If the invention is novel (passes Step 2), test for obviousness:
+
+**Two/three-reference combination test**: Can 2-3 references be combined to render the claim obvious?
+
+For each combination of the top references:
+1. **Primary reference**: Which reference is closest to the claimed invention?
+2. **Secondary reference(s)**: Which reference(s) teach the missing element(s)?
+3. **Motivation to combine**: Would a POSITA have reason to combine these references?
+   - Explicit suggestion in the references themselves?
+   - Same field, same problem?
+   - Common design incentive?
+   - Known technique for improving similar devices?
+
+Format as a matrix:
+
+| Combination | Primary | Secondary | Missing Elements | Motivation to Combine | Obvious? |
+|-------------|---------|-----------|-----------------|----------------------|----------|
+| Ref1 + Ref2 | Ref1 | Ref2 | Feature D | Same field, similar problem | Yes/No |
+
+### Step 4: Cross-Model Examiner Verification
+
+Call `REVIEWER_MODEL` via a dedicated Codex reviewer agent at xhigh reasoning:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are a senior patent examiner at the [USPTO/CNIPA/EPO].
+    Examine the following invention for patentability.
+
+    INVENTION: [invention description + preliminary claims]
+
+    PRIOR ART: [prior art references with key teachings]
+
+    Please analyze:
+    1. Anticipation (novelty): Does any single reference anticipate any claim?
+    2. Obviousness: Can any combination of references render claims obvious?
+    3. Claim scope: Are the claims broad enough to be valuable?
+    4. Recommended amendments if any claim is rejected.
+    Be rigorous and cite specific references.
+```
+
+### Step 5: Jurisdiction-Specific Assessment
+
+For each target jurisdiction, provide a patentability assessment:
+
+**Under 35 USC 102/103 (US)**:
+- Novelty: PASS / FAIL (cite specific reference if fail)
+- Non-obviousness: PASS / FAIL (cite combination if fail)
+
+**Under Article 22 CN Patent Law (CN)**:
+- 新颖性 (Novelty): 通过 / 未通过
+- 创造性 (Inventive Step): 通过 / 未通过
+
+**Under Article 54/56 EPC (EP)**:
+- Novelty: PASS / FAIL
+- Inventive step: PASS / FAIL (problem-solution approach)
+
+### Step 6: Output
+
+Write `patent/NOVELTY_ASSESSMENT.md`:
+
+```markdown
+## Patentability Assessment
+
+### Invention Summary
+[description]
+
+### Overall Assessment
+[PATENTABLE / PATENTABLE WITH AMENDMENTS / NOT PATENTABLE]
+
+### Anticipation Analysis
+[claim-by-claim matrix against each reference]
+
+### Obviousness Analysis
+[combination analysis with motivation to combine]
+
+### Cross-Model Examiner Review
+[summary of GPT-5.4 examiner feedback]
+
+### Recommended Claim Amendments
+[If claims need modification to overcome prior art, suggest specific amendments]
+
+### Risk Factors
+[What could cause rejection during actual prosecution?]
+```
+
+## Key Rules
+
+- Patent novelty is absolute: any public disclosure before the priority date counts as prior art, worldwide.
+- Research novelty ("has anyone published this?") is NOT the same as patent novelty ("does any single reference teach every claim element?").
+- Obviousness requires BOTH: (1) a combination of references AND (2) a motivation to combine them.
+- Never assume the invention is patentable just because no identical patent exists.
+- The assessment is advisory only -- actual prosecution may reveal different prior art.
+- If reviewer delegation is unavailable in the current Codex host, stop and ask the user to enable Codex agent support before continuing.

--- a/skills/skills-codex/patent-pipeline/SKILL.md
+++ b/skills/skills-codex/patent-pipeline/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: patent-pipeline
+description: "Full patent drafting pipeline from invention description to jurisdiction-formatted filing documents. Supports CN (CNIPA), US (USPTO), EP (EPO). Supports invention patents and utility models. Use when user says \"写专利\", \"patent pipeline\", \"专利申请\", \"draft patent\", \"写权利要求书\", or wants to draft a complete patent application."
+argument-hint: [invention-description — jurisdiction]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill
+---
+
+# Patent Pipeline: From Invention to Filing
+
+Draft a complete patent application based on: **$ARGUMENTS**
+
+## Overview
+
+This skill orchestrates the full patent drafting lifecycle -- from prior art search through jurisdiction-formatted filing documents. It chains sub-skills into a patent-specific pipeline:
+
+```
+/prior-art-search → /patent-novelty-check → /invention-structuring → /claims-drafting → /specification-writing → /patent-review → /jurisdiction-format
+     (search)           (verify)              (structure)             (claims)            (description)          (examiner)         (compile)
+                                                                                              ├── /figure-description
+                                                                                              └── /embodiment-description
+```
+
+**This is a parallel branch, not part of the linear research pipeline.** After `/idea-discovery` produces validated ideas, the user can either:
+- Go to `/experiment-bridge` → `/auto-review-loop` → `/paper-writing` (publish track)
+- Go to `/grant-proposal` (funding track)
+- Go to `/patent-pipeline` (patent track) **<-- this skill**
+
+```
+                    ┌→ /experiment-bridge → /auto-review-loop → /paper-writing  (publish track)
+/idea-discovery ────┤
+                    ├→ /grant-proposal → [get funded] → ...  (funding track)
+                    └→ /patent-pipeline → [file patent]       (patent track)
+```
+
+Patents are about **protecting inventions** (legal scope), not publishing results (academic contribution). This skill handles the unique requirements of patent drafting: prior art analysis, claims hierarchy design, specification writing with enablement support, embodiment descriptions, and jurisdiction-specific formatting.
+
+## Constants
+
+- **JURISDICTION = `CN`** — Target patent jurisdiction. Options: `CN` (CNIPA), `US` (USPTO), `EP` (EPO), `ALL` (generate all three). Override via argument (e.g., `/patent-pipeline "invention — US"`).
+- **PATENT_TYPE = `invention`** — `invention` (发明专利, 20 year protection) or `utility_model` (实用新型, CN only, 10 year protection, apparatus claims only). Override via argument.
+- **REVIEWER_MODEL = `gpt-5.4`** — Model used via Codex MCP for examiner-style review.
+- **MAX_REVIEW_ROUNDS = 2** — Maximum review-revision cycles.
+- **AUTO_PROCEED = false** — At each checkpoint, **always wait for explicit user confirmation**. Patent applications require inventor judgment at every stage. Set `true` only if user explicitly requests autonomous mode.
+- **LANGUAGE = `auto`** — Output language. Auto-detected from jurisdiction: CN->Chinese, US->English, EP->English. Override explicitly if needed.
+- **OUTPUT_DIR = `patent/`** — Directory for generated patent files.
+- **OUTPUT_FORMAT = `markdown`** — Draft format. `markdown` for review, `docx` for filing-ready.
+
+> Override defaults via arguments: `/patent-pipeline "invention — US, utility model"` or `/patent-pipeline "invention — ALL, language: Chinese"`.
+
+## Patent Type Specifications
+
+### Invention Patent (发明专利)
+
+| Field | Detail |
+|-------|--------|
+| **Protection** | 20 years from filing date |
+| **Subject matter** | Methods, systems, products, compositions, processes |
+| **Examination** | Substantive examination required |
+| **Inventive step** | High (must involve an inventive step / 创造性) |
+| **Timeline** | 2-4 years to grant (CN); 2-3 years (US); 3-5 years (EP) |
+| **Claims** | Method + system + product claims allowed |
+
+### Utility Model (实用新型) — CN Only
+
+| Field | Detail |
+|-------|--------|
+| **Protection** | 10 years from filing date |
+| **Subject matter** | Product shape, structure, or combination thereof only |
+| **Examination** | Formal examination only (no substantive examination) |
+| **Inventive step** | Lower than invention patent |
+| **Timeline** | 6-8 months to grant |
+| **Claims** | Apparatus/device claims only. NO method claims. |
+| **Restriction** | CN jurisdiction only |
+
+## State Persistence (Compact Recovery)
+
+Patent drafting is a long task that may trigger context compaction. Persist state to `patent/PATENT_STATE.json` after each phase:
+
+```json
+{
+  "phase": 3,
+  "jurisdiction": "CN",
+  "patent_type": "invention",
+  "language": "Chinese",
+  "codex_thread_id": "019cfcf4-...",
+  "invention_title": "...",
+  "claims_count": 15,
+  "status": "in_progress",
+  "timestamp": "2026-04-10T15:00:00"
+}
+```
+
+**Write this file at the end of every phase.** On invocation, check for this file:
+- If absent or `status: "completed"` -> fresh start
+- If `status: "in_progress"` and within 24h -> **resume** from saved phase (read output files to restore context)
+- If older than 24h -> fresh start (stale state)
+
+On completion, set `"status": "completed"`.
+
+## Workflow
+
+### Phase 0: Input Parsing & Context Gathering
+
+Parse `$ARGUMENTS` to extract:
+
+1. **Invention description** — may be structured (references INVENTION_BRIEF.md), conversational with figures, or output from IDEA_REPORT.md
+2. **Jurisdiction** — detect from keywords (e.g., "CN" or "中国" -> CN, "US" or "USPTO" -> US, "EP" or "EPO" -> EP, "ALL")
+3. **Patent type** — detect from keywords (e.g., "utility model" or "实用新型" -> utility_model, default -> invention)
+4. **Overrides** — language, output format, review rounds
+
+Then gather context from the project directory:
+
+1. Read `INVENTION_BRIEF.md` if it exists (user filled in the template)
+2. Read `IDEA_REPORT.md` if it exists (from `/idea-discovery` -- can extract invention from research results)
+3. Read `refine-logs/FINAL_PROPOSAL.md` if it exists
+4. Read `NARRATIVE_REPORT.md` if it exists (research results that may be patentable)
+5. Search for user-provided figures (PNG, JPG, SVG, PDF) in the project directory
+6. Check for `patent/PATENT_STATE.json` (resume from prior interrupted run)
+
+If insufficient context exists:
+- No invention description at all -> suggest user describe the invention or fill in `INVENTION_BRIEF.md`
+- Has IDEA_REPORT.md -> extract patentable aspects from the research
+- Has figures -> reference them in the invention brief
+- No figures -> note that figures will be needed and plan what drawings are required
+
+**If the input is conversational** (not a structured brief), parse the description into the invention brief structure and write `patent/INVENTION_BRIEF.md` for downstream phases.
+
+### Phase 1: Prior Art Search & Novelty Assessment
+
+#### 1.1 Prior Art Search
+
+Invoke `/prior-art-search`:
+
+```
+/prior-art-search "patent/INVENTION_BRIEF.md"
+```
+
+This searches patent databases (Google Patents, Espacenet) and academic literature for relevant prior art.
+
+#### 1.2 Novelty Check
+
+Invoke `/patent-novelty-check`:
+
+```
+/patent-novelty-check "patent/INVENTION_BRIEF.md"
+```
+
+This assesses novelty and non-obviousness against the prior art found in step 1.1.
+
+**🚦 Checkpoint:** Present the prior art landscape and novelty assessment:
+
+```
+Prior art search complete:
+- [X] patent references found
+- [Y] non-patent literature references found
+- Closest prior art: [reference] -- [why it's closest]
+- Novelty assessment: [PATENTABLE / PATENTABLE WITH AMENDMENTS / NOT PATENTABLE]
+- Key risk areas: [list]
+
+Ready to proceed with invention structuring?
+```
+
+**⛔ STOP HERE and wait for user response.** Do NOT auto-proceed unless AUTO_PROCEED=true.
+
+Options:
+- Reply **"go"** -> proceed to Phase 2
+- Reply with **adjustments** -> refine the invention scope and re-check novelty
+- Reply **"stop"** -> save progress to `patent/DRAFT_NOTES.md`
+
+**State**: Write `PATENT_STATE.json` with `phase: 1`.
+
+### Phase 2: Invention Structuring & Claims Design
+
+#### 2.1 Structure the Invention
+
+Invoke `/invention-structuring`:
+
+```
+/invention-structuring "patent/INVENTION_BRIEF.md"
+```
+
+This decomposes the invention into core inventive concept, supporting features, and optional features. Produces `patent/INVENTION_DISCLOSURE.md`.
+
+#### 2.2 Draft Claims
+
+Invoke `/claims-drafting`:
+
+```
+/claims-drafting "patent/INVENTION_DISCLOSURE.md"
+```
+
+This drafts the claims hierarchy -- the most critical part of the patent. Produces `patent/CLAIMS.md`.
+
+**🚦 Checkpoint:** Present the invention structure and claims:
+
+```
+Invention structured:
+- Core inventive concept: [summary]
+- Claim categories: [method, system, etc.]
+- Claims drafted: [X] independent + [Y] dependent = [Z] total
+- Independent claim 1 (broadest): [first 50 words of claim 1]
+- Examiner review score: [X]/10
+
+The claims define the legal scope of protection. Please review before proceeding to specification.
+```
+
+**⛔ STOP HERE and wait for user response.** Do NOT auto-proceed unless AUTO_PROCEED=true.
+
+Options:
+- Reply **"go"** -> proceed to Phase 3
+- Reply with **adjustments** (e.g., "broaden claim 1", "add more dependent claims") -> revise claims
+- Reply **"stop"** -> save progress
+
+**State**: Write `PATENT_STATE.json` with `phase: 2`.
+
+### Phase 3: Specification Writing
+
+Invoke `/specification-writing`:
+
+```
+/specification-writing "patent/CLAIMS.md"
+```
+
+This writes the full specification section by section. Internally invokes `/figure-description` (if user-provided figures exist) and `/embodiment-description` for the detailed description. The specification-writing skill handles figure processing and embodiment writing as sub-skills.
+
+**🚦 Checkpoint:** Present the specification overview:
+
+```
+Specification written:
+- Title: [title]
+- Sections: Technical Field, Background, Summary, Drawings Description, Detailed Description, Abstract
+- Embodiments: [X]
+- Reference numerals: [Y] components mapped
+- Abstract length: [Z] words (limit: [jurisdiction limit])
+- Claim support: [all elements covered / X elements missing]
+
+Ready to proceed to review?
+```
+
+**⛔ STOP HERE and wait for user response.**
+
+**State**: Write `PATENT_STATE.json` with `phase: 3`.
+
+### Phase 4: Patent Review
+
+Invoke `/patent-review`:
+
+```
+/patent-review "patent/"
+```
+
+This runs 2 rounds of examiner-style review via GPT-5.4 xhigh. The examiner evaluates clarity, written description, enablement, novelty, non-obviousness, and claim scope.
+
+**State**: Write `PATENT_STATE.json` with `phase: 4` and review score.
+
+### Phase 5: Jurisdiction Formatting & Output
+
+Invoke `/jurisdiction-format`:
+
+```
+/jurisdiction-format "patent/"
+```
+
+This compiles the application into the target jurisdiction format(s).
+
+#### Final Deliverables
+
+| Output | Location | Description |
+|--------|----------|-------------|
+| CN: 权利要求书 | `patent/output/CN/` | Claims in CNIPA format |
+| CN: 说明书 | `patent/output/CN/` | Description in CNIPA format |
+| CN: 说明书摘要 | `patent/output/CN/` | Abstract (CN) |
+| US: Claims | `patent/output/US/` | Claims in USPTO format |
+| US: Specification | `patent/output/US/` | Description in USPTO format |
+| US: Abstract | `patent/output/US/` | Abstract (US) |
+| EP: Claims | `patent/output/EP/` | Claims in EPO format |
+| EP: Description | `patent/output/EP/` | Description in EPO format |
+| EP: Abstract | `patent/output/EP/` | Abstract (EP) |
+
+#### Final Report
+
+```markdown
+## Patent Pipeline Complete
+
+### Application Summary
+- Title: [invention title]
+- Jurisdiction: [CN/US/EP/ALL]
+- Patent Type: [Invention / Utility Model]
+- Language: [Chinese/English]
+- Total Claims: [X] independent + [Y] dependent
+
+### Pipeline Scores
+| Phase | Score |
+|-------|-------|
+| Prior Art Search | [completeness assessment] |
+| Novelty Assessment | [PATENTABLE/PATENTABLE WITH AMENDMENTS/NOT PATENTABLE] |
+| Examiner Review Round 1 | [X]/10 |
+| Examiner Review Round 2 | [Y]/10 |
+| Final | [Z]/10 |
+
+### Output Files
+[Table of all generated files with paths]
+
+### Next Steps
+- [ ] Have a patent attorney review the application
+- [ ] Conduct professional prior art search (this tool's search is preliminary)
+- [ ] Prepare formal drawings (if user figures need professional rendering)
+- [ ] File with the patent office
+- [ ] For utility model (CN): formal examination typically takes 6-8 months
+- [ ] For invention patent: substantive examination may take 2-4 years
+```
+
+**State**: Write `PATENT_STATE.json` with `phase: 5, status: "completed"`.
+
+## Key Rules
+
+- Never fabricate prior art references, patent numbers, or citations.
+- Claims must be supported by the specification (written description requirement).
+- Each jurisdiction has strict format requirements -- do not mix formats.
+- Utility model (实用新型) applies ONLY to CN jurisdiction and ONLY covers apparatus/device claims.
+- AUTO_PROCEED defaults to false -- patent applications require human review at every phase. Sub-skills inherit this flag: when AUTO_PROCEED=false, sub-skills present results and wait at their own internal checkpoints too.
+- The patent pipeline produces drafts for attorney review, not final filing documents.
+- Large file handling: if a Write operation fails, retry with Bash `cat <<'EOF'` heredoc.
+- Never include experimental results or empirical evaluations in the specification.
+- Consistent terminology is mandatory -- same word for the same concept throughout.
+- If a downstream reviewer step is requested but reviewer delegation is unavailable in the current Codex host, stop and ask the user to enable Codex agent support before continuing.
+
+## Composing with Other Workflows
+
+The patent pipeline can start from multiple entry points:
+
+```
+User describes invention directly ──→ /patent-pipeline
+
+/idea-discovery produces IDEA_REPORT.md ──→ /patent-pipeline (extract patentable aspects)
+
+/research-refine produces FINAL_PROPOSAL.md ──→ /patent-pipeline (from refined research idea)
+
+/auto-review-loop produces strong results ──→ /patent-pipeline (patent the method)
+```
+
+## Acknowledgements
+
+Built on the ARIS (Auto-claude-code-research-in-sleep) skill architecture. Patent writing principles adapted from MPEP (US), CN Patent Examination Guidelines (CN), and EPO Guidelines for Examination (EP).

--- a/skills/skills-codex/patent-review/SKILL.md
+++ b/skills/skills-codex/patent-review/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: patent-review
+description: "Get an external patent examiner review of a patent application. Use when user says \"专利审查\", \"patent review\", \"审查意见\", \"examiner review\", or wants critical feedback on patent claims and specification."
+argument-hint: [patent-directory-or-scope]
+allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
+---
+
+# Patent Examiner Review via Codex MCP (xhigh reasoning)
+
+Get a multi-round patent examiner review of the patent application based on: **$ARGUMENTS**
+
+Adapted from `/research-review`. The reviewer persona is a patent examiner, not a paper reviewer.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — Model used via Codex MCP
+- `REVIEW_ROUNDS = 2` — Number of review rounds
+- `EXAMINER_PERSONA = "patent-examiner"` — GPT-5.4 persona
+
+## Prerequisites
+
+- Codex MCP Server configured:
+  ```bash
+  claude mcp add codex -s user -- codex mcp-server
+  ```
+
+## Inputs
+
+1. `patent/CLAIMS.md` — all drafted claims
+2. `patent/specification/` — all specification sections
+3. `patent/figures/numeral_index.md` — reference numeral mapping
+4. `patent/PRIOR_ART_REPORT.md` — known prior art
+5. `patent/INVENTION_DISCLOSURE.md` — invention structure
+
+## Workflow
+
+### Step 1: Gather Patent Context
+
+Before calling the external reviewer, compile a comprehensive briefing:
+1. Read all claims (independent + dependent)
+2. Read specification sections (at least summary and detailed description)
+3. Read prior art report for context
+4. Identify: core inventive concept, claim scope, known prior art, target jurisdiction
+
+### Step 2: Round 1 — Full Examiner Review
+
+Send to `REVIEWER_MODEL` via `spawn_agent` with xhigh reasoning:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are a senior patent examiner at the [USPTO/CNIPA/EPO].
+    Examine this patent application and issue a detailed office action.
+
+    CLAIMS:
+    [all claims]
+
+    SPECIFICATION SUMMARY:
+    [key sections: title, technical field, background, summary, abstract]
+
+    PRIOR ART KNOWN:
+    [prior art references]
+
+    PATENTABILITY STANDARDS TO APPLY:
+    [US: 35 USC 101/102/103/112 | CN: Articles 22, 26 | EP: Articles 54, 56, 83, 84]
+
+    Please issue an office action covering:
+
+    1. CLAIM CLARITY (112(b)/Art 84):
+       - Are all terms definite?
+       - Any indefinite functional language?
+       - Antecedent basis issues?
+
+    2. WRITTEN DESCRIPTION (112(a)/Art 83 first para):
+       - Does the spec support ALL claim scope?
+       - Any claim elements without spec support?
+
+    3. ENABLEMENT (112(a)/Art 83):
+       - Can a POSITA practice the invention?
+       - Any missing algorithm/structure for functional claims?
+
+    4. NOVELTY (102/Art 54):
+       - Would any known reference anticipate any claim?
+       - Identify the closest single reference.
+
+    5. NON-OBVIOUSNESS (103/Art 56):
+       - Would any combination render claims obvious?
+       - What is the motivation to combine?
+
+    6. CLAIM SCOPE:
+       - Are independent claims broad enough to be commercially valuable?
+       - Do dependent claims provide meaningful fallback positions?
+       - Any claims that are too broad (likely rejected) or too narrow (not valuable)?
+
+    7. SPECIFICATION QUALITY:
+       - Language issues (subjective terms, relative terms, result-to-be-achieved)
+       - Reference numeral consistency
+       - Missing embodiments
+
+    Format your response as a formal office action with:
+    - GROUNDS OF REJECTION for each issue (cite statute)
+    - SUGGESTED AMENDMENTS for each issue
+    - OVERALL PATENTABILITY SCORE: 1-10
+
+    Be rigorous and specific. This is a real examination.
+```
+
+### Step 3: Implement Fixes (Round 1)
+
+Based on the examiner's office action:
+
+1. **CRITICAL issues** (102 rejection, 112 indefiniteness, missing enablement):
+   - Must be fixed before proceeding
+   - Amend claims or add specification support
+
+2. **MAJOR issues** (103 obviousness, weak claim scope, missing support):
+   - Should be fixed or argued
+   - Consider claim amendments or specification additions
+
+3. **MINOR issues** (language quality, numeral consistency, formatting):
+   - Fix if time permits
+   - Document in output for later cleanup
+
+For each fix:
+- Show the specific change (old claim -> new claim)
+- Explain how the fix addresses the examiner's concern
+
+### Step 4: Round 2 — Follow-Up Review
+
+Use `send_input` with the saved reviewer id from Round 1:
+
+```text
+send_input:
+  target: [saved reviewer id from Round 1]
+  message: |
+    Here is the revised patent application after addressing your office action.
+
+    CHANGES MADE:
+    [list of all changes with rationale]
+
+    REVISED CLAIMS:
+    [updated claims]
+
+    REVISED SPECIFICATION EXCERPTS:
+    [changed sections]
+
+    Please re-examine:
+    1. Are the previous rejections overcome?
+    2. Are there new issues introduced by the amendments?
+    3. What is the updated patentability score?
+    4. Any remaining grounds for rejection?
+```
+
+### Step 5: Generate Improvement Report
+
+Write `patent/PATENT_REVIEW.md`:
+
+```markdown
+## Patent Review Report
+
+### Application Summary
+[Title, claims count, jurisdiction]
+
+### Review Round 1
+#### Office Action Summary
+[Key findings from examiner]
+
+#### Issues Found
+| # | Type | Severity | Claim/Section | Issue | Citation | Fix Applied |
+|---|------|----------|--------------|-------|----------|-------------|
+| 1 | Clarity | CRITICAL | Claim 3 | Indefinite term "rapid" | 112(b) | Defined in spec |
+| 2 | Novelty | MAJOR | Claim 1 | Ref X anticipates element C | 102 | Amended claim |
+
+#### Score After Round 1: [X]/10
+
+### Review Round 2
+#### Follow-Up Assessment
+[Are previous rejections overcome?]
+
+#### Remaining Issues
+[Any issues still outstanding]
+
+#### Score After Round 2: [X]/10
+
+### Recommendations
+[Final recommendations before proceeding to jurisdiction formatting]
+- [ ] All CRITICAL issues resolved
+- [ ] All MAJOR issues resolved or argued
+- [ ] Specification supports all claim amendments
+- [ ] Ready for jurisdiction formatting
+```
+
+## Key Rules
+
+- The reviewer persona must be a patent examiner, not a paper reviewer or academic.
+- Always use `model_reasoning_effort: "xhigh"` for maximum analysis depth.
+- Address CRITICAL and MAJOR issues before proceeding to the next phase.
+- Document all changes in the review report for traceability.
+- If the patentability score is below 5/10 after Round 2, recommend significant rework before filing.
+- The review is advisory -- actual prosecution may proceed differently.

--- a/skills/skills-codex/pixel-art/SKILL.md
+++ b/skills/skills-codex/pixel-art/SKILL.md
@@ -112,7 +112,7 @@ Row 7 (legs):         2+2 pixels — with gap in middle
 
 ### Step 2: Generate SVG
 - Write to a temp file or project directory
-- Open with `open <file.svg>` for preview
+- Open with a local preview command for visual inspection
 - Keep viewBox tight — measure actual content bounds
 
 ### Step 3: Iterate with User
@@ -126,6 +126,10 @@ Row 7 (legs):         2+2 pixels — with gap in middle
 - Clean up: remove unused defs, tighten viewBox
 - Suggest adding to README: `![Alt text](filename.svg)`
 
+## Capability Rule
+
+If the user expects local preview or interactive visual iteration and the current environment cannot open or preview the generated asset, stop and tell the user what needs to be configured. Do not silently downgrade into a write-only path unless the user explicitly asked for that mode.
+
 ## Common Pitfalls
 - **Arrow direction**: `orient="auto"` follows line direction. Line going right→left = arrowhead points left
 - **Bubble overlap**: keep 38-44px vertical spacing between rows
@@ -133,4 +137,3 @@ Row 7 (legs):         2+2 pixels — with gap in middle
 - **Character overlap with bubbles**: keep character x-zone and bubble x-zone separated by ≥10px
 - **viewBox too large**: match viewBox to actual content, add ~10px padding
 - **Tail stroke artifact**: always add a small `<rect>` at the bubble-tail junction to cover the stroke line
-

--- a/skills/skills-codex/prior-art-search/SKILL.md
+++ b/skills/skills-codex/prior-art-search/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: prior-art-search
+description: "Search patent databases and academic literature for prior art relevant to an invention. Use when user says \"现有技术检索\", \"prior art search\", \"专利检索\", \"check patents\", or wants to find relevant prior art."
+argument-hint: [invention-description-or-path]
+allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write, Agent
+---
+
+# Prior Art Search
+
+Search patents and literature for prior art relevant to: **$ARGUMENTS**
+
+Adapted from `/research-lit` for patent-specific searching.
+
+## Constants
+
+- `MAX_PATENT_RESULTS = 20` — Maximum patent documents to analyze in detail
+- `MAX_PAPER_RESULTS = 15` — Maximum academic papers to analyze in detail
+- `SEARCH_YEARS = 10` — How many years back to search
+- `PATENT_DATABASES = "google-patents, espacenet"` — Patent databases to search
+
+## Inputs
+
+Read the invention description from:
+1. `$ARGUMENTS` if it contains technical details
+2. `patent/INVENTION_BRIEF.md` if it exists
+3. `INVENTION_BRIEF.md` if it exists at project root
+
+## Shared References
+
+Load `../shared-references/prior-art-databases.md` for search strategy templates and IPC/CPC classification guidance.
+
+## Workflow
+
+### Step 1: Extract Search Concepts
+
+From the invention description, identify:
+1. **Core inventive concept**: The primary technical contribution (1-2 sentences)
+2. **Technical problem**: What problem it solves
+3. **Key technical features**: 4-6 specific technical elements that define the invention
+4. **IPC/CPC classes**: Predict relevant classification codes (e.g., G06N, G06F)
+
+### Step 2: Patent Search
+
+For EACH search concept, search via:
+
+**Google Patents** (via WebSearch):
+```
+WebSearch: "site:patents.google.com [keywords]"
+WebSearch: "[keywords] patent"
+```
+- Try primary keywords + technical problem keywords
+- Search in English regardless of target jurisdiction
+- For CN inventions, also search Chinese keywords via WebSearch
+
+**Espacenet** (via WebFetch):
+- WebFetch worldwide.espacenet.com/search results for key queries
+- Search by predicted IPC/CPC classes
+
+**Assignee/Inventor Search**:
+- If known companies/universities work in this area, search their patent portfolios
+- WebSearch: "[assignee name] patent [technical area]"
+
+For each potentially relevant patent found:
+- WebFetch the patent page to extract: title, abstract, representative claims, filing date, assignee, current status
+- Record IPC/CPC classification codes
+
+### Step 3: Academic Literature Search
+
+Search the same concepts in academic databases:
+
+1. **Google Scholar** (via WebSearch): `WebSearch "[keywords] site:scholar.google.com"`
+2. **arXiv** (via `/arxiv` if available, or WebSearch): Search for preprints
+3. **Semantic Scholar** (via `/semantic-scholar` if API key set, or WebSearch)
+
+For each relevant paper found:
+- Extract title, authors, venue, year, key contribution
+
+### Step 4: Classification and Analysis
+
+For each reference found, assess:
+
+1. **Relevance**: How closely does it relate to the invention?
+2. **Overlap Risk**: Does it disclose the same or similar technical solution?
+   - HIGH: Anticipates one or more claim elements
+   - MEDIUM: Discloses a related but different approach
+   - LOW: Same general field, different approach
+3. **Relationship**: Is it anticipating, relevant, or merely background?
+
+Organize results by IPC/CPC classification to see the technical landscape.
+
+### Step 5: Freedom-to-Operate Assessment (Preliminary)
+
+Based on the search results:
+- Identify patents with claims that potentially cover the invention
+- Note any expired patents (public domain)
+- Flag areas where claim scope overlap is significant
+
+**Disclaimer**: This is a preliminary assessment only. A professional freedom-to-operate analysis by a patent attorney is recommended before filing.
+
+### Step 6: Output
+
+Write `patent/PRIOR_ART_REPORT.md` with:
+
+```markdown
+## Prior Art Search Report
+
+### Invention Summary
+[1-2 sentence description of the searched invention]
+
+### Search Strategy
+- Keywords used: [...]
+- IPC/CPC classes searched: [...]
+- Databases searched: Google Patents, Espacenet, Google Scholar, arXiv
+- Date range: [year] to present
+
+### Patent References Found
+
+| # | Patent No. | Title | Date | Assignee | IPC/CPC | Key Teaching | Overlap Risk |
+|---|-----------|-------|------|----------|---------|-------------|-------------|
+| 1 | CN... / US... | [title] | [date] | [assignee] | [codes] | [2-3 sentences] | HIGH/MEDIUM/LOW |
+
+### Non-Patent Literature Found
+
+| # | Reference | Title | Authors/Venue | Year | Key Contribution | Relevance |
+|---|-----------|-------|--------------|------|-----------------|-----------|
+| 1 | [DOI/link] | [title] | [authors] | [year] | [1-2 sentences] | HIGH/MEDIUM/LOW |
+
+### Prior Art Landscape
+[Organized by technical approach or IPC class, not just chronological]
+
+### Freedom-to-Operate Preliminary Assessment
+[Which existing patents might block the invention? What is the risk level?]
+
+### Recommendations
+- Suggested claim scope adjustments based on prior art
+- Areas where novelty appears strongest
+- References to watch during prosecution
+```
+
+## Key Rules
+
+- Never fabricate patent numbers or citations. Mark uncertain references with `[VERIFY]`.
+- Search in English AND the target jurisdiction language (Chinese for CN).
+- Patent prior art includes everything published before the priority date, not just patents.
+- Academic papers are valid prior art for both novelty and inventive step.
+- Include expired patents -- they are public domain but still relevant for novelty.

--- a/skills/skills-codex/proof-checker/SKILL.md
+++ b/skills/skills-codex/proof-checker/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: proof-checker
+description: Rigorous mathematical proof verification and fixing workflow. Reads a LaTeX proof, identifies gaps via cross-model review (Codex GPT-5.4 xhigh), fixes each gap with full derivations, re-reviews, and generates an audit report. Use when user says "检查证明", "verify proof", "proof check", "审证明", "check this proof", or wants rigorous mathematical verification of a theory paper.
+argument-hint: [path-to-tex-file or proof-description]
+allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
+---
+
+# Proof Checker: Rigorous Mathematical Verification & Fixing
+
+Systematically verify a mathematical proof via cross-model adversarial review, fix identified gaps, re-review until convergence, and generate a detailed audit report with proof-obligation accounting.
+
+## Context: $ARGUMENTS
+
+## Constants
+
+- MAX_REVIEW_ROUNDS = 3
+- REVIEWER_MODEL = `gpt-5.4` via Codex reviewer agent, reasoning effort always `xhigh`
+- **REVIEWER_BACKEND = `codex`** — Default: Codex reviewer agent (`spawn_agent`, xhigh). Override with `— reviewer: oracle-pro` for GPT-5.4 Pro via Oracle MCP. See `shared-references/reviewer-routing.md`.
+- AUDIT_DOC: `PROOF_AUDIT.md` at the paper directory root, alongside `main.tex` (cumulative log; when invoked via `/paper-writing`, this is `paper/PROOF_AUDIT.md`)
+- REPORT_TEX: `proof_audit_report.tex` (formal before/after PDF)
+- STATE_FILE: `PROOF_CHECK_STATE.json` (for recovery)
+- SKELETON_DOC: `PROOF_SKELETON.md` (micro-claim inventory)
+
+### Acceptance Gate (objective, replaces subjective scoring)
+
+The proof passes when ALL of the following hold:
+1. Zero open FATAL or CRITICAL issues
+2. Every theorem/lemma has: (i) explicit hypotheses, (ii) proof with all interchanges justified, (iii) every application discharges hypotheses in the ledger
+3. All big-O/Θ/o statements have declared parameter dependence and uniformity scope
+4. Counterexample pass executed on all key lemmas (log candidates even if none found)
+
+## Issue Taxonomy (20 categories, 4 groups)
+
+### Group A: Logic & Proof Structure
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| **UNJUSTIFIED_ASSERTION** | Claim stated without proof or reference | "The Hessian splits into Gram blocks" |
+| **UNPROVEN_SUBCLAIM** | "Clearly" / "it follows" hides a nontrivial lemma | "By symmetry, the cross-terms vanish" without checking |
+| **QUANTIFIER_ERROR** | Wrong order ∀/∃, missing "for sufficiently small κ" | "For all π, there exists ε" vs "there exists ε for all π" |
+| **IMPLICATION_REVERSAL** | Uses (A⇒B) as (B⇒A), or claims equivalence with only one direction | |
+| **CASE_INCOMPLETE** | Misses boundary/degenerate cases | Singular covariance, zero weight, non-unique argmin |
+| **CIRCULAR_DEPENDENCY** | Lemma uses theorem that depends on it | |
+| **LOGICAL_GAP** | A step is not justified by what precedes it | B=Θ(1) → β_K=0 without analyzing W |
+
+### Group B: Analysis & Measure Theory
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| **ILLEGAL_INTERCHANGE** | Swaps limit/expectation/derivative/integral without DCT/MCT/Fubini | Differentiating under E without domination |
+| **NONUNIFORM_CONVERGENCE** | Pointwise convergence used as uniform | sup and limit swapped |
+| **MISSING_DOMINATION** | DCT cited but no dominating function given | |
+| **INTEGRABILITY_GAP** | Uses E|X|^p without proving/assuming finite moments | |
+| **REGULARITY_GAP** | Differentiability/Lipschitz/convexity used but not established | |
+| **STOCHASTIC_MODE_CONFUSION** | Mixes a.s./in prob./in L²/in expectation | |
+
+### Group C: Model & Parameter Tracking
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| **MISSING_DERIVATION** | A quantity is used but never derived from the model | Risk functional with undefined B, W |
+| **HIDDEN_ASSUMPTION** | Proof silently uses a condition not in the theorem | Gaussianity assumed but not stated |
+| **INSUFFICIENT_ASSUMPTION** | Hypotheses too weak for proof (counterexample exists) | Moment conditions admitting 2-point distributions |
+| **DIMENSION_TRACKING** | Parameter dependence (d, n, K, ...) not explicit | d enters only through κ |
+| **NORMALIZATION_MISMATCH** | Coordinate/scaling conventions inconsistent | Rescaled vs raw coordinates |
+| **CONSTANT_DEPENDENCE_HIDDEN** | "C" depends on d,n,K but treated as universal | |
+
+### Group D: Scope & Claims
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| **SCOPE_OVERCLAIM** | Conclusion stated more broadly than proof supports | "β_K=0" with only generic overlap |
+| **REFERENCE_MISMATCH** | Cited theorem's hypotheses not verified at point of use | |
+
+## Two-Axis Severity System
+
+### Axis A — Proof Status (what is wrong)
+
+| Status | Meaning |
+|--------|---------|
+| **INVALID** | Statement false as written (counterexample exists or contradiction) |
+| **UNJUSTIFIED** | Could be true, but current proof does not establish it |
+| **UNDERSTATED** | True only after strengthening assumptions |
+| **OVERSTATED** | True only after weakening conclusion / adding qualifiers |
+| **UNCLEAR** | Ambiguous notation / definition drift (not wrong per se) |
+
+### Axis B — Impact (how much breaks)
+
+| Impact | Meaning |
+|--------|---------|
+| **GLOBAL** | Breaks main theorem or core dependency chain |
+| **LOCAL** | Affects a side result but not the main theorem |
+| **COSMETIC** | Exposition only |
+
+### Severity Labels (derived)
+
+| Label | Definition |
+|-------|------------|
+| **FATAL** | INVALID + GLOBAL |
+| **CRITICAL** | (INVALID + LOCAL) or (UNJUSTIFIED + GLOBAL) |
+| **MAJOR** | (UNJUSTIFIED + LOCAL) or (UNDERSTATED/OVERSTATED + GLOBAL) |
+| **MINOR** | Clarity / notation / dimension bookkeeping that doesn't change claims |
+
+## Side-Condition Checklists for Common Theorems
+
+When the proof invokes any of the following, require explicit verification of ALL listed conditions:
+
+| Theorem | Required Conditions |
+|---------|-------------------|
+| **DCT** (Dominated Convergence) | Pointwise a.e. convergence + integrable dominating function |
+| **MCT** (Monotone Convergence) | Monotone increasing + non-negative |
+| **Fubini/Tonelli** | Product measurability + integrability (Fubini) or non-negative (Tonelli) |
+| **Leibniz integral rule** | Continuity of integrand + dominating function for derivative |
+| **Implicit Function Theorem** | Continuous differentiability + non-singular Jacobian |
+| **Taylor with remainder** | Sufficient differentiability + remainder form (Lagrange/integral) |
+| **Jensen's inequality** | Convexity of function + integrability |
+| **Cauchy-Schwarz** | Correct inner product space + integrability of both factors |
+| **Weyl/Davis-Kahan** | Symmetry/Hermiticity + perturbation bound conditions |
+| **Analytic continuation** | Domain connectivity + identity theorem conditions |
+| **WLOG reduction** | Invariance under claimed symmetry + reduction is reversible |
+
+## Workflow
+
+### Phase 0: Preparation
+
+1. **Locate the proof**: Find the main `.tex` file(s).
+2. **Read the entire proof**: Extract list of all theorems/lemmas/propositions/corollaries/definitions/assumptions.
+3. **Read reference materials**: Reference papers, prior results.
+4. **Build a section map**: Structured list with line numbers and key claims.
+5. **Identify the main theorem**: Central result, assumptions, claims.
+
+### Phase 0.5: Proof-Obligation Ledger
+
+Build formal accounting artifacts. Save to `PROOF_SKELETON.md`:
+
+#### 1. Dependency DAG
+Nodes = Definitions / Assumptions / Lemmas / Theorems. Edges = "uses". **Detect cycles** (including semantic circularity where Lemma A uses a corollary that quietly depends on A).
+
+#### 2. Assumption Ledger
+For each theorem/lemma, list every hypothesis with WHERE each is verified (or mark "UNVERIFIED"). Track **usage-minimal assumption sets** — which assumptions were actually used vs merely stated.
+
+#### 3. Typed Symbol Table
+Each symbol must have a **type signature**:
+```
+κ : scalar ∈ (0,1), depends on (d, α_t, Σ, μ)
+u* : vector ∈ ℝ^d, u* = C^{-1}m
+B^even : matrix ∈ ℝ^{(L+1)×(L+1)}, symmetric PSD
+Ψ_v : function ℝ → ℝ, analytic in (ζ,κ), parity determined by v
+```
+Flag any symbol whose meaning changes or whose type is inconsistent across uses.
+
+#### 4. Canonical Quantified Statements
+For each theorem/lemma, rewrite the statement with **explicit quantifiers, domains, and limit order**:
+```
+∀K ≥ 3, ∀π ∈ Π_K^{ms,∘} \ E_K, ∃κ_0 > 0 such that ∀κ ∈ (0, κ_0):
+  h_act^{(K,π)} = Θ(κ^{α_K^act})  [uniform in π on compact subsets]
+```
+If you cannot restate a theorem this precisely, mark it **UNCLEAR — needs disambiguation**.
+
+#### 5. Micro-Claim Inventory
+Every nontrivial step becomes a numbered micro-claim in **sequent form**:
+```
+MC-17: Context: [Lemma 3.1, κ < κ_0, Z_κ has bounded moments up to order 2m+2]
+       ⊢ Goal: P̂_0 is positive definite
+       Rule: monomials linearly independent on support of continuous distribution
+       Side-conditions: positive density near origin ✓ (by GMM weak convergence)
+```
+Each micro-claim has: justification rule name + required conditions + where conditions are proven.
+
+#### 6. Limit-Order Map
+Track every asymptotic statement's **limit order and uniformity scope**:
+```
+h_act = Θ(κ^α)  [as κ→0, uniform in π on compact subsets of Π_K, for fixed K]
+τ_act ~ (b/a)n   [as n→∞, for fixed κ,K,π with x_K ≪ 1]
+```
+Flag any statement where limit order is ambiguous or uniformity is unclear.
+
+### Phase 1: First Review (Codex GPT-5.4 xhigh)
+
+Submit the **complete proof content** with the following **mandatory reviewer checklist** in the prompt:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are performing a rigorous mathematical proof review. For EVERY theorem,
+    lemma, and proposition, check ALL of the following:
+
+    ## MANDATORY CHECKS
+
+    A. DEFINITIONS: List any symbol whose meaning is ambiguous or changes.
+    B. HYPOTHESIS DISCHARGE: For each lemma/theorem APPLICATION (not statement),
+       list each hypothesis and whether it was verified, with location.
+    C. INEQUALITY AUDIT: For each inequality chain, verify direction, missing
+       absolute values, missing conditions (convexity, PSD, integrability).
+    D. INTERCHANGE AUDIT: Flag every limit/derivative/expectation/integral
+       interchange. State which theorem justifies it (DCT/MCT/Fubini/Leibniz)
+       and which conditions are verified/missing.
+    E. PROBABILITY MODE: Track whether claims are a.s./in prob./in expectation/
+       w.h.p. Ensure transitions are justified.
+    F. UNIFORMITY & CONSTANTS: For every O(·), o(·), Θ(·), ≲, state whether
+       it is uniform over all parameters. List hidden parameter dependence.
+    G. EDGE/DEGENERATE CASES: Attempt to break each key lemma with a 1D,
+       low-rank, or extreme-parameter construction.
+    H. DEPENDENCY CONSISTENCY: Detect cycles or forward references to unproven
+       results.
+
+    ## OUTPUT FORMAT (per issue)
+    For each issue found, provide:
+    - id: sequential number
+    - status: INVALID / UNJUSTIFIED / UNDERSTATED / OVERSTATED / UNCLEAR
+    - impact: GLOBAL / LOCAL / COSMETIC
+    - category: [from taxonomy]
+    - location: section/equation/line
+    - statement: what the proof claims
+    - why_invalid: why this is wrong or unjustified
+    - counterexample: YES (describe) / NO / CANDIDATE (describe attempt)
+    - affects: which downstream results break if this is wrong
+    - minimal_fix: how to fix it
+
+    [FULL PROOF CONTENT HERE]
+```
+
+**Save the threadId.** Parse into structured issue list. Write to `PROOF_AUDIT.md`.
+
+### Phase 1.5: Counterexample Red Team
+
+For each CRITICAL or MAJOR issue, and for every key lemma that introduces:
+- a new inequality bound
+- an identifiability/uniqueness claim
+- a curvature/PSD/strong convexity assertion
+- a uniform-in-parameter claim
+- a convergence mode upgrade (pointwise → uniform, in prob → w.h.p.)
+
+Systematically attempt to construct counterexamples using:
+
+| Strategy | Description |
+|----------|-------------|
+| **Dimensional collapse** | Set d=1 or 2, K=2, n small |
+| **Degeneracy** | Singular covariance, tiny weight, overlapping means, identical components |
+| **Extremal distributions** | Two-point ±a, bounded non-subGaussian, heavy tails |
+| **Adversarial parameter scaling** | Pick parameters making neglected terms dominate |
+| **Numeric falsification** | Translate lemma to a function, brute-force optimize over small domain |
+
+**Rule**: Label "counterexample found" ONLY if algebraically verified. Otherwise log as "candidate counterexample — needs verification."
+
+Record all attempts (successful or not) in `PROOF_AUDIT.md`.
+
+### Phase 2: Fix Implementation
+
+For each issue, ordered by severity (FATAL → CRITICAL → MAJOR → MINOR):
+
+#### Step 2a: Choose fix strategy
+For each issue, explicitly choose one of:
+- **ADD_DERIVATION**: Write missing proof steps
+- **STRENGTHEN_ASSUMPTION**: Add conditions to theorem statement
+- **WEAKEN_CLAIM**: Reduce conclusion scope
+- **ADD_REFERENCE**: Cite known result + verify its conditions apply
+
+Log this choice — it is a scope-changing decision when it alters theorem statements.
+
+#### Step 2b: Derive the fix mathematically
+- Complete mathematical derivation, not just a claim
+- If new proposition/lemma needed, write in full theorem-proof style
+
+#### Step 2c: Implement in LaTeX
+- Edit the `.tex` file
+- Preserve existing `\label` references where possible
+
+#### Step 2d: Record the fix
+```markdown
+### Fix N: [SHORT TITLE]
+**Issue**: [id] [CATEGORY] — [description]
+**Severity**: FATAL / CRITICAL / MAJOR / MINOR
+**Status**: INVALID / UNJUSTIFIED / UNDERSTATED / OVERSTATED
+**Impact**: GLOBAL / LOCAL / COSMETIC
+**Fix strategy**: ADD_DERIVATION / STRENGTHEN_ASSUMPTION / WEAKEN_CLAIM / ADD_REFERENCE
+**Location**: Section X, Lines Y-Z
+
+**BEFORE**: [what the proof originally did]
+**WHY WRONG**: [mathematical problem, with counterexample if applicable]
+**AFTER**: [what the fix does]
+**KEY EQUATION**: [central new equation]
+**PROOF OBLIGATIONS ADDED**: [new conditions/lemmas introduced]
+**DOWNSTREAM EFFECTS**: [which results now need re-checking]
+```
+
+#### Step 2e: Compile check
+```bash
+pdflatex -interaction=nonstopmode <file>.tex 2>&1 | grep -E "Error|Warning|undefined"
+```
+
+### Phase 3: Re-Review (Codex GPT-5.4 xhigh)
+
+Launch a fresh reviewer agent for the next review round. Do not use `send_input` here; proof-checker keeps each round independent. Request the same mandatory checklist.
+
+Check acceptance gate. If not met, repeat Phases 2-3 (up to MAX_REVIEW_ROUNDS).
+
+### Phase 3.5: Global Closure & Independent Verification
+
+#### Global closure checks
+After all fixes, verify the proof as a whole:
+- **Statement–conclusion match**: Does the proof end with EXACTLY what the theorem claims (quantifiers, constants, uniformity)?
+- **All obligations discharged**: Every node in the obligation DAG is proven or explicitly assumed (and the theorem statement includes it).
+- **Case analysis coverage**: Cases partition the domain AND include boundary/degenerate cases.
+- **Induction correctness** (if applicable): Base case, inductive step, correct use of IH, induction measure strictly decreases.
+- **WLOG reductions**: Each "without loss of generality" spawns a micro-claim proving the reduction is lossless.
+- **No silent assumption strengthening**: Any fix that strengthened assumptions has propagated to the main theorem statement.
+
+#### Independent second review for FATAL/CRITICAL fixes
+For any fix that resolved a FATAL or CRITICAL issue, submit the **fixed section alone** (without showing the previous critique) to a **fresh Codex thread**:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    Blind review of the following proof section. You have NOT seen any prior
+    review or discussion. Check every step for correctness, hidden assumptions,
+    illegal interchanges, and counterexamples.
+    [FIXED SECTION ONLY]
+```
+
+If the blind reviewer finds new issues, re-enter Phase 2.
+
+#### Regression proof-audit
+After fixes, re-run:
+- DAG acyclicity check (no new cycles introduced)
+- Counterexample suite on all DOWNSTREAM lemmas of modified results
+- Assumption-delta report: what became stronger/weaker due to fixes?
+
+### Phase 3.9: Unrecoverable Proof Protocol
+
+If acceptance gate is not met after MAX_REVIEW_ROUNDS, output a **Proof Unrecoverable Report**:
+1. Minimal set of blocking FATAL/CRITICAL issues that could not be resolved
+2. Salvage options ranked: (a) weaken claim, (b) strengthen assumptions, (c) add missing lemmas, (d) restructure argument
+3. Which parts of the proof are likely still reusable
+4. Recommended next steps for the author
+
+Do NOT silently declare success. The report must be honest.
+
+### Phase 4: Audit Report Generation
+
+Generate `proof_audit_report.tex` with:
+
+1. **Overview table**: All issues with two-axis severity, category, fix strategy, status
+2. **Before/After logic chain**: Red (BEFORE) → Green (AFTER) comparison
+3. **For each fix**: original proof → why wrong → counterexample (if any) → complete derivation → remaining subtleties
+4. **Proof-obligation diff**: What was unverified before, what is verified now
+5. **Summary**: Now proven / still assumed / open problems
+6. **Colored boxes**: BEFORE (red), AFTER (green), WHY WRONG (orange), KEY INSIGHT (blue), WARNING (yellow)
+
+Compile: `pdflatex proof_audit_report.tex && pdflatex proof_audit_report.tex`
+
+### Phase 5: State Persistence
+
+Write `PROOF_CHECK_STATE.json`:
+```json
+{
+  "status": "completed",
+  "rounds": 2,
+  "threadId": "...",
+  "fatal_fixed": 0,
+  "critical_fixed": 3,
+  "major_fixed": 2,
+  "minor_fixed": 1,
+  "counterexamples_found": 1,
+  "counterexample_candidates": 2,
+  "acceptance_gate": "PASS",
+  "timestamp": "..."
+}
+```
+
+## Key Rules
+
+### Mathematical rigor
+- **Never accept a proof step on faith**. "Clearly" / "it follows" / "by standard arguments" are red flags — each must spawn a micro-claim.
+- **Hypothesis discharge**: Every time a lemma is APPLIED, verify EACH of its hypotheses at that point. Use the side-condition checklists above.
+- **Interchange discipline**: Every swap of limit/expectation/derivative/integral must cite a theorem (DCT/MCT/Fubini/Leibniz) and verify its conditions with explicit dominating function or integrability proof.
+- **Uniformity discipline**: Every O(·)/Θ(·) must declare what parameters it is uniform over. "O(1)" that secretly depends on d,n,K is a CONSTANT_DEPENDENCE_HIDDEN issue.
+- **Quantifier discipline**: Check ∀/∃ order. "For sufficiently small κ" must specify: does κ₀ depend on K? On π? On d?
+- **Counterexample-first**: Before trying to fix a gap, first try to break it.
+- **WLOG prohibition**: Every "without loss of generality" must have an explicit micro-claim proving the reduction. No free WLOGs.
+- **No silent assumption strengthening**: Any fix that adds conditions must propagate to the theorem statement.
+
+### Cross-model protocol
+- **Claude analyzes, Codex reviews**: Claude reads proof, formulates questions, implements fixes. Codex provides adversarial review.
+- **Codex reasoning always xhigh**: Never downgrade.
+- **Send full content**: Don't summarize — send actual math for line-by-line checking.
+- **Preserve threadId**: Use `codex-reply` for follow-up rounds.
+
+### Fix quality
+- **Minimal fixes**: Fix exactly what's broken, nothing more.
+- **Full derivation**: Every fix includes complete mathematical argument.
+- **Explicit scope decisions**: Each fix is tagged ADD_DERIVATION / STRENGTHEN_ASSUMPTION / WEAKEN_CLAIM / ADD_REFERENCE.
+- **Compile after each fix**: LaTeX must compile cleanly.
+
+### Scope honesty
+- **Don't overclaim**: If a fix makes a result conditional, say so.
+- **Separate "proven" from "assumed"**: The audit report has an explicit section for this.
+- **Log open problems**: Issues requiring future work are listed, not hidden.
+
+## Output Files
+
+| File | Content | When |
+|------|---------|------|
+| `PROOF_SKELETON.md` | Dependency DAG + assumption ledger + micro-claims | Phase 0.5 |
+| `PROOF_AUDIT.md` | Cumulative round-by-round audit log | Updated each round |
+| `PROOF_AUDIT.json` | Machine-readable submission verdict (see below) | Always emitted |
+| `proof_audit_report.tex/.pdf` | Formal before/after report | Phase 4 |
+| `PROOF_CHECK_STATE.json` | State for recovery | Phase 5 |
+
+## Submission Artifact Emission
+
+This skill **always** writes `PROOF_AUDIT.json` at the paper directory
+root (i.e. `paper/PROOF_AUDIT.json` when invoked from `/paper-writing`
+with paper-dir `paper/`; `<your-paper-dir>/PROOF_AUDIT.json` when invoked
+standalone), regardless of caller or whether the paper contains theorems.
+A paper with no `\begin{theorem}` / `\begin{lemma}` / `\begin{proof}` emits
+verdict `NOT_APPLICABLE`; silent skip is forbidden. `paper-writing`
+Phase 6 and `tools/verify_paper_audits.sh` both rely on this artifact
+existing at `<paper-dir>/PROOF_AUDIT.json`.
+
+The artifact conforms to the schema in `shared-references/assurance-contract.md`:
+
+```json
+{
+  "audit_skill":      "proof-checker",
+  "verdict":          "PASS | WARN | FAIL | NOT_APPLICABLE | BLOCKED | ERROR",
+  "reason_code":      "all_proofs_complete | minor_gaps | critical_gap | no_theorems | ...",
+  "summary":          "One-line human-readable verdict summary.",
+  "audited_input_hashes": {
+    "main.tex":                 "sha256:...",
+    "sections/4.theory.tex":    "sha256:..."
+  },
+  "trace_path":       ".aris/traces/proof-checker/<date>_run<NN>/",
+  "thread_id":        "<codex mcp thread id>",
+  "reviewer_model":   "gpt-5.4",
+  "reviewer_reasoning": "xhigh",
+  "generated_at":     "<UTC ISO-8601>",
+  "details": {
+    "theorems_audited": <int>,
+    "issues": [ { "id": "T1-H3", "severity": "FATAL|CRITICAL|MAJOR|MINOR",
+                  "category": "quantifier|domination|...",
+                  "location": "sections/4.theory.tex:L182",
+                  "note": "..." }, ... ]
+  }
+}
+```
+
+### `audited_input_hashes` scope
+
+Hash the **declared input set** actually reviewed — the theorem-bearing
+`.tex` files passed into this invocation — not a repo-wide union and not
+the reviewer's self-reported opened subset. The external verifier rehashes
+these entries; any mismatch flags `STALE`.
+
+**Path convention** (must match `tools/verify_paper_audits.sh`): keys are
+**paths relative to the paper directory** (no `paper/` prefix — the
+verifier resolves relative to the paper dir; prefixing produces
+`paper/paper/...` and false-fails as STALE). Use **absolute paths** for
+files outside the paper dir.
+
+### Verdict decision table
+
+| Input state                                           | Verdict          | `reason_code` example |
+|-------------------------------------------------------|------------------|-----------------------|
+| No theorems / lemmas / proofs in paper                | `NOT_APPLICABLE` | `no_theorems`         |
+| Theorems present but referenced files unreadable      | `BLOCKED`        | `source_unreadable`   |
+| All proof obligations discharged, no gaps             | `PASS`           | `all_proofs_complete` |
+| Only MINOR issues (notation / exposition)             | `WARN`           | `minor_gaps`          |
+| Any FATAL or CRITICAL issue (logic gap, wrong claim)  | `FAIL`           | `critical_gap`        |
+| Reviewer invocation failed (network / malformed)      | `ERROR`          | `reviewer_error`      |
+
+MAJOR issues alone map to `WARN` or `FAIL` at the reviewer's discretion and
+must carry an explicit justification in `summary` + `details.issues`.
+
+### Thread independence
+
+Every invocation uses a fresh reviewer agent. Never use `send_input` across
+proof-checker runs. Do not accept prior audit outputs
+(PAPER_CLAIM_AUDIT, CITATION_AUDIT, EXPERIMENT_LOG) as input — the fresh
+thread preserves reviewer independence per
+`shared-references/reviewer-independence.md`.
+
+This skill never blocks by itself; `paper-writing` Phase 6 plus the
+verifier decide whether the verdict blocks finalization based on the
+`assurance` level.
+
+## Example Invocations
+
+```
+/proof-checker "neurips_2025.tex"
+/proof-checker "check the GMM generalization proof, focus on dimension dependence"
+/proof-checker "verify proof in paper.tex — difficulty: nightmare"
+```

--- a/skills/skills-codex/qzcli/SKILL.md
+++ b/skills/skills-codex/qzcli/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: qzcli
+description: Manage GPU compute jobs on the Qizhi (启智) platform using qzcli — a kubectl-style CLI tool. Use when user says "qzcli", "启智平台", "submit job", "stop job", "查计算组", "avail", "list jobs", "batch submit", or needs to manage distributed training jobs on a Qizhi instance.
+argument-hint: [login|avail|list|create|stop <job-id>|batch|status|watch]
+allowed-tools: Bash(*), Read, Write
+---
+
+# qzcli — 启智平台任务管理
+
+A kubectl/docker-style CLI for managing GPU compute jobs on the Qizhi (启智) platform.
+
+**GitHub:** [tianyilt/qzcli_tool](https://github.com/tianyilt/qzcli_tool)
+
+## Installation
+
+```bash
+pip install rich requests prompt_toolkit mcp
+git clone https://github.com/tianyilt/qzcli_tool
+cd qzcli_tool && pip install -e .
+```
+
+### MCP Integration (optional)
+
+To use qzcli as an MCP tool directly from Claude Code or Codex:
+
+```bash
+# Claude Code
+claude mcp add qzcli -- qzcli-mcp
+
+# Codex
+codex mcp add qzcli -- qzcli-mcp
+```
+
+---
+
+## Configuration
+
+Credentials are read in this priority order:
+`CLI args > --password-stdin > env vars > QZCLI_ENV_FILE (.env) > ~/.qzcli/config.json > interactive input`
+
+```bash
+# Option A: env file (recommended)
+mkdir -p ~/.qzcli
+cat > ~/.qzcli/.env <<'EOF'
+QZCLI_USERNAME="your_username"
+QZCLI_PASSWORD="your_password"
+EOF
+
+# Option B: environment variables
+export QZCLI_USERNAME="your_username"
+export QZCLI_PASSWORD="your_password"
+export QZCLI_API_URL="https://qz.yourorg.edu.cn"
+```
+
+Config files are stored in `~/.qzcli/`: `config.json`, `.cookie`, `resources.json`, `jobs.json`.
+
+---
+
+## Quick Start
+
+```bash
+# 1. Login
+qzcli login
+
+# 2. Discover and cache workspaces/compute groups (run once, re-run after joining new workspaces)
+qzcli res -u
+
+# 3. Check available nodes
+qzcli avail
+
+# 4. List running jobs
+qzcli ls -c -r
+```
+
+---
+
+## Authentication
+
+```bash
+# Interactive login
+qzcli login
+
+# With credentials
+qzcli login -u YOUR_USERNAME -p 'YOUR_PASSWORD'
+
+# Read password from stdin (for scripts)
+echo 'YOUR_PASSWORD' | qzcli login -u YOUR_USERNAME --password-stdin
+
+# Check current cookie
+qzcli cookie --show
+
+# Clear cookie
+qzcli cookie --clear
+```
+
+**Note:** `qzcli avail` auto-refreshes the cookie if it expires and credentials are configured.
+
+---
+
+## Resource Discovery
+
+```bash
+# List cached workspaces
+qzcli res --list
+
+# Refresh all workspace resource cache (run this first!)
+qzcli res -u
+
+# Refresh a specific workspace
+qzcli res -w MY_WORKSPACE -u
+
+# Set a human-readable alias for a workspace
+qzcli res -w ws-xxxxxxxx --name "My Workspace"
+```
+
+---
+
+## Check Available Nodes
+
+```bash
+# All workspaces
+qzcli avail
+
+# Including low-priority task nodes (slower but more accurate)
+qzcli avail --lp
+
+# Specific workspace
+qzcli avail -w MY_WORKSPACE
+
+# Find compute groups with N free nodes
+qzcli avail -n 4
+
+# Export IDs for scripting
+qzcli avail -n 4 -e
+
+# Show idle node names
+qzcli avail -w MY_WORKSPACE -v
+```
+
+---
+
+## Job Submission
+
+### Interactive (recommended for first-time use)
+
+```bash
+# Full interactive selection: workspace → project → compute group → spec
+qzcli create -i
+
+# Interactive for a specific workspace only
+qzcli create -i -w "My Workspace"
+```
+
+The TUI shows GPU type, availability, and spec status at each level. Press `Enter/→` to go deeper, `←` to go back.
+
+### Non-interactive
+
+```bash
+# Using names (resolved from qzcli res cache)
+qzcli create \
+  --name "my-training-job" \
+  --command "bash /path/to/train.sh" \
+  --workspace "My Workspace" \
+  --compute-group "My Compute Group" \
+  --image YOUR_REGISTRY/team/image:tag \
+  --instances 4 \
+  --priority 10
+
+# Using IDs directly
+qzcli create \
+  --name "my-job" \
+  --command "bash /path/to/train.sh" \
+  --workspace ws-YOUR_WORKSPACE_ID \
+  --compute-group lcg-YOUR_LCG_ID \
+  --spec YOUR_SPEC_ID \
+  --image YOUR_REGISTRY/team/image:tag \
+  --instances 4
+```
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--name` / `-n` | required | Job name |
+| `--command` / `-c` | required | Command to run |
+| `--workspace` / `-w` | | Workspace name or ID (`ws-...`) |
+| `--compute-group` / `-g` | auto | Compute group name or ID (`lcg-...`) |
+| `--spec` / `-s` | auto | Resource spec ID |
+| `--image` / `-m` | | Docker image |
+| `--instances` | 1 | Number of instances |
+| `--shm` | 1200 | Shared memory (GiB) |
+| `--priority` | 10 | Priority (1–10) |
+| `--dry-run` | | Preview only, don't submit |
+| `--json` | | JSON output for scripting |
+
+```bash
+# Preview before submitting
+qzcli create --name test --command "echo hi" --workspace "My Workspace" \
+  --image YOUR_IMAGE --dry-run
+```
+
+### Env-var passthrough (for existing submission scripts)
+
+```bash
+# Pass vars directly — do NOT use "export VAR; bash script.sh"
+WORKSPACE_ID="ws-YOUR_WORKSPACE_ID" \
+LCG_ID="lcg-YOUR_LCG_ID" \
+SPEC_ID="YOUR_SPEC_ID" \
+CHECKPOINT_DIR="/path/to/checkpoint" \
+bash YOUR_SUBMIT_SCRIPT.sh
+```
+
+### HPC / CPU jobs (Slurm)
+
+```bash
+qzcli hpc \
+  --name "my-cpu-job" \
+  --workspace ws-YOUR_WORKSPACE_ID \
+  --compute-group lcg-YOUR_LCG_ID \
+  --predef-quota-id YOUR_QUOTA_ID \
+  --cpu 55 --mem-gi 300 --instances 30 \
+  --image YOUR_REGISTRY/team/cpu-image:tag \
+  --entrypoint "cd /path/to/dir && bash run.sh"
+```
+
+---
+
+## Batch Submission
+
+```bash
+# Submit from config file
+qzcli batch batch_config.json --delay 3
+
+# Preview all jobs
+qzcli batch batch_config.json --dry-run
+
+# Continue on error
+qzcli batch batch_config.json --continue-on-error
+```
+
+**Config format** (`batch_config.json`):
+
+```json
+{
+  "defaults": {
+    "workspace": "ws-YOUR_WORKSPACE_ID",
+    "compute_group": "lcg-YOUR_LCG_ID",
+    "spec": "YOUR_SPEC_ID",
+    "image": "YOUR_REGISTRY/team/image:tag",
+    "instances": 4,
+    "priority": 10
+  },
+  "matrix": {
+    "checkpoint": ["/path/to/ckpt1", "/path/to/ckpt2"],
+    "step": [50000, 100000]
+  },
+  "name_template": "eval-{checkpoint_basename}-step{step}",
+  "command_template": "bash eval.sh --checkpoint {checkpoint} --step {step}"
+}
+```
+
+Matrix keys are Cartesian-producted (2×2 = 4 jobs above). Use `{key_basename}` for path basenames.
+
+### Shell loop (alternative)
+
+```bash
+for step in 040000 050000 060000; do
+  qzcli create \
+    --name "eval-step${step}" \
+    --command "bash eval.sh --step $step" \
+    --workspace "My Workspace" \
+    --compute-group "My Compute Group" \
+    --instances 4
+  sleep 3
+done
+```
+
+---
+
+## Job Management
+
+```bash
+# List jobs
+qzcli ls -c -w MY_WORKSPACE          # specific workspace
+qzcli ls -c --all-ws                 # all workspaces
+qzcli ls -c -w MY_WORKSPACE -r       # running only
+qzcli ls -c -w MY_WORKSPACE -n 50    # show 50
+
+# Stop a job
+qzcli stop JOB_ID
+
+# Job status / details
+qzcli status JOB_ID
+
+# Watch all running jobs (refresh every 10s)
+qzcli watch -i 10
+
+# Workspace view with GPU utilization
+qzcli ws
+qzcli ws -a           # all projects
+qzcli ws -p "My Project"
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Cookie expired | Session gap | Re-run `qzcli login` |
+| `未找到名称为 'xxx' 的工作空间` | Stale cache | Run `qzcli res -u` |
+| No resources in `create -i` | Cache empty | Run `qzcli login && qzcli res -u` |
+| `qzcli-mcp` not found | Not installed | `cd qzcli_tool && pip install -e .` |
+| Spec not in workspace | ID mismatch | Match spec ID to the correct workspace |
+| Silent job failure | Script `sys.exit(0)` | Check job logs directly |
+| zsh glob errors | Remote shell is zsh | Wrap commands in `bash -c` or use Python |

--- a/skills/skills-codex/rebuttal/SKILL.md
+++ b/skills/skills-codex/rebuttal/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: "rebuttal"
-description: "Workflow 4: Submission rebuttal pipeline. Parses external reviews, enforces coverage and grounding, drafts a safe text-only rebuttal under venue limits, and manages follow-up rounds."
+name: rebuttal
+description: "Workflow 4: Submission rebuttal pipeline. Parses external reviews, enforces coverage and grounding, drafts a safe text-only rebuttal under venue limits, and manages follow-up rounds. Use when user says \"rebuttal\", \"reply to reviewers\", \"ICML rebuttal\", \"OpenReview response\", or wants to answer external reviews safely."
+argument-hint: [paper-path-or-review-bundle]
+allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill
 ---
 
 # Workflow 4: Rebuttal
@@ -10,7 +12,6 @@ Prepare and maintain a grounded, venue-compliant rebuttal for: **$ARGUMENTS**
 ## Scope
 
 This skill is optimized for:
-
 - ICML-style **text-only rebuttal**
 - strict **character limits**
 - **multiple reviewers**
@@ -18,11 +19,12 @@ This skill is optimized for:
 - safe drafting with **no fabrication**, **no overpromise**, and **full issue coverage**
 
 This skill does **not**:
-
-- run new experiments automatically unless `AUTO_EXPERIMENT = true`
+- run new experiments automatically
 - generate new theorem claims automatically
 - edit or upload a revised PDF
 - submit to OpenReview / CMT / HotCRP
+
+If the user already has new results, derivations, or approved commitments, the skill can incorporate them as **user-confirmed evidence**.
 
 ## Lifecycle Position
 
@@ -36,14 +38,15 @@ Workflow 4:   rebuttal (post-submission external reviews)
 
 ## Constants
 
-- **VENUE = `ICML`** — Default venue
-- **RESPONSE_MODE = `TEXT_ONLY`** — v1 default
-- **REVIEWER_MODEL = `gpt-5.4`** — Used via a secondary Codex agent for internal stress-testing
-- **MAX_INTERNAL_DRAFT_ROUNDS = 2**
-- **MAX_STRESS_TEST_ROUNDS = 1**
-- **MAX_FOLLOWUP_ROUNDS = 3**
-- **AUTO_EXPERIMENT = false** — When `true`, invoke `/experiment-bridge` for reviewer concerns that require new evidence
-- **QUICK_MODE = false** — When `true`, only run Phase 0-3 and stop after strategy
+- **VENUE = `ICML`** — Default venue. Override if needed.
+- **RESPONSE_MODE = `TEXT_ONLY`** — v1 default.
+- **REVIEWER_MODEL = `gpt-5.4`** — Used via Codex MCP for internal stress-testing.
+- **REVIEWER_BACKEND = `codex`** — Default: Codex xhigh stress tester. Use `--reviewer: oracle-pro` only when explicitly requested; if Oracle is unavailable, warn and fall back to Codex xhigh. See `../shared-references/reviewer-routing.md`.
+- **MAX_INTERNAL_DRAFT_ROUNDS = 2** — draft → lint → revise.
+- **MAX_STRESS_TEST_ROUNDS = 1** — One Codex MCP critique round.
+- **MAX_FOLLOWUP_ROUNDS = 3** — per reviewer thread.
+- **AUTO_EXPERIMENT = false** — When `true`, automatically invoke `/experiment-bridge` to run supplementary experiments when the strategy plan identifies reviewer concerns that require new empirical evidence. When `false` (default), pause and present the evidence gap to the user for manual handling.
+- **QUICK_MODE = false** — When `true`, only run Phase 0-3 (parse reviews, atomize concerns, build strategy). Outputs `ISSUE_BOARD.md` + `STRATEGY_PLAN.md` and stops — no drafting, no stress test. Useful for quickly understanding what reviewers want before deciding how to respond.
 - **REBUTTAL_DIR = `rebuttal/`**
 
 > Override: `/rebuttal "paper/" — venue: NeurIPS, character limit: 5000`
@@ -55,28 +58,28 @@ Workflow 4:   rebuttal (post-submission external reviews)
 3. **Venue rules** — venue name, character/word limit, text-only or revised PDF allowed
 4. **Current stage** — initial rebuttal or follow-up round
 
-If venue rules or limit are missing, stop and ask before drafting.
+If venue rules or limit are missing, **stop and ask** before drafting.
 
 ## Safety Model
 
-Three hard gates. If any fails, do not finalize:
+Three hard gates — if any fails, do NOT finalize:
 
-1. **Provenance gate** — every factual statement maps to a known source
-2. **Commitment gate** — every promise maps to already-done / approved-for-rebuttal / future-work-only
-3. **Coverage gate** — every reviewer concern ends in answered / deferred intentionally / needs user input
+1. **Provenance gate** — every factual statement maps to: `paper`, `review`, `user_confirmed_result`, `user_confirmed_derivation`, or `future_work`. No source = blocked.
+2. **Commitment gate** — every promise maps to: `already_done`, `approved_for_rebuttal`, or `future_work_only`. Not approved = blocked.
+3. **Coverage gate** — every reviewer concern ends in: `answered`, `deferred_intentionally`, or `needs_user_input`. No issue disappears.
 
 ## Workflow
 
 ### Phase 0: Resume or Initialize
 
-1. If `rebuttal/REBUTTAL_STATE.md` exists, resume from the recorded phase
-2. Otherwise, create `rebuttal/` and initialize the output documents
-3. Load the paper, reviews, venue rules, and any user-confirmed evidence
+1. If `rebuttal/REBUTTAL_STATE.md` exists → resume from recorded phase
+2. Otherwise → create `rebuttal/`, initialize all output documents
+3. Load paper, reviews, venue rules, any user-confirmed evidence
 
 ### Phase 1: Validate Inputs and Normalize Reviews
 
-1. Validate that venue rules are explicit
-2. Normalize all reviewer text into `rebuttal/REVIEWS_RAW.md` verbatim
+1. Validate venue rules are explicit
+2. Normalize all reviewer text into `rebuttal/REVIEWS_RAW.md` (verbatim)
 3. Record metadata in `rebuttal/REBUTTAL_STATE.md`
 4. If ambiguous, pause and ask
 
@@ -84,68 +87,134 @@ Three hard gates. If any fails, do not finalize:
 
 Create `rebuttal/ISSUE_BOARD.md`.
 
-For each atomic concern, record:
-
-- `issue_id`
-- `reviewer`, `round`, `raw_anchor`
-- `issue_type`
-- `severity`
-- `reviewer_stance`
-- `response_mode`
-- `status`
+For each atomic concern:
+- `issue_id` (e.g., R1-C2)
+- `reviewer`, `round`, `raw_anchor` (short quote)
+- `issue_type`: assumptions / theorem_rigor / novelty / empirical_support / baseline_comparison / complexity / practical_significance / clarity / reproducibility / other
+- `severity`: critical / major / minor
+- `reviewer_stance`: positive / swing / negative / unknown
+- `response_mode`: direct_clarification / grounded_evidence / nearest_work_delta / assumption_hierarchy / narrow_concession / future_work_boundary
+- `status`: open / answered / deferred / needs_user_input
 
 ### Phase 3: Build Strategy Plan
 
 Create `rebuttal/STRATEGY_PLAN.md`.
 
-1. Identify 2-4 global themes resolving shared concerns
-2. Choose a response mode per issue
-3. Build the character budget
-4. Identify blocked claims
-5. If unresolved blockers exist, pause and present them to the user
+1. Identify 2-4 **global themes** resolving shared concerns
+2. Choose **response mode** per issue
+3. Build **character budget** (10-15% opener, 75-80% per-reviewer, 5-10% closing)
+4. Identify **blocked claims** (ungrounded or unapproved)
+5. If unresolved blockers → pause and present to user
 
-**QUICK_MODE exit**: if `QUICK_MODE = true`, stop here and present `ISSUE_BOARD.md` + `STRATEGY_PLAN.md`.
+**QUICK_MODE exit**: If `QUICK_MODE = true`, stop here. Present `ISSUE_BOARD.md` + `STRATEGY_PLAN.md` to the user and summarize: how many issues per reviewer, shared vs unique concerns, recommended priorities, and evidence gaps. The user can then decide to continue with full rebuttal (`/rebuttal — quick mode: false`) or write manually.
 
 ### Phase 3.5: Evidence Sprint (when AUTO_EXPERIMENT = true)
 
-**Skip entirely if `AUTO_EXPERIMENT` is `false`.**
+**Skip entirely if `AUTO_EXPERIMENT` is `false` — instead, pause and present the evidence gaps to the user.**
 
-If the strategy plan identifies issues that require new empirical evidence:
+If the strategy plan identifies issues that require new empirical evidence (tagged `response_mode: grounded_evidence` with `evidence_source: needs_experiment`):
 
-1. Generate a mini experiment plan from the reviewer concerns
-2. Invoke `/experiment-bridge "rebuttal/REBUTTAL_EXPERIMENT_PLAN.md"`
-3. Wait for results, then update `ISSUE_BOARD.md`
-4. If experiments fail or are inconclusive, switch to `narrow_concession` or `future_work_boundary`
-5. Save experiment results to `rebuttal/REBUTTAL_EXPERIMENTS.md`
+1. Generate a mini experiment plan from the reviewer concerns:
+   - What to run (ablation, baseline comparison, scale-up, condition check)
+   - Success criterion (what result would satisfy the reviewer)
+   - Estimated GPU-hours
+
+2. Invoke `/experiment-bridge` with the mini plan:
+   ```
+   /experiment-bridge "rebuttal/REBUTTAL_EXPERIMENT_PLAN.md"
+   ```
+
+3. Wait for results, then update `ISSUE_BOARD.md`:
+   - Tag completed experiments as `user_confirmed_result`
+   - Update evidence source for relevant issue cards
+
+4. If experiments fail or are inconclusive:
+   - Switch response mode to `narrow_concession` or `future_work_boundary`
+   - Do NOT fabricate positive results
+
+5. Save experiment results to `rebuttal/REBUTTAL_EXPERIMENTS.md` for provenance tracking.
+
+**Time guard**: If estimated GPU-hours exceed rebuttal deadline, skip and flag for manual handling.
 
 ### Phase 4: Draft Initial Rebuttal
 
 Create `rebuttal/REBUTTAL_DRAFT_v1.md`.
 
 Structure:
+1. **Short opener** — thank reviewers + 2-4 global resolutions
+2. **Per-reviewer numbered responses** — answer → evidence → implication
+3. **Short closing** — resolved / remaining / acceptance case
 
-1. Short opener
-2. Per-reviewer numbered responses
-3. Short closing
+Default reply pattern per issue:
+- Sentence 1: direct answer
+- Sentence 2-4: grounded evidence
+- Last sentence: implication for the paper
 
-Also generate `rebuttal/PASTE_READY.txt` with exact character count.
+Heuristics from 5 successful rebuttals:
+- Evidence > assertion
+- Global narrative first, per-reviewer detail second
+- Concrete numbers for counter-intuitive points
+- Name closest prior work + exact delta for novelty disputes
+- Concede narrowly when reviewer is right
+- For theory: separate core vs technical assumptions
+- Answer friendly reviewers too
+
+Hard rules:
+- NEVER invent experiments, numbers, derivations, citations, or links
+- NEVER promise what user hasn't approved
+- If no strong evidence exists, say less not more
+
+Also generate `rebuttal/PASTE_READY.txt` (plain text, exact character count).
+
+Also generate `rebuttal/REVISION_PLAN.md` — the **overall revision checklist**.
+
+This document is the single source of truth for every paper revision promised (explicitly or implicitly) in the rebuttal draft. It exists so the author can track follow-through after the rebuttal is submitted, and so the commitment gate in Phase 5 has a concrete artifact to validate against.
+
+Structure:
+
+1. **Header**
+   - Paper title, venue, character limit, rebuttal round
+   - Links back to `ISSUE_BOARD.md`, `STRATEGY_PLAN.md`, `REBUTTAL_DRAFT_v1.md`
+
+2. **Overall checklist** — a single flat GitHub-style checklist covering **every** revision item, so the author can tick items off as they land in the camera-ready / revised PDF:
+
+   ```markdown
+   ## Overall Checklist
+
+   - [ ] (R1-C2) Add assumption hierarchy table to Section 3.1 — commitment: `approved_for_rebuttal` — owner: author — status: pending
+   - [ ] (R2-C1) Clarify novelty delta vs. Smith'24 in Section 2 related work — commitment: `already_done` — status: verify wording
+   - [ ] (R3-C4) Add runtime breakdown figure to Appendix B — commitment: `future_work_only` — status: deferred, note in camera-ready
+   - ...
+   ```
+
+   Checklist items must be **atomic** (one paper edit per line) and each must reference its `issue_id` so it maps back to `ISSUE_BOARD.md`.
+
+3. **Grouped view** — the same items regrouped by (a) paper section/location and (b) severity, so the author can plan the revision pass efficiently.
+
+4. **Commitment summary** — counts of `already_done` / `approved_for_rebuttal` / `future_work_only`, plus any `needs_user_input` items that are blocking.
+
+5. **Out-of-scope log** — reviewer concerns that will **not** trigger a paper revision (e.g. `deferred_intentionally`, `narrow_concession` with no edit), with a one-line reason each. This keeps the checklist honest: nothing silently disappears.
+
+Rules for `REVISION_PLAN.md`:
+- Every checklist item must map to at least one `issue_id` from `ISSUE_BOARD.md`.
+- Every promise in `REBUTTAL_DRAFT_v1.md` that implies a paper edit must appear as a checklist item — if it is not in the plan, it is a commitment-gate violation.
+- Never add items that are not backed by the draft or by user-confirmed evidence.
+- On rerun / follow-up rounds, update checkbox state in place rather than regenerating from scratch.
 
 ### Phase 5: Safety Validation
 
 Run all lints:
+1. **Coverage** — every issue maps to draft anchor
+2. **Provenance** — every factual sentence has source
+3. **Commitment** — promises are approved AND every paper-edit promise in the draft appears as a checklist item in `REVISION_PLAN.md` (and vice versa — no orphan items in the plan)
+4. **Tone** — flag aggressive/submissive/evasive phrases
+5. **Consistency** — no contradictions across reviewer replies
+6. **Limit** — exact character count, compress if over (redundancy → friendly → opener → wording, never drop critical answers)
 
-1. Coverage
-2. Provenance
-3. Commitment
-4. Tone
-5. Consistency
-6. Limit
+### Phase 6: Codex Reviewer Stress Test
 
-### Phase 6: Stress Test
-
-```text
+```
 spawn_agent:
-  model: gpt-5.4
   reasoning_effort: xhigh
   message: |
     Stress-test this rebuttal draft:
@@ -155,40 +224,66 @@ spawn_agent:
     2. Unsupported factual statements?
     3. Risky or unapproved promises?
     4. Tone problems?
-    5. Paragraph most likely to backfire with a meta-reviewer?
-    6. Minimal grounded fixes only. Do not invent evidence.
+    5. Paragraph most likely to backfire with meta-reviewer?
+    6. Minimal grounded fixes only. Do NOT invent evidence.
 
     Verdict: safe to submit / needs revision
 ```
 
-Save the full response to `rebuttal/MCP_STRESS_TEST.md`. If a hard safety blocker remains, revise before finalizing.
+Save full response to `rebuttal/MCP_STRESS_TEST.md`. If hard safety blocker → revise before finalizing.
 
 ### Phase 7: Finalize — Two Versions
 
-Produce:
+Produce **two outputs** for different purposes:
 
-1. **`rebuttal/PASTE_READY.txt`** — strict version, ready to paste
-2. **`rebuttal/REBUTTAL_DRAFT_rich.md`** — extended version with optional sections marked
+1. **`rebuttal/PASTE_READY.txt`** — the strict version
+   - Plain text, exact character count, fits venue limit
+   - Ready to paste directly into OpenReview / CMT / HotCRP
+   - No markdown formatting, no extras
+
+2. **`rebuttal/REBUTTAL_DRAFT_rich.md`** — the extended version
+   - Same structure but with **more detail**: fuller explanations, additional evidence, optional paragraphs
+   - Marked with `[OPTIONAL — cut if over limit]` for sections that exceed the strict version
+   - Author can read this to understand the full reasoning, then manually decide what to keep/cut/rewrite
+   - Useful for follow-up rounds — the extra material is pre-written
+
 3. Update `rebuttal/REBUTTAL_STATE.md`
-4. Present the remaining risks and any lines needing manual approval
+4. Refresh `rebuttal/REVISION_PLAN.md` so the overall checklist matches the final draft (add items, mark `already_done` as checked, carry forward any `pending` items)
+5. Present to user:
+   - `PASTE_READY.txt` character count vs venue limit
+   - `REBUTTAL_DRAFT_rich.md` for review and manual editing
+   - `REVISION_PLAN.md` checklist — counts of pending / approved / deferred
+   - Remaining risks + lines needing manual approval
 
 ### Phase 8: Follow-Up Rounds
 
 When new reviewer comments arrive:
 
-1. Append them to `rebuttal/FOLLOWUP_LOG.md`
+1. Append verbatim to `rebuttal/FOLLOWUP_LOG.md`
 2. Link to existing issues or create new ones
-3. Draft the delta reply only
-4. Re-run safety lints
-5. If continuity helps, reuse the same reviewer agent via `send_input`
-6. Escalate technically, not rhetorically
+3. Draft **delta reply only** (not full rewrite)
+4. Update `rebuttal/REVISION_PLAN.md` in place — add any new checklist items introduced by the follow-up, tick off items the author has already completed, and keep existing items' status current
+5. Re-run safety lints
+6. Use Codex MCP reply for continuity if useful
+7. Rules: escalate technically not rhetorically; concede if reviewer is correct; stop arguing if reviewer is immovable and no new evidence exists
 
 ## Key Rules
 
-- Never fabricate evidence, numbers, derivations, citations, or links
-- Never overpromise. Only promise what the user explicitly approved.
-- Every reviewer concern must be tracked and accounted for
-- Preserve raw records
-- Shared concerns go in the opener; reviewer-specific details go in the per-reviewer sections
-- Answer friendly reviewers too
-- Respect the hard character limit
+- **Large file handling**: If Write fails, retry with Bash heredoc silently.
+- **Never fabricate.** No invented evidence, numbers, derivations, citations, or links.
+- **Never overpromise.** Only promise what user explicitly approved.
+- **Full coverage.** Every reviewer concern tracked and accounted for.
+- **Preserve raw records.** Reviews and MCP outputs stored verbatim.
+- **Global + per-reviewer structure.** Shared concerns in opener.
+- **Answer friendly reviewers too.** Reinforce supportive framing.
+- **Meta-reviewer closing.** Summarize resolved/remaining/why accept.
+- **Evidence > rhetoric.** Derivations and numbers over prose.
+- **Concede selectively.** Narrow honest concessions > broad denials.
+- **Don't waste space on unwinnable arguments.** Answer once, move on.
+- **Respect the limit.** Character budget is a hard constraint.
+- **Resume cleanly.** Continue from REBUTTAL_STATE.md on rerun.
+- **Anti-hallucination citations.** Any reference added must go through DBLP → CrossRef → [VERIFY].
+
+## Review Tracing
+
+After each `spawn_agent` or `send_input` reviewer call, save the trace following `../shared-references/review-tracing.md`. Write files directly to `.aris/traces/rebuttal/<date>_run<NN>/`. Respect the `--- trace:` parameter when present (default: `full`).

--- a/skills/skills-codex/research-lit/SKILL.md
+++ b/skills/skills-codex/research-lit/SKILL.md
@@ -16,12 +16,14 @@ Research topic: $ARGUMENTS
 - **MAX_LOCAL_PAPERS = 20** — Maximum number of local PDFs to scan (read first 3 pages each). If more are found, prioritize by filename relevance to the topic.
 - **ARXIV_DOWNLOAD = false** — When `true`, download top 3-5 most relevant arXiv PDFs to PAPER_LIBRARY after search. When `false` (default), only fetch metadata (title, abstract, authors) via arXiv API — no files are downloaded.
 - **ARXIV_MAX_DOWNLOAD = 5** — Maximum number of PDFs to download when `ARXIV_DOWNLOAD = true`.
+- **REVIEWER_BACKEND = `codex`** — Default reviewer route for optional literature synthesis cross-checks. Use `--reviewer: oracle-pro` only when explicitly requested; if Oracle is unavailable, warn and continue with Codex xhigh or local synthesis.
 
 > 💡 Overrides:
 > - `/research-lit "topic" — paper library: ~/my_papers/` — custom local PDF path
 > - `/research-lit "topic" — sources: zotero, local` — only search Zotero + local PDFs
 > - `/research-lit "topic" — sources: zotero` — only search Zotero
 > - `/research-lit "topic" — sources: web` — only search the web (skip all local)
+> - `/research-lit "topic" — sources: web, semantic-scholar` — also search Semantic Scholar for published venue papers
 > - `/research-lit "topic" — sources: deepxiv` — only search via DeepXiv progressive retrieval
 > - `/research-lit "topic" — sources: all, deepxiv` — use default sources plus DeepXiv
 > - `/research-lit "topic" — arxiv download: true` — download top relevant arXiv PDFs
@@ -29,13 +31,13 @@ Research topic: $ARGUMENTS
 
 ## Data Sources
 
-This skill checks multiple sources **in priority order**. All are optional — if a source is not configured or not requested, skip it silently.
+This skill checks multiple sources **in priority order**.
 
 ### Source Selection
 
 Parse `$ARGUMENTS` for a `— sources:` directive:
-- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `deepxiv`, `exa`, `all`.
-- **If not specified**: Default to `all` — search every available source in priority order (`deepxiv` and `exa` are excluded from `all`; they must be explicitly listed).
+- **If `— sources:` is specified**: Only search the listed sources (comma-separated). Valid values: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, `all`.
+- **If not specified**: Default to `all` — search every available source in priority order (`semantic-scholar`, `deepxiv`, and `exa` are excluded from `all`; they must be explicitly listed).
 
 Examples:
 ```
@@ -45,8 +47,10 @@ Examples:
 /research-lit "diffusion models" — sources: zotero, web → Zotero + web
 /research-lit "diffusion models" — sources: local       → local PDFs only
 /research-lit "topic" — sources: obsidian, local, web   → skip Zotero
+/research-lit "topic" — sources: web, semantic-scholar  → web + Semantic Scholar API
 /research-lit "topic" — sources: deepxiv                → DeepXiv only
 /research-lit "topic" — sources: all, deepxiv           → default sources + DeepXiv
+/research-lit "topic" — sources: all, semantic-scholar  → default sources + Semantic Scholar API
 /research-lit "topic" — sources: exa                    → Exa only (broad web + content extraction)
 /research-lit "topic" — sources: all, exa               → default sources + Exa web search
 ```
@@ -59,16 +63,17 @@ Examples:
 | 2 | **Obsidian** (via MCP) | `obsidian` | Try calling any `mcp__obsidian-vault__*` tool — if unavailable, skip | Research notes, paper summaries, tagged references, wikilinks |
 | 3 | **Local PDFs** | `local` | `Glob: papers/**/*.pdf, literature/**/*.pdf` | Raw PDF content (first 3 pages) |
 | 4 | **Web search** | `web` | Always available (WebSearch) | arXiv, Semantic Scholar, Google Scholar |
-| 5 | **DeepXiv CLI** | `deepxiv` | `tools/deepxiv_fetch.py` and installed `deepxiv` CLI | Progressive paper retrieval: search, brief, head, section, trending, web search. **Only runs when explicitly requested** |
-| 6 | **Exa Search** | `exa` | `tools/exa_search.py` and installed `exa-py` SDK | AI-powered broad web search with content extraction (highlights, text, summaries). Covers blogs, docs, news, companies, and research papers beyond arXiv/S2. **Only runs when explicitly requested** |
+| 5 | **Semantic Scholar API** | `semantic-scholar` | ARIS `tools/semantic_scholar_fetch.py` helper | Published venue papers (IEEE, ACM, Springer) with structured metadata: citation counts, venue info, TLDR. **Only runs when explicitly requested** |
+| 6 | **DeepXiv CLI** | `deepxiv` | ARIS `tools/deepxiv_fetch.py` helper or installed `deepxiv` CLI | Progressive paper retrieval: search, brief, head, section, trending, web search. **Only runs when explicitly requested** |
+| 7 | **Exa Search** | `exa` | ARIS `tools/exa_search.py` helper or installed `exa-py` SDK | AI-powered broad web search with content extraction (highlights, text, summaries). Covers blogs, docs, news, companies, and research papers beyond arXiv/S2. **Only runs when explicitly requested** |
 
-> **Graceful degradation**: If no MCP servers are configured, the skill works exactly as before (local PDFs + web search). Zotero and Obsidian are pure additions.
+> If the user explicitly requests Zotero or Obsidian and that source is not configured, stop and tell the user how to enable it. Only sources that were not requested may be skipped silently.
 
 ## Workflow
 
 ### Step 0a: Search Zotero Library (if available)
 
-**Skip this step entirely if Zotero MCP is not configured.**
+**If the user explicitly requested Zotero and the Zotero MCP is not configured, stop and ask the user to configure it. Otherwise skip this step entirely.**
 
 Try calling a Zotero MCP tool (e.g., search). If it succeeds:
 
@@ -86,7 +91,7 @@ Try calling a Zotero MCP tool (e.g., search). If it succeeds:
 
 ### Step 0b: Search Obsidian Vault (if available)
 
-**Skip this step entirely if Obsidian MCP is not configured.**
+**If the user explicitly requested Obsidian and the Obsidian MCP is not configured, stop and ask the user to configure it. Otherwise skip this step entirely.**
 
 Try calling an Obsidian MCP tool (e.g., search). If it succeeds:
 
@@ -134,31 +139,69 @@ Before searching online, check if the user already has relevant papers locally:
 
 Locate the fetch script and search arXiv directly:
 ```bash
-# Try to find arxiv_fetch.py
-SCRIPT=$(find tools/ -name "arxiv_fetch.py" 2>/dev/null | head -1)
-# If not found, check ARIS install
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/arxiv_fetch.py" ] && SCRIPT="$ARIS_REPO/tools/arxiv_fetch.py"
+[ -z "$SCRIPT" ] && SCRIPT=$(find tools/ -name "arxiv_fetch.py" 2>/dev/null | head -1)
 [ -z "$SCRIPT" ] && SCRIPT=$(find ~/.codex/skills/arxiv/ -name "arxiv_fetch.py" 2>/dev/null | head -1)
 
 # Search arXiv API for structured results (title, abstract, authors, categories)
-python3 "$SCRIPT" search "QUERY" --max 10
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" search "QUERY" --max 10
 ```
 
 If `arxiv_fetch.py` is not found, fall back to WebSearch for arXiv (same as before).
 
 The arXiv API returns structured metadata (title, abstract, full author list, categories, dates) — richer than WebSearch snippets. Merge these results with WebSearch findings and de-duplicate.
 
+**Semantic Scholar API search** (only when `semantic-scholar` is in sources):
+
+When the user explicitly requests `— sources: semantic-scholar` or `— sources: web, semantic-scholar`, search for published venue papers beyond arXiv:
+
+```bash
+S2_SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/semantic_scholar_fetch.py" ] && S2_SCRIPT="$ARIS_REPO/tools/semantic_scholar_fetch.py"
+[ -z "$S2_SCRIPT" ] && S2_SCRIPT=$(find tools/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+[ -z "$S2_SCRIPT" ] && S2_SCRIPT=$(find ~/.codex/skills/semantic-scholar/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+
+if [ -n "$S2_SCRIPT" ]; then
+    python3 "$S2_SCRIPT" search "QUERY" --max 10 --fields title,authors,year,venue,citationCount,externalIds,tldr,url
+else
+    echo "Semantic Scholar unavailable: no semantic_scholar_fetch.py helper; skipping this optional source." >&2
+fi
+```
+
+Why use Semantic Scholar? Many IEEE/ACM journal papers are not on arXiv. S2 fills the gap for published venue-only papers with citation counts and venue metadata.
+
+De-duplication between arXiv and S2:
+- Match by arXiv ID first (`externalIds.ArXiv`), then normalized title.
+- If a paper appears in both and S2 has venue / DOI / citation metadata, use S2 as authoritative metadata while keeping the arXiv PDF link.
+- S2 results without `externalIds.ArXiv` are venue-only papers and should be preserved as unique value.
+
 **DeepXiv search** (only when `deepxiv` is in sources):
 
 When the user explicitly requests `— sources: deepxiv` (or includes `deepxiv` in a combined source list), use the DeepXiv adapter for progressive retrieval:
 
 ```bash
-python3 tools/deepxiv_fetch.py search "QUERY" --max 10
-python3 tools/deepxiv_fetch.py paper-brief ARXIV_ID
-python3 tools/deepxiv_fetch.py paper-head ARXIV_ID
-python3 tools/deepxiv_fetch.py paper-section ARXIV_ID "Experiments"
+DEEPXIV_SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/deepxiv_fetch.py" ] && DEEPXIV_SCRIPT="$ARIS_REPO/tools/deepxiv_fetch.py"
+[ -z "$DEEPXIV_SCRIPT" ] && DEEPXIV_SCRIPT=$(find tools/ -name "deepxiv_fetch.py" 2>/dev/null | head -1)
+[ -z "$DEEPXIV_SCRIPT" ] && DEEPXIV_SCRIPT=$(find ~/.codex/skills/deepxiv/ -name "deepxiv_fetch.py" 2>/dev/null | head -1)
+if [ -n "$DEEPXIV_SCRIPT" ]; then
+    python3 "$DEEPXIV_SCRIPT" search "QUERY" --max 10
+    python3 "$DEEPXIV_SCRIPT" paper-brief ARXIV_ID
+    python3 "$DEEPXIV_SCRIPT" paper-head ARXIV_ID
+    python3 "$DEEPXIV_SCRIPT" paper-section ARXIV_ID "Experiments"
+elif command -v deepxiv >/dev/null 2>&1; then
+    deepxiv search "QUERY" --limit 10 --format json
+    deepxiv paper ARXIV_ID --brief --format json
+    deepxiv paper ARXIV_ID --head --format json
+    deepxiv paper ARXIV_ID --section "Experiments" --format json
+else
+    echo "DeepXiv unavailable: no deepxiv_fetch.py adapter and no deepxiv CLI; skipping this optional source." >&2
+fi
 ```
 
-If `tools/deepxiv_fetch.py` or the `deepxiv` CLI is unavailable, skip this source gracefully and continue with the remaining requested sources.
+If `deepxiv_fetch.py` or the `deepxiv` CLI is unavailable, skip this source gracefully and continue with the remaining requested sources.
 
 **De-duplication against other sources**:
 - Match by arXiv ID first
@@ -170,16 +213,20 @@ If `tools/deepxiv_fetch.py` or the `deepxiv` CLI is unavailable, skip this sourc
 When the user explicitly requests `— sources: exa` (or includes `exa` in a combined source list), use the Exa tool for broad AI-powered web search with content extraction:
 
 ```bash
-EXA_SCRIPT=$(find tools/ -name "exa_search.py" 2>/dev/null | head -1)
+EXA_SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/exa_search.py" ] && EXA_SCRIPT="$ARIS_REPO/tools/exa_search.py"
+[ -z "$EXA_SCRIPT" ] && EXA_SCRIPT=$(find tools/ -name "exa_search.py" 2>/dev/null | head -1)
+[ -z "$EXA_SCRIPT" ] && EXA_SCRIPT=$(find ~/.codex/skills/exa-search/ -name "exa_search.py" 2>/dev/null | head -1)
 
 # Search for research papers with highlights
-python3 "$EXA_SCRIPT" search "QUERY" --max 10 --category "research paper" --content highlights
+[ -n "$EXA_SCRIPT" ] && python3 "$EXA_SCRIPT" search "QUERY" --max 10 --category "research paper" --content highlights
 
 # Search for broader web content (blogs, docs, news)
-python3 "$EXA_SCRIPT" search "QUERY" --max 10 --content highlights
+[ -n "$EXA_SCRIPT" ] && python3 "$EXA_SCRIPT" search "QUERY" --max 10 --content highlights
+[ -n "$EXA_SCRIPT" ] || echo "Exa unavailable: no exa_search.py helper; skipping this optional source." >&2
 ```
 
-If `tools/exa_search.py` or the `exa-py` SDK is unavailable, skip this source gracefully and continue with the remaining requested sources.
+If `exa_search.py` or the `exa-py` SDK is unavailable, skip this source gracefully and continue with the remaining requested sources.
 
 **De-duplication against other sources**:
 - Match by URL first, then normalized title
@@ -191,7 +238,7 @@ If `tools/exa_search.py` or the `exa-py` SDK is unavailable, skip this source gr
 After all sources are searched and papers are ranked by relevance:
 ```bash
 # Download top N most relevant arXiv papers
-python3 "$SCRIPT" download ARXIV_ID --dir papers/
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" download ARXIV_ID --dir papers/
 ```
 - Only download papers ranked in the top ARXIV_MAX_DOWNLOAD by relevance
 - Skip papers already in the local library
@@ -229,11 +276,24 @@ If Zotero BibTeX was exported, include a `references.bib` snippet for direct use
 - Update related work notes in project memory
 - If Obsidian is available, optionally create a literature review note in the vault
 
+### Step 6: Update Research Wiki
+
+If the project has an active research wiki, update it after producing the literature review:
+
+1. Add or update the topic page with the final paper table, grouped themes, and open gaps.
+2. Link each paper to its canonical source and local PDF path if available.
+3. Record which sources were used: Zotero, Obsidian, local PDFs, arXiv, Semantic Scholar, DeepXiv, Exa, or broader web.
+4. Mark unresolved search gaps and papers requiring follow-up reading.
+5. Follow the wiki integration contract in [`shared-references/integration-contract.md`](../shared-references/integration-contract.md).
+6. When the wiki helper is available, rebuild `query_pack.md` after updating literature entries so `/idea-creator` can reuse the latest gaps and failed directions.
+
+If the wiki path or format is unclear, ask before writing. Do not invent a wiki location.
+
 ## Key Rules
 - Always include paper citations (authors, year, venue)
 - Distinguish between peer-reviewed and preprints
 - Be honest about limitations of each paper
 - Note if a paper directly competes with or supports our approach
-- **Never fail because a MCP server is not configured** — always fall back gracefully to the next data source
+- If a user-requested Zotero or Obsidian source is unavailable, stop and report the missing configuration instead of silently degrading.
+- Only unrequested optional sources may be skipped automatically.
 - Zotero/Obsidian tools may have different names depending on how the user configured the MCP server (e.g., `mcp__zotero__search` or `mcp__zotero-mcp__search_items`). Try the most common patterns and adapt.
-

--- a/skills/skills-codex/research-pipeline/SKILL.md
+++ b/skills/skills-codex/research-pipeline/SKILL.md
@@ -12,23 +12,28 @@ End-to-end autonomous research workflow for: **$ARGUMENTS**
 - **AUTO_PROCEED = true** — When `true`, Gate 1 auto-selects the top-ranked idea (highest pilot signal + novelty confirmed) and continues to implementation. When `false`, always waits for explicit user confirmation before proceeding.
 - **ARXIV_DOWNLOAD = false** — When `true`, `/research-lit` downloads the top relevant arXiv PDFs during literature survey. When `false` (default), only fetches metadata via arXiv API. Passed through to `/idea-discovery` → `/research-lit`.
 - **HUMAN_CHECKPOINT = false** — When `true`, the auto-review loops (Stage 4) pause after each round's review to let you see the score and provide custom modification instructions before fixes are implemented. When `false` (default), loops run fully autonomously. Passed through to `/auto-review-loop`.
+- **REVIEWER_DIFFICULTY = medium** — Passed through to `/auto-review-loop`. `medium` uses Codex xhigh review; `hard` adds Reviewer Memory and Debate Protocol; `nightmare` adds direct repository-reading adversarial verification.
+- **AUTO_WRITE = false** — When `true`, automatically invoke Workflow 3 (`/paper-writing`) after Stage 5. Requires `VENUE` to be set. When `false` (default), Stage 5 generates `NARRATIVE_REPORT.md` and stops so the user can invoke `/paper-writing` manually.
+- **VENUE = ICLR** — Target venue for paper writing when `AUTO_WRITE=true`. Options: `ICLR`, `NeurIPS`, `ICML`, `CVPR`, `ACL`, `AAAI`, `ACM`, `IEEE_CONF`, `IEEE_JOURNAL`.
 
-> 💡 Override via argument, e.g., `/research-pipeline "topic" — AUTO_PROCEED: false, human checkpoint: true`.
+> 💡 Override via argument, e.g., `/research-pipeline "topic" — AUTO_PROCEED: false, human checkpoint: true, difficulty: nightmare, auto_write: true, venue: NeurIPS`.
 
 ## Overview
 
 This skill chains the entire research lifecycle into a single pipeline:
 
 ```
-/idea-discovery → implement → /run-experiment → /auto-review-loop → submission-ready
-├── Workflow 1 ──┤            ├────────── Workflow 2 ──────────────┤
+/idea-discovery → implement → /run-experiment → /auto-review-loop → /paper-writing (optional)
+├── Workflow 1 ──┤            ├────────── Workflow 2 ──────────────┤ ├── Workflow 3 ──┤
 ```
 
-It orchestrates two major workflows plus the implementation bridge between them.
+It orchestrates up to three major workflows plus the implementation bridge between them. Workflow 3 is optional and controlled by `AUTO_WRITE`.
 
 ## Pipeline
 
 ### Stage 1: Idea Discovery (Workflow 1)
+
+If `RESEARCH_BRIEF.md` exists in the project root, it will be loaded by `/idea-discovery` as detailed context and used as the primary brief for the pipeline. The one-line `$ARGUMENTS` still sets the high-level direction.
 
 Invoke the idea discovery pipeline:
 
@@ -85,16 +90,25 @@ Once the user confirms which idea to pursue:
 
 ### Stage 3: Deploy Experiments (Workflow 2 — Part 1)
 
-Deploy the full-scale experiments:
+Deploy the full-scale experiments. Route by job count:
 
+**Small batch (≤5 jobs)** — direct deployment:
 ```
 /run-experiment [experiment command]
 ```
+
+**Large batch (≥10 jobs, multi-seed sweeps, teacher→student chains)** — queue scheduler:
+```
+/experiment-queue [grid spec or manifest]
+```
+
+`experiment-bridge` auto-routes based on milestone job count. For pipeline runs with multi-seed sweeps from the start, allow an explicit `batch: queue` override to force `/experiment-queue` for all milestones.
 
 **What this does:**
 - Check GPU availability on configured servers
 - Sync code to remote server
 - Launch experiments in screen sessions with proper CUDA_VISIBLE_DEVICES
+- For `/experiment-queue`: also OOM retry, stale-screen cleanup, phase dependencies, and crash-safe state
 - Verify experiments started successfully
 
 **Monitor progress:**
@@ -113,6 +127,8 @@ Once initial results are in, start the autonomous improvement loop:
 /auto-review-loop "$ARGUMENTS — [chosen idea title]"
 ```
 
+Pass `REVIEWER_DIFFICULTY` through unchanged. For `hard` and `nightmare`, the downstream loop must preserve Reviewer Memory, Debate Protocol, Review Tracing, and any saved reviewer `agent_id` across rounds.
+
 **What this does (up to 4 rounds):**
 1. GPT-5.4 xhigh reviews the work (score, weaknesses, minimum fixes)
 2. Codex implements fixes (code changes, new experiments, reframing)
@@ -121,9 +137,26 @@ Once initial results are in, start the autonomous improvement loop:
 
 **Output:** `review-stage/AUTO_REVIEW.md` with full review history and final assessment.
 
-### Stage 5: Final Summary
+### Stage 5: Research Summary & Writing Handoff
 
-After the auto-review loop completes, write a final status report:
+After the auto-review loop completes, prepare the handoff for paper writing.
+
+**Step 1:** Write the final research status report.
+
+**Step 2:** Generate `NARRATIVE_REPORT.md` from:
+- `idea-stage/IDEA_REPORT.md` (chosen idea, hypothesis, novelty justification)
+- implementation details from the repo
+- experiment configs and final results
+- `review-stage/AUTO_REVIEW.md` (review history, weaknesses fixed, remaining limitations)
+
+The narrative report must contain:
+- problem statement and core claim
+- method summary
+- key quantitative results with evidence for each claim
+- figure/table inventory (which exist, which need manual creation)
+- limitations and remaining follow-up items
+
+**Output:** `NARRATIVE_REPORT.md` + research pipeline report.
 
 ```markdown
 # Research Pipeline Report
@@ -139,15 +172,32 @@ After the auto-review loop completes, write a final status report:
 - Experiments: [number of GPU experiments, total compute time]
 - Review rounds: N/4, final score: X/10
 
-## Final Status
-- [ ] Ready for submission / [ ] Needs manual follow-up
+## Writing Handoff
+- NARRATIVE_REPORT.md: generated
+- Venue: [VENUE or "not set — run /paper-writing manually"]
+- Manual figures needed: [list or "none"]
 
 ## Remaining TODOs (if any)
 - [items flagged by reviewer that weren't addressed]
-
-## Files Changed
-- [list of key files created/modified]
 ```
+
+### Stage 6: Paper Writing (Workflow 3 — Optional)
+
+Skip this stage if `AUTO_WRITE=false` (default). Present the manual command:
+
+```
+/paper-writing "NARRATIVE_REPORT.md" — venue: ICLR
+```
+
+If `AUTO_WRITE=true`, stop and ask if `VENUE` is missing. Do not silently use a default venue. If manual figures are required, pause and list them before invoking paper writing.
+
+When ready, invoke:
+
+```
+/paper-writing "NARRATIVE_REPORT.md" — venue: $VENUE
+```
+
+Workflow 3 handles its own phases: `/paper-plan → /paper-figure → /paper-write → /paper-compile → /auto-paper-improvement-loop`. When it finishes, update the pipeline report with final PDF path, improvement scores, and remaining issues.
 
 ## Output Protocols
 
@@ -177,4 +227,3 @@ After the auto-review loop completes, write a final status report:
 | 4. Auto Review | 1-4 hours (depends on experiments) | Yes ✅ |
 
 **Sweet spot**: Run Stage 1-2 in the evening, launch Stage 3-4 before bed, wake up to a reviewed paper.
-

--- a/skills/skills-codex/research-review/SKILL.md
+++ b/skills/skills-codex/research-review/SKILL.md
@@ -10,6 +10,7 @@ Get a multi-round critical review of research work from an external LLM with max
 ## Constants
 
 - REVIEWER_MODEL = `gpt-5.4` — Model used via a secondary Codex agent. Must be an OpenAI model (e.g., `gpt-5.4`, `o3`, `gpt-4o`)
+- **REVIEWER_BACKEND = `codex`** — Default: Codex xhigh reviewer. Use `--reviewer: oracle-pro` only when explicitly requested; if Oracle is unavailable, warn and fall back to Codex xhigh.
 
 ## Context: $ARGUMENTS
 
@@ -45,6 +46,19 @@ spawn_agent:
 ### Step 3: Iterative Dialogue (Rounds 2-N)
 Use `send_input` with the returned agent id to continue the conversation:
 
+```text
+send_input:
+  target: [saved reviewer id from Step 2]
+  message: |
+    Please continue the review using the revised materials below.
+
+    Revised files:
+    - /absolute/path/to/file1
+    - /absolute/path/to/file2
+
+    Focus on unresolved weaknesses and whether the revision actually fixed them.
+```
+
 For each round:
 1. **Respond** to criticisms with evidence/counterarguments
 2. **Ask targeted follow-ups** on the most actionable points
@@ -73,6 +87,10 @@ Save the full interaction and conclusions to a review document in the project ro
 
 Update project memory/notes with key review conclusions.
 
+### Step 6: Review Tracing
+
+Save a trace for every `spawn_agent`, `send_input`, or `oracle-pro` review call following `../shared-references/review-tracing.md`. Record the reviewer route, saved agent id, prompt summary, raw response path, decisions, and action items. This preserves the Claude mainline Review Tracing semantics while using Codex-native reviewer calls.
+
 ## Key Rules
 
 - ALWAYS use `reasoning_effort: xhigh` for reviews
@@ -99,4 +117,3 @@ Update project memory/notes with key review conclusions.
 
 ### For mock review:
 "Please write a mock NeurIPS review with: Summary, Strengths, Weaknesses, Questions for Authors, Score, Confidence, and What Would Move Toward Accept."
-

--- a/skills/skills-codex/research-wiki/SKILL.md
+++ b/skills/skills-codex/research-wiki/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: research-wiki
+description: "Persistent research knowledge base that accumulates papers, ideas, experiments, claims, and their relationships across the entire research lifecycle. Inspired by Karpathy's LLM Wiki pattern. Use when user says \"知识库\", \"research wiki\", \"add paper\", \"wiki query\", \"查知识库\", or wants to build/query a persistent field map."
+argument-hint: [subcommand: init|ingest|sync|query|update|lint|stats]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch
+---
+
+# Research Wiki: Persistent Research Knowledge Base
+
+Subcommand: **$ARGUMENTS**
+
+## Overview
+
+The research wiki is a persistent, per-project knowledge base that accumulates structured knowledge across the entire ARIS research lifecycle. Unlike one-off literature surveys that are used and forgotten, the wiki **compounds** — every paper read, idea tested, experiment run, and review received makes the wiki smarter.
+
+Inspired by [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): compile knowledge once, keep it current, don't re-derive on every query.
+
+## Core Concepts
+
+### Four Entity Types
+
+| Entity | Directory | Node ID format | What it represents |
+|--------|-----------|---------------|--------------------|
+| **Paper** | `papers/` | `paper:<slug>` | A published or preprint research paper |
+| **Idea** | `ideas/` | `idea:<id>` | A research idea (proposed, tested, or failed) |
+| **Experiment** | `experiments/` | `exp:<id>` | A concrete experiment run with results |
+| **Claim** | `claims/` | `claim:<id>` | A testable scientific claim with evidence status |
+
+### Typed Relationships (`graph/edges.jsonl`)
+
+| Edge type | From → To | Meaning |
+|-----------|-----------|---------|
+| `extends` | paper → paper | Builds on prior work |
+| `contradicts` | paper → paper | Disagrees with results/claims |
+| `addresses_gap` | paper\|idea → gap | Targets a known field gap |
+| `inspired_by` | idea → paper | Idea sourced from this paper |
+| `tested_by` | idea\|claim → exp | Tested in this experiment |
+| `supports` | exp → claim\|idea | Experiment confirms claim |
+| `invalidates` | exp → claim\|idea | Experiment disproves claim |
+| `supersedes` | paper → paper | Newer work replaces older |
+
+Edges are stored in `graph/edges.jsonl` only. The `## Connections` section on each page is **auto-generated** from the graph — never hand-edit it.
+
+## Wiki Directory Structure
+
+```
+research-wiki/
+  index.md               # categorical index (auto-generated)
+  log.md                 # append-only timeline
+  gap_map.md             # field gaps with stable IDs (G1, G2, ...)
+  query_pack.md          # compressed summary for /idea-creator (auto-generated, max 8000 chars)
+  papers/
+    <slug>.md            # one page per paper
+  ideas/
+    <idea_id>.md         # one page per idea
+  experiments/
+    <exp_id>.md          # one page per experiment
+  claims/
+    <claim_id>.md        # one page per testable claim
+  graph/
+    edges.jsonl          # materialized current relationship graph
+```
+
+## Subcommands
+
+### `/research-wiki init`
+
+Initialize the wiki for the current project:
+
+1. Create `research-wiki/` directory structure
+2. Create empty `index.md`, `log.md`, `gap_map.md`
+3. Create empty `graph/edges.jsonl`
+4. Log: "Wiki initialized"
+
+### `/research-wiki ingest "<paper title>" — arxiv: <id>`
+
+Add a paper to the wiki. This subcommand is thin wrapping around the
+canonical helper `python3 "$ARIS_REPO/tools/research_wiki.py" ingest_paper …`, which
+is the single implementation of paper ingest in ARIS (per
+[`shared-references/integration-contract.md`](../shared-references/integration-contract.md)
+— one helper, no copies). The helper does all of:
+
+1. **Fetch metadata** — queries the arXiv Atom API when `--arxiv-id` is given
+2. **Generate slug** — `<first_author_last_name><year>_<keyword>`
+3. **Check dedup** — skip an existing page unless `--update-on-exist`
+4. **Create page** — `papers/<slug>.md` with the schema below
+5. **Rebuild `index.md`** and `query_pack.md`
+6. **Append `log.md`**
+
+Edge extraction (step 5/8 in the old manual flow) is **not** in
+`ingest_paper`; do it as a follow-up with `add_edge` per relationship
+identified:
+
+```bash
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+WIKI_SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+[ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+[ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+
+# arXiv-known paper
+[ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+    --arxiv-id 2501.12345 --thesis "One-line claim from abstract."
+
+# Venue paper with no arXiv mirror
+[ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+    --title "Attention Is All You Need" \
+    --authors "Ashish Vaswani, Noam Shazeer, …" --year 2017 --venue "NeurIPS"
+
+# Manual edge after ingest
+[ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ \
+    --from "paper:vaswani2017_attention_all_you" \
+    --to "paper:chen2025_factorized_gap" \
+    --type "extends" --evidence "Section 3.2: adapts the encoder block …"
+```
+
+Other skills (`/research-lit`, `/arxiv`, `/alphaxiv`, `/deepxiv`,
+`/semantic-scholar`, `/exa-search`) call the same helper directly in
+their own last step — they don't re-route through `/research-wiki
+ingest` as a subcommand, so they don't need an LLM roundtrip.
+
+### `/research-wiki sync — arxiv-ids <id1>,<id2>,...`
+
+Batch backfill: ingest one or more arXiv IDs that were read earlier
+without being ingested (e.g., because `research-wiki/` was set up after
+the reading happened, or a hook didn't fire).
+
+```bash
+# Explicit list
+[ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" sync research-wiki/ \
+    --arxiv-ids 2310.06770,1706.03762
+
+# From a file (one id per line, # comments ok)
+[ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" sync research-wiki/ --from-file ids.txt
+```
+
+Dedup is handled per-id; already-ingested papers are skipped silently.
+This is the recommended **manual repair** step (see integration
+contract §5 Backfill). `sync` does not scan session traces — callers
+declare the ids explicitly.
+
+**Paper page schema** (exactly what `ingest_paper` emits — do not
+handwrite alternative fields; `lint` will flag drift):
+
+```markdown
+---
+type: paper
+node_id: paper:<slug>
+title: "<full title>"
+authors: ["First A. Author", "Second B. Author"]
+year: 2025
+venue: "arXiv"
+external_ids:
+  arxiv: "2501.12345"
+  doi: null
+  s2: null
+tags: ["tag1", "tag2"]
+added: 2026-04-07T10:12:00Z
+---
+
+# <full title>
+
+## One-line thesis
+
+[Single sentence capturing the paper's core contribution]
+
+## Problem / Gap
+
+## Method
+
+## Key Results
+
+## Assumptions
+
+## Limitations / Failure Modes
+
+## Reusable Ingredients
+
+[Techniques, datasets, or insights that could be repurposed]
+
+## Open Questions
+
+## Claims
+
+[Reference claim pages: claim:C1, claim:C2, etc.]
+
+## Connections
+
+[AUTO-GENERATED from graph/edges.jsonl — do not edit manually]
+
+## Relevance to This Project
+
+[Why this paper matters for our specific research direction]
+```
+
+_Additionally, when the paper was ingested via `--arxiv-id` and the arXiv
+API returned an abstract, the helper appends an `## Abstract (original)`
+section after `Relevance to This Project` containing the raw abstract
+text as a blockquote. Manual ingests (no `--arxiv-id`) do not include
+this section._
+
+### `/research-wiki query "<topic>"`
+
+Generate `query_pack.md` — a compressed, context-window-friendly summary:
+
+**Fixed budget (max 8000 chars / ~2000 tokens):**
+
+| Section | Budget | Content |
+|---------|--------|---------|
+| Project direction | 300 chars | From AGENTS.md or RESEARCH_BRIEF.md |
+| Top 5 gaps | 1200 chars | From gap_map.md, ranked by: unresolved + linked ideas + failed experiments |
+| Paper clusters | 1600 chars | 3-5 clusters by tag overlap, 2-3 sentences each |
+| Failed ideas | 1400 chars | **Always included** — highest anti-repetition value |
+| Top papers | 1800 chars | 8-12 pages ranked by: linked gaps, linked ideas, centrality, relevance flag |
+| Active chains | 900 chars | limitation → opportunity relationship chains |
+| Open unknowns | 500 chars | Unresolved questions across the wiki |
+
+**Pruning priority** (when over budget): low-ranked papers > cluster detail > chain detail. **Never prune** failed ideas or top gaps first.
+
+**Key rule:** Read from short fields only (frontmatter, one-line thesis, gap summary, failure note). Do not summarize full page bodies every time.
+
+### `/research-wiki update <node_id> — <field>: <value>`
+
+Update a specific entity:
+
+```
+/research-wiki update paper:chen2025 — relevance: core
+/research-wiki update idea:001 — outcome: negative
+/research-wiki update claim:C1 — status: invalidated
+```
+
+After any update: rebuild `query_pack.md`, update `log.md`.
+
+### `/research-wiki lint`
+
+Health check the wiki:
+
+1. **Orphan pages** — entities with zero edges
+2. **Stale claims** — claims with `status: reported` older than 14 days
+3. **Contradictions** — claims with both `supports` and `invalidates` edges
+4. **Missing connections** — papers sharing 2+ tags but no explicit relationship
+5. **Dead ideas** — `stage: proposed` ideas that were never tested
+6. **Sparse pages** — pages with 3+ empty sections
+
+Output a `LINT_REPORT.md` with suggested fixes.
+
+### `/research-wiki stats`
+
+Quick overview:
+
+```
+📚 Research Wiki Stats
+Papers: 28 (12 core, 10 related, 6 peripheral)
+Ideas: 7 (2 active, 3 failed, 1 partial, 1 succeeded)
+Experiments: 12
+Claims: 15 (5 supported, 3 invalidated, 7 reported)
+Edges: 64
+Gaps: 8 (3 unresolved)
+Last updated: 2026-04-07T10:12:00Z
+```
+
+## Integration with Existing Workflows
+
+All paper-reading skills follow the same **integration contract** (see
+[`shared-references/integration-contract.md`](../shared-references/integration-contract.md)):
+
+- single predicate — `[ -d research-wiki/ ]`
+- single canonical helper — `python3 "$ARIS_REPO/tools/research_wiki.py" ingest_paper …`
+- concrete artifact — `papers/<slug>.md` + `log.md` entry
+- backfill — `sync --arxiv-ids …`
+- diagnostic — `$ARIS_REPO/tools/verify_wiki_coverage.sh`
+
+### Hook 1: After `/research-lit` finds papers
+
+```
+# At end of research-lit, after synthesis:
+if research-wiki/ exists:
+    ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+    WIKI_SCRIPT=""
+    [ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+    for paper in top_relevant_papers (limit 8-12):
+        [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+            --arxiv-id <id> [--thesis "..."] [--tags "..."]
+        for each explicit relation to existing wiki paper:
+            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ \
+                --from "paper:<slug>" --to "<target>" \
+                --type <extends|contradicts|addresses_gap|...> \
+                --evidence "..."
+    log "research-lit ingested N papers"
+```
+
+Each paper-reading skill ships its own Step "Update Research Wiki (if
+active)" that calls the same helper once per paper it touched. The
+business logic is not duplicated — only the loop over that skill's
+specific result set differs.
+
+### Hook 2: `/idea-creator` reads AND writes wiki
+
+**Before ideation:**
+```
+if research-wiki/query_pack.md exists (and < 7 days old):
+    prepend query_pack to landscape context
+    treat failed ideas as banlist
+    treat top gaps as search seeds
+    still run fresh literature search for last 3-6 months
+```
+
+**After ideation (THIS IS CRITICAL — without it, ideas/ stays empty):**
+```
+for idea in all_generated_ideas (recommended + killed):
+    /research-wiki upsert_idea(idea)
+    for paper_id in idea.based_on:
+        add_edge(idea.node_id, paper_id, "inspired_by")
+    for gap_id in idea.target_gaps:
+        add_edge(idea.node_id, gap_id, "addresses_gap")
+rebuild query_pack
+log "idea-creator wrote N ideas to wiki"
+```
+
+### Hook 3: After `/result-to-claim` verdict
+
+```
+# Create experiment page
+exp_id = upsert_experiment(experiment_data)
+
+# Update each claim's status
+for claim_id in resolved_claims:
+    if verdict == "yes":
+        set_claim_status(claim_id, "supported")
+        add_edge(exp_id, claim_id, "supports")
+    elif verdict == "partial":
+        set_claim_status(claim_id, "partial")
+        add_edge(exp_id, claim_id, "supports")  # partial
+    else:
+        set_claim_status(claim_id, "invalidated")
+        add_edge(exp_id, claim_id, "invalidates")
+
+# Update idea outcome
+update_idea(active_idea_id, outcome=verdict)
+
+# If failed, record WHY for future ideation
+if verdict in ("no", "partial"):
+    update_idea failure_notes with specific metrics and reasons
+
+rebuild query_pack
+log "result-to-claim: exp_id updated, verdict=..."
+```
+
+## Re-ideation Trigger
+
+After significant wiki updates, suggest re-running `/idea-creator`:
+
+- ≥5 new papers ingested since last ideation
+- ≥3 new failed/partial ideas since last ideation
+- New contradiction discovered in the graph
+- New gap identified that no existing idea addresses
+
+The system suggests but does not auto-trigger. User decides.
+
+## Key Rules
+
+- **One source of truth for relationships**: `graph/edges.jsonl`. Page `Connections` sections are auto-generated views.
+- **Canonical node IDs everywhere**: `paper:<slug>`, `idea:<id>`, `exp:<id>`, `claim:<id>`, `gap:<id>`. Never use raw titles or inconsistent shorthands.
+- **Failed ideas are the most valuable memory.** Never prune them from query_pack.
+- **query_pack.md is hard-budgeted** at 8000 chars. Deterministic generation, not open-ended summarization.
+- **Append to log.md for every mutation.** The log is the audit trail.
+- **Reviewer independence applies.** When the wiki is read by cross-model review skills, pass file paths only — do not summarize wiki content for the reviewer.
+
+## Acknowledgements
+
+Inspired by [Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — "compile knowledge once, keep it current, don't re-derive on every query."

--- a/skills/skills-codex/result-to-claim/SKILL.md
+++ b/skills/skills-codex/result-to-claim/SKILL.md
@@ -1,18 +1,15 @@
 ---
 name: result-to-claim
-description: "Use when experiments complete to judge what claims the results support, what they do not, and what evidence is still missing. A secondary Codex agent evaluates results against intended claims and routes to the next action (pivot, supplement, or confirm). Use after experiments finish - before writing the paper or running ablations."
+description: Use when experiments complete to judge what claims the results support, what they don't, and what evidence is still missing. A secondary Codex agent evaluates results against intended claims and routes to next action (pivot, supplement, or confirm). Use after experiments finish — before writing the paper or running ablations.
+argument-hint: [experiment-description-or-wandb-run]
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
 ---
 
 # Result-to-Claim Gate
 
-Experiments produce numbers; this gate decides what those numbers *mean*. Collect results from available sources, get an objective judgment, then route based on the verdict.
+Experiments produce numbers; this gate decides what those numbers *mean*. Collect results from available sources, get a secondary Codex judgment, then auto-route based on the verdict.
 
 ## Context: $ARGUMENTS
-
-## Constants
-
-- **REVIEWER_MODEL = `gpt-5.4`** - Used via a secondary Codex agent for objective claim assessment.
 
 ## When to Use
 
@@ -26,26 +23,24 @@ Experiments produce numbers; this gate decides what those numbers *mean*. Collec
 
 Gather experiment data from whatever sources are available in the project:
 
-1. **W&B** (preferred): `wandb.Api().run("<entity>/<project>/<run_id>").history()` - metrics, training curves, comparisons
-2. **`EXPERIMENT_LOG.md`** - full results table with baselines and verdicts
-3. **`EXPERIMENT_TRACKER.md`** - check which experiments are done vs still running
-4. **Log files** - `ssh server "tail -100 /path/to/training.log"` if no other source
-5. **`docs/research_contract.md`** or project notes - intended claims and experiment design
+1. **W&B** (preferred): `wandb.Api().run("<entity>/<project>/<run_id>").history()` — metrics, training curves, comparisons
+2. **EXPERIMENT_LOG.md**: full results table with baselines and verdicts
+3. **EXPERIMENT_TRACKER.md**: check which experiments are DONE vs still running
+4. **Log files**: `ssh server "tail -100 /path/to/training.log"` if no other source
+5. **docs/research_contract.md**: intended claims and experiment design
 
 Assemble the key information:
-
 - What experiments were run (method, dataset, config)
 - Main metrics and baseline comparisons (deltas)
 - The intended claim these experiments were designed to test
 - Any known confounds or caveats
 
-### Step 2: Secondary Codex Judgment
+### Step 2: Codex Judgment
 
 Send the collected results to a secondary Codex agent for objective evaluation:
 
 ```text
 spawn_agent:
-  model: REVIEWER_MODEL
   reasoning_effort: xhigh
   message: |
     RESULT-TO-CLAIM EVALUATION
@@ -61,7 +56,7 @@ spawn_agent:
     [paste key numbers, comparison deltas, significance]
 
     Baselines:
-    [baseline numbers and sources - reproduced or from paper]
+    [baseline numbers and sources — reproduced or from paper]
 
     Known caveats:
     [any confounding factors, limited datasets, missing comparisons]
@@ -79,11 +74,9 @@ spawn_agent:
     A single positive result on one dataset does not support a general claim.
 ```
 
-If delegation is unavailable, run the same evaluation locally and mark the verdict `[pending external review]` instead of blocking the pipeline.
-
 ### Step 3: Parse and Normalize
 
-Extract structured fields from the response:
+Extract structured fields from the secondary Codex response:
 
 ```markdown
 - claim_supported: yes | partial | no
@@ -95,35 +88,103 @@ Extract structured fields from the response:
 - confidence: high | medium | low
 ```
 
+### Step 3.5: Check Experiment Integrity (if audit exists)
+
+**Skip this step if `EXPERIMENT_AUDIT.json` does not exist.**
+
+```
+if EXPERIMENT_AUDIT.json exists:
+    read integrity_status from file
+    attach to verdict output:
+        integrity_status: pass | warn | fail
+
+    if integrity_status == "fail":
+        append to verdict: "[INTEGRITY CONCERN] — audit found issues, see EXPERIMENT_AUDIT.md"
+        downgrade confidence to "low" regardless of Codex judgment
+
+    if integrity_status == "warn":
+        append to verdict: "[INTEGRITY: WARN] — audit flagged potential issues"
+else:
+    integrity_status = "unavailable"
+    verdict is labeled "provisional — no integrity audit run"
+    (this does NOT block anything — pipeline continues normally)
+```
+
+See `shared-references/experiment-integrity.md` for the full integrity protocol.
+
 ### Step 4: Route Based on Verdict
 
-#### `no` - Claim not supported
+#### `no` — Claim not supported
 
-1. Record a postmortem in `findings.md`:
-   - What was tested, what failed, and hypotheses for why
-   - Constraints for future attempts (what **not** to try again)
-2. Update the project pipeline status in project notes
-3. Decide whether to pivot to the next idea from `IDEA_CANDIDATES.md` or try an alternative approach
+1. Record postmortem in findings.md (Research Findings section):
+   - What was tested, what failed, hypotheses for why
+   - Constraints for future attempts (what NOT to try again)
+2. Update the project pipeline status in `AGENTS.md` or project notes
+3. Decide whether to pivot to next idea from IDEA_CANDIDATES.md or try an alternative approach
 
-#### `partial` - Claim partially supported
+#### `partial` — Claim partially supported
 
-1. Update the working claim to reflect what **is** supported
-2. Record the gap in `findings.md`
+1. Update the working claim to reflect what IS supported
+2. Record the gap in findings.md
 3. Design and run supplementary experiments to fill evidence gaps
-4. Re-run `/result-to-claim` after supplementary experiments complete
-5. If the same claim gets multiple `partial` verdicts, record the analysis in `findings.md` and consider narrowing the claim scope or switching ideas
+4. Re-run result-to-claim after supplementary experiments complete
+5. **Multiple rounds of `partial` on the same claim** → record analysis in findings.md, consider whether to narrow the claim scope or switch ideas
 
-#### `yes` - Claim supported
+#### `yes` — Claim supported
 
-1. Record the confirmed claim in project notes
-2. If ablation studies are incomplete, trigger `/ablation-planner`
-3. If all evidence is in, move to paper writing
+1. Record confirmed claim in project notes
+2. If ablation studies are incomplete → trigger `/ablation-planner`
+3. If all evidence is in → ready for paper writing
+
+### Step 5: Update Research Wiki (if active)
+
+**Skip this step entirely if `research-wiki/` does not exist.**
+
+```
+if research-wiki/ exists:
+    # 1. Create experiment page
+    Create research-wiki/experiments/<exp_id>.md with:
+      - node_id: exp:<id>
+      - idea_id: idea:<active_idea>
+      - date, hardware, duration, metrics
+      - verdict, confidence, reasoning summary
+
+    # 2. Update claim status
+    for each claim resolved by this verdict:
+        if verdict == "yes":
+            Update claim page: status → supported
+            run the installed ARIS research_wiki.py helper to add a supports edge from "exp:<id>" to "claim:<cid>"
+        elif verdict == "partial":
+            Update claim page: status → partial
+            run the installed ARIS research_wiki.py helper to add a partial supports edge from "exp:<id>" to "claim:<cid>"
+        else:
+            Update claim page: status → invalidated
+            run the installed ARIS research_wiki.py helper to add an invalidates edge from "exp:<id>" to "claim:<cid>"
+
+    # 3. Update idea outcome
+    Update research-wiki/ideas/<idea_id>.md:
+      - outcome: positive | mixed | negative
+      - If negative: fill "Failure / Risk Notes" and "Lessons Learned"
+      - If positive: fill "Actual Outcome" and "Reusable Components"
+
+    # 4. Rebuild + log
+    rebuild the query pack with the installed ARIS research_wiki.py helper
+    log "result-to-claim: exp:<id> verdict=<verdict> for idea:<idea_id>" with the installed ARIS research_wiki.py helper
+
+    # 5. Re-ideation suggestion
+    Count failed/partial ideas since last /idea-creator run.
+    If >= 3: print "💡 3+ ideas tested since last ideation. Consider re-running /idea-creator — the wiki now knows what doesn't work."
+```
 
 ## Rules
 
 - **The secondary Codex agent is the judge, not the local executor.** The local executor collects evidence and routes; the reviewer agent evaluates. This prevents post-hoc rationalization.
-- Do not inflate claims beyond what the data supports. If the verdict says `partial`, do not round up to `yes`.
+- Do not inflate claims beyond what the data supports. If Codex says "partial", do not round up to "yes".
 - A single positive result on one dataset does not support a general claim. Be honest about scope.
 - If `confidence` is low, treat the judgment as inconclusive and add experiments rather than committing to a claim.
-- If reviewer delegation is unavailable, make the best local judgment you can and mark it `[pending external review]`.
-- Always record the verdict and reasoning in `findings.md`, regardless of outcome.
+- If reviewer delegation is unavailable, make the best local judgment you can and mark it `[pending external review]` - do not block the pipeline.
+- Always record the verdict and reasoning in findings.md, regardless of outcome.
+
+## Review Tracing
+
+After the secondary Codex judgment, save a trace following `../shared-references/review-tracing.md`. Write files directly to `.aris/traces/result-to-claim/<date>_run<NN>/` and include the prompt, raw reviewer response, parsed verdict, routing action, and whether the result is `[pending external review]`. Respect the `--- trace:` parameter when present (default: `full`).

--- a/skills/skills-codex/run-experiment/SKILL.md
+++ b/skills/skills-codex/run-experiment/SKILL.md
@@ -15,6 +15,8 @@ Read the project's `AGENTS.md` to determine the experiment environment:
 
 - **Local GPU**: Look for local CUDA/MPS setup info
 - **Remote server**: Look for SSH alias, conda env, code directory
+- **Vast.ai instance**: Look for `gpu: vast`, `vast_instance`, SSH host/port, remote path, and optional `auto_destroy`
+- **Modal serverless**: Look for `gpu: modal`, app/function name, image/dependency setup, and secrets
 
 If no server info is found in `AGENTS.md`, ask the user.
 
@@ -59,6 +61,17 @@ ssh <server> "cd <remote_dst> && git pull"
 ```
 
 Benefits: version-tracked, multi-server sync with one push, no rsync include/exclude rules needed.
+
+#### Option C: Vast.ai instance
+
+If `gpu: vast` is configured, treat the Vast.ai machine as a remote server with an explicit lifecycle:
+
+1. Verify the instance is running and reachable.
+2. Sync code to the configured remote path.
+3. Confirm data/checkpoints are already mounted or intentionally copied.
+4. Record the instance id in the launch summary for later cleanup.
+
+Do not silently ignore a requested Vast.ai route. If Vast.ai CLI credentials or instance metadata are missing, stop and ask the user to configure them.
 
 ### Step 3.5: W&B Integration (when `wandb: true` in AGENTS.md)
 
@@ -112,6 +125,24 @@ ssh <server> "screen -dmS <exp_name> bash -c '\
   CUDA_VISIBLE_DEVICES=<gpu_id> python <script> <args> 2>&1 | tee <log_file>'"
 ```
 
+#### Vast.ai instance
+
+Use the same SSH + screen pattern, but include the Vast.ai instance id, public SSH endpoint, and remote working directory in the report. If `auto_destroy: true`, write a cleanup command to the run notes before launch.
+
+Record the estimated hourly cost, expected run duration, and cleanup owner. If the command fails to start or the instance becomes unreachable, do not relaunch blindly; capture logs and ask for a rescue / second opinion before spending more GPU time.
+
+#### Modal (serverless)
+
+If `gpu: modal` is configured, deploy through Modal instead of SSH:
+
+```bash
+modal run <module_or_app>.py -- <args>
+```
+
+Before launch, verify required secrets, volumes, image dependencies, and output persistence. If Modal is requested but the project lacks Modal configuration, stop and ask the user to configure it rather than falling back to local execution.
+
+Record the Modal app/function name, GPU type, timeout, mounted volumes, and where results will be stored. If Modal reports an image, secret, or volume error, preserve the exact error and run a configuration fix before retrying.
+
 #### Local
 
 ```bash
@@ -140,6 +171,17 @@ After deployment is verified, check `~/.codex/feishu.json`:
 - Send `experiment_done` notification: which experiments launched, which GPUs, estimated time
 - If config absent or mode `"off"`: skip entirely (no-op)
 
+### Step 7: Auto-Destroy Vast.ai Instance (when `gpu: vast` and `auto_destroy: true`)
+
+Only run this after the experiment has completed and results/logs/checkpoints have been copied or otherwise persisted.
+
+1. Verify the target process has exited.
+2. Copy result files and logs to the configured durable location.
+3. Ask for confirmation unless AGENTS.md explicitly says `auto_destroy: true`.
+4. Destroy only the recorded instance id for this run.
+
+If any artifact copy fails, do not destroy the instance.
+
 ## Key Rules
 
 - ALWAYS check GPU availability first — never blindly assign GPUs
@@ -163,6 +205,19 @@ Users should add their server info to their project's `AGENTS.md`:
 - wandb: false              # set to "true" to auto-add W&B logging to experiment scripts
 - wandb_project: my-project # W&B project name (required if wandb: true)
 - wandb_entity: my-team     # W&B team/user (optional, uses default if omitted)
+
+## Vast.ai
+- gpu: vast
+- vast_instance: 123456
+- SSH: `ssh -p 12345 root@ssh.vast.ai`
+- Code dir: `/workspace/experiments/`
+- auto_destroy: false
+
+## Modal
+- gpu: modal
+- modal_app: `train.py`
+- modal_secrets: `wandb-secret`
+- modal_volume: `experiment-results`
 
 ## Local Environment
 - Mac MPS / Linux CUDA

--- a/skills/skills-codex/semantic-scholar/SKILL.md
+++ b/skills/skills-codex/semantic-scholar/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: semantic-scholar
+description: Search published venue papers (IEEE, ACM, Springer, etc.) via Semantic Scholar API. Complements /arxiv (preprints) with citation counts, venue metadata, and TLDR. Use when user says "search semantic scholar", "find IEEE papers", "find journal papers", "venue papers", "citation search", or wants published literature beyond arXiv preprints.
+argument-hint: query-or-paper-id
+allowed-tools: Bash(*), Read, Write
+---
+
+# Semantic Scholar Paper Search
+
+Search topic or paper ID: $ARGUMENTS
+
+## Role & Positioning
+
+This skill is the **published venue** counterpart to `/arxiv`:
+
+| Skill | Source | Best for |
+|-------|--------|----------|
+| `/arxiv` | arXiv API | Latest preprints, cutting-edge unrefereed work |
+| `/semantic-scholar` | Semantic Scholar API | **Published** journal/conference papers (IEEE, ACM, Springer, etc.) with citation counts, venue info, TLDR |
+
+**Do NOT duplicate arXiv's job.** If results contain an `externalIds.ArXiv` field, the paper is also on arXiv — note this but do not re-fetch from arXiv.
+
+## Constants
+
+- **MAX_RESULTS = 10** — Default number of search results.
+- **FETCH_SCRIPT** — `$ARIS_REPO/tools/semantic_scholar_fetch.py` from the ARIS repo recorded by the Codex install manifest. Fall back to inline Python if not found.
+- **DEFAULT_FILTERS** — For general research queries, apply these by default to reduce noise:
+  - `--fields-of-study "Computer Science,Engineering"`
+  - `--publication-types JournalArticle,Conference`
+
+> Overrides (append to arguments):
+> - `/semantic-scholar "topic" - max: 20` — return up to 20 results
+> - `/semantic-scholar "topic" - type: journal` — only journal articles
+> - `/semantic-scholar "topic" - type: conference` — only conference papers
+> - `/semantic-scholar "topic" - min-citations: 50` — only highly-cited papers
+> - `/semantic-scholar "topic" - year: 2022-` — papers from 2022 onward
+> - `/semantic-scholar "topic" - fields: all` — remove default field-of-study filter
+> - `/semantic-scholar "topic" - sort: citations` — bulk search sorted by citation count
+> - `/semantic-scholar "DOI:10.1109/..."` — fetch a single paper by DOI
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for directives:
+
+- **Query or ID**: main search term, or a paper identifier:
+  - DOI: `10.1109/TWC.2024.1234567`
+  - Semantic Scholar ID: `f9314fd99be5f2b1b3efcfab87197d578160d553`
+  - ArXiv: `ARXIV:2006.10685`
+  - Corpus: `CorpusId:219792180`
+- **`- max: N`**: override MAX_RESULTS
+- **`- type: journal|conference|review|all`**: map to `--publication-types`
+- **`- min-citations: N`**: map to `--min-citations`
+- **`- year: RANGE`**: map to `--year` (e.g. `2022-`, `2020-2024`)
+- **`- fields: FIELDS`**: override `--fields-of-study` (use `all` to remove filter)
+- **`- sort: citations|date`**: use `search-bulk` with `--sort citationCount:desc` or `publicationDate:desc`
+
+If the argument matches a DOI pattern (`10.XXXX/...`), a Semantic Scholar ID (40-char hex), or a prefixed ID (`ARXIV:...`, `CorpusId:...`), skip search and go directly to Step 3.
+
+### Step 2: Search Papers
+
+Locate the fetch script:
+
+```bash
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/semantic_scholar_fetch.py" ] && SCRIPT="$ARIS_REPO/tools/semantic_scholar_fetch.py"
+[ -z "$SCRIPT" ] && SCRIPT=$(find tools/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+[ -z "$SCRIPT" ] && SCRIPT=$(find ~/.codex/skills/semantic-scholar/ -name "semantic_scholar_fetch.py" 2>/dev/null | head -1)
+```
+
+**Standard search** (default — relevance-ranked):
+
+```bash
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" search "QUERY" --max MAX_RESULTS \
+  --fields-of-study "Computer Science,Engineering" \
+  --publication-types JournalArticle,Conference
+```
+
+**Bulk search** (when `- sort:` is specified, or MAX_RESULTS > 100):
+
+```bash
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" search-bulk "QUERY" --max MAX_RESULTS \
+  --sort citationCount:desc \
+  --fields-of-study "Computer Science" \
+  --year "2020-"
+```
+
+If `semantic_scholar_fetch.py` is not found, fall back to inline Python using `urllib` against `https://api.semanticscholar.org/graph/v1/paper/search`.
+
+**Recommended filter combos** (from testing):
+
+| Goal | Flags |
+|------|-------|
+| High-quality journal papers | `--publication-types JournalArticle --min-citations 10` |
+| CS/EE papers, recent | `--fields-of-study "Computer Science,Engineering" --year "2022-"` |
+| Foundational / high-impact | `search-bulk --sort citationCount:desc --fields-of-study "Computer Science"` |
+| Conference papers only | `--publication-types Conference` |
+
+> **Note**: `--venue` requires exact venue names (e.g. "IEEE Transactions on Signal Processing"), not partial matches like "IEEE". Avoid using `--venue` in automated flows — prefer `--publication-types` + `--fields-of-study`.
+
+### Step 3: Fetch Details for a Specific Paper
+
+When a single paper ID is requested:
+
+```bash
+[ -n "$SCRIPT" ] && python3 "$SCRIPT" paper "PAPER_ID"
+```
+
+Where PAPER_ID can be:
+- DOI: `10.1109/TSP.2021.3071210`
+- ArXiv: `ARXIV:2006.10685`
+- CorpusId: `CorpusId:219792180`
+- S2 ID: `f9314fd99be5f2b1b3efcfab87197d578160d553`
+
+### Step 4: De-duplicate Against arXiv
+
+For each result, check `externalIds.ArXiv`:
+- If present → paper is also on arXiv. Note this in output but do NOT re-fetch via `/arxiv`.
+- If absent → paper is **venue-only** (e.g. IEEE without preprint). This is the unique value of this skill.
+
+### Step 5: Present Results
+
+Present results as a table:
+
+```text
+| # | Title | Venue | Year | Citations | Authors | Type |
+|---|-------|-------|------|-----------|---------|------|
+| 1 | Deep Learning Enabled... | IEEE Trans. Signal Process. | 2021 | 1364 | Xie et al. | Journal |
+```
+
+For each paper, also show:
+- **DOI link**: `https://doi.org/DOI` (for IEEE/ACM papers, this is the canonical link)
+- **Open Access PDF**: if `openAccessPdf.url` is non-empty, show it
+- **TLDR**: if available, show the one-line summary
+- **Also on arXiv**: if `externalIds.ArXiv` exists, note the arXiv ID
+
+### Step 6: Detailed Summary
+
+For each paper (or top 5 if many results):
+
+```markdown
+## [Title]
+
+- **Venue**: [venue name] ([publicationVenue.type]: journal/conference)
+- **Year**: [year] | **Citations**: [citationCount]
+- **Authors**: [full author list]
+- **DOI**: [doi link]
+- **Fields**: [fieldsOfStudy]
+- **TLDR**: [tldr.text if available]
+- **Abstract**: [abstract]
+- **Open Access**: [openAccessPdf.url or "Not available"]
+- **Also on arXiv**: [ArXiv ID if exists, else "No"]
+```
+
+### Step 7: Update Research Wiki (if active)
+
+**Required when `research-wiki/` exists in the project**; skip silently
+otherwise. Ingest the papers presented to the user. For results with an
+`externalIds.ArXiv` field, use `--arxiv-id`; for venue-only papers (no
+arXiv mirror — common for IEEE/ACM), fall back to manual metadata:
+
+```
+if [ -d research-wiki/ ]:
+    WIKI_SCRIPT=""
+    [ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+    for each paper in results:
+        if paper.externalIds.ArXiv:
+            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+                --arxiv-id "<ArXiv>"
+        else:
+            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+                --title "<title>" --authors "<authors joined by , >" \
+                --year <year> --venue "<venue>" \
+                [--external-id-doi "<externalIds.DOI>"]
+```
+
+The helper handles slug / dedup / page / index / log — **do not
+handwrite `papers/<slug>.md`**. See
+[`shared-references/integration-contract.md`](../shared-references/integration-contract.md).
+Backfill with `/research-wiki sync --arxiv-ids <id1>,<id2>,...` for
+arXiv-available papers.
+
+### Step 8: Final Output
+
+Summarize what was done:
+
+- `Found N published papers for "query"`
+- `Filters applied: [publication types, fields, year range, etc.]`
+- `N papers are venue-only (not on arXiv)`
+- `Wiki-ingested N papers` (if `research-wiki/` was present)
+
+Suggest follow-up skills:
+
+```text
+/arxiv "topic"           - search arXiv preprints (complements this search)
+/research-lit "topic"    - multi-source review: Zotero + local PDFs + arXiv + S2
+/novelty-check "idea"    - verify novelty against literature
+```
+
+## Key Rules
+
+- **Default to filtered search**: Always apply `--fields-of-study` and `--publication-types` unless user says `- fields: all`. Without filters, S2 returns cross-discipline noise (linguistics, psychology, etc.).
+- **Citation count is gold**: S2's citation data is its main advantage over arXiv. Always show `citationCount` prominently and use it to rank/prioritize results.
+- **Venue metadata matters**: Show `venue` and `publicationVenue.type` (journal vs conference) — this helps users assess paper quality.
+- **DOI is the canonical ID for published papers**: Always show DOI links for IEEE/ACM/Springer papers.
+- **Rate limiting**: S2 API without key is heavily rate-limited (~1 req/s, strict cooldown). If HTTP 429 occurs, wait and retry. Recommend users set `SEMANTIC_SCHOLAR_API_KEY` env var for higher limits (free at https://www.semanticscholar.org/product/api#api-key-form).
+- **TLDR may be null**: Some publishers (notably IEEE) elide the TLDR field. Fall back to showing the first sentence of the abstract.
+- **openAccessPdf may be empty**: Many IEEE papers are closed access. Always provide the DOI link as fallback.
+- If the S2 API is unreachable, suggest using `/arxiv` or `/research-lit "topic" - sources: web` as fallback.

--- a/skills/skills-codex/serverless-modal/SKILL.md
+++ b/skills/skills-codex/serverless-modal/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: serverless-modal
+description: "Run GPU workloads on Modal — training, fine-tuning, inference, batch processing. Zero-config serverless: no SSH, no Docker, auto scale-to-zero. Use when user says \"modal run\", \"modal training\", \"modal inference\", \"deploy to modal\", \"need a GPU\", \"run on modal\", \"serverless GPU\", or needs remote GPU compute."
+argument-hint: [task-description]
+allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent
+---
+
+# Modal Cloud GPU — Training & Inference
+
+Task: $ARGUMENTS
+
+## Overview
+
+**Modal** is a serverless GPU cloud. Key advantages over SSH-based platforms (vast.ai, remote servers):
+- **Zero config**: no SSH, no Docker, no port forwarding. Write Python → `modal run` → done.
+- **Auto scale-to-zero**: billing stops the instant your code finishes. No idle instances.
+- **Local-first**: run `modal run` from your laptop. Code, data, and results stay local; only the GPU function runs remotely.
+- **Reproducible environments**: dependencies declared in code via `modal.Image`, not system-level packages.
+
+**Best for**: Users without a local GPU who need to debug CUDA code, run small-scale tests, or iterate quickly on experiments. The $5 free tier (no card) is enough for code debugging; $30 (with card) covers most small-scale experiment runs.
+
+**Trade-off**: Modal costs more per GPU-hour than vast.ai or Lightning for some GPU tiers, but eliminates setup time and idle billing, often making it cheaper for short/medium workloads. For long training runs (>4 hours), consider vast.ai for lower $/hr.
+
+## Authentication
+
+```bash
+pip install modal
+modal setup          # Opens browser login, writes token to ~/.modal.toml
+# Verify:
+modal run -q 'print("ok")'
+```
+
+- Sign up: https://modal.com (GitHub/Google login)
+- Free (no card): **$5/month** — enough for quick tests
+- Free (with card): **$30/month** — bind a payment method at https://modal.com/settings for the full free tier. Set a **workspace spending limit** to prevent accidental overcharge (Settings → Usage → Spending Limit)
+- Academic: apply for $10k credits | Startups: apply for $25k credits
+- Secrets: `modal secret create huggingface-secret HF_TOKEN=hf_xxxxx`
+
+> **Recommended setup**: Bind a card to unlock $30/month, then immediately set a spending limit (e.g., $30) so you never exceed the free tier. Modal will pause your workloads when the limit is hit.
+>
+> **SECURITY WARNING**: Always bind your card and set spending limits directly on https://modal.com/settings in your browser. NEVER enter payment information, card numbers, or billing details through Codex, Claude Code, or any CLI tool. Only the official Modal website is safe for payment operations.
+
+## Pricing (source: modal.com/pricing, per-second billing)
+
+| GPU | $/sec | ≈$/hr | VRAM | Bandwidth GB/s | Free budget → hours |
+|---|---|---|---|---|---|
+| T4 | $0.000164 | $0.59 | 16GB | 300 | ~8.5 hr ($5) / 50.8 hr ($30) |
+| L4 | $0.000222 | $0.80 | 24GB | 300 | ~6.3 hr / 37.5 hr |
+| A10 | $0.000306 | $1.10 | 24GB | 600 | ~4.5 hr / 27.3 hr |
+| L40S | $0.000542 | $1.95 | 48GB | 864 | ~2.6 hr / 15.4 hr |
+| A100-40GB | $0.000583 | $2.10 | 40GB | 1555 | ~2.4 hr / 14.3 hr |
+| A100-80GB | $0.000694 | $2.50 | 80GB | 2039 | ~2.0 hr / 12.0 hr |
+| H100 | $0.001097 | $3.95 | 80GB | 3352 | ~1.3 hr / 7.6 hr |
+| H200 | $0.001261 | $4.54 | 141GB | 4800 | ~1.1 hr / 6.6 hr |
+| B200 | $0.001736 | $6.25 | 192GB | 8000 | ~0.8 hr / 4.8 hr |
+
+CPU: $0.047/core/hr | RAM: $0.008/GiB/hr (GPU typically 90%+ of total cost)
+
+## !! Cost Estimation Required !!
+
+Before EVERY run, estimate cost and show to user for confirmation.
+
+Key insights:
+- Inference bottleneck is **memory bandwidth**, not compute → high-bandwidth GPUs are often cheaper overall
+- 7-8B BF16 inference needs **~22GB VRAM** (weights 15G + KV cache 1G + overhead), T4 (16GB) insufficient
+- H100 is often **cheaper than L4** for benchmarks (11x faster but only 5x more expensive)
+
+### Cost Estimation Template (required before every run)
+
+```
+Cost estimate (Modal):
+  Model: [name] ([params], [precision])
+  VRAM: ~[X]GB (weights + KV cache + overhead)
+  GPU: [type] ([VRAM]GB, $[X]/sec = $[X]/hr, bandwidth [X] GB/s)
+  Estimate: ~[N] min, ~$[X]
+```
+
+### 7-8B BF16 Benchmark Cost Comparison
+
+| GPU | Speed tok/s | $/hr | 1000 samples x 200tok cost | Duration |
+|---|---|---|---|---|
+| **H100** | **224** | $3.95 | **$0.98** | **15 min** |
+| A100-40GB | 104 | $2.10 | $1.12 | 32 min |
+| L4 | 20 | $0.80 | $2.22 | 167 min |
+
+## Workflow
+
+### Step 1: Analyze Task → Estimate Cost → Choose GPU
+
+Same analysis as any GPU skill — determine VRAM needs from model size, pick GPU, estimate hours, calculate cost. See pricing table above.
+
+**VRAM Rules of Thumb:**
+| Model Size | FP16 VRAM | Recommended GPU |
+|---|---|---|
+| ≤3B | ~8GB | T4, L4 |
+| 7-8B | ~22GB | L4, A10, A100-40GB |
+| 13B | ~30GB | L40S, A100-40GB |
+| 30B | ~65GB | A100-80GB, H100 |
+| 70B | ~140GB | H100:2, H200 |
+
+### Step 2: Generate Modal Launcher
+
+Based on the task type, generate the appropriate launcher script.
+
+#### Pattern A: One-Shot GPU Function (training, evaluation, benchmark)
+
+The most common pattern for `run-experiment` integration. Wraps an existing training script:
+
+```python
+import modal
+
+app = modal.App("experiment-name")
+image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "torch", "transformers", "accelerate", "datasets", "wandb"
+)
+
+# Mount local project code into the container
+local_code = modal.Mount.from_local_dir(".", remote_path="/workspace")
+# Persistent volume for checkpoints and results
+volume = modal.Volume.from_name("experiment-results", create_if_missing=True)
+
+@app.function(
+    image=image,
+    gpu="A100-80GB",          # Chosen based on Step 1 analysis
+    mounts=[local_code],
+    volumes={"/results": volume},
+    timeout=3600 * 6,         # 6 hours max
+    secrets=[modal.Secret.from_name("wandb-secret")],  # Optional
+)
+def train():
+    import subprocess
+    subprocess.run(
+        ["python", "train.py", "--output_dir", "/results/run_001"],
+        cwd="/workspace",
+        check=True,
+    )
+    volume.commit()  # Persist results to volume
+
+@app.local_entrypoint()
+def main():
+    train.remote()
+    print("Training complete. Results saved to Modal volume 'experiment-results'.")
+```
+
+Run: `modal run launcher.py`
+
+#### Pattern B: Web API (persistent inference service)
+
+```python
+import modal
+
+app = modal.App("inference-api")
+image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "torch", "transformers", "accelerate"
+)
+
+@app.cls(image=image, gpu="L40S")
+@modal.concurrent(max_inputs=10)
+class InferenceAPI:
+    @modal.enter()
+    def load_model(self):
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B")
+        self.model = AutoModelForCausalLM.from_pretrained(
+            "meta-llama/Llama-3.2-1B", device_map="auto"
+        )
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate(self, request: dict):
+        inputs = self.tokenizer(request.get("prompt", ""), return_tensors="pt").to("cuda")
+        outputs = self.model.generate(**inputs, max_new_tokens=256)
+        return {"text": self.tokenizer.decode(outputs[0], skip_special_tokens=True)}
+```
+
+Deploy: `modal deploy app.py`
+
+#### Pattern C: vLLM High-Performance Inference
+
+```python
+import modal, subprocess
+
+app = modal.App("vllm-server")
+image = modal.Image.debian_slim(python_version="3.11").pip_install("vllm")
+VOLUME = modal.Volume.from_name("model-cache", create_if_missing=True)
+MODEL = "Qwen/Qwen3-4B"
+
+@app.function(image=image, gpu="H100", volumes={"/models": VOLUME}, timeout=3600)
+@modal.concurrent(max_inputs=100)
+@modal.web_server(port=8000)
+def serve():
+    subprocess.Popen(["python", "-m", "vllm.entrypoints.openai.api_server",
+                      "--model", MODEL, "--download-dir", "/models", "--port", "8000"])
+```
+
+#### Pattern D: Batch Parallel (map over dataset)
+
+```python
+@app.function(image=image, gpu="T4", timeout=600)
+def process_item(item: dict) -> dict:
+    # ... process one item ...
+    return {"result": "processed"}
+
+@app.local_entrypoint()
+def main():
+    results = list(process_item.map([{"id": i} for i in range(1000)]))
+```
+
+#### Pattern E: LoRA Fine-Tuning
+
+```python
+@app.function(
+    image=image, gpu="A100-80GB", volumes={"/output": volume},
+    timeout=3600 * 6, secrets=[modal.Secret.from_name("huggingface-secret")],
+)
+def train():
+    # ... transformers + peft + trl training code ...
+    trainer.save_model("/output/final")
+    volume.commit()
+```
+
+#### Pattern F: Multi-GPU Distributed Training
+
+```python
+@app.function(image=image, gpu="H100:4", volumes={"/output": volume}, timeout=3600 * 12)
+def train_distributed():
+    import subprocess
+    subprocess.run(["accelerate", "launch", "--num_processes", "4",
+                    "--mixed_precision", "bf16", "train.py"], check=True)
+```
+
+### Step 3: Run
+
+```bash
+modal run launcher.py     # One-shot execution (most common for experiments)
+modal deploy app.py       # Persistent service deployment
+```
+
+### Step 4: Verify & Monitor
+
+```bash
+modal app list            # List running apps
+modal app logs <app-name> # Stream logs
+```
+
+### Step 5: Collect Results
+
+Results collection depends on the pattern used:
+
+**Volume-based** (recommended for training):
+```python
+# Download results from volume after run completes
+# Option A: In the launcher script, copy results to local mount before exit
+# Option B: Use modal volume commands
+modal volume ls experiment-results
+modal volume get experiment-results /run_001/results.json ./results/
+```
+
+**Stdout/return-based** (for evaluation/benchmarks):
+Results are printed to terminal or returned from the function — already local.
+
+### Step 6: Cleanup
+
+Modal auto-scales to zero — no manual instance destruction needed. But clean up unused resources:
+
+```bash
+modal app stop <app-name>     # Stop a deployed service
+modal volume rm <volume-name> # Delete a volume when done
+```
+
+## CLI Reference
+
+```bash
+modal run app.py          # Run once
+modal deploy app.py       # Deploy persistent service
+modal app logs <app>      # View logs
+modal app list            # List apps
+modal app stop <app>      # Stop
+modal volume ls           # List volumes
+modal volume get <vol> <remote> <local>  # Download from volume
+modal secret create NAME KEY=VALUE       # Create secret
+```
+
+## Key Tips
+
+- GPU fallback: `gpu=["H100", "A100-80GB", "L40S"]` — Modal tries each in order
+- Multi-GPU: `gpu="H100:4"` (up to 8 GPUs, cost scales linearly)
+- Volume: `modal.Volume.from_name("x", create_if_missing=True)` for persistent storage
+- `@modal.enter()` loads model once per container | `@modal.concurrent()` for concurrent requests
+- Long training: set `timeout=3600 * N` (default is 5 min)
+- Local code: `modal.Mount.from_local_dir(".", remote_path="/workspace")`
+- W&B integration: `secrets=[modal.Secret.from_name("wandb-secret")]` + `wandb.init()` in your script
+
+## Composing with Other Skills
+
+```
+/run-experiment "train model"       <- detects gpu: modal, calls /serverless-modal
+  -> /serverless-modal              <- analyzes task, generates launcher, runs
+  -> Results returned locally or to Modal Volume
+  -> No destroy step needed (auto scale-to-zero)
+
+/serverless-modal                   <- standalone: any Modal GPU workload
+/serverless-modal "deploy vLLM"     <- inference service deployment
+```
+
+## AGENTS.md Example
+
+```markdown
+## Modal
+- gpu: modal                 # tells run-experiment to use Modal serverless
+- modal_gpu: A100-80GB       # optional: override GPU selection (default: auto-select)
+- modal_timeout: 21600       # optional: max seconds (default: 6 hours)
+- modal_volume: my-results   # optional: named volume for results persistence
+```
+
+No SSH keys, no Docker images, no instance management needed. Just `pip install modal && modal setup`.
+
+> **Cost protection**: After `modal setup`, go to https://modal.com/settings in your browser (NEVER through CLI) → bind a payment method to unlock $30/month free tier (without card: only $5/month). Then set a **workspace spending limit** equal to your free tier amount — Modal will auto-pause workloads when the limit is reached, preventing any surprise charges.
+
+## Documentation
+
+- Docs: https://modal.com/docs/guide
+- GPU: https://modal.com/docs/guide/gpu
+- Pricing: https://modal.com/pricing
+- Examples: https://modal.com/docs/examples

--- a/skills/skills-codex/shared-references/assurance-contract.md
+++ b/skills/skills-codex/shared-references/assurance-contract.md
@@ -1,0 +1,121 @@
+# Assurance Contract
+
+ARIS audits emit machine-readable verdicts. The `assurance` axis decides whether those verdicts are advisory in draft mode or load-bearing gates in submission mode.
+
+This contract is referenced by `paper-writing`, `paper-claim-audit`, `citation-audit`, `proof-checker`, and the external verifier `tools/verify_paper_audits.sh`.
+
+## Why a separate axis from `effort`
+
+`effort` controls depth and cost. `assurance` controls audit strictness.
+
+| Axis | Controls | Default |
+|------|----------|---------|
+| `effort` | depth/cost, papers, rounds, ideation | `balanced` |
+| `assurance` | audit strictness, silent-skip allowed vs verdict required | derived from `effort` |
+
+Override either independently. For example, `— effort: balanced, assurance: submission` means normal depth but every audit must emit a verdict before finalization.
+
+## Assurance Levels
+
+### `draft`
+
+- Audits run only if their content detector matches.
+- Silent skip is allowed.
+- `paper-writing` can produce a final report without the submission verifier.
+- Use for rapid iteration and early drafts.
+
+### `submission`
+
+- All mandatory audits must emit a verdict.
+- Silent skip is forbidden.
+- `paper-writing` runs `tools/verify_paper_audits.sh`.
+- A non-zero verifier exit blocks the Final Report.
+- The Final Report marks `submission-ready: yes/no` from verifier output.
+
+## Default Mapping
+
+| `effort` | implied `assurance` |
+|----------|---------------------|
+| `lite` | `draft` |
+| `balanced` | `draft` |
+| `max` | `submission` |
+| `beast` | `submission` |
+
+Users who want strict audits at lower depth should pass `— assurance: submission`.
+
+## Verdict State Machine
+
+Every mandatory audit must emit exactly one of these verdicts:
+
+| Verdict | Meaning | Submission-blocking? |
+|---------|---------|----------------------|
+| `PASS` | All checks passed | No |
+| `WARN` | Issues found, none disqualifying | No |
+| `FAIL` | Disqualifying issues found | Yes |
+| `NOT_APPLICABLE` | Detector negative; nothing to audit | No |
+| `BLOCKED` | Audit should apply but prerequisites are missing | Yes |
+| `ERROR` | Audit invocation failed | Yes |
+
+`NOT_APPLICABLE` means the audit phase ran and wrote an artifact documenting that there was nothing to verify. It is not the same as a silent skip.
+
+`BLOCKED` means the audit should have run but could not, such as numeric claims with no raw result files.
+
+## Required Audit Artifact Schema
+
+Every mandatory audit must write a JSON artifact, and may also write a Markdown sibling:
+
+```json
+{
+  "audit_skill": "paper-claim-audit",
+  "verdict": "PASS",
+  "reason_code": "all_numbers_match",
+  "summary": "Verified 23 numeric claims against 4 result files; no mismatches.",
+  "audited_input_hashes": {
+    "main.tex": "sha256:a3f8...",
+    "sections/5_evidence.tex": "sha256:b2d1..."
+  },
+  "trace_path": ".aris/traces/paper-claim-audit/2026-04-21_run01/",
+  "agent_id": "019dae73-fc12-4ab8-...",
+  "reviewer_model": "gpt-5.4",
+  "reviewer_reasoning": "xhigh",
+  "generated_at": "2026-04-21T14:23:01Z",
+  "details": {}
+}
+```
+
+Field rules:
+
+- `audit_skill` identifies the child audit skill.
+- `verdict` is one of the six allowed verdicts.
+- `audited_input_hashes` contains SHA256 hashes for every file consumed by the audit.
+- In-paper paths are relative to the paper directory passed to the verifier.
+- Files outside the paper directory may use absolute paths.
+- `trace_path` points to the saved reviewer trace.
+- `agent_id` is the Codex reviewer id when a reviewer agent was used.
+- `reviewer_model` and `reviewer_reasoning` document the reviewer route.
+- `generated_at` is UTC ISO-8601.
+
+## Verifier Contract
+
+`tools/verify_paper_audits.sh <paper-dir>` is the single source of truth for mandatory audit completeness. It must:
+
+1. Locate expected audit artifacts.
+2. Validate JSON required fields.
+3. Verify each verdict is allowed.
+4. Recompute `audited_input_hashes` and flag stale artifacts.
+5. Verify `trace_path` exists when required.
+6. Exit 0 only when all mandatory audits are green.
+
+At `assurance: submission`, `paper-writing` must treat verifier exit 1 as blocking.
+
+## Subskill Contract
+
+Child audit skills follow this contract:
+
+- Always emit a verdict artifact, even on detector-negative or error paths.
+- Never decide final submission readiness themselves.
+- The parent skill and verifier decide whether a verdict blocks finalization.
+
+## Backward Compatibility
+
+The default `effort: balanced` maps to `assurance: draft`, preserving normal draft behavior. `effort: max` and `effort: beast` imply `assurance: submission` unless the user explicitly overrides with `assurance: draft`.

--- a/skills/skills-codex/shared-references/integration-contract.md
+++ b/skills/skills-codex/shared-references/integration-contract.md
@@ -1,0 +1,159 @@
+# Integration Contract
+
+When one ARIS skill delegates work to another (or to persistent project
+state), the coupling must be **engineered**, not assumed. This document
+formalizes what every cross-skill integration inside ARIS must provide.
+
+Rule of thumb: **SKILL.md prose can *describe* an integration; it cannot
+*guarantee* one.** Any integration whose silent failure would damage the
+research result needs the components below. Prose-only "MUST invoke X"
+has repeatedly failed in practice — the executor skips under context
+pressure and the caller has no way to detect it.
+
+## Known failure mode (why this contract exists)
+
+Two bugs in the same week, same pathology:
+
+1. **Assurance gate bypass (2026-04-21).** `/paper-writing` ran at
+   `— effort: beast` silently skipped `/proof-checker`,
+   `/paper-claim-audit`, and `/citation-audit` because each phase's
+   content detector could return negative and the outer prose said
+   "audit is optional."
+2. **Research wiki ingest no-op (2026-04-21).** `/research-wiki init`
+   created `research-wiki/papers/` but no paper ever landed there:
+   `/arxiv`, `/alphaxiv`, `/deepxiv`, `/semantic-scholar`, `/exa-search`,
+   raw `Read`/`WebFetch` — none carried a wiki-ingest hook, and the two
+   that did (`/research-lit`, `/idea-creator`) only had soft prose
+   ("optional and automatic").
+
+Both bugs ship through the same gap: **one skill "called" another via
+prose without a canonical helper, a concrete artifact, or a verifier**.
+
+## Required components
+
+Every integration between two ARIS skills (or between a skill and a
+persistent project artifact) must provide all six:
+
+### 1. Activation predicate — single, explicit, observable
+
+A one-line test that says "does this integration fire in this context?"
+Must be observable from outside the LLM (a file exists, an argument is
+set, an environment variable is present). Not a vibe, not "probably
+relevant."
+
+- ✅ `if [ -d research-wiki/ ]`
+- ✅ `if assurance == "submission"`
+- ❌ "if the user seems to want this"
+
+### 2. Canonical helper — one implementation, not copy-pasted
+
+The business logic lives in **exactly one place** — a script under
+`tools/`, or a single subcommand of an existing helper. Every caller
+invokes the same entrypoint.
+
+- ✅ `python3 tools/research_wiki.py ingest_paper <root> --arxiv-id <id>`
+- ✅ `bash tools/verify_paper_audits.sh <paper> --assurance submission`
+- ❌ N skills each paraphrasing the same 10-line bash snippet. When one
+     drifts, they all drift.
+
+If the same 3+ lines of prose appear in more than two SKILL.md files,
+factor them into a helper.
+
+### 3. Concrete artifact or log entry
+
+Successful execution must leave an observable side effect: a file, a
+JSON record, a log line. The artifact is the receipt — something a
+third party (verifier, code reviewer, human auditor) can inspect to
+answer "did this integration run?"
+
+- ✅ `paper/PROOF_AUDIT.json` with the 6-state verdict schema
+- ✅ `research-wiki/papers/<slug>.md` + `research-wiki/log.md` append
+- ❌ "the model said it ran"
+
+### 4. Visible checklist — for long workflows
+
+If the integration fires inside a multi-step workflow (paper-writing
+Phase 6, idea-discovery Phase 7, etc.), render a **visible checkbox
+block** at the start of the phase so the executor has to confront each
+row before claiming done. Prose-only "MUST" inside a long SKILL.md is
+the first thing to get skipped.
+
+```
+📋 Submission audits required before Final Report:
+   [ ] 1. /proof-checker   → paper/PROOF_AUDIT.json
+   [ ] 2. /paper-claim-audit → paper/PAPER_CLAIM_AUDIT.json
+   [ ] 3. /citation-audit  → paper/CITATION_AUDIT.json
+   [ ] 4. bash tools/verify_paper_audits.sh paper/ --assurance submission
+   [ ] 5. Block Final Report iff verifier exit code != 0
+```
+
+Cheap, and empirically resists lazy skipping. Skip only for single-step
+invocations (one-off skills like `/arxiv 2501.12345`).
+
+### 5. Backfill / repair command — explicit manual fallback
+
+An escape hatch for when the integration didn't fire. Users must be
+able to run a command that **declares** the missed inputs and ingests
+them retroactively. Prefer explicit arguments over trace-scanning — the
+helper should not have to guess what to backfill.
+
+- ✅ `/research-wiki sync --arxiv-ids 2501.12345,1706.03762`
+- ✅ `/research-wiki sync --from-file ids.txt`
+- ⚠️ `/research-wiki sync` that scans `.aris/traces/` for arxiv IDs —
+     only as a best-effort secondary mode, not the primary UX, and
+     clearly labeled as heuristic.
+
+### 6. Verifier or diagnostic (only when load-bearing)
+
+If silent failure of this integration would damage the research result
+(wrong numbers shipped to a conference, claims unsupported by
+evidence, citations in wrong context), a verifier script must exist
+whose exit code is the source of truth for downstream gates.
+
+- ✅ `tools/verify_paper_audits.sh` — exit 1 blocks Final Report
+- ✅ `tools/verify_wiki_coverage.sh` — diagnostic only, reports gaps
+     but does not block (coverage is not load-bearing on any research
+     outcome)
+
+Verifiers must be **external processes** (not LLM self-report), must
+validate **concrete artifacts** (§3) against a schema, and must emit a
+structured report callers can parse.
+
+A diagnostic-only verifier (no exit-1 blocking) is still valuable — it
+surfaces drift to humans. But do not market a diagnostic as a gate.
+
+## Anti-patterns to refuse in review
+
+When reviewing a new integration proposal, reject any of:
+
+- **"Optional and automatic"** — contradicts itself; if it's automatic,
+  it's not optional. Pick one and mean it.
+- **"The skill will intelligently decide"** — indecision surface, not
+  a predicate (§1).
+- **"Copy the following 10 lines into each caller"** — missing helper
+  (§2); will drift within a month.
+- **"The reviewer can see from the logs that..."** — if the evidence is
+  unstructured logs, write a schema and make it an artifact (§3).
+- **"Users should remember to..."** — missing backfill (§5); humans
+  don't reliably remember.
+- **"Trust the LLM to self-report completion"** — missing verifier (§6)
+  when the failure is load-bearing.
+
+## Known ARIS integrations under this contract
+
+| Integration | Predicate | Helper | Artifact | Checklist | Backfill | Verifier |
+|---|---|---|---|---|---|---|
+| Submission audits (`max`/`beast`) | `paper/.aris/assurance.txt = submission` | `verify_paper_audits.sh` + 3 audit skills emit JSON | `paper/PROOF_AUDIT.json`, `PAPER_CLAIM_AUDIT.json`, `CITATION_AUDIT.json` + `paper/.aris/audit-verifier-report.json` | Phase 6.0 pre-flight checklist | Rerun the failed audit | `verify_paper_audits.sh` (exit 1 blocks) |
+| Research wiki ingest | `research-wiki/` exists | `research_wiki.py ingest_paper` | `research-wiki/papers/<slug>.md` + `log.md` entry | Step in each paper-reading skill | `research_wiki.py sync --arxiv-ids …` | `verify_wiki_coverage.sh` (diagnostic) |
+
+When adding a new cross-skill integration, add a row to the table above
+and confirm all six columns are populated.
+
+## See Also
+
+- `shared-references/assurance-contract.md` — implementation of the
+  paper-writing submission gate under this contract
+- `shared-references/reviewer-independence.md` — the adjacent contract
+  for cross-model review (executor never filters reviewer inputs)
+- `tools/verify_paper_audits.sh`, `tools/research_wiki.py ingest_paper`,
+  `tools/verify_wiki_coverage.sh` — current canonical helpers

--- a/skills/skills-codex/shared-references/output-language.md
+++ b/skills/skills-codex/shared-references/output-language.md
@@ -1,0 +1,45 @@
+# Output Language Protocol
+
+## Language Detection
+
+Determine the output language using this priority:
+1. Check `AGENTS.md` for a `language:` field in `## Pipeline Status` — if `language: zh` or `language: cn`, output in Chinese
+2. If the user's most recent message is in Chinese, output in Chinese
+3. Default: English
+
+## What to Localize
+
+- Section headings and labels
+- Descriptions, analysis, commentary, recommendations
+- Template boilerplate text
+- Status messages and warnings
+
+## What NOT to Localize
+
+- Code, shell commands, file paths, directory names
+- Paper titles, author names, venue names, BibTeX entries
+- Technical terms with no standard Chinese translation (keep English, optionally annotate: "attention mechanism (注意力机制)")
+- LaTeX content — paper-writing workflow always outputs English for venue submission
+- JSON state files — keys and structure remain English
+- **Machine-parsed markers** — never localize the following, regardless of language setting:
+  - Markdown frontmatter keys (e.g., `outcome:`, `node_id:`, `title:`, `type:`)
+  - Research Wiki schema fields parsed by `tools/research_wiki.py` (e.g., `outcome: negative`, `outcome: positive`, `node_id:`)
+  - `MANIFEST.md` column headers and table structure
+  - Any field that downstream tools or scripts read programmatically
+
+## Skill-Specific Rules
+
+| Skill | Language Support | Notes |
+|-------|-----------------|-------|
+| /idea-creator | Full | IDEA_REPORT.md follows language setting |
+| /idea-discovery | Full | Inherits from sub-skills |
+| /analyze-results | Full | Result analysis follows language setting |
+| /auto-review-loop | Partial | AUTO_REVIEW.md follows setting; reviewer prompts stay English |
+| /experiment-plan | Full | EXPERIMENT_PLAN.md follows setting |
+| /experiment-bridge | Full | EXPERIMENT_RESULTS.md follows setting |
+| /research-refine | Full | FINAL_PROPOSAL.md follows setting |
+| /research-refine-pipeline | Full | PIPELINE_SUMMARY.md follows setting |
+| /research-pipeline | Full | Inherits from sub-skills |
+| /result-to-claim | Full | Claim descriptions follow setting |
+| /paper-writing | Skip | Always English LaTeX for submission |
+| /paper-write | Skip | Always English LaTeX |

--- a/skills/skills-codex/shared-references/output-manifest.md
+++ b/skills/skills-codex/shared-references/output-manifest.md
@@ -1,0 +1,40 @@
+# Output Manifest Protocol
+
+After writing any output file, append an entry to `MANIFEST.md` in the project root.
+
+## Format
+
+If `MANIFEST.md` does not exist, create it with this header:
+
+```markdown
+# Research Output Manifest
+
+> Auto-maintained by ARIS skills. Tracks all generated artifacts across the research lifecycle.
+
+| Timestamp | Skill | File | Stage | Description |
+|-----------|-------|------|-------|-------------|
+```
+
+Then append one row per output file written:
+
+```
+| 2025-06-15 14:30 | /idea-creator | idea-stage/IDEA_REPORT_20250615_143022.md | idea-discovery | 12 ideas generated from "LLM reasoning" direction |
+| 2025-06-15 14:30 | /idea-creator | idea-stage/IDEA_REPORT.md | idea-discovery | latest copy |
+```
+
+## Stage Values
+
+| Stage | Skills |
+|-------|--------|
+| `idea-discovery` | /idea-creator, /idea-discovery, /novelty-check, /research-review |
+| `implementation` | /research-refine, /research-refine-pipeline, /experiment-plan, /experiment-bridge, /run-experiment |
+| `review` | /auto-review-loop |
+| `paper` | /paper-writing, /paper-write, /paper-compile |
+
+## Pre-flight Check
+
+Before writing output, if the skill depends on a prerequisite file from a previous stage:
+1. Check if the prerequisite file exists at its expected stage-scoped path (e.g., `idea-stage/IDEA_REPORT.md`, `review-stage/AUTO_REVIEW.md`)
+2. If not found at the stage-scoped path, check the legacy root-level path (e.g., `./IDEA_REPORT.md`, `./AUTO_REVIEW.md`) — see [Path Fallback Rule](output-versioning.md#path-fallback-rule-backward-compatibility)
+3. If not found at either path, warn: "⚠️ Expected {file} (from {skill}) but not found. Run {skill} first?"
+4. Do not block — the user may have the file elsewhere or want to proceed anyway

--- a/skills/skills-codex/shared-references/output-versioning.md
+++ b/skills/skills-codex/shared-references/output-versioning.md
@@ -1,0 +1,111 @@
+# Output Versioning Protocol
+
+When writing any output file that would overwrite an existing file, use timestamped filename + fixed-name latest copy:
+
+1. Write output to timestamped file: `{FILENAME}_{YYYYMMDD_HHmmss}.md` (or `.json`, `.tex` as appropriate)
+   - Timestamp precision to seconds to reduce collisions. In the rare case of sub-second conflicts, append `_2`, `_3` etc.
+   - Place the timestamped file in the same directory as the fixed-name file
+2. Copy the same content to the fixed-name file: `{FILENAME}.md` (overwrites the previous latest copy)
+3. Downstream skills always read the fixed-name file — they do not need to know about timestamps
+
+## Directory Structure
+
+All ARIS output files are organized by workflow stage:
+
+```
+project/
+├── AGENTS.md                              # Dashboard / agent instructions (root — read by all stages)
+├── findings.md                            # Cross-stage discovery log (root — append-only)
+├── MANIFEST.md                            # Output tracking manifest (root)
+│
+├── idea-stage/                            # W1: Idea Discovery
+│   ├── IDEA_REPORT.md                     # Latest copy
+│   ├── IDEA_REPORT_20250615_143022.md     # Timestamped version
+│   ├── IDEA_CANDIDATES.md
+│   ├── REF_PAPER_SUMMARY.md
+│   └── docs/
+│       └── research_contract.md
+│
+├── refine-logs/                           # W1.5: Experiment Planning & Refinement
+│   ├── EXPERIMENT_PLAN.md
+│   ├── EXPERIMENT_TRACKER.md
+│   ├── EXPERIMENT_RESULTS.md
+│   ├── FINAL_PROPOSAL.md
+│   ├── PIPELINE_SUMMARY.md
+│   ├── REFINE_STATE.json
+│   ├── REVIEW_SUMMARY.md
+│   ├── REFINEMENT_REPORT.md
+│   └── round_N_*.md
+│
+├── review-stage/                          # W2: Auto Review
+│   ├── AUTO_REVIEW.md
+│   └── REVIEW_STATE.json
+│
+├── paper/                                 # W3: Paper Writing
+│   ├── main.tex
+│   └── roundN/
+│
+└── research-wiki/                         # Persistent knowledge base
+```
+
+## What to Timestamp
+
+Files that get overwritten on re-runs:
+- `IDEA_REPORT.md`, `IDEA_CANDIDATES.md`, `REF_PAPER_SUMMARY.md`
+- `EXPERIMENT_PLAN.md`, `EXPERIMENT_TRACKER.md`, `EXPERIMENT_RESULTS.md`
+- `FINAL_PROPOSAL.md`, `PIPELINE_SUMMARY.md`
+- `AUTO_REVIEW.md` (when starting a new review loop, not within a loop)
+- `paper/main.tex`
+- State files: `REFINE_STATE.json`, `REVIEW_STATE.json`
+
+## What NOT to Timestamp
+
+- **Append-only files**: `findings.md`, `research-wiki/log.md` — these accumulate entries, not overwrite
+- **Per-round files**: `refine-logs/round_N_*.md` — already versioned by round number
+- **Dashboard**: `AGENTS.md` — single source of truth, always latest
+- **MANIFEST.md** — append-only tracking file
+
+Never delete timestamped files. They are the permanent history.
+
+## Path Fallback Rule (Backward Compatibility)
+
+Skills that **read** stage-scoped files must fall back to the old root-level location for projects created before this layout was introduced:
+
+```
+# For idea-stage files:
+Read from idea-stage/IDEA_REPORT.md
+If not found → fall back to ./IDEA_REPORT.md
+
+Read from idea-stage/IDEA_CANDIDATES.md
+If not found → fall back to ./IDEA_CANDIDATES.md
+
+# For review-stage files:
+Read from review-stage/AUTO_REVIEW.md
+If not found → fall back to ./AUTO_REVIEW.md
+
+Read from review-stage/REVIEW_STATE.json
+If not found → fall back to ./REVIEW_STATE.json
+```
+
+Skills that **write** always use the stage-scoped path (never write to root). This ensures new runs migrate output forward while old projects continue to work.
+
+## Migration for Existing Projects
+
+If you find root-level files (`IDEA_REPORT.md`, `AUTO_REVIEW.md`, etc.) and the stage directories do not yet exist, you may optionally offer to migrate:
+
+```
+📁 Found legacy root-level files. Migrate to stage directories?
+  mv IDEA_REPORT.md idea-stage/IDEA_REPORT.md
+  mv AUTO_REVIEW.md review-stage/AUTO_REVIEW.md
+  (etc.)
+Only do this if the user confirms — do not auto-migrate silently.
+```
+
+## Stale State Detection
+
+Before reading a state file (`REFINE_STATE.json`, `REVIEW_STATE.json`, `DSE_STATE.json`):
+1. Check the file's last modified time via `ls -la` or `stat`
+2. Default staleness threshold: **24 hours** (individual skills may override — e.g., `auto-review-loop` uses 24h, `research-refine` uses 24h). If a skill defines its own threshold, that takes precedence.
+3. If older than the threshold, warn the user:
+   "⚠️ State file {filename} is {N} hours/days old. It may be from a previous research direction. Continue with this state, or start fresh?"
+4. If the user chooses to start fresh, write a timestamped archive copy and proceed without the old state

--- a/skills/skills-codex/shared-references/patent-format-cn.md
+++ b/skills/skills-codex/shared-references/patent-format-cn.md
@@ -1,0 +1,199 @@
+# CNIPA Patent Format Guide (中国专利格式指南)
+
+Use this reference when drafting Chinese patent applications for filing with CNIPA (国家知识产权局).
+
+## When to Read
+
+- Read when `JURISDICTION = "CN"` or `JURISDICTION = "ALL"`
+- Read before writing claims in Chinese format
+- Read during `/jurisdiction-format` for CN output
+- Read when choosing between invention patent (发明专利) and utility model (实用新型)
+
+## Applicable Law and Regulations
+
+- Patent Law of the People's Republic of China (中华人民共和国专利法, 2020 amendment)
+- Implementing Regulations of the Patent Law (专利法实施细则)
+- Guidelines for Patent Examination (专利审查指南, 2023 revision)
+
+## Document Structure
+
+A CNIPA patent application consists of:
+
+### 1. 权利要求书 (Claims)
+
+**Format rules:**
+- Independent claims use two-part form (two-part form / 两部式):
+  - 前序部分 (Preamble): Known technical features shared with closest prior art
+  - 特征部分 (Characterizing part): After "其特征在于" -- the inventive features
+- Dependent claims: "根据权利要求X所述的..., 其特征在于..."
+- Each claim must be a single technical solution
+- Claims must be clear, concise, and supported by the description
+- Method claims: "一种...的方法，其特征在于，包括以下步骤："
+- Apparatus claims: "一种...的装置/设备/系统，其特征在于，包括："
+
+**Numbering:**
+- Arabic numerals: 权利要求1, 权利要求2, ...
+- Dependent claims must reference prior claims by number
+- Multiple dependent claims are allowed but should be used sparingly
+
+**Example structure:**
+```
+1. 一种[技术主题]的方法，包括：
+   前序部分的已知技术特征；
+   其特征在于，还包括：
+   特征部分的技术特征。
+
+2. 根据权利要求1所述的方法，其特征在于，所述[技术特征]具体为...
+```
+
+### 2. 说明书 (Description)
+
+Required sections in order:
+
+#### 发明名称 (Title)
+- Concise, typically under 25 characters
+- Must reflect the technical content, not marketing language
+- No trademarks, no "新型" or "改进的"
+- Format: "一种[技术领域]的[技术主题]" for methods; "[技术领域]的[技术主题]装置" for apparatus
+
+#### 技术领域 (Technical Field)
+- 1-2 sentences identifying the technical domain
+- Use IPC classification references where appropriate
+
+#### 背景技术 (Background Technology)
+- Describe the closest prior art (引用现有技术)
+- Identify specific deficiencies (不足之处)
+- This is NOT a literature review -- it directly sets up the problem the invention solves
+- Must cite specific prior art documents where possible
+
+#### 发明内容 (Summary of Invention)
+Three parts:
+1. **要解决的技术问题** (Technical Problem to Solve): Derived from background deficiencies
+2. **技术方案** (Technical Solution): How the invention solves the problem, matching claim scope
+3. **有益效果** (Beneficial Effects): Quantifiable advantages over prior art
+
+#### 附图说明 (Brief Description of Drawings)
+- List each figure with a one-sentence description
+- Format: "图1是...的示意图；图2是...的流程图；"
+
+#### 具体实施方式 (Detailed Description of Embodiments)
+- At least one complete embodiment (实施例)
+- Reference numerals must match figures exactly
+- Describe in sufficient detail for a skilled person to practice
+- Include specific parameters, ranges, materials where applicable
+- Multiple embodiments strengthen the application
+
+### 3. 说明书摘要 (Abstract)
+
+- Maximum 300 words (typically Chinese characters)
+- Must summarize the technical solution and key advantages
+- Include the most representative claim number
+- Abstract is for search purposes only, not for interpreting scope
+
+### 4. 摘要附图 (Abstract Drawing)
+
+- Select the most representative figure
+- Must be one of the figures in the application
+
+### 5. 附图 (Drawings)
+
+- Numbered sequentially: 图1, 图2, ...
+- Reference numerals in Arabic: 101, 102, 103...
+- No text in figures except reference numerals and standard terms
+- Black and white preferred; color only when necessary
+
+## Word Limits and Practical Constraints
+
+| Item | Limit |
+|------|-------|
+| Title | Typically under 25 characters |
+| Abstract | 300 words maximum |
+| Claims | No hard limit, but examiners prefer focused sets (10-20 claims typical) |
+| Description | No hard limit, but excessive length delays examination |
+| Figures | No hard limit, but cost increases per page |
+
+## Fees (2026 approximate, in CNY)
+
+| Item | Invention (发明专利) | Utility Model (实用新型) |
+|------|---------------------|------------------------|
+| Filing fee | 900 | 500 |
+| Claims fee (per claim over 10) | 150 each | 150 each |
+| Examination fee (invention only) | 2500 | N/A |
+| Annual fees | Increasing by year | Increasing by year |
+
+## Utility Model (实用新型) Specific Rules
+
+- Covers only product shape/structure or combination thereof (产品的形状、构造或其结合)
+- NO method claims allowed
+- NO process claims allowed
+- Lower inventive step requirement than invention patent
+- No substantive examination -- only formal examination
+- Faster grant: typically 6-8 months vs. 2-4 years for invention
+- Shorter protection: 10 years vs. 20 years
+
+## Critical Chinese Patent Writing Rules
+
+### Claims (权利要求书)
+
+1. **Continuous numbering required**: Claims must be numbered 1, 2, 3, ... sequentially without gaps. Independent and dependent claims are intermixed, NOT grouped separately. Even if independent claims are 1, 5, 8 in the hierarchy, the final numbering must be 1-10 continuous.
+
+2. **No experimental results in claims**: Claims must describe ONLY structural features or method steps. Do NOT include detection principles, signal characteristics, or measurement results (e.g., "产生负脉冲信号", "谐振频率下降" belong in the specification, not in claims).
+
+3. **Standard claim opening formats**:
+   - Product: "1. 一种[主题]，其特征在于，包括：[组件A]、[组件B]和[组件C]。"
+   - Method: "1. 一种[主题]的方法，其特征在于，包括以下步骤：步骤S1...；步骤S2...；"
+   - System: "1. 一种[主题]的系统，其特征在于，包括：[组件]。"
+
+4. **Two-part form (两部式)**: The "其特征在于" separates known features (before) from inventive features (after). Known features should be minimal — just enough to set context.
+
+### Specification (说明书)
+
+5. **No experimental data in 具体实施方式**: The detailed description teaches HOW to make and use the invention. Do NOT include test results, accuracy percentages, detection rates, precision values, or comparative performance data. These belong in papers, not patents.
+
+   WRONG: "传感器对直径超过150μm的金属颗粒实现了100%的检测精度，即使在检测限处仍保持94%的高精度。"
+   RIGHT: "当不锈钢颗粒通过间隙传感区域时，谐振频率下降。颗粒直径越大，频率偏移幅度越大。"
+
+6. **Formulas and principles go in 具体实施方式, NOT 发明内容**: The "发明内容" section is a high-level overview (problem + solution + advantages). Detailed derivation, RLC circuit models, and mathematical formulas belong in "具体实施方式".
+
+7. **有益效果 must be qualitative or derived from structure**: Avoid specific numerical claims unless they appear in the claims themselves. Use structural reasoning: "由于采用了...结构，因此具有...效果。"
+
+8. **Use "所述" consistently**: After first introducing a component with "一个" or "一种", all subsequent references must use "所述" (the said). Example: "一个处理器" → "所述处理器".
+
+### Common CN Patent Phrases
+
+| Usage | Correct Chinese |
+|-------|----------------|
+| Introducing invention | "本发明提供一种..." |
+| Problem statement | "本发明要解决的技术问题是..." |
+| Solution intro | "为解决上述技术问题，本发明采用的技术方案是：" |
+| Benefits intro | "本发明的有益效果是：" |
+| Embodiment intro | "下面结合附图和实施例对本发明作进一步详细描述。" |
+| Referring to figure | "参照图1" |
+| Component reference | "印刷电路板（101）" on first mention, "印刷电路板101" thereafter |
+
+## Chinese Patent Terminology Glossary
+
+| Chinese | English | Usage |
+|---------|---------|-------|
+| 权利要求 | Claim | "权利要求1" |
+| 说明书 | Description | "如说明书所述" |
+| 发明名称 | Title of invention | |
+| 技术领域 | Technical field | |
+| 背景技术 | Background technology | |
+| 发明内容 | Summary of invention | |
+| 附图说明 | Brief description of drawings | |
+| 具体实施方式 | Detailed description of embodiments | |
+| 其特征在于 | Characterized in that | Claim divider |
+| 所述 | Said / The (definite article) | "所述处理器" |
+| 包括 | Comprising (open) | |
+| 由...组成 | Consisting of (closed) | Use rarely |
+| 可选地 | Optionally | |
+| 优选地 | Preferably | |
+| 在一个实施例中 | In one embodiment | |
+| 在另一个实施例中 | In another embodiment | |
+| 进一步地 | Further / Furthermore | Dependent claims |
+| 其中 | Wherein | |
+| 与...通信 | In communication with | |
+| 响应于 | In response to | |
+| 基于 | Based on | |
+| 使得 | Such that | |

--- a/skills/skills-codex/shared-references/patent-format-ep.md
+++ b/skills/skills-codex/shared-references/patent-format-ep.md
@@ -1,0 +1,173 @@
+# EPO Patent Format Guide
+
+Use this reference when drafting European patent applications for filing with the EPO.
+
+## When to Read
+
+- Read when `JURISDICTION = "EP"` or `JURISDICTION = "ALL"`
+- Read before writing claims in EP format
+- Read during `/jurisdiction-format` for EP output
+
+## Applicable Law
+
+- European Patent Convention (EPC), 2000 revision
+- Rules 42-43 EPC (Description and Claims format)
+- EPO Guidelines for Examination, Part F
+- Protocol on the Interpretation of Article 69 EPC
+
+## Document Structure
+
+### 1. Claims (Rule 43 EPC)
+
+**Two-part form is MANDATORY for independent claims (Rule 43(1) EPC):**
+
+The claim must contain:
+- **(a) Characterising portion**: A statement indicating:
+  - The category/title of the invention ("A method of...", "An apparatus for...")
+  - Those features of the invention which are necessary to define the claimed subject-matter but which, in combination, form part of the prior art
+- **(b) Characterising portion**: After the phrase "characterised in that" (or "characterised by")
+  - Those features of the invention for which protection is sought in combination with the features of part (a)
+
+```
+1. A method for [purpose], comprising:
+   [known feature A];
+   [known feature B]; and
+   [known feature C],
+   characterised in that
+   [inventive feature D],
+   [inventive feature E].
+```
+
+```
+10. A system for [purpose], comprising:
+    [known component A] configured to [function];
+    [known component B],
+    characterised in that the system further comprises:
+    [inventive component C] configured to [function].
+```
+
+**Important:** The two-part form separates known features from inventive features. This is NOT optional at the EPO -- it is a formal requirement. The examiner will raise an objection if the form is not followed.
+
+**When two-part form is NOT applicable:**
+- Product-by-process claims (rare exceptions)
+- Claims to new chemical compounds per se
+- Claims where the invention cannot be characterized by prior art features
+
+**Dependent claims (Rule 43(4) EPC):**
+```
+2. The method according to claim 1, characterised in that the [feature] comprises [specific limitation].
+3. The method according to any one of claims 1 to 2, characterised in that [additional limitation].
+```
+
+**Multiple dependent claims:**
+- EPO allows multiple dependent claims (unlike some jurisdictions)
+- May refer to multiple preceding claims: "The method according to any one of claims 1 to 3..."
+- However, examiners may raise clarity objections if excessive
+- Multiple dependent claims referring to other multiple dependent claims are NOT allowed
+
+### 2. Description (Rule 42 EPC)
+
+Required structure:
+
+#### Title of the Invention
+- Must correspond to the title in the claims
+- Should be clear and concise
+- No trademarks
+
+#### Technical Field
+- "The invention relates to..."
+- Identify the technical area
+
+#### Background Art
+- Cite relevant prior art documents
+- "Document D1 (EP XXXXXXXX) discloses..."
+- "However, this approach has the disadvantage that..."
+- Distinguish from "Related Work" in academic papers -- focus on technical deficiencies
+
+#### Disclosure of the Invention
+
+**The EPO has a specific structure for this section:**
+
+1. **Problem to be solved**: State the technical problem underlying the invention
+2. **Solution**: How the invention solves this problem, referencing the claim features
+3. **Advantageous effects**: The advantages of the invention over the prior art
+
+```
+The invention is defined in claim 1.
+
+The problem underlying the present invention is to [state problem].
+
+This problem is solved by [reference to characterising features].
+
+The invention has the advantage that [state advantages].
+```
+
+**Inventive step (Article 56 EPC):**
+- The description should support arguments for inventive step
+- Unexpected technical effects strengthen inventive step arguments
+- "Compared to the closest prior art (D1), the invention achieves [specific technical effect] which would not have been predictable from the prior art"
+
+#### Description of Embodiments
+- Detailed description with reference to figures
+- "FIG. 1 shows..." or "Figure 1 shows..."
+- Reference numerals in brackets: "the processor (102) is connected to the memory (104)"
+- At least one embodiment corresponding to the claims
+- Include variations and alternatives
+
+#### Reference Signs List
+- EPO requires a list of reference signs at the end of the description
+- Format: "LIST OF REFERENCE SIGNS: 102 processor, 104 memory, 106 bus..."
+- Organized by figure or alphabetically
+
+### 3. Abstract
+
+- Maximum 150 words (Rule 47(1) EPO)
+- Should indicate the technical field and the gist of the invention
+- Must not contain statements on the alleged merits or value of the invention
+- Must not contain any matter not disclosed in the application
+
+### 4. Drawings
+
+- Reference numerals must match description
+- Must show all features of at least one claim
+- Format: "FIG. 1" or "Figure 1" (both acceptable)
+
+## Key EPO-Specific Rules
+
+### No Functional Claiming Without Disclosure
+
+The EPO is stricter than USPTO on functional claiming:
+- Features defined by their function are allowed only if the specification provides sufficient disclosure
+- "configured to" is acceptable but must be supported by detailed description
+- Pure result-to-be-achieved claims will be rejected under Article 84 EPC
+
+### Inventive Step (Problem-Solution Approach)
+
+The EPO uses a specific three-step approach:
+1. Determine the closest prior art
+2. Identify the distinguishing features and the objective technical problem
+3. Assess whether the claimed invention would have been obvious to a skilled person
+
+The description should be written to support this analysis.
+
+### Added Matter (Article 123(2) EPC)
+
+The EPO is extremely strict about added matter:
+- Nothing may be added that is not directly and unambiguously derivable from the application as filed
+- Even "implicit" disclosures must be truly unambiguous
+- This is stricter than the US written description standard
+
+### Clarity (Article 84 EPC)
+
+- Claims must be clear and concise
+- Claims must be supported by the description
+- The EPO interprets "supported by" strictly: the description must provide basis for every claim feature
+
+## PCT Entry into European Phase
+
+For PCT applications entering the European phase:
+- Deadline: 31 months from priority date
+- Must file translation if not in EN/FR/DE
+- Must pay designation fees
+- Must file request for examination (can be filed with application)
+- Must respond to Rule 161/162 communication (optional amendment opportunity)

--- a/skills/skills-codex/shared-references/patent-format-us.md
+++ b/skills/skills-codex/shared-references/patent-format-us.md
@@ -1,0 +1,161 @@
+# USPTO Patent Format Guide
+
+Use this reference when drafting US patent applications for filing with USPTO.
+
+## When to Read
+
+- Read when `JURISDICTION = "US"` or `JURISDICTION = "ALL"`
+- Read before writing claims in US format
+- Read during `/jurisdiction-format` for US output
+
+## Applicable Law
+
+- Title 35, United States Code
+- Manual of Patent Examining Procedure (MPEP), 9th Edition, Rev. 2024
+- America Invents Act (AIA, 2011)
+
+## Document Structure
+
+A USPTO patent application consists of:
+
+### 1. Claims Section
+
+**Format rules:**
+- Claims are numbered sequentially with Arabic numerals starting from 1
+- Independent claims stand alone; dependent claims reference prior claims
+- Each claim is a single sentence (grammatically complex but technically one sentence)
+- Use semicolons to separate elements within a claim
+
+**Claim Preamble Types:**
+
+**Process/Method claims:**
+```
+1. A method for [purpose], comprising:
+   [step A];
+   [step B]; and
+   [step C].
+```
+
+**System/Apparatus claims:**
+```
+10. A system for [purpose], comprising:
+    a [component A] configured to [function];
+    a [component B] in communication with the [component A]; and
+    a [component C] configured to [function].
+```
+
+**Computer-readable medium claims (US-specific):**
+```
+15. A non-transitory computer-readable storage medium storing instructions that, when executed by a processor, cause the processor to perform operations comprising:
+    [operation A];
+    [operation B].
+```
+
+**Transitional Phrases:**
+| Phrase | Type | Meaning |
+|--------|------|---------|
+| comprising | Open | Includes the listed elements but may also include others |
+| consisting of | Closed | Limited to ONLY the listed elements |
+| consisting essentially of | Semi-open | Allows only insubstantial additional elements |
+
+**Default: use "comprising"** unless there is a specific reason to use a closed transition.
+
+**Dependent Claim Format:**
+```
+2. The method of claim 1, wherein the [element] comprises [specific limitation].
+3. The method of claim 1 or claim 2, further comprising [additional step].
+4. The system of claim 10, wherein the [component A] is a [specific type].
+```
+
+**Multiple Dependent Claims (US rules):**
+- US allows multiple dependent claims but ONLY in the alternative ("or", not "and")
+- "The method of claim 1 or claim 2, wherein..." -- VALID
+- "The method of claims 1 and 2, wherein..." -- INVALID
+- Each multiple dependent claim counts as one claim for fee purposes
+
+### 2. Specification
+
+#### Title
+- Concise and specific (MPEP 606)
+- No more than 500 characters
+- No trademarks, no "improved", no "new"
+- Must describe the invention, not its use
+
+#### Cross-Reference to Related Applications
+- If claiming priority to earlier applications, include at the very beginning
+- Format: "This application claims the benefit of U.S. Provisional Application No. XX/XXX,XXX, filed [date]"
+
+#### Statement Regarding Federally Sponsored Research
+- Include if invention was made with government funding
+
+#### Field of the Invention
+- 1-2 sentences: "The present invention relates generally to [field], and more particularly to [specific area]."
+
+#### Background of the Invention
+- Describe the field
+- Describe existing approaches and their limitations
+- Do NOT admit prior art as "the best" or "superior"
+- Set up the technical problem the invention solves
+- Do NOT include citations to prior art here (that's for IDS)
+
+#### Brief Summary of the Invention
+- "In accordance with one or more embodiments..."
+- Problem-Solution-Advantage structure
+- Mirror the claim scope
+
+#### Brief Description of the Drawings
+- "FIG. 1 is a block diagram showing..."
+- "FIG. 2 is a flowchart illustrating..."
+- One sentence per figure
+
+#### Detailed Description of Preferred Embodiments
+- Must enable a POSITA to make and use the invention (35 USC 112(a))
+- Must provide written description support for all claim scope (35 USC 112(a))
+- Reference numerals: use consistent numbering (100-series for FIG. 1, 200-series for FIG. 2)
+- Include at least one "preferred embodiment" or "exemplary embodiment"
+- Describe alternatives and variations to support broad claim interpretation
+- Best mode: must disclose the best way known to the inventor (less enforced post-AIA but still required by statute)
+
+#### Abstract
+- 150 words or 2500 characters maximum (37 CFR 1.72(b))
+- Purpose: enable efficient prior art searching
+- Include the most important technical features
+- Do NOT include legal phrases or claim references
+
+### 3. Drawings (Figures)
+
+- Must show every feature specified in the claims
+- Reference numerals must match specification
+- Black and white line drawings preferred
+- Format: "FIG. 1", "FIG. 2" (not "Figure 1")
+- No text except reference numerals and essential labels
+
+## IDS (Information Disclosure Statement)
+
+Under the duty of disclosure (37 CFR 1.56), applicants must cite all known material prior art:
+- List all patents, publications, and other references known to be material
+- Use form PTO/SB/08 for listing references
+- Filed during prosecution, not as part of the initial application
+
+## Means-Plus-Function (35 USC 112(f))
+
+When a claim element uses "means for [function]" or equivalent language:
+- The claim is limited to the corresponding structure, material, or acts described in the specification AND equivalents thereof
+- Must disclose the algorithm/structure that performs the function
+- Software "means for" claims MUST disclose the algorithm (flowchart, pseudocode)
+
+**Safer alternative:** Use "a processor configured to [function]" instead of "means for [function]"
+
+## Continuation and CIP Strategy
+
+- **Continuation**: Same disclosure, new claims
+- **Continuation-in-part (CIP)**: Adds new matter, claims to new matter get new priority date
+- **Divisional**: Required when examiner issues restriction requirement
+
+## Common 102/103 Rejection Responses
+
+Document these patterns for use in `/patent-review`:
+- Amend claims to distinguish over cited reference
+- Argue the reference does not teach a specific claim element
+- Argue the combination of references would not have been obvious
+- Provide evidence of unexpected results or commercial success

--- a/skills/skills-codex/shared-references/patent-writing-principles.md
+++ b/skills/skills-codex/shared-references/patent-writing-principles.md
@@ -1,0 +1,197 @@
+# Patent Writing Principles
+
+Use this reference when `claims-drafting`, `specification-writing`, or `invention-structuring` need guidance on patent-specific writing rules.
+
+## When to Read
+
+- Read before drafting any claims.
+- Read when specification text needs to support claim scope.
+- Read when choosing between claim formats (Jepson vs. two-part vs. open-ended).
+- Read when the language feels too academic or too vague for patent purposes.
+- Read before jurisdiction-specific formatting.
+
+## Contents
+
+- [Core Patent Writing Rules](#core-patent-writing-rules)
+- [Claim Drafting Principles](#claim-drafting-principles)
+- [Specification Writing Rules](#specification-writing-rules)
+- [Common Pitfalls](#common-pitfalls)
+- [Terminology Discipline](#terminology-discipline)
+
+---
+
+## Core Patent Writing Rules
+
+### The Three Requirements
+
+Every patent application must satisfy three fundamental requirements:
+
+1. **Novelty** (新颖性): The invention must be new -- not anticipated by a single prior art reference.
+2. **Inventive Step / Non-obviousness** (创造性): The invention must not be obvious to a person skilled in the art (POSITA) based on prior art.
+3. **Industrial Applicability / Utility** (实用性): The invention must be capable of being made or used in industry.
+
+### The Written Description Requirement
+
+The specification must demonstrate that the inventor was in **possession** of the claimed invention as of the filing date. This means:
+
+- Every element in every claim must find explicit or inherent support in the specification.
+- Broader claims require broader disclosure. If you claim "a processor," the spec must show you had a processor in mind, not just one specific chip.
+- Adding claim scope after filing that wasn't in the original disclosure is not permitted (no new matter).
+
+### The Enablement Requirement
+
+The specification must teach a **Person Skilled in the Art (POSITA)** to make and use the invention without undue experimentation. Test: could a skilled practitioner reproduce the invention from your description alone?
+
+### Claims Define Scope, Specification Enables It
+
+- **Claims** = the legal boundary (what is protected)
+- **Specification** = the teaching (how to practice the invention)
+- **Figures** = the visual aid (reference numerals link claims to specification)
+
+---
+
+## Claim Drafting Principles
+
+### Broadest Reasonable Interpretation (BRI)
+
+Claims are interpreted under the **broadest reasonable interpretation** during prosecution (USPTO standard; EPO uses a different but analogous approach). This means:
+
+- Common words are given their ordinary meaning.
+- Terms are NOT limited to the embodiments described in the specification.
+- If you want a term to have a special meaning, you must explicitly define it in the specification.
+
+### Claim Structure (Universal)
+
+Every claim has:
+1. **Preamble**: Identifies the category of invention (e.g., "A method for...", "A system comprising...", "An apparatus for...")
+2. **Transitional phrase**: Defines scope boundary
+   - "comprising" / "including" / "containing" = OPEN (additional elements allowed)
+   - "consisting of" = CLOSED (no additional elements)
+   - "consisting essentially of" = SEMI-OPEN (allows insubstantial variations)
+3. **Body**: The claim elements/limitations, each separated by semicolons or commas
+
+### Antecedent Basis
+
+- First mention of an element: use indefinite article ("a", "an") -- "a processor"
+- Subsequent mentions: use definite article ("the", "said") -- "the processor"
+- Never use "the" for something not previously introduced in the claim.
+- Never use "a" again for the same element (implies a second instance).
+
+### Independent vs. Dependent Claims
+
+**Independent claims** define the broadest defensible scope. Draft these first.
+
+**Dependent claims** narrow the scope by adding specific limitations. Each dependent claim:
+- Must refer back to a prior claim ("The method of claim 1, wherein...")
+- Must add at least one meaningful limitation
+- Should provide fallback positions if the independent claim is rejected
+- Should cover preferred embodiments described in the specification
+
+### Multiple Claim Categories
+
+For the same invention, draft claims in multiple categories:
+- **Method/process claims**: Steps performed
+- **System/apparatus claims**: Structural components
+- **Computer-readable medium claims**: (US) Tangible medium storing instructions
+- **Product-by-process claims**: (when structure is difficult to define)
+
+This multiplies the scope of protection without requiring separate applications.
+
+---
+
+## Specification Writing Rules
+
+### Section Structure (Universal)
+
+1. **Title**: Concise, matches broadest claim scope, no trademark names, no "improved" or "new"
+2. **Technical Field** (技术领域): 1-2 paragraphs identifying the technical domain
+3. **Background** (背景技术): Prior art and its deficiencies -- NOT a literature review, but specific technical shortcomings that the invention addresses
+4. **Summary** (发明内容): Problem-Solution-Advantage triple
+5. **Brief Description of Drawings** (附图说明): One sentence per figure
+6. **Detailed Description** (具体实施方式): Detailed embodiments with reference numerals
+7. **Abstract** (摘要): Jurisdiction-specific word limits
+
+### Language Rules for Specifications
+
+**DO:**
+- Use "embodiment", "aspect", "implementation", "configuration"
+- Use "optionally", "preferably", "in some implementations"
+- Use "may" for optional features, "shall" or "is configured to" for required features
+- Reference figures by numeral: "As shown in FIG. 1, the processor 102..."
+- Use consistent terminology throughout (same word for same concept)
+
+**DO NOT:**
+- Use subjective adjectives: "excellent", "surprising", "revolutionary", "superior"
+- Use result-to-be-achieved language: "configured to achieve high accuracy" (instead describe HOW)
+- Use relative terms without definition: "thin", "strong", "fast", "small"
+- Admit prior art is better: avoid "unlike the prior art, which works well, we..."
+- Include experimental results tables (save for prosecution arguments, not the spec itself)
+
+### Reference Numeral Convention
+
+- Use consistent numbering series: 100-series for FIG. 1, 200-series for FIG. 2
+- Every component mentioned in specification must have a numeral
+- Every numeral in figures must be explained in the specification
+- Format: "processor 102", "memory 104", "bus 106" (numeral follows the noun)
+
+---
+
+## Common Pitfalls
+
+### Negative Limitations
+
+Avoid claims that define the invention by what it is NOT:
+- Bad: "A method that does not use a database"
+- Good: "A method comprising storing data in a local cache"
+
+Negative limitations are sometimes necessary but require explicit basis in the specification.
+
+### Result-to-Be-Achieved Claims
+
+Do not claim a result without describing the mechanism:
+- Bad: "A method for achieving 99% accuracy in image classification"
+- Good: "A method comprising: extracting features using a convolutional neural network having at least three residual blocks..."
+
+### Indefinite Terms
+
+Avoid terms that create uncertainty about scope:
+- "approximately", "about", "substantially" -- acceptable if the specification defines the range
+- "high quality", "efficient", "optimal" -- too vague, will receive 112(b) rejection (US)
+- "etc.", "and the like", "or similar" -- creates open-ended ambiguity
+
+### Functional Claiming (Means-Plus-Function)
+
+In US practice, "means for [function]" triggers 35 USC 112(f) and is limited to the corresponding structure in the specification. Use with caution:
+- "means for processing" = limited to the specific processor embodiments described
+- "a processor configured to process" = broader (not means-plus-function)
+- In CN/EP practice, functional claiming is generally more restrictive
+
+### Claim Differentiation Doctrine
+
+Dependent claims are presumed to have different scope from their parent claims. Do not:
+- Copy the parent claim verbatim into a dependent claim
+- Add a limitation that is already inherent in the parent claim
+- Create dependent claims that are merely cumulative combinations of other dependent claims
+
+---
+
+## Terminology Discipline
+
+### Consistency Rule
+
+Once a term is introduced, use it identically throughout:
+- Do NOT alternate between "processor", "processing unit", "CPU", "computing device" for the same component
+- If the invention has a specific component, name it once and reuse that name
+
+### Definition Rule
+
+If a term has a meaning specific to your invention:
+1. Define it explicitly in the specification
+2. Use "hereinafter referred to as" or "herein defined as" language
+3. Use the defined term consistently thereafter
+
+### Jurisdiction-Specific Terminology
+
+- **CN**: Use standard patent Chinese. "所述" (said/the), "其特征在于" (characterized in that), "一种...的方法/装置" (a method/apparatus for...)
+- **US**: Use standard patent English. "comprising", "configured to", "in communication with"
+- **EP**: Follow EPO Guidelines for Examination. Two-part claim form mandatory.

--- a/skills/skills-codex/shared-references/prior-art-databases.md
+++ b/skills/skills-codex/shared-references/prior-art-databases.md
@@ -1,0 +1,141 @@
+# Prior Art Search Databases Guide
+
+Use this reference in `/prior-art-search` for systematic patent and literature searching.
+
+## When to Read
+
+- Read when conducting prior art searches
+- Read when formulating search queries for patents
+- Read when classifying search results by IPC/CPC codes
+
+## Patent Databases (Free, Web-Accessible)
+
+### Google Patents
+- **URL**: patents.google.com
+- **Coverage**: US, EP, CN, WIPO, JP, KR, and 100+ jurisdictions
+- **Search syntax**: Full-text search, inventor:, assignee:, CPC:, before:, after:
+- **Strengths**: Best free full-text search, automatic translation of CN/JP/KR patents, family grouping
+- **Weaknesses**: No legal status data, may lag behind official databases by weeks
+- **Usage in skills**: `WebSearch "site:patents.google.com [keywords]"` or `WebFetch` for specific patent pages
+
+### Espacenet (EPO)
+- **URL**: worldwide.espacenet.com
+- **Coverage**: 150+ million patent documents from 100+ authorities
+- **Search syntax**: Classification=(CPC/IPC), Applicant=, Title/Abstract/Claims full text
+- **Strengths**: Most comprehensive free database, machine translation, legal status via INPADOC
+- **Weaknesses**: Interface is less intuitive, some features require registration
+- **Usage**: `WebFetch` for search results and individual patent pages
+
+### CNIPA Patent Search (中国及多国专利审查信息查询)
+- **URL**: pss-system.cponline.cnipa.gov.cn (or similar)
+- **Coverage**: Chinese patents (CN), the authoritative source for CN applications
+- **Strengths**: Official Chinese patent data, full Chinese text, examination status
+- **Weaknesses**: Interface in Chinese only, limited foreign coverage
+- **Usage**: `WebFetch` for Chinese-specific searches
+
+### USPTO Patent Full-Text Databases
+- **PatFT**: patents.google.com/patents (US granted patents)
+- **AppFT**: patents.google.com (US published applications)
+- **PAIR**: patentcenter.uspto.gov (prosecution history)
+- **Coverage**: US patents and applications
+- **Usage**: `WebFetch` for specific US patent numbers
+
+### WIPO PATENTSCOPE
+- **URL**: patentscope.wipo.int
+- **Coverage**: PCT international applications (WO publications)
+- **Strengths**: Full PCT application texts, CLIR cross-lingual search
+- **Usage**: `WebFetch` for PCT applications
+
+## Academic Literature Databases
+
+These are also prior art (non-patent literature, NPL):
+
+| Database | URL | Coverage | API Available |
+|----------|-----|----------|---------------|
+| Google Scholar | scholar.google.com | Broadest academic coverage | No API, use WebSearch |
+| Semantic Scholar | semanticscholar.org | CS, biomedical, 200M+ papers | Yes (SEMANTIC_SCHOLAR_API_KEY) |
+| arXiv | arxiv.org | Preprints (CS, physics, math, etc.) | Yes (arxiv_fetch.py) |
+| DBLP | dblp.org | CS bibliography | Yes (XML API) |
+| CrossRef | crossref.org | DOIs for all published works | Yes (free, no key needed) |
+| OpenAlex | openalex.org | 250M+ scholarly works | Yes (free, no key needed) |
+
+## IPC/CPC Classification System
+
+The International Patent Classification (IPC) and Cooperative Patent Classification (CPC) organize patents hierarchically:
+
+### Structure
+```
+A 61 K  39 / 395
+│  │  │  │   │
+│  │  │  │   └─ Subgroup (specific)
+│  │  │  └─ Group
+│  │  └─ Subclass
+│  └─ Class
+└─ Section (A=Human necessities, B=Performing operations, C=Chemistry, etc.)
+```
+
+### Most Relevant Sections for Software/ML Inventions
+- **G06F**: Electric digital data processing
+- **G06N**: Computing arrangements based on specific computational models (AI/ML)
+- **G06K**: Recognition of data; Presentation of data
+- **G06T**: Image data processing or generation
+- **G06Q**: Data processing systems for business/finance/administration
+- **H04L**: Transmission of digital information (networking)
+- **H04N**: Pictorial communication (video, image)
+
+### Search Strategy with Classifications
+
+1. Identify relevant IPC/CPC classes from the invention description
+2. Search within those classes for targeted results
+3. Expand to parent/child classes for broader coverage
+4. Combine class-restricted searches with keyword searches
+
+## Search Strategy Template
+
+For each invention, execute this search protocol:
+
+### Step 1: Keyword Search
+```
+Primary: [core inventive concept keywords]
+Secondary: [technical problem keywords]
+Tertiary: [advantage/feature keywords]
+```
+
+### Step 2: Classification Search
+```
+IPC/CPC: [identified classes]
+Cross-reference: [related classes]
+```
+
+### Step 3: Assignee/Inventor Search
+```
+Key assignees: [known companies/universities in the field]
+Key inventors: [known researchers in the field]
+```
+
+### Step 4: Citation Analysis
+- Forward citations: who cited the closest prior art?
+- Backward citations: what did the closest prior art cite?
+
+### Step 5: Family Analysis
+- Group results by patent family (same invention, different jurisdictions)
+- Only the most relevant family member needs detailed analysis
+
+## Output Format
+
+For each prior art reference found:
+
+```markdown
+| Field | Content |
+|-------|---------|
+| Reference ID | [Patent number or paper DOI] |
+| Type | Patent / Paper / Other |
+| Title | [Full title] |
+| Date | [Publication/priority date] |
+| Assignee/Authors | [Who] |
+| IPC/CPC | [Classification codes] |
+| Key Teaching | [What does it teach, 2-3 sentences] |
+| Relevant Claims | [Which claims, if patent] |
+| Overlap Risk | HIGH / MEDIUM / LOW |
+| Relationship | [Anticipating / Relevant / Background] |
+```

--- a/skills/skills-codex/shared-references/review-tracing.md
+++ b/skills/skills-codex/shared-references/review-tracing.md
@@ -1,0 +1,99 @@
+# Review Tracing Protocol
+
+## Purpose
+
+Save full prompt/response pairs for every reviewer call, enabling:
+
+- reviewer-independence audit
+- reproducibility across follow-up reviewer turns
+- meta-optimization from real review traces
+
+## When to Trace
+
+Trace every Codex reviewer call that serves a critique, scoring, claim-verification, experiment-audit, or patch-gating function.
+
+This includes:
+
+- `spawn_agent` reviewer calls
+- `send_input` reviewer continuations
+- optional overlay reviewer routes
+- adversarial reviewer calls used for stress tests
+
+Do not trace purely informational agent calls that are not acting as reviewers.
+
+## Trace Directory
+
+```text
+.aris/traces/<skill-name>/<YYYY-MM-DD>_run<NN>/
+  run.meta.json
+  001-<purpose>.request.json
+  001-<purpose>.response.md
+  001-<purpose>.meta.json
+  002-<purpose>.request.json
+  ...
+```
+
+## File Schemas
+
+`run.meta.json`:
+
+```json
+{
+  "skill": "auto-review-loop",
+  "run_id": "2026-04-15_run01",
+  "started_at": "2026-04-15T14:30:00+08:00",
+  "executor": "codex",
+  "project_dir": "/path/to/project"
+}
+```
+
+`NNN-<purpose>.request.json`:
+
+```json
+{
+  "call_number": 1,
+  "purpose": "round-1-review",
+  "timestamp": "2026-04-15T14:31:00+08:00",
+  "tool": "spawn_agent",
+  "model": "gpt-5.4",
+  "reasoning_effort": "xhigh",
+  "files_referenced": ["paper/sections/3_method.tex", "results/table1.csv"],
+  "prompt": "<full prompt text>"
+}
+```
+
+`NNN-<purpose>.response.md` stores the full reviewer response verbatim.
+
+`NNN-<purpose>.meta.json`:
+
+```json
+{
+  "call_number": 1,
+  "purpose": "round-1-review",
+  "timestamp": "2026-04-15T14:33:00+08:00",
+  "agent_id": "019d8fe0-b25d-...",
+  "model": "gpt-5.4",
+  "duration_ms": 142000,
+  "status": "ok"
+}
+```
+
+## Configuration
+
+Respect inline parameter `--- trace: off | meta | full`:
+
+- `full` default: save full prompt and full response
+- `meta`: save metadata only
+- `off`: disable tracing
+
+## Events
+
+After writing a trace, append a compact event to `.aris/meta/events.jsonl`:
+
+```json
+{"event":"review_trace","skill":"auto-review-loop","purpose":"round-1-review","agent_id":"...","trace_path":".aris/traces/auto-review-loop/2026-04-15_run01/","status":"ok"}
+```
+
+## Privacy
+
+`.aris/traces/` is project-local and should not be committed. Use `--- trace: off` for strict confidentiality projects.

--- a/skills/skills-codex/shared-references/reviewer-independence.md
+++ b/skills/skills-codex/shared-references/reviewer-independence.md
@@ -2,78 +2,65 @@
 
 ## Core Principle
 
-**Content must reach the reviewer unfiltered. The executor points to files and sets the review task; the reviewer reads and judges independently.**
+The reviewer must judge primary artifacts directly. The executor can define the review role, scope, and file list, but must not pre-digest the content into a preferred narrative.
 
-Cross-model adversarial collaboration only works if the reviewer forms its own assessment from primary artifacts. If the executor pre-digests, summarizes, or interprets content before passing it to the reviewer, the reviewer is evaluating the executor's framing — not the actual work. This re-introduces the correlated blind spots that heterogeneous review is designed to avoid.
+## What Can Be Passed
 
-## What CAN be passed to the reviewer
+- reviewer role or persona
+- review objective
+- absolute file paths
+- structural metadata such as section count or venue
+- concrete output schema
 
-- **Role/persona** — e.g., "Review as a NeurIPS-level reviewer"
-- **Review objective** — e.g., "Evaluate publishability", "Check code correctness", "Score 1-10 on clarity"
-- **File paths** — let the reviewer read file contents directly
-- **Structural metadata** — e.g., "The paper has 8 sections", "Experiments are in experiments/"
-- **Venue constraints** — e.g., "ICLR format, 9-page limit"
+## What Must Not Be Passed
 
-## What CANNOT be passed (counts as "subjective interference")
+- executor summaries of file contents
+- executor interpretations of results
+- executor recommendations about what the reviewer should conclude
+- "what changed since last round" narratives unless the skill explicitly requires diff-focused follow-up
+- leading or coaching questions
 
-- ❌ Executor's summary or paraphrase of file contents
-- ❌ Executor's interpretation of results (e.g., "I think the problem is...", "This suggests...")
-- ❌ Executor's recommendations or conclusions (e.g., "I suggest changing...", "The likely cause is...")
-- ❌ Key findings or bullet points extracted by the executor
-- ❌ Leading questions (e.g., "Is this publishable?", "Is this trade-off reasonable?")
-- ❌ Previous review rounds' feedback or critique (let the reviewer assess the current state fresh)
-- ❌ Executor's description of what was changed since last round (e.g., "I fixed X, Y, Z")
-- ❌ Statements asserting the current approach's strengths
+## Correct Pattern
 
-## Why this matters
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    Review the project as a senior ML reviewer.
 
-| With filtering | Without filtering |
-|---|---|
-| Reviewer sees executor's framing | Reviewer sees raw artifacts |
-| Correlated blind spots persist | Genuinely independent assessment |
-| Executor can "coach" favorable review | Review probes real weaknesses |
-| Defeats the purpose of cross-model | Achieves adversarial collaboration |
-
-## Correct pattern
-
-```
-mcp__codex__codex:
-  prompt: |
-    Review the following research project as a senior ML reviewer.
-
-    Files to read:
-    - Proposal: /path/to/PROPOSAL.md
-    - Experiment results: /path/to/EXPERIMENT_LOG.md
-    - Paper draft: /path/to/paper/main.tex
-    - Code: /path/to/src/
-
-    Please read all files yourself and provide a complete review.
-    Score 1-10 on: novelty, soundness, clarity, significance.
+    Files to read directly:
+    - /path/to/PROPOSAL.md
+    - /path/to/EXPERIMENT_LOG.md
+    - /path/to/paper/main.tex
+    - /path/to/src/
 ```
 
-## Incorrect pattern
+## Incorrect Pattern
 
-```
-mcp__codex__codex:
-  prompt: |
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
     The main contribution is a new loss function that improves by 15%.
-    However, I noticed the ablation is incomplete.
-    Here's my summary of the key results: [...]
-    Please review whether this is publishable.
+    I think the weak point is the ablation.
+    Please confirm this is publishable.
 ```
 
-## When to apply
+## Multi-Round Follow-Up
 
-This protocol applies to ALL cross-model review calls in ARIS:
-- `/research-review` — paper review
-- `/auto-review-loop` — iterative review
-- `/paper-plan` — outline review
-- `/paper-write` — section review
-- `/paper-figure` — figure quality review
-- `/rebuttal` — stress test
-- `/meta-optimize` — patch review
-- Any skill that sends artifacts to `mcp__codex__codex` or `mcp__codex__codex-reply`
+When a skill uses multi-round review, reuse the same reviewer id with `send_input`, but still avoid injecting executor conclusions. Pass revised artifacts or targeted follow-up requests, not spin.
 
-## Exception
+## Applies To
 
-Multi-round review within the SAME thread (`codex-reply`) may reference the reviewer's own previous feedback to check resolution — but still must not include executor interpretations of that feedback.
+This protocol applies to all cross-agent review calls in `skills/skills-codex/`, including:
+
+- `research-review`
+- `auto-review-loop`
+- `paper-plan`
+- `paper-write`
+- `paper-figure`
+- `rebuttal`
+- `meta-optimize`
+- any skill that launches a reviewer via `spawn_agent` or continues one via `send_input`

--- a/skills/skills-codex/shared-references/reviewer-routing.md
+++ b/skills/skills-codex/shared-references/reviewer-routing.md
@@ -1,89 +1,85 @@
 # Reviewer Routing
 
-## Default (NEVER changes without explicit user request)
+## Default Reviewer Contract
 
-All review calls use **Codex MCP** (`mcp__codex__codex`) with `reasoning_effort: xhigh`.
+All reviewer-heavy Codex base skills use the same default contract:
 
-This is the default for ALL skills. No parameter, no config, no effort level changes this.
+- executor: current Codex main agent
+- reviewer: second Codex reviewer
+- reasoning effort: `xhigh`
+- round 1: `spawn_agent`
+- follow-up rounds: `send_input`
 
-## Optional: GPT-5.4 Pro via Oracle
+This is the base default for `skills/skills-codex/`. No effort level or unrelated parameter changes it.
 
-When the user explicitly passes `— reviewer: oracle-pro`, route the review through Oracle MCP instead of Codex MCP.
+## Default Pattern
 
-### Routing Logic (add to any reviewer-invoking skill)
+Single-round review:
 
-```
-Parse $ARGUMENTS for `— reviewer:` directive.
-
-If not specified OR `— reviewer: codex`:
-    → Use mcp__codex__codex with reasoning_effort: xhigh
-    → This is the DEFAULT. No change from current behavior.
-
-If `— reviewer: oracle-pro`:
-    → Check if mcp__oracle__consult tool is available
-    → If available:
-        Use mcp__oracle__consult with:
-          model: "gpt-5.4-pro"
-          prompt: [same prompt you would send to Codex]
-          files: [file paths for reviewer to read directly]
-        Note: Oracle may use API mode (fast, needs OPENAI_API_KEY)
-              or browser mode (slow ~1-2 min, needs Chrome + ChatGPT login)
-    → If NOT available:
-        Print: "⚠️ Oracle MCP not installed. Falling back to Codex xhigh."
-        Use mcp__codex__codex as normal.
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    [role + task]
+    Read the listed files directly.
 ```
 
-### Invariants
+Multi-round review:
 
-- `— reviewer: oracle-pro` ONLY takes effect when explicitly passed
-- Reviewer independence protocol still applies (pass file paths, not summaries)
-- `effort` and `difficulty` are orthogonal — they don't change reviewer backend
-- `beast` mode may RECOMMEND oracle-pro but never requires it
-- Browser mode: acceptable for one-shot reviews; NOT recommended inside multi-round loops (too slow/brittle)
-
-### Oracle MCP Call Format
-
-```
-mcp__oracle__consult:
-  prompt: |
-    [role + task + output schema]
-    Read all listed files directly.
-  model: "gpt-5.4-pro"
-  files:
-    - /absolute/path/to/file1
-    - /absolute/path/to/file2
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    [initial review prompt]
 ```
 
-### Skills That Support `— reviewer: oracle-pro`
+Save the returned reviewer id, then continue with:
 
-| Skill | Use case for Pro |
-|-------|-----------------|
-| `/research-review` | Deeper critique on paper drafts |
-| `/auto-review-loop` | Final stress test (last round only in browser mode) |
-| `/experiment-audit` | Line-by-line eval code audit |
-| `/proof-checker` | Deep mathematical reasoning |
-| `/rebuttal` | Stress test before submission |
-| `/idea-creator` | Idea evaluation depth |
-| `/research-lit` | Literature analysis depth |
-
-### Installation
-
-```bash
-# Install Oracle CLI + MCP
-npm install -g @steipete/oracle
-
-# Add Oracle MCP to Claude Code
-claude mcp add oracle -s user -- oracle-mcp
-
-# Restart Claude Code session to load
-
-# API mode (fast, recommended):
-export OPENAI_API_KEY="your-key"
-
-# Browser mode (no API key, slower):
-# Just log in to ChatGPT in Chrome
+```text
+send_input:
+  target: <saved reviewer id>
+  message: |
+    [follow-up materials only]
 ```
 
-### NOT installed = ZERO impact
+## Oracle Pro Override
 
-If Oracle is not installed, `— reviewer: oracle-pro` gracefully falls back to Codex. No error, no breakage, just a warning.
+When the user explicitly passes `--reviewer: oracle-pro`, switch only the reviewer route:
+
+- default reviewer remains Codex xhigh if no reviewer is specified
+- `oracle-pro` is optional, not the base default
+
+Routing rule:
+
+```text
+If reviewer is omitted or reviewer=codex:
+  use spawn_agent / send_input with Codex reviewer at xhigh
+
+If reviewer=oracle-pro:
+  check Oracle MCP availability
+  if available:
+    call mcp__oracle__consult with model gpt-5.4-pro
+  if unavailable:
+    print a clear warning
+    fall back to the default Codex xhigh reviewer
+```
+
+## Invariants
+
+- Base skills do not use the legacy Codex MCP thread path as the default reviewer route.
+- Reviewer independence still applies: pass file paths and task framing, not executor summaries.
+- Overlay packages may replace only the reviewer route.
+- Overlay packages do not change executor semantics.
+- Browser-based Oracle review is acceptable for one-shot stress tests, not ideal for tight multi-round loops.
+
+## Skills That Commonly Benefit From `oracle-pro`
+
+- `research-review`
+- `auto-review-loop`
+- `experiment-audit`
+- `proof-checker`
+- `rebuttal`
+- `idea-creator`
+- `research-lit`

--- a/skills/skills-codex/specification-writing/SKILL.md
+++ b/skills/skills-codex/specification-writing/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: specification-writing
+description: "Write the full patent specification from claims and invention disclosure. Use when user says \"撰写说明书\", \"write specification\", \"写说明书\", \"patent description\", or wants to draft the complete patent specification."
+argument-hint: [claims-path]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, Skill, WebSearch, WebFetch
+---
+
+# Specification Writing: Section-by-Section Patent Description
+
+Write the patent specification based on: **$ARGUMENTS**
+
+Adapted from `/paper-write` for patent specifications. The specification supports the claims -- it is not a paper.
+
+## Constants
+
+- `REVIEWER_MODEL = gpt-5.4` — External reviewer for specification quality
+- `JURISDICTION = "auto"` — Inherit from pipeline or detect from args; `CN`, `US`, `EP`, `ALL`
+- `OUTPUT_FORMAT = "markdown"` — Markdown drafts; converted to filing format by `/jurisdiction-format`
+- `OUTPUT_DIR = "patent/"` — Base output directory
+- `LANGUAGE = "auto"` — Auto from jurisdiction: CN->Chinese, US/EP->English
+
+## Inputs
+
+1. `patent/CLAIMS.md` — the drafted claims (primary source)
+2. `patent/INVENTION_DISCLOSURE.md` — invention decomposition
+3. `patent/PRIOR_ART_REPORT.md` — for background section
+4. User-provided figures (if any)
+
+## Shared References
+
+Load `../shared-references/patent-writing-principles.md` for specification writing rules, language guidelines, and reference numeral conventions.
+Load `../shared-references/patent-format-cn.md` or `patent-format-us.md` or `patent-format-ep.md` based on jurisdiction.
+
+## Workflow
+
+### Step 1: Initialize Specification Structure
+
+Create the output directory and section files:
+
+```
+patent/specification/
+├── title.md
+├── technical_field.md
+├── background.md
+├── summary.md
+├── drawings_description.md
+├── detailed_description.md
+└── abstract.md
+```
+
+### Step 2: Write Title (发明名称)
+
+- Must match the broadest claim scope
+- No trademarks, no "improved" or "new" or "novel"
+- CN format: "一种[领域]的[技术主题]" or "[领域]的[技术主题]装置"
+- US/EP format: "[Technical topic] for [purpose]" or "[Technical topic] and method thereof"
+- Keep concise (CN: typically under 25 characters; US: under 500 characters)
+
+### Step 3: Write Technical Field (技术领域)
+
+1-2 paragraphs identifying the technical domain:
+- "The present invention relates to [broad field], and more particularly to [specific area]."
+- CN: "本发明涉及[技术领域]，具体涉及[具体领域]。"
+
+### Step 4: Write Background (背景技术)
+
+This is NOT a literature review. It directly sets up the problem.
+
+Structure:
+1. Describe the closest prior art approaches (2-3 paragraphs)
+2. Identify specific technical deficiencies of each approach
+3. The deficiencies must be technical, not commercial or social
+4. DO NOT admit the prior art is "superior" or "better"
+5. DO NOT cite specific patent numbers unless they are known prior art (citations go in IDS for US, or Background section for CN)
+
+CN format: "背景技术" section describing existing technology and its shortcomings.
+
+### Step 5: Write Summary (发明内容)
+
+Three parts, directly mirroring INVENTION_DISCLOSURE.md:
+
+**Technical Problem (要解决的技术问题)**:
+- State the problem derived from background deficiencies
+- CN: "本发明要解决的技术问题是..."
+
+**Technical Solution (技术方案)**:
+- Describe how the invention solves the problem
+- Must provide support for ALL claim elements
+- Start from the broadest claim and describe the core inventive concept
+- CN: "为解决上述技术问题，本发明采用的技术方案是：..."
+- **NO formulas, NO mathematical derivations, NO circuit models** — these belong in 具体实施方式, not 发明内容
+
+**Advantages (有益效果)**:
+- Benefits derived from the structural/technical features (qualitative reasoning)
+- CN: "本发明的有益效果是：..."
+- **NO specific numerical results** (e.g., "detection limit 70μm", "response time 105ms") — these are experimental findings, not invention properties
+- Frame advantages structurally: "由于采用了...结构，因此具有...效果"
+
+### Step 6: Write Brief Description of Drawings (附图说明)
+
+Invoke `/figure-description` as a sub-skill if user has provided figures:
+```
+/figure-description "patent/figures/"
+```
+
+If no user figures, describe what figures should exist based on the claims.
+
+Format:
+- CN: "图1是...的示意图；图2是...的流程图；"
+- US: "FIG. 1 is a block diagram showing...; FIG. 2 is a flowchart illustrating..."
+
+### Step 7: Write Detailed Description (具体实施方式)
+
+Invoke `/embodiment-description` as a sub-skill:
+```
+/embodiment-description "patent/CLAIMS.md"
+```
+
+This section must:
+- Describe at least one complete embodiment with reference numerals
+- Enable a POSITA to make and use the invention
+- Support every claim element with explicit description
+- Include variations and alternatives for broader claim interpretation
+
+### Step 8: Write Abstract (摘要)
+
+Jurisdiction-specific word limits:
+
+| Jurisdiction | Word Limit | Notes |
+|-------------|-----------|-------|
+| CN | 300 words (Chinese characters) | Include most representative claim reference |
+| US | 150 words (2500 characters) | Enable efficient searching, no legal phrases |
+| EP | ~150 words | No statements on merits or value |
+
+The abstract summarizes:
+1. The technical field
+2. The problem being solved
+3. The technical solution (core features)
+4. Key advantages
+
+### Step 9: Claim Support Verification
+
+Verify every claim element finds support in the specification:
+
+| Claim | Element | Specification Section | Paragraph(s) | Reference Numeral |
+|-------|---------|----------------------|-------------|-------------------|
+| 1 | step a | detailed_description | ¶3 | 202 |
+| 1 | step b | detailed_description | ¶4 | 204 |
+| X | component A | detailed_description | ¶2 | 102 |
+
+If any element lacks support, add the necessary description before proceeding.
+
+### Step 10: Cross-Model Review
+
+Call `REVIEWER_MODEL` via a dedicated Codex reviewer agent at xhigh reasoning:
+
+```text
+spawn_agent:
+  model: gpt-5.4
+  reasoning_effort: xhigh
+  message: |
+    You are a patent examiner reviewing a specification for completeness.
+    CLAIMS: [all claims]
+    SPECIFICATION: [all specification sections]
+
+    Check for:
+    1. Written description support: Does every claim element have explicit or inherent support?
+    2. Enablement: Can a POSITA practice the invention from this specification?
+    3. Consistency: Do reference numerals match across figures and specification?
+    4. Language quality: Any subjective terms, relative terms without definition, or result-to-be-achieved language?
+    5. Missing embodiments: Are there claim features that need additional embodiments?
+    6. Background deficiencies: Are they technical and specific enough?
+```
+
+### Step 11: Output
+
+All specification sections are in `patent/specification/`.
+
+Summary file: `patent/specification/SPECIFICATION_INDEX.md` with:
+```markdown
+## Patent Specification
+
+### Sections
+| Section | File | Word Count | Status |
+|---------|------|-----------|--------|
+| Title | title.md | | Complete |
+| Technical Field | technical_field.md | | Complete |
+| Background | background.md | | Complete |
+| Summary | summary.md | | Complete |
+| Drawings Description | drawings_description.md | | Complete |
+| Detailed Description | detailed_description.md | | Complete |
+| Abstract | abstract.md | | Complete |
+
+### Claim Support Status
+| Claim | Elements Supported | Elements Missing |
+|-------|-------------------|-----------------|
+| 1 | All | None |
+| X | All | None |
+```
+
+## Key Rules
+
+- The specification supports the claims, not the other way around. Every claim element must have support.
+- Use consistent terminology -- same word for the same concept throughout.
+- DO NOT include experimental results, accuracy metrics, or empirical evaluations.
+- DO NOT use subjective language ("excellent", "surprising", "superior").
+- Reference numerals must be consistent: same component, same numeral, everywhere.
+- Background section describes specific deficiencies, not general "need for improvement."
+- Multiple embodiments strengthen the specification but are not always required.
+- Large file handling: if a Write operation fails, retry with Bash `cat <<'EOF'` heredoc.
+- If reviewer delegation is unavailable in the current Codex host, stop and ask the user to enable Codex agent support before continuing.

--- a/skills/skills-codex/system-profile/SKILL.md
+++ b/skills/skills-codex/system-profile/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: system-profile
+description: Profile a target (script, process, GPU, memory, interconnect) using external tools and code instrumentation. Produces structured performance reports with actionable recommendations. Use when user says "profile", "benchmark", "bottleneck", or wants performance analysis.
+argument-hint: <target, e.g. "train.py", "gpu", "pid 1234", "vllm serving">
+---
+
+# System Profile
+
+Profile the specified target and summarize the results. Target: $ARGUMENTS
+
+## Instructions
+
+You are a profiling assistant. Based on the user's target, choose appropriate profiling strategies, **including writing instrumentation code when needed**, then run profiling, analyze results, and produce a summary.
+
+### Step 1: Determine the profiling target
+
+Parse `$ARGUMENTS` to understand what to profile. Examples:
+- A Python script or module
+- A running process (PID or service name)
+- A specific function or code block
+- An entire framework or system (e.g., "autogen", "vllm serving") — profile its end-to-end execution, identify bottlenecks across components
+- "gpu" / "interconnect" / "memory" for focused profiling
+
+If `$ARGUMENTS` is empty or unclear, ask the user.
+
+### Step 2: Choose profiling methods
+
+Select from external tools and/or code instrumentation as appropriate. Don't limit yourself to the examples below — use whatever makes sense for the target.
+
+**External tools** (check availability first):
+- CPU: `cProfile`, `py-spy`, `line_profiler`, `perf stat`, `/usr/bin/time -v`
+- Memory: `tracemalloc`, `memory_profiler`, `memray`
+- GPU: `nvidia-smi`, `nvidia-smi dmon`, `nvitop`, `torch.profiler`, `nsys`
+- Interconnect: `nvidia-smi topo -m`, `nvidia-smi nvlink`, `NCCL_DEBUG=INFO`
+- System: `strace -c`, `iostat`, `vmstat`
+
+**Code instrumentation** — when external tools are insufficient, write and insert profiling code into the target. Typical scenarios:
+- Timing specific code blocks (wall time vs CPU time)
+- Measuring CPU-GPU or GPU-GPU transfer size, frequency, and bandwidth
+- Tracking memory allocation across CPU and GPU to detect redundancy
+- Wrapping NCCL collectives to measure latency and throughput
+- Adding CUDA event timing around kernels
+
+Design the instrumentation based on what you observe in the code — don't use a fixed template.
+
+### Step 3: Key dimensions to investigate
+
+Depending on the target, focus on some or all of these:
+
+**CPU overhead**
+- Context switching (voluntary / involuntary)
+- CPU utilization: ratio of CPU time to wall time
+- Per-function execution time hotspots
+
+**Memory overhead**
+- CPU and GPU memory usage (allocated vs reserved vs peak)
+- Redundant replication: same data living on both CPU and GPU
+- Per-device allocation balance in multi-GPU setups
+
+**Interconnect & communication**
+- CPU-GPU transfer: frequency, per-transfer size, total volume, bandwidth achieved
+- GPU-GPU transfer: P2P bandwidth, NVLink vs PCIe topology impact
+- NCCL collectives: operation type, message size distribution, latency
+- Communication-to-computation ratio
+
+**GPU compute**
+- SM utilization, kernel launch overhead
+- Memory bandwidth utilization vs peak
+
+### Step 4: Instrumentation guidelines
+
+When inserting code into the target:
+1. Read and understand the target code first
+2. Prefer wrapping (decorator, context manager, standalone runner) over inline edits
+3. If inline edits are necessary, mark them clearly (e.g., `# [PROFILE]` comments)
+4. Minimize observer effect — don't instrument tight inner loops; sample instead
+5. Collect results into a structured log, don't scatter print statements
+
+### Step 5: Run profiling
+
+1. Check available tools and hardware topology
+2. Run the chosen methods, capture all output
+3. Save artifacts (flamegraphs, traces, logs) to `./profile_output/`
+
+### Step 6: Produce the report
+
+**Part A — Profiling results** (structured tables by dimension, as applicable):
+- CPU overhead table
+- Memory overhead table (with redundancy column)
+- Interconnect table (transfer type / frequency / size / latency / bandwidth)
+- Hotspots / bottleneck identification
+- Actionable recommendations ranked by expected impact
+
+**Part B — Instrumentation changelog** (MANDATORY):
+List every file that was modified or created for profiling purposes:
+
+| File | Change type | What was added/modified | Line(s) |
+|------|-------------|------------------------|---------|
+| ... | modified | ... | ... |
+| ... | created | ... | — |
+
+This allows the user to review and revert all instrumentation changes.
+Offer to clean up (remove all instrumentation) when the user is done.

--- a/skills/skills-codex/training-check/SKILL.md
+++ b/skills/skills-codex/training-check/SKILL.md
@@ -1,128 +1,83 @@
 ---
 name: training-check
-description: "Periodically check WandB metrics during training to catch problems early (NaN, loss divergence, idle GPUs). Avoids wasting GPU hours on broken runs. Use when training is running and you want automated health checks."
-allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
+description: "Interactively monitor training metrics from the current Codex session, periodically checking WandB or fallback logs for NaN, divergence, plateaus, and broken runs."
+argument-hint: [wandb-run-or-monitoring-brief]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 
 # Training Check
 
-Periodically read WandB metrics during training to catch problems early. Do not wait until training finishes to discover it was a waste of GPU time.
+You are now in **interactive watch** / 交互式训练监控模式.
 
-## Context: $ARGUMENTS
+Keep the current session open and report directly in the current terminal. The user is watching this terminal for updates. By default, run a training health check every 30 minutes, output a concise but complete analysis report after each check, state the next check time, then continue monitoring.
 
-## Constants
+This skill checks training **quality**, not basic process health. Process health checks such as whether a tmux session exists or whether the GPU is idle can be handled by watchdog-style tooling; this skill focuses on whether the run is still worth continuing.
 
-- **WANDB_RUN** - Read from project notes or pass as `entity/project/run_id`.
-- **CHECK_INTERVAL** - Starts at 10 minutes, then gradually increases if consistently healthy: 10 min -> 20 min -> 30 min -> 60 min (cap).
-- **REVIEWER_MODEL = `gpt-5.4`** - Used via a secondary Codex agent for ambiguous cases only.
+## Inputs To Establish First
 
-## When to Use
+Before the first check, identify or ask for the minimum monitoring context:
 
-- After training is confirmed running (session alive, loss decreasing for the first few steps)
-- When the user wants recurring health checks during training
-- **This skill checks training QUALITY, not process HEALTH.** Process health (session alive, GPU utilization) belongs to watchdog-style monitoring.
+- WandB run path or URL, if available.
+- Fallback log path, SSH command, or local command for reading recent training logs.
+- Training target, expected baseline, and key metrics that define success.
+- How the training was launched, so it can be stopped if needed.
+- Project notes path for recording decisions and evidence.
 
-## Workflow
+If a source is unavailable, say so clearly and continue with the available source. If both WandB and fallback logs are unreachable, report the connectivity issue, classify the round as `WAIT`, and check again later. Do not infer that training is bad only because data is unreachable.
 
-### Step 1: Read WandB Metrics
+## Per-Round Check
 
-```python
-import wandb
-api = wandb.Api()
-run = api.run("<entity>/<project>/<run_id>")
-history = run.history()
-```
+Every round, read WandB first when configured. If WandB is unreachable, read the fallback logs. Inspect at least:
 
-If WandB is unreachable (API error, network issue), fall back to reading the log file directly via SSH:
+- Training loss trend over recent checkpoints or steps.
+- Eval metrics and whether they improve, flatten, or degrade against baseline.
+- NaN or Inf in loss, gradients, activations, or logged metrics.
+- Sudden loss spikes, divergence, or repeated failed evaluations.
+- Learning rate schedule behavior.
+- Gradient norm, if logged.
+- Plateau patterns that suggest the run is no longer useful.
 
-```bash
-ssh server "tail -100 /path/to/training.log"
-```
-
-Check these signals:
-
-- **Loss trend** - Is training loss decreasing over the last N steps?
-- **Eval metrics** - Are evaluation metrics improving (or at least not degrading)?
-- **NaN / Inf** - Any NaN or Inf values in loss or gradients?
-- **Spikes** - Sudden large jumps in loss (>10x normal variance)?
-- **Learning rate** - Is the schedule behaving as expected?
-- **Gradient norm** - Exploding or vanishing?
-
-### Step 2: Judgment
-
-| Signal | Judgment | Action |
-|--------|----------|--------|
-| NaN/Inf in loss | **Clearly bad** | Stop training, investigate |
-| Loss diverging (increasing for >N steps) | **Clearly bad** | Stop training, investigate |
-| Eval metrics significantly worse than baseline | **Clearly bad** | Stop training, investigate |
-| Loss decreasing, metrics improving | **Clearly fine** | Continue, increase check interval |
-| Loss flat but not diverging | **Unsure** | -> Step 3 (secondary review) |
-| Metrics noisy, can't tell trend | **Unsure** | -> Step 3 (secondary review) |
-| Slightly worse than baseline but still early | **Unsure** | -> Step 3 (secondary review) |
-
-### Step 3: Secondary Codex Judgment (only when unsure)
-
-Only escalate when the signal is ambiguous. For clearly good or clearly bad signals, act directly.
+Output one report in the current terminal with this structure:
 
 ```text
-spawn_agent:
-  model: REVIEWER_MODEL
-  reasoning_effort: high
-  message: |
-    TRAINING HEALTH CHECK - need your judgment on ambiguous metrics.
+## Training Check - <local timestamp>
 
-    Run: <entity>/<project>/<run_id>
-    Current epoch/step: X / Y total
-    Training loss (last 10 checkpoints): [values]
-    Eval metrics (last 3 evals): [values]
-    Baseline reference: [numbers from paper/reproduction]
-
-    What I'm unsure about: [specific concern]
-
-    Please respond with exactly one of:
-    - STOP: clearly problematic, should kill training
-    - CONTINUE: looks fine, check again next interval
-    - WAIT: not enough data to judge, check again sooner
+- Data source: wandb_ok | log_fallback | unreachable
+- Run: <wandb run or training identifier>
+- Recent metrics: <loss/eval/lr/grad summary>
+- Anomalies: <NaN/Inf/spike/divergence/plateau findings>
+- Evidence: <WandB URL, log lines, metric values, or files inspected>
+- Decision: CONTINUE | WAIT | STOP
+- Reason: <why this decision is justified>
+- Next check: <local timestamp, normally 30 minutes later unless ending>
 ```
 
-If delegation is unavailable, make a local judgment using the same rubric and mark the decision `[pending external review]`. In ambiguous cases with no hard failure, prefer `WAIT` over `STOP`.
+Use the decisions as follows:
 
-### Step 4: Act
+| Decision | Meaning | Action |
+|----------|---------|--------|
+| `CONTINUE` | Run looks healthy enough to keep training. | Keep monitoring and check again in 30 minutes. |
+| `WAIT` | Evidence is inconclusive, noisy, too early, or temporarily unreachable. | Do not stop training; keep monitoring and check again later. |
+| `STOP` | Training is clearly problematic or no longer worth continuing. | Stop the training task, save evidence, write notes, output final summary, and end monitoring. |
 
-| Decision | Action |
-|----------|--------|
-| **Stop** | Kill the training session. Save the WandB run URL, key metrics, and reason for stopping. Log to project notes for debugging. |
-| **Continue** | Do nothing. Re-run at the next interval (increase interval if consistently healthy). |
-| **Wait** | Do nothing but keep the current short interval (do not increase). |
+## Stop Behavior
 
-## Integration with Watchdog
+When the decision is `STOP`:
 
-`training-check` and watchdog-style monitoring operate at different levels:
+- Stop the training task.
+- If the context contains `stop_command`, run `stop_command` first.
+- If no `stop_command` is available, choose the appropriate stop action from how the training was launched, such as stopping the relevant tmux session, local process, remote process, scheduler job, or notebook job.
+- Save evidence: WandB URL, key metrics, relevant log snippets, files inspected, and the reason for stopping.
+- Append a project note for debugging and future analysis.
+- Output `FINAL_SUMMARY` in the terminal.
+- End the interactive monitoring loop.
 
-| Layer | Tool | What it checks | Frequency |
-|-------|------|----------------|-----------|
-| Process health | watchdog | Session alive? GPU active? | Every 60s (continuous) |
-| Training quality | training-check | Loss trend? Metrics improving? | Every 10-60 min (periodic) |
+Never stop on the first sign of ordinary metric noise. Look for sustained trends, hard failures, or clear divergence. Always preserve enough evidence for a later agent or human to understand why the run was stopped.
 
-Use both together:
+## Interactive Loop Guidance
 
-- Watchdog catches crashes and idle GPUs immediately
-- `training-check` catches subtle quality issues (loss plateau, metric degradation)
-
-## Rules
-
-- Do not stop training on the first sign of noise - some loss spikes are normal. Look at **trends over multiple checkpoints**.
-- When stopping training, always save the WandB run URL and key metrics as evidence.
-- If both WandB and log files are unreachable, report the connectivity issue and try again next interval. Do not assume training is broken.
-- Gradually increase check interval when healthy (10 -> 20 -> 30 -> 60 min). Reset to 10 min after any anomaly.
-- This skill is meant to be automated via a recurring scheduler. If the user wants ongoing monitoring, set up the best local mechanism available instead of waiting for manual reruns.
-
-## Recurring Setup Example
-
-```text
-After training is confirmed stable:
-  Create a recurring job (cron, task scheduler, tmux loop, etc.)
-  that runs `/training-check <entity>/<project>/<run_id>` every 10 minutes.
-```
-
-As the check interval increases, update the old recurring job to match the new interval.
+- The normal interval is 30 minutes.
+- If a round is `CONTINUE`, announce the next check time and wait until then.
+- If a round is `WAIT`, explain what evidence is missing or noisy and check again later. Use a shorter interval only when the run looks suspicious but not yet stop-worthy.
+- If an anomaly recovers, say so explicitly and continue monitoring.
+- Keep the user-facing report short enough to read in a terminal, but include concrete metric values and evidence paths.

--- a/skills/skills-codex/vast-gpu/SKILL.md
+++ b/skills/skills-codex/vast-gpu/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: vast-gpu
+description: "Rent, manage, and destroy GPU instances on vast.ai. Use when user says \"rent gpu\", \"vast.ai\", \"rent a server\", \"cloud gpu\", or needs on-demand GPU without owning hardware."
+argument-hint: [task-description or action]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
+---
+
+# Vast.ai GPU Management
+
+Manage vast.ai GPU instance: $ARGUMENTS
+
+## Overview
+
+Rent cheap, capable GPUs from vast.ai on demand. This skill **analyzes the training task** to determine GPU requirements, searches for the best-value offers, presents options with estimated total cost, and handles the full lifecycle: rent → setup → run → destroy.
+
+Users do NOT specify GPU models or hardware. They describe the task — the skill figures out what to rent.
+
+**Prerequisites:** The `vastai` CLI must be installed (requires **Python ≥ 3.10**) and authenticated:
+```bash
+pip install vastai
+vastai set api-key YOUR_API_KEY
+```
+
+> If your system Python is < 3.10, create a virtual environment with Python ≥ 3.10 (e.g., `conda create`, `pyenv`, `uv venv`, etc.) and install `vastai` there.
+
+SSH public key **must be uploaded at https://cloud.vast.ai/manage-keys/ BEFORE creating any instance**. Keys are baked into instances at creation time — if you add a key after renting, you must destroy and re-create the instance.
+
+## State File
+
+All active vast.ai instances are tracked in `vast-instances.json` at the project root:
+```json
+[
+  {
+    "instance_id": 33799165,
+    "offer_id": 25831376,
+    "gpu_name": "RTX_3060",
+    "num_gpus": 1,
+    "dph": 0.0414,
+    "ssh_url": "ssh://root@1.208.108.242:58955",
+    "ssh_host": "1.208.108.242",
+    "ssh_port": 58955,
+    "created_at": "2026-03-29T21:12:00Z",
+    "status": "running",
+    "experiment": "exp01_baseline",
+    "estimated_hours": 4.0,
+    "estimated_cost": 0.17
+  }
+]
+```
+
+This file is the source of truth for `/run-experiment` and `/monitor-experiment` to connect to vast.ai instances.
+
+## Workflow
+
+### Action: Provision (default)
+
+Analyze the task, find the best GPU, and present cost-optimized options. This is the main entry point — called directly or automatically by `/run-experiment` when `gpu: vast` is set.
+
+**Step 1: Analyze Task Requirements**
+
+Read available context to determine what the task needs:
+
+1. **From the experiment plan** (`refine-logs/EXPERIMENT_PLAN.md`):
+   - Compute budget (total GPU-hours)
+   - Hardware hints (e.g., "4x RTX 3090")
+   - Model architecture and dataset size
+   - Run order and per-milestone cost estimates
+
+2. **From experiment scripts** (if already written):
+   - Model size — scan for model class, `num_parameters`, config files
+   - Batch size, sequence length — estimate VRAM from these
+   - Dataset — estimate training time from dataset size + epochs
+   - Multi-GPU — check for `DataParallel`, `DistributedDataParallel`, `accelerate`, `deepspeed`
+
+3. **From user description** (if no plan/scripts exist):
+   - Model name/size (e.g., "fine-tune LLaMA-7B", "train ResNet-50")
+   - Dataset scale (e.g., "ImageNet", "10k samples")
+   - Estimated duration (e.g., "about 2 hours")
+
+**Step 2: Determine GPU Requirements**
+
+Based on the task analysis, determine:
+
+| Factor | How to estimate |
+|--------|----------------|
+| **Min VRAM** | Model params × 4 bytes (fp32) or × 2 (fp16/bf16) + optimizer states + activations. Rules of thumb: 7B model ≈ 16 GB (fp16), 13B ≈ 28 GB, 70B ≈ 140 GB (needs multi-GPU). ResNet/ViT ≈ 4-8 GB. Add 20% headroom. |
+| **Num GPUs** | 1 unless: model doesn't fit in single GPU VRAM, or scripts use DDP/FSDP/DeepSpeed, or plan specifies multi-GPU |
+| **Est. hours** | From experiment plan's cost column, or: (dataset_size × epochs) / (throughput × batch_size). Default to user estimate if available. Add 30% buffer for setup + unexpected slowdowns |
+| **Min disk** | 20 GB base + model checkpoint size + dataset size. Default: 50 GB |
+| **CUDA version** | Match PyTorch version. PyTorch 2.x needs CUDA ≥ 11.8. Default: 12.1 |
+
+**Step 3: Search Offers**
+
+Search across multiple GPU tiers to find the best value. Always search broadly — do NOT limit to one GPU model:
+
+```bash
+# Tier 1: Budget GPUs (good for small models, fine-tuning, ablations)
+vastai search offers "gpu_ram>=<MIN_VRAM> num_gpus>=<N> reliability>0.95 inet_down>100" -o 'dph+' --storage <DISK> --limit 10
+
+# Tier 2: If VRAM > 24 GB, also search high-VRAM cards specifically
+vastai search offers "gpu_ram>=48 num_gpus>=<N> reliability>0.95" -o 'dph+' --storage <DISK> --limit 5
+```
+
+The output is a table with columns: `ID`, `CUDA`, `N` (GPU count), `Model`, `PCIE`, `cpu_ghz`, `vCPUs`, `RAM`, `Disk`, `$/hr`, `DLP` (deep learning perf), `score`, `NV Driver`, `Net_up`, `Net_down`, `R` (reliability %), `Max_Days`, `mach_id`, `status`, `host_id`, `ports`, `country`.
+
+The **first column (`ID`)** is the offer ID needed for `vastai create instance`.
+
+**Step 4: Present Cost-Optimized Options**
+
+Present **3 options** to the user, ranked by estimated total cost:
+
+```
+Task analysis:
+- Model: [model name/size] → estimated VRAM: ~[X] GB
+- Training: ~[Y] hours estimated
+- Requirements: [N] GPU(s), ≥[X] GB VRAM, ~[Z] GB disk
+
+Recommended options (sorted by estimated total cost):
+
+| # | GPU          | VRAM  | $/hr   | Est. Hours | Est. Total | Reliability | Offer ID  |
+|---|-------------|-------|--------|------------|------------|-------------|-----------|
+| 1 | RTX 3060    | 12 GB | $0.04  | ~6h        | ~$0.25     | 99.4%       | 25831376  |  ← cheapest
+| 2 | RTX 4090    | 24 GB | $0.28  | ~4h        | ~$1.12     | 99.2%       | 6995713   |  ← best value
+| 3 | A100 SXM    | 80 GB | $0.95  | ~2h        | ~$1.90     | 99.5%       | 7023456   |  ← fastest
+
+Option 1 is cheapest overall. Option 3 finishes fastest.
+Pick a number (or type a different offer ID):
+```
+
+**Key presentation rules:**
+- Always show **estimated total cost** ($/hr × estimated hours), not just $/hr
+- Faster GPUs have shorter estimated hours (scale by relative FLOPS)
+- Flag if a cheap option has reliability < 0.97 ("budget pick — 3% chance of interruption")
+- If task is small (<1 hour), recommend interruptible pricing for even lower cost
+- If no offers meet VRAM requirements, explain why and suggest alternatives (e.g., multi-GPU, quantization)
+
+**Relative speed scaling (approximate, for estimating hours across GPU tiers):**
+
+| GPU | Relative Speed (FP16) |
+|-----|-----------------------:|
+| RTX 3060 | 0.5× |
+| RTX 3090 | 1.0× |
+| RTX 4090 | 1.6× |
+| A5000 | 0.9× |
+| A6000 | 1.1× |
+| L40S | 1.5× |
+| A100 SXM | 2.0× |
+| H100 SXM | 3.3× |
+
+Use these to scale the base estimated hours across offers.
+
+### Action: Rent
+
+Create an instance from a user-selected offer.
+
+**Step 1: Create Instance**
+
+```bash
+vastai create instance <OFFER_ID> \
+  --image <DOCKER_IMAGE> \
+  --disk <DISK_GB> \
+  --ssh \
+  --direct \
+  --onstart-cmd "apt-get update && apt-get install -y git screen rsync"
+```
+
+Default Docker image: `pytorch/pytorch:2.1.0-cuda12.1-cudnn8-devel` (override via `AGENTS.md` `image:` field if set).
+
+The output looks like:
+```
+Started. {'success': True, 'new_contract': 33799165, 'instance_api_key': '...'}
+```
+
+The **`new_contract` value is the instance ID** — save this for all subsequent commands.
+
+**Step 2: Wait for Instance Ready**
+
+Poll instance status every 20 seconds until it's running (typically takes 30-60 seconds, max ~5 minutes):
+```bash
+vastai show instances --raw | python3 -c "
+import sys, json
+instances = json.load(sys.stdin)
+for inst in instances:
+    if inst['id'] == <INSTANCE_ID>:
+        print(inst['actual_status'])
+"
+```
+
+Wait states: `loading` → `running`. If stuck in `loading` for >5 minutes, warn the user — the host may be slow or the image may be large.
+
+**Step 3: Get SSH Connection Details**
+
+```bash
+vastai ssh-url <INSTANCE_ID>
+```
+
+This returns a URL in the format: `ssh://root@<HOST>:<PORT>`
+
+Parse out host and port from this URL. Example:
+- Input: `ssh://root@1.208.108.242:58955`
+- Host: `1.208.108.242`, Port: `58955`
+
+> **Important:** Always use `vastai ssh-url` to get connection details — do NOT rely on `ssh_host`/`ssh_port` from `vastai show instances`, as those may point to proxy servers that differ from the direct connection endpoint.
+
+**Step 4: Verify SSH Connectivity**
+
+```bash
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=15 -p <PORT> root@<HOST> "nvidia-smi && echo 'CONNECTION_OK'"
+```
+
+If SSH fails with "Permission denied (publickey)":
+- The user's SSH key was not uploaded to https://cloud.vast.ai/manage-keys/ **before** the instance was created
+- **Fix:** Destroy this instance, have user upload their key, then create a new instance. Keys are baked in at creation time — there is no way to add keys to a running instance.
+
+If SSH fails with "Connection refused":
+- The instance may still be initializing. Retry up to 3 times with 15-second intervals.
+
+**Step 5: Update State File**
+
+Write/update `vast-instances.json` with the new instance details including the `ssh_url` from Step 3, estimated hours and cost.
+
+**Step 6: Report**
+
+```
+Vast.ai instance ready:
+- Instance ID: <ID>
+- GPU: <GPU_NAME> x <NUM_GPUS>
+- Cost: $<DPH>/hr (estimated total: ~$<TOTAL>)
+- SSH: ssh -p <PORT> root@<HOST>
+- Docker: <IMAGE>
+
+To deploy: /run-experiment (will auto-detect this instance)
+To destroy when done: /vast-gpu destroy <ID>
+```
+
+### Action: Setup
+
+Set up the rented instance for a specific experiment. Called automatically by `/run-experiment` when targeting a vast.ai instance.
+
+**Step 1: Install Dependencies**
+
+```bash
+ssh -p <PORT> root@<HOST> "pip install -q wandb tensorboard scipy scikit-learn pandas"
+```
+
+If a `requirements.txt` exists in the project, install that instead:
+```bash
+scp -P <PORT> requirements.txt root@<HOST>:/workspace/
+ssh -p <PORT> root@<HOST> "pip install -q -r /workspace/requirements.txt"
+```
+
+> Note: `scp` uses uppercase `-P` for port, while `ssh` uses lowercase `-p`.
+
+**Step 2: Sync Code**
+
+```bash
+rsync -avz -e "ssh -p <PORT>" \
+  --include='*.py' --include='*.yaml' --include='*.yml' --include='*.json' \
+  --include='*.txt' --include='*.sh' --include='*/' \
+  --exclude='*.pt' --exclude='*.pth' --exclude='*.ckpt' \
+  --exclude='__pycache__' --exclude='.git' --exclude='data/' \
+  --exclude='wandb/' --exclude='outputs/' \
+  ./ root@<HOST>:/workspace/project/
+```
+
+**Step 3: Verify Setup**
+
+```bash
+ssh -p <PORT> root@<HOST> "cd /workspace/project && python -c 'import torch; print(f\"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}, GPUs: {torch.cuda.device_count()}\")'"
+```
+
+Expected output: `PyTorch 2.1.0, CUDA: True, GPUs: 1` (or more GPUs if multi-GPU instance).
+
+### Action: Destroy
+
+Tear down a vast.ai instance to stop billing.
+
+**Step 1: Confirm Results Collected**
+
+Before destroying, check if there are experiment results to download:
+```bash
+ssh -p <PORT> root@<HOST> "ls /workspace/project/results/ 2>/dev/null || echo 'NO_RESULTS_DIR'"
+```
+
+If results exist, download them first:
+```bash
+rsync -avz -e "ssh -p <PORT>" root@<HOST>:/workspace/project/results/ ./results/
+```
+
+Also download logs:
+```bash
+scp -P <PORT> root@<HOST>:/workspace/*.log ./logs/ 2>/dev/null
+```
+
+**Step 2: Destroy Instance**
+
+```bash
+vastai destroy instance <INSTANCE_ID>
+```
+
+Output: `destroying instance <INSTANCE_ID>.`
+
+> Destruction is **irreversible** — all data on the instance is permanently deleted.
+
+**Step 3: Update State File**
+
+Remove the instance from `vast-instances.json` or mark its status as `destroyed`.
+
+**Step 4: Report Cost**
+
+Calculate actual cost based on creation time and $/hr:
+```
+Instance <ID> destroyed.
+- Duration: ~X.X hours
+- Actual cost: ~$X.XX (estimated was $Y.YY)
+- Results downloaded to: ./results/
+```
+
+### Action: List
+
+Show all active vast.ai instances:
+```bash
+vastai show instances
+```
+
+Cross-reference with `vast-instances.json` for experiment associations.
+
+### Action: Destroy All
+
+Tear down all active instances (use after all experiments complete):
+
+1. Download results from each instance
+2. Destroy all instances
+3. Clear `vast-instances.json`
+4. Report total cost
+
+## Key Rules
+
+- **Task-driven selection** — NEVER ask users to pick GPU models. Analyze the task, estimate requirements, present cost-optimized options with total price
+- **ALWAYS destroy instances when experiments are done** — vast.ai bills per second, leaving instances running wastes money
+- **Download results before destroying** — data is lost permanently on destroy
+- **Prefer on-demand pricing** for short experiments (<2 hours). Suggest interruptible/bid pricing for long runs (>4 hours) with checkpointing
+- **Check reliability > 0.95** — unreliable hosts may crash mid-training
+- **Use `--direct` SSH** when creating instances — faster than proxy SSH
+- **Always use `vastai ssh-url <ID>`** to get connection details — the host/port from `show instances` may differ
+- **SSH keys must be uploaded BEFORE creating instances** — keys are baked in at creation time. If SSH fails with "Permission denied", destroy and recreate after adding the key
+- **Default Docker image**: `pytorch/pytorch:2.1.0-cuda12.1-cudnn8-devel` unless user specifies otherwise
+- **Working directory on instance**: `/workspace/` (Docker default). Code syncs to `/workspace/project/`
+- **State file `vast-instances.json` must stay up to date** — other skills depend on it
+- **Show estimated total cost, not just $/hr** — a $0.90/hr GPU that finishes in 2h ($1.80) beats a $0.30/hr GPU that takes 8h ($2.40)
+- **`vastai` CLI requires Python ≥ 3.10** — if system Python is older, use a conda env
+
+## AGENTS.md Example
+
+Users only need to set `gpu: vast` — no hardware preferences required:
+
+```markdown
+## Vast.ai
+- gpu: vast                  # tells run-experiment to use vast.ai
+- auto_destroy: true         # auto-destroy after experiment completes (default: true)
+- max_budget: 5.00           # optional: max total $ to spend (skill warns if estimate exceeds this)
+- image: pytorch/pytorch:2.1.0-cuda12.1-cudnn8-devel  # optional: override Docker image
+```
+
+The skill analyzes experiment scripts and plans to determine what GPU to rent. No need to specify GPU model, VRAM, or instance count.
+
+## Composing with Other Skills
+
+```
+/run-experiment "train model"       ← detects gpu: vast, calls /vast-gpu provision
+  ↳ /vast-gpu provision             ← analyzes task, presents options with cost
+  ↳ user picks option               ← rent + setup + deploy
+  ↳ /vast-gpu destroy               ← auto-destroy when done (if auto_destroy: true)
+
+/vast-gpu provision                 ← manual: analyze task + show options
+/vast-gpu rent <offer_id>           ← manual: rent a specific offer
+/vast-gpu list                      ← show active instances
+/vast-gpu destroy <instance_id>     ← tear down, stop billing
+/vast-gpu destroy-all               ← tear down everything
+```

--- a/skills/skills-codex/writing-systems-papers/SKILL.md
+++ b/skills/skills-codex/writing-systems-papers/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: writing-systems-papers
+description: "Paragraph-level structural blueprint for 10-12 page systems papers targeting OSDI, SOSP, ASPLOS, NSDI, and EuroSys. Provides page allocation, paragraph templates, and writing patterns. Use when user says \"写系统论文\", \"systems paper structure\", \"OSDI paper\", \"SOSP paper\", or wants fine-grained structural guidance for a systems conference submission."
+argument-hint: [venue-or-section]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch
+---
+
+# Writing Systems Papers: Paragraph-Level Blueprint
+
+Structural guidance for **$ARGUMENTS**
+
+## Relationship to Other ARIS Skills
+
+- **paper-write**: General paper generation workflow with citation verification. This skill complements it with systems-specific structural blueprints.
+- **paper-slides**: Conference presentation generation (Beamer+PPTX). Already covers talks — no overlap.
+- **paper-plan**: Research outline creation. Use paper-plan first, then this skill for paragraph-level structure.
+
+**Boundary**: paper-write handles the generation workflow (LaTeX output, DBLP verification, section-by-section drafting). This skill provides the **structural skeleton** — page budgets, paragraph roles, and writing patterns specific to systems venues.
+
+---
+
+## Page Allocation: 12-Page Systems Paper
+
+| Section | Pages | Key Content |
+|---------|-------|-------------|
+| Abstract | ~0.25 | 150–250 words, 5 sentences |
+| S1 Introduction | 1.5–2 | Problem → Gap → Insight → Contributions |
+| S2 Background & Motivation | 1–1.5 | Terms + Production observations |
+| S3 Design | 3–4 | Architecture + Modules + Alternatives |
+| S4 Implementation | 0.5–1 | Prototype, LOC, engineering |
+| S5 Evaluation | 3–4 | Setup + E2E + Ablation + Scalability |
+| S6 Related Work | 1 | By methodology, explicit comparison |
+| S7 Conclusion | 0.5 | 3-sentence summary |
+
+---
+
+## Section Blueprints
+
+### Abstract (5 sentences)
+
+```text
+S1: Problem context and importance
+S2: Gap in existing approaches
+S3: Thesis — "X is better for Y in environment Z" (Irene Zhang formula)
+S4: Approach summary + headline results
+S5: Impact or availability
+```
+
+Sources: Levin & Redell — "Can you state the new idea concisely?"; Irene Zhang — "abstract cannot use terms introduced in the paper."
+
+### S1 Introduction (1.5–2 pages)
+
+1. **Problem** (~0.5p) — Domain + concrete numbers + why it matters
+2. **Gap analysis** (~0.5p) — G1–Gn: specific shortcomings with evidence
+3. **Key insight** (1 para) — Thesis: "X is better for Y in Z"
+4. **Contributions** (~0.5p) — 3–5 numbered, testable claims with §N references
+
+Pattern: hzwer Move 1 (territory) → Move 2 (niche) → Move 3 (occupy).
+
+### S2 Background & Motivation (1–1.5 pages)
+
+1. **Technical background** (~0.5p) — Define-before-use (Gernot Heiser)
+2. **Observations** (~0.5–1p) — O1, O2, O3 from production data → design insights
+
+### S3 Design (3–4 pages)
+
+1. **Architecture overview** (~0.5p) — Diagram first (Yi Ding: "draw a picture first")
+2. **Module details** (~2–2.5p) — Per module: choice, alternatives, why
+3. **Trade-offs** (~0.5–1p) — Summary of design decisions
+
+Rule: "Every design choice must discuss alternatives" (Irene Zhang).
+
+### S4 Implementation (0.5–1 page)
+
+Language, LOC, framework, key engineering decisions. Keep concise.
+
+### S5 Evaluation (3–4 pages)
+
+1. **Setup** (~0.5p) — Hardware, baselines, workloads, metrics
+2. **End-to-end** (~1–1.5p) — X vs baselines for Y on Z
+3. **Ablation** (~1–1.5p) — Remove each component, measure impact
+4. **Scalability** (~0.5p) — Behavior at increasing scale
+
+**Three-statement rule** (Irene Zhang): Every conclusion stated as:
+- Hypothesis (section opening)
+- Conclusion (section closing)
+- Caption (figure caption)
+
+### S6 Related Work (1 page)
+
+Group by methodology. For each group: what they do, limitation, how we differ.
+
+### S7 Conclusion (0.5 page)
+
+Three sentences: problem, solution, result. No new information.
+
+---
+
+## Writing Patterns
+
+### Pattern 1: Gap Analysis
+Enumerate G1–Gn in intro → A1–An in design → verify in evaluation.
+*Example*: Lucid (ASPLOS'23) — 5 gaps mapped to 5 answers.
+
+### Pattern 2: Observation-Driven
+O1–O3 from production data → insights → design components.
+*Example*: GFS (arXiv 2025) — 3 observations drive 3 components.
+
+### Pattern 3: Contribution List
+Numbered contributions in intro, each with §N cross-reference.
+*Example*: Blox (EuroSys'24) — 7 contributions; Sia (SOSP'23) — 5 contributions.
+
+### Pattern 4: Thesis Formula
+"X is better for Y in Z" structures the entire paper.
+Combine with other patterns for maximum impact.
+
+---
+
+## Conference Differences
+
+> Always verify against current CFP — rules change yearly.
+
+| Venue | Format | Pages | Camera-Ready |
+|-------|--------|-------|-------------|
+| OSDI | USENIX | 12 | 14 |
+| NSDI | USENIX | 12 | 14 |
+| SOSP | ACM SIGOPS | 12 | — |
+| ASPLOS | ACM SIGPLAN | 11 | 13 |
+| EuroSys | ACM | 12 | — |
+
+Based on 2025/2026 CFPs.
+
+---
+
+## Workflow
+
+```text
+1. Determine venue and page limit
+2. Choose writing pattern (Gap/Observation/Contribution/Thesis)
+3. Allocate pages per section using the table above
+4. Draft Abstract following 5-sentence template
+5. Draft Introduction: Problem → Gap → Insight → Contributions
+6. Draft Motivation with production observations (if available)
+7. Draw architecture figure, then write Design
+8. Draft Implementation (concise)
+9. Draft Evaluation: setup → E2E → ablation → scalability
+10. Draft Related Work by methodology groups
+11. Draft Conclusion: 3 sentences
+12. Run pre-submission checklist
+13. Hand off to /paper-write for LaTeX generation and citation verification
+```
+
+---
+
+## Quick Self-Check
+
+- [ ] Thesis follows "X is better for Y in Z"
+- [ ] 3–5 numbered contributions with §N references
+- [ ] Design discusses alternatives for every major choice
+- [ ] Eval conclusions stated 3 times (hypothesis, result, caption)
+- [ ] Related work grouped by methodology
+- [ ] Page budget within venue limits
+- [ ] No fabricated observations, traces, or results
+- [ ] All citations verified (delegate to /paper-write)
+
+---
+
+## Academic Integrity
+
+- Never fabricate observations, traces, or experimental results
+- Never generate citations from memory — use /paper-write citation workflow
+- Disclose LLM use per venue policy
+- This blueprint provides structural guidance, not copy-paste text
+
+---
+
+## Authoritative Sources
+
+1. Levin & Redell — "How (and How Not) to Write a Good Systems Paper" (USENIX)
+2. Irene Zhang — "Hints on how to write an SOSP paper"
+3. Gernot Heiser — Style Guide + Paper Writing Talk
+4. Timothy Roscoe — "Writing reviews for systems conferences"
+5. Yi Ding — "How to write good systems papers?"
+6. hzwer & DingXiaoH — WritingAIPaper (GitHub)

--- a/tests/test_codex_install_update.py
+++ b/tests/test_codex_install_update.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = REPO_ROOT / "tools" / "install_aris_codex.sh"
+UPDATE_SCRIPT = REPO_ROOT / "tools" / "smart_update_codex.sh"
+
+
+def run(
+    cmd: list[str], *, cwd: Path | None = None, check: bool = True, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd or REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=check,
+        env=env,
+    )
+
+
+def make_skill(path: Path, body: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(body)
+
+
+def make_minimal_aris_repo(root: Path) -> Path:
+    repo = root / "aris"
+    make_skill(repo / "skills" / "skills-codex" / "alpha", "# alpha\n")
+    make_skill(repo / "skills" / "skills-codex" / "beta", "# beta-base\n")
+    (repo / "skills" / "skills-codex" / "shared-references").mkdir(parents=True, exist_ok=True)
+    (repo / "skills" / "skills-codex" / "shared-references" / "reviewer-routing.md").write_text("base\n")
+    make_skill(repo / "skills" / "skills-codex-claude-review" / "beta", "# beta-claude-overlay\n")
+    make_skill(repo / "skills" / "skills-codex-gemini-review" / "beta", "# beta-gemini-overlay\n")
+    return repo
+
+
+def test_install_aris_codex_dry_run_has_no_project_writes(tmp_path: Path) -> None:
+    repo = make_minimal_aris_repo(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    dry_run = run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(repo),
+            "--dry-run",
+        ]
+    )
+
+    assert "(dry-run) no changes made" in dry_run.stdout
+    assert not (project / ".aris").exists()
+    assert not (project / ".agents").exists()
+    assert not (project / "AGENTS.md").exists()
+
+
+def test_install_aris_codex_avoids_bash4_associative_arrays() -> None:
+    text = INSTALL_SCRIPT.read_text()
+    assert "declare -A" not in text
+
+
+def test_install_aris_codex_reconcile_and_uninstall(tmp_path: Path) -> None:
+    repo = make_minimal_aris_repo(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(repo),
+            "--quiet",
+        ]
+    )
+
+    manifest = project / ".aris" / "installed-skills-codex.txt"
+    assert manifest.exists()
+    assert (project / "AGENTS.md").exists()
+    agents_text = (project / "AGENTS.md").read_text()
+    assert "ARIS Codex Skill Scope" in agents_text
+    assert f"ARIS repo root: `{repo}`" in agents_text
+    assert "repo_root" in agents_text
+    assert '$1=="repo_root"{print $2; exit}' in agents_text
+    assert "$1==repo_root" not in agents_text
+    assert (project / ".agents" / "skills" / "alpha").is_symlink()
+    assert (project / ".agents" / "skills" / "beta").resolve() == (repo / "skills" / "skills-codex" / "beta")
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(repo),
+            "--reconcile",
+            "--with-claude-review-overlay",
+            "--quiet",
+        ]
+    )
+    assert (project / ".agents" / "skills" / "beta").resolve() == (
+        repo / "skills" / "skills-codex-claude-review" / "beta"
+    )
+
+    (repo / "skills" / "skills-codex" / "alpha").rename(repo / "skills" / "skills-codex" / "alpha-removed")
+    make_skill(repo / "skills" / "skills-codex" / "gamma", "# gamma\n")
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(repo),
+            "--reconcile",
+            "--with-claude-review-overlay",
+            "--quiet",
+        ]
+    )
+    assert not (project / ".agents" / "skills" / "alpha").exists()
+    assert (project / ".agents" / "skills" / "gamma").is_symlink()
+
+    (project / ".agents" / "skills" / "local-only").mkdir(parents=True)
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(repo),
+            "--uninstall",
+            "--quiet",
+        ]
+    )
+    assert (project / ".agents" / "skills" / "local-only").exists()
+    assert not (project / ".agents" / "skills" / "beta").exists()
+    assert (project / ".aris" / "installed-skills-codex.txt.prev").exists()
+    assert "ARIS Codex Skill Scope" not in (project / "AGENTS.md").read_text()
+
+
+def test_install_aris_codex_uninstall_uses_manifest_repo_root(tmp_path: Path) -> None:
+    original_repo = make_minimal_aris_repo(tmp_path / "original")
+    other_repo = make_minimal_aris_repo(tmp_path / "other")
+    project = tmp_path / "project"
+    project.mkdir()
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(original_repo),
+            "--quiet",
+        ]
+    )
+
+    alpha_link = project / ".agents" / "skills" / "alpha"
+    assert alpha_link.is_symlink()
+    assert alpha_link.resolve() == original_repo / "skills" / "skills-codex" / "alpha"
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(other_repo),
+            "--uninstall",
+            "--quiet",
+        ]
+    )
+
+    assert not alpha_link.exists()
+    assert not (project / ".agents" / "skills" / "beta").exists()
+    assert not (project / ".agents" / "skills" / "shared-references").exists()
+    assert not (project / ".aris" / "installed-skills-codex.txt").exists()
+    assert (project / ".aris" / "installed-skills-codex.txt.prev").exists()
+
+
+def test_install_aris_codex_reconcile_removes_stale_links_from_manifest_repo(tmp_path: Path) -> None:
+    original_repo = make_minimal_aris_repo(tmp_path / "original")
+    new_repo = make_minimal_aris_repo(tmp_path / "new")
+    (new_repo / "skills" / "skills-codex" / "alpha").rename(
+        new_repo / "skills" / "skills-codex" / "alpha-removed"
+    )
+    make_skill(new_repo / "skills" / "skills-codex" / "gamma", "# gamma\n")
+    project = tmp_path / "project"
+    project.mkdir()
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(original_repo),
+            "--quiet",
+        ]
+    )
+
+    alpha_link = project / ".agents" / "skills" / "alpha"
+    beta_link = project / ".agents" / "skills" / "beta"
+    assert alpha_link.is_symlink()
+    assert alpha_link.resolve() == original_repo / "skills" / "skills-codex" / "alpha"
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(new_repo),
+            "--reconcile",
+            "--quiet",
+        ]
+    )
+
+    assert not alpha_link.exists()
+    assert beta_link.resolve() == new_repo / "skills" / "skills-codex" / "beta"
+    assert (project / ".agents" / "skills" / "gamma").resolve() == (
+        new_repo / "skills" / "skills-codex" / "gamma"
+    )
+    manifest = (project / ".aris" / "installed-skills-codex.txt").read_text()
+    assert "\talpha\t" not in manifest
+    assert f"repo_root\t{new_repo}" in manifest
+
+
+def test_install_aris_codex_reconcile_accepts_already_deleted_stale_link(tmp_path: Path) -> None:
+    original_repo = make_minimal_aris_repo(tmp_path / "original")
+    new_repo = make_minimal_aris_repo(tmp_path / "new")
+    (new_repo / "skills" / "skills-codex" / "alpha").rename(
+        new_repo / "skills" / "skills-codex" / "alpha-removed"
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(original_repo),
+            "--quiet",
+        ]
+    )
+
+    alpha_link = project / ".agents" / "skills" / "alpha"
+    assert alpha_link.is_symlink()
+    alpha_link.unlink()
+
+    run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            str(project),
+            "--aris-repo",
+            str(new_repo),
+            "--reconcile",
+            "--quiet",
+        ]
+    )
+
+    manifest = (project / ".aris" / "installed-skills-codex.txt").read_text()
+    assert "\talpha\t" not in manifest
+
+
+def test_smart_update_codex_copy_install_and_symlink_refusal(tmp_path: Path) -> None:
+    upstream = tmp_path / "upstream"
+    make_skill(upstream / "alpha", "# alpha-v2\n")
+    make_skill(upstream / "beta", "# beta\n")
+    make_skill(upstream / "gamma", "../shared-references/integration-contract.md\n")
+    (upstream / "shared-references").mkdir(parents=True, exist_ok=True)
+    (upstream / "shared-references" / "reviewer-routing.md").write_text("new\n")
+    (upstream / "shared-references" / "integration-contract.md").write_text("integration\n")
+
+    local = tmp_path / "local"
+    make_skill(local / "alpha", "# alpha-v1\n")
+    (local / "shared-references").mkdir(parents=True, exist_ok=True)
+    (local / "shared-references" / "reviewer-routing.md").write_text("old\n")
+    make_skill(local / "local-only", "# keep-me\n")
+
+    dry_run = run(
+        [
+            "bash",
+            str(UPDATE_SCRIPT),
+            "--upstream",
+            str(upstream),
+            "--local",
+            str(local),
+        ]
+    )
+    assert "Safe update: 0" in dry_run.stdout
+    assert "New: 2" in dry_run.stdout
+    assert "Needs merge: 2" in dry_run.stdout
+    assert "New shared references: 1" in dry_run.stdout
+    assert "shared-references/integration-contract.md" in dry_run.stdout
+    assert "Local only: 1" in dry_run.stdout
+    assert not (local / "shared-references" / "integration-contract.md").exists()
+
+    run(
+        [
+            "bash",
+            str(UPDATE_SCRIPT),
+            "--upstream",
+            str(upstream),
+            "--local",
+            str(local),
+            "--apply",
+        ]
+    )
+    assert "# alpha-v1" in (local / "alpha" / "SKILL.md").read_text()
+    assert (local / "beta" / "SKILL.md").exists()
+    assert (local / "gamma" / "SKILL.md").exists()
+    assert (local / "shared-references" / "integration-contract.md").read_text() == "integration\n"
+    assert (local / "shared-references" / "reviewer-routing.md").read_text() == "old\n"
+    assert (local / "local-only" / "SKILL.md").exists()
+
+    managed_project = tmp_path / "managed-project"
+    (managed_project / ".agents" / "skills").mkdir(parents=True)
+    (managed_project / ".agents" / "skills" / "auto-review-loop").symlink_to(
+        REPO_ROOT / "skills" / "skills-codex" / "auto-review-loop"
+    )
+    refused = run(
+        ["bash", str(UPDATE_SCRIPT), "--project", str(managed_project)],
+        check=False,
+    )
+    assert refused.returncode != 0
+    assert "install_aris_codex.sh" in refused.stderr
+
+
+def test_smart_update_codex_local_uses_default_upstream(tmp_path: Path) -> None:
+    local = tmp_path / "local"
+    local.mkdir()
+
+    dry_run = run(["bash", str(UPDATE_SCRIPT), "--local", str(local)])
+
+    assert dry_run.returncode == 0
+    assert f"Upstream: {REPO_ROOT / 'skills' / 'skills-codex'}" in dry_run.stdout
+    assert f"Local:    {local}" in dry_run.stdout
+
+
+def test_smart_update_codex_allows_unrelated_symlinked_skills(tmp_path: Path) -> None:
+    local = tmp_path / "local"
+    third_party = tmp_path / "third-party-skill"
+    local.mkdir()
+    make_skill(third_party, "# third-party\n")
+    (local / "third-party").symlink_to(third_party)
+
+    dry_run = run(["bash", str(UPDATE_SCRIPT), "--local", str(local)])
+
+    assert dry_run.returncode == 0
+    assert "third-party" in dry_run.stdout
+
+
+def test_smart_update_codex_refuses_aris_symlinked_skills(tmp_path: Path) -> None:
+    local = tmp_path / "local"
+    local.mkdir()
+    (local / "auto-review-loop").symlink_to(
+        REPO_ROOT / "skills" / "skills-codex" / "auto-review-loop"
+    )
+
+    refused = run(["bash", str(UPDATE_SCRIPT), "--local", str(local)], check=False)
+
+    assert refused.returncode != 0
+    assert "symlink-managed ARIS entry 'auto-review-loop'" in refused.stderr
+
+
+def test_smart_update_codex_ignores_local_only_shared_reference_failures(tmp_path: Path) -> None:
+    upstream = tmp_path / "upstream"
+    make_skill(upstream / "alpha", "# alpha\n")
+    (upstream / "shared-references").mkdir(parents=True, exist_ok=True)
+
+    local = tmp_path / "local"
+    local.mkdir()
+    make_skill(local / "local-only", "../shared-references/local-contract.md\n")
+
+    result = run(
+        [
+            "bash",
+            str(UPDATE_SCRIPT),
+            "--upstream",
+            str(upstream),
+            "--local",
+            str(local),
+            "--apply",
+        ]
+    )
+
+    assert result.returncode == 0
+    assert (local / "alpha" / "SKILL.md").exists()
+    assert (local / "local-only" / "SKILL.md").exists()
+
+
+def test_smart_update_codex_local_respects_overlay(tmp_path: Path) -> None:
+    local = tmp_path / "local"
+    local.mkdir()
+
+    run(
+        [
+            "bash",
+            str(UPDATE_SCRIPT),
+            "--local",
+            str(local),
+            "--overlay",
+            "claude-review",
+            "--apply",
+        ]
+    )
+
+    installed = (local / "auto-review-loop" / "SKILL.md").read_text()
+    overlay = (
+        REPO_ROOT
+        / "skills"
+        / "skills-codex-claude-review"
+        / "auto-review-loop"
+        / "SKILL.md"
+    ).read_text()
+    base = (REPO_ROOT / "skills" / "skills-codex" / "auto-review-loop" / "SKILL.md").read_text()
+
+    assert installed == overlay
+    assert installed != base
+
+
+def test_smart_update_codex_overlay_updates_existing_base_copy(tmp_path: Path) -> None:
+    local = tmp_path / "local"
+    local.mkdir()
+    base_skill = REPO_ROOT / "skills" / "skills-codex" / "auto-review-loop"
+    overlay_skill = (
+        REPO_ROOT
+        / "skills"
+        / "skills-codex-claude-review"
+        / "auto-review-loop"
+    )
+
+    run(["cp", "-a", str(base_skill), str(local / "auto-review-loop")])
+
+    dry_run = run(
+        [
+            "bash",
+            str(UPDATE_SCRIPT),
+            "--local",
+            str(local),
+            "--overlay",
+            "claude-review",
+        ]
+    )
+    assert "Safe update: 1" in dry_run.stdout
+    assert "  auto-review-loop" in dry_run.stdout
+
+    run(
+        [
+            "bash",
+            str(UPDATE_SCRIPT),
+            "--local",
+            str(local),
+            "--overlay",
+            "claude-review",
+            "--apply",
+        ]
+    )
+
+    assert (local / "auto-review-loop" / "SKILL.md").read_text() == (
+        overlay_skill / "SKILL.md"
+    ).read_text()
+
+
+def test_smart_update_codex_overlay_preserves_custom_local_copy(tmp_path: Path) -> None:
+    local = tmp_path / "local"
+    local.mkdir()
+    base_skill = REPO_ROOT / "skills" / "skills-codex" / "auto-review-loop"
+
+    run(["cp", "-a", str(base_skill), str(local / "auto-review-loop")])
+    custom_text = (local / "auto-review-loop" / "SKILL.md").read_text() + "\n<!-- local customization -->\n"
+    (local / "auto-review-loop" / "SKILL.md").write_text(custom_text)
+
+    result = run(
+        [
+            "bash",
+            str(UPDATE_SCRIPT),
+            "--local",
+            str(local),
+            "--overlay",
+            "claude-review",
+            "--apply",
+        ]
+    )
+
+    assert "Needs merge: 1" in result.stdout
+    assert (local / "auto-review-loop" / "SKILL.md").read_text() == custom_text

--- a/tests/test_codex_skill_mirror.py
+++ b/tests/test_codex_skill_mirror.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAIN_SKILLS = REPO_ROOT / "skills"
+CODEX_SKILLS = REPO_ROOT / "skills" / "skills-codex"
+CLAUDE_OVERLAY = REPO_ROOT / "skills" / "skills-codex-claude-review"
+GEMINI_OVERLAY = REPO_ROOT / "skills" / "skills-codex-gemini-review"
+
+
+def skill_names(root: Path) -> set[str]:
+    return {path.parent.name for path in root.glob("*/SKILL.md")}
+
+
+def read(path: Path) -> str:
+    return path.read_text()
+
+
+def has_spawn_agent_block(text: str) -> bool:
+    return re.search(r"(?m)^\s*spawn_agent:", text) is not None
+
+
+def has_send_input_block(text: str) -> bool:
+    return re.search(r"(?m)^\s*send_input:", text) is not None
+
+
+def test_codex_skill_set_matches_mainline() -> None:
+    main_names = skill_names(MAIN_SKILLS)
+    codex_names = skill_names(CODEX_SKILLS)
+    assert len(main_names) == 67
+    assert main_names == codex_names
+
+
+def test_codex_reviewer_contract_partition() -> None:
+    codex_names = skill_names(CODEX_SKILLS)
+    single_round: set[str] = set()
+    multi_round: set[str] = set()
+    non_reviewer: set[str] = set()
+
+    for name in codex_names:
+        text = read(CODEX_SKILLS / name / "SKILL.md")
+        spawn = has_spawn_agent_block(text)
+        send = has_send_input_block(text)
+        if spawn and send:
+            multi_round.add(name)
+        elif spawn:
+            single_round.add(name)
+        else:
+            non_reviewer.add(name)
+
+    assert multi_round
+    assert single_round
+    assert non_reviewer
+    assert single_round.isdisjoint(multi_round)
+    assert (single_round | multi_round | non_reviewer) == codex_names
+
+    for name in multi_round:
+        text = read(CODEX_SKILLS / name / "SKILL.md")
+        assert has_spawn_agent_block(text)
+        assert has_send_input_block(text)
+        assert re.search(r"(?m)^\s*(target|id|agent_id):\s*\[saved", text) is not None
+        assert "saved" in text or "same reviewer" in text or "same agent" in text
+
+    for name in non_reviewer:
+        text = read(CODEX_SKILLS / name / "SKILL.md")
+        assert not has_spawn_agent_block(text)
+        assert not has_send_input_block(text)
+
+
+def test_overlay_boundaries_are_exact() -> None:
+    expected_claude = {
+        "auto-paper-improvement-loop",
+        "auto-review-loop",
+        "novelty-check",
+        "paper-figure",
+        "paper-plan",
+        "paper-write",
+        "research-refine",
+        "research-review",
+    }
+    expected_gemini = {
+        "auto-paper-improvement-loop",
+        "auto-review-loop",
+        "grant-proposal",
+        "idea-creator",
+        "idea-discovery",
+        "idea-discovery-robot",
+        "novelty-check",
+        "paper-figure",
+        "paper-plan",
+        "paper-poster",
+        "paper-slides",
+        "paper-write",
+        "paper-writing",
+        "research-refine",
+        "research-review",
+    }
+    assert skill_names(CLAUDE_OVERLAY) == expected_claude
+    assert skill_names(GEMINI_OVERLAY) == expected_gemini
+
+
+def test_non_degrading_skill_rules_are_documented() -> None:
+    checks = {
+        "comm-lit-review": "Do not silently downgrade",
+        "research-lit": "stop and ask the user to configure",
+        "paper-poster": "Do not silently degrade",
+        "pixel-art": "Do not silently downgrade",
+    }
+    for name, needle in checks.items():
+        text = read(CODEX_SKILLS / name / "SKILL.md")
+        assert needle in text
+
+
+def test_codex_skill_helper_commands_use_installed_aris_repo() -> None:
+    bad_command_patterns = [
+        r"python3 tools/",
+        r"python tools/",
+        r"bash tools/",
+        r"sh tools/",
+        r"find tools/",
+        r"relative to the current project",
+        r"relative to the project root",
+    ]
+    allowed_bundled_mentions = {
+        "experiment-queue",
+    }
+    allowed_claude_style_fallbacks = {
+        "alphaxiv",
+        "arxiv",
+        "deepxiv",
+        "exa-search",
+        "figure-spec",
+        "research-lit",
+        "research-wiki",
+        "semantic-scholar",
+    }
+
+    failures: list[str] = []
+    for skill_file in CODEX_SKILLS.glob("*/SKILL.md"):
+        skill_name = skill_file.parent.name
+        if skill_name in allowed_bundled_mentions or skill_name in allowed_claude_style_fallbacks:
+            continue
+        text = read(skill_file)
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if any(re.search(pattern, line) for pattern in bad_command_patterns):
+                failures.append(f"{skill_file.relative_to(REPO_ROOT)}:{line_no}: {line}")
+
+    assert not failures, "Codex skills must not assume helper scripts exist in the user project:\n" + "\n".join(failures)
+
+
+def test_codex_shared_reference_links_exist() -> None:
+    failures: list[str] = []
+    pattern = re.compile(r"\.\./shared-references/([A-Za-z0-9._-]+\.md)")
+
+    for skill_file in CODEX_SKILLS.glob("*/SKILL.md"):
+        text = read(skill_file)
+        for ref_name in pattern.findall(text):
+            if not (CODEX_SKILLS / "shared-references" / ref_name).exists():
+                failures.append(f"{skill_file.relative_to(REPO_ROOT)} -> shared-references/{ref_name}")
+
+    assert not failures, "Codex skill shared-reference links must resolve inside skills-codex:\n" + "\n".join(failures)
+
+
+def test_codex_high_risk_skills_preserve_claude_semantics() -> None:
+    required_terms = {
+        "auto-review-loop": [
+            "REVIEWER_DIFFICULTY",
+            "Reviewer Memory",
+            "Debate Protocol",
+            "nightmare",
+            "Review Tracing",
+            "oracle-pro",
+            "Phase B.5",
+            "Phase B.6",
+            "Debate Transcript",
+        ],
+        "research-pipeline": [
+            "REVIEWER_DIFFICULTY",
+            "Reviewer Memory",
+            "Debate Protocol",
+            "nightmare",
+            "Review Tracing",
+            "AUTO_WRITE",
+            "NARRATIVE_REPORT.md",
+            "experiment-queue",
+            "Stage 6: Paper Writing",
+        ],
+        "experiment-bridge": [
+            "Vast.ai",
+            "Modal",
+            "rescue",
+            "second opinion",
+            "CODE_REVIEW",
+            "Cross-Model Code Review",
+        ],
+        "run-experiment": [
+            "Vast.ai",
+            "Modal",
+            "hourly cost",
+            "rescue",
+        ],
+        "monitor-experiment": [
+            "Vast.ai",
+            "Modal",
+            "W&B dashboard links",
+            "cost",
+        ],
+        "research-review": [
+            "Review Tracing",
+            "oracle-pro",
+        ],
+        "research-lit": [
+            "semantic-scholar",
+            "Semantic Scholar API search",
+            "semantic_scholar_fetch.py",
+        ],
+        "arxiv": [
+            "Update Research Wiki",
+            "integration-contract.md",
+            "export ARIS_REPO",
+        ],
+        "rebuttal": [
+            "Review Tracing",
+            "oracle-pro",
+        ],
+    }
+
+    failures: list[str] = []
+    for skill, terms in required_terms.items():
+        text = read(CODEX_SKILLS / skill / "SKILL.md")
+        for term in terms:
+            if term not in text:
+                failures.append(f"{skill}: missing {term}")
+
+    assert not failures, "High-risk Codex skills must preserve Claude semantics:\n" + "\n".join(failures)
+
+
+def test_codex_medium_risk_skills_preserve_claude_semantics() -> None:
+    required_terms = {
+        "idea-creator": [
+            "Load Research Wiki",
+            "query_pack.md",
+            "Write Ideas to Research Wiki",
+            "review-tracing.md",
+        ],
+        "idea-discovery": [
+            "Load Research Brief",
+            "RESEARCH_BRIEF.md",
+            "Research Brief",
+        ],
+        "paper-writing": [
+            "Architecture & Illustration Generation",
+            "Submission pre-flight checklist",
+            "Invoking the three audits",
+            "Running the verifier",
+            "Optional hardening",
+            "assurance-contract.md",
+        ],
+        "deepxiv": [
+            "Semantic Scholar",
+            "integration-contract.md",
+        ],
+        "comm-lit-review": [
+            "Source Selection",
+            "Retrieval Order",
+            "Graceful degradation rules",
+            "IEEE Xplore",
+            "ScienceDirect",
+            "ACM Digital Library",
+        ],
+        "mermaid-diagram": [
+            "Score Breakdown Guide",
+            "CRITICAL - any failure = score <= 6",
+            "any failure = score <= 7",
+        ],
+    }
+
+    failures: list[str] = []
+    for skill, terms in required_terms.items():
+        text = read(CODEX_SKILLS / skill / "SKILL.md")
+        for term in terms:
+            if term not in text:
+                failures.append(f"{skill}: missing {term}")
+
+    assert not failures, "Medium-risk Codex skills must preserve Claude semantics:\n" + "\n".join(failures)
+
+
+def test_codex_optional_helpers_are_guarded() -> None:
+    checks = {
+        "research-lit": [
+            'if [ -n "$DEEPXIV_SCRIPT" ]; then',
+            '[ -n "$EXA_SCRIPT" ] && python3 "$EXA_SCRIPT"',
+            'echo "DeepXiv unavailable',
+            'echo "Exa unavailable',
+        ],
+        "deepxiv": [
+            '[ -n "$SCRIPT" ] && python3 "$SCRIPT"',
+            "fall back to raw `deepxiv` commands",
+        ],
+    }
+    for skill, needles in checks.items():
+        text = read(CODEX_SKILLS / skill / "SKILL.md")
+        for needle in needles:
+            assert needle in text
+
+
+def test_codex_training_check_defaults_to_interactive_watch() -> None:
+    text = read(CODEX_SKILLS / "training-check" / "SKILL.md")
+    assert "interactive watch" in text
+    assert "交互式训练监控模式" in text
+    assert "every 30 minutes" in text
+    assert "current terminal" in text
+    assert "If the context contains `stop_command`, run `stop_command` first." in text
+    assert "Optional Background Mode" not in text
+    assert "codex-training-check" not in text
+    assert "codex_training_check.py" not in text
+    assert "CronCreate" not in text
+    assert "tmux loop" not in text
+    assert "codex exec" not in text
+
+
+def test_codex_skill_instructions_use_codex_paths() -> None:
+    auto_paper = read(CODEX_SKILLS / "auto-paper-improvement-loop" / "SKILL.md")
+    paper_writing = read(CODEX_SKILLS / "paper-writing" / "SKILL.md")
+    figure_spec = read(CODEX_SKILLS / "figure-spec" / "SKILL.md")
+    meta_optimize = read(CODEX_SKILLS / "meta-optimize" / "SKILL.md")
+
+    assert "~/.codex/feishu.json" in auto_paper
+    assert "~/.claude/feishu.json" not in auto_paper
+    assert ".aris/installed-skills-codex.txt" in paper_writing
+    assert ".agents/skills/paper-writing" in paper_writing
+    assert "~/.claude/skills/paper-writing/SKILL.md" not in paper_writing
+    assert "~/.claude/settings.json" not in paper_writing
+    assert 'python3 "$FIGURE_RENDERER"' in figure_spec
+    assert '[ -n "$FIGURE_RENDERER" ] ||' in figure_spec
+    assert "figure_renderer.py not found" in figure_spec
+    assert "Codex-compatible event logger" in meta_optimize
+    assert ".claude/settings.json" not in meta_optimize
+    assert "templates/claude-hooks/meta_logging.json" not in meta_optimize
+
+
+def test_codex_experiment_queue_points_to_bundled_helpers() -> None:
+    text = read(CODEX_SKILLS / "experiment-queue" / "SKILL.md")
+
+    assert "tools/experiment_queue/queue_manager.py" in text
+    assert "tools/experiment_queue/build_manifest.py" in text
+    assert "tools/queue_manager.py" not in text
+    assert "tools/build_manifest.py" not in text
+    assert ".aris/installed-skills-codex.txt" in text

--- a/tools/exa_search.py
+++ b/tools/exa_search.py
@@ -69,17 +69,17 @@ _INSTALL_MESSAGE = "exa-py not found. Install it with: pip install exa-py"
 
 def _get_client() -> Any:
     """Create and return an Exa client with the integration tracking header."""
-    try:
-        from exa_py import Exa
-    except ImportError:
-        raise RuntimeError(_INSTALL_MESSAGE)
-
     api_key = os.getenv("EXA_API_KEY", "").strip()
     if not api_key:
         raise RuntimeError(
             "EXA_API_KEY environment variable is required. "
             "Get your key from: https://exa.ai"
         )
+
+    try:
+        from exa_py import Exa
+    except ImportError:
+        raise RuntimeError(_INSTALL_MESSAGE)
 
     client = Exa(api_key=api_key)
     client.headers["x-exa-integration"] = "auto-claude-code-research-in-sleep"

--- a/tools/install_aris_codex.sh
+++ b/tools/install_aris_codex.sh
@@ -1,0 +1,693 @@
+#!/usr/bin/env bash
+# install_aris_codex.sh -- Project-local ARIS Codex skill installation.
+#
+# This installer manages a flat Codex project layout:
+#   <project>/.agents/skills/<skill-name> -> <aris-repo>/skills/<package>/<skill-name>
+#
+# Managed entries are tracked in:
+#   <project>/.aris/installed-skills-codex.txt
+#
+# Default package set:
+#   - skills/skills-codex
+#
+# Optional overlays:
+#   --with-claude-review-overlay
+#   --with-gemini-review-overlay
+#
+# Usage:
+#   bash tools/install_aris_codex.sh [project_path] [options]
+#
+# Actions (mutually exclusive, default: auto):
+#   default          install if no manifest, else reconcile
+#   --reconcile      explicit reconcile; refuse if no manifest
+#   --uninstall      remove only entries in manifest; delete manifest
+#
+# Options:
+#   --aris-repo PATH                 override repo discovery
+#   --with-claude-review-overlay     install skills-codex-claude-review on top
+#   --with-gemini-review-overlay     install skills-codex-gemini-review on top
+#   --dry-run                        show plan, no writes
+#   --quiet                          no prompts
+#   --no-doc                         skip AGENTS.md managed block update
+#   --replace-link NAME              replace a conflicting symlink for NAME
+#   --clear-stale-lock               clear a stale installer lock
+
+set -euo pipefail
+
+MANIFEST_VERSION="1"
+MANIFEST_NAME="installed-skills-codex.txt"
+MANIFEST_PREV_NAME="installed-skills-codex.txt.prev"
+ARIS_DIR_NAME=".aris"
+LOCK_DIR_NAME=".install-codex.lock.d"
+SKILLS_REL=".agents/skills"
+DOC_FILE_NAME="AGENTS.md"
+BLOCK_BEGIN="<!-- ARIS-CODEX:BEGIN -->"
+BLOCK_END="<!-- ARIS-CODEX:END -->"
+SAFE_NAME_REGEX='^[A-Za-z0-9][A-Za-z0-9._-]*$'
+BASE_PACKAGE="skills-codex"
+
+PROJECT_PATH=""
+ARIS_REPO_OVERRIDE=""
+ACTION="auto"
+DRY_RUN=false
+QUIET=false
+NO_DOC=false
+CLEAR_STALE_LOCK=false
+WITH_CLAUDE_OVERLAY=false
+WITH_GEMINI_OVERLAY=false
+REPLACE_LINK_NAMES=()
+
+usage() { sed -n '2,34p' "$0" | sed 's/^# \?//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --reconcile) ACTION="reconcile"; shift ;;
+        --uninstall) ACTION="uninstall"; shift ;;
+        --aris-repo) ARIS_REPO_OVERRIDE="${2:?--aris-repo requires path}"; shift 2 ;;
+        --with-claude-review-overlay) WITH_CLAUDE_OVERLAY=true; shift ;;
+        --with-gemini-review-overlay) WITH_GEMINI_OVERLAY=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --quiet) QUIET=true; shift ;;
+        --no-doc) NO_DOC=true; shift ;;
+        --replace-link) REPLACE_LINK_NAMES+=("${2:?--replace-link requires NAME}"); shift 2 ;;
+        --clear-stale-lock) CLEAR_STALE_LOCK=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --*) echo "Unknown option: $1" >&2; exit 2 ;;
+        *)
+            if [[ -z "$PROJECT_PATH" ]]; then
+                PROJECT_PATH="$1"
+            else
+                echo "Error: unexpected positional argument: $1" >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+log() { $QUIET && return 0; echo "$@"; }
+warn() { echo "warning: $*" >&2; }
+die() { echo "error: $*" >&2; exit 1; }
+prompt() { $QUIET && return 0; printf "%s " "$1" >&2; read -r REPLY; [[ "$REPLY" =~ ^[Yy]$ ]]; }
+abs_path() { ( cd "$1" 2>/dev/null && pwd ) || return 1; }
+is_safe_name() { [[ "$1" =~ $SAFE_NAME_REGEX ]]; }
+is_symlink() { [[ -L "$1" ]]; }
+name_in_replace_allowlist() {
+    local needle="$1"
+    local item
+    for item in "${REPLACE_LINK_NAMES[@]}"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+read_link_target() {
+    if command -v greadlink >/dev/null 2>&1; then greadlink "$1"
+    else readlink "$1"; fi
+}
+
+canonicalize() {
+    if command -v greadlink >/dev/null 2>&1; then greadlink -f "$1" 2>/dev/null || true
+    elif readlink -f "$1" 2>/dev/null; then :
+    else
+        local d f
+        if [[ -d "$1" ]]; then
+            ( cd "$1" && pwd )
+        else
+            d="$(dirname "$1")"
+            f="$(basename "$1")"
+            ( cd "$d" 2>/dev/null && echo "$(pwd)/$f" )
+        fi
+    fi
+}
+
+resolve_aris_repo() {
+    local p
+    if [[ -n "$ARIS_REPO_OVERRIDE" ]]; then
+        p="$(abs_path "$ARIS_REPO_OVERRIDE")" || die "--aris-repo path not found: $ARIS_REPO_OVERRIDE"
+    else
+        local script_dir parent guess
+        script_dir="$(cd "$(dirname "$0")" && pwd)"
+        parent="$(cd "$script_dir/.." && pwd)"
+        if [[ -d "$parent/skills/$BASE_PACKAGE" ]]; then
+            p="$parent"
+        elif [[ -n "${ARIS_REPO:-}" && -d "$ARIS_REPO/skills/$BASE_PACKAGE" ]]; then
+            p="$(abs_path "$ARIS_REPO")"
+        else
+            for guess in \
+                "$HOME/Desktop/Auto-claude-code-research-in-sleep" \
+                "$HOME/Auto-claude-code-research-in-sleep" \
+                "$HOME/aris_repo" \
+                "$HOME/.codex/Auto-claude-code-research-in-sleep"; do
+                if [[ -d "$guess/skills/$BASE_PACKAGE" ]]; then
+                    p="$(abs_path "$guess")"
+                    break
+                fi
+            done
+        fi
+    fi
+    [[ -n "${p:-}" ]] || die "cannot find ARIS repo with skills/$BASE_PACKAGE. Use --aris-repo PATH."
+    [[ -d "$p/skills/$BASE_PACKAGE" ]] || die "repo missing skills/$BASE_PACKAGE: $p"
+    echo "$p"
+}
+
+selected_packages() {
+    local packages=("$BASE_PACKAGE")
+    $WITH_CLAUDE_OVERLAY && packages+=("skills-codex-claude-review")
+    $WITH_GEMINI_OVERLAY && packages+=("skills-codex-gemini-review")
+    printf "%s\n" "${packages[@]}"
+}
+
+build_upstream_inventory() {
+    local repo="$1" out="$2"
+    local package package_dir d name kind source_rel tmp
+    tmp="$(mktemp -t aris-codex-upstream-raw.XXXX)"
+    : > "$out"
+    : > "$tmp"
+
+    while IFS= read -r package; do
+        [[ -z "$package" ]] && continue
+        package_dir="$repo/skills/$package"
+        [[ -d "$package_dir" ]] || die "selected package missing: $package_dir"
+        for d in "$package_dir"/*; do
+            [[ -d "$d" ]] || continue
+            name="$(basename "$d")"
+            is_safe_name "$name" || { warn "skipping unsafe upstream name: $name"; continue; }
+            if [[ "$name" == "shared-references" ]]; then
+                kind="support"
+            elif [[ -f "$d/SKILL.md" ]]; then
+                kind="skill"
+            else
+                continue
+            fi
+            source_rel="skills/$package/$name"
+            printf "%s|%s|%s\n" "$kind" "$name" "$source_rel" >> "$tmp"
+        done
+    done < <(selected_packages)
+
+    if [[ ! -s "$tmp" ]]; then
+        rm -f "$tmp"
+        die "upstream inventory empty"
+    fi
+
+    # Keep the last entry for duplicate names so overlays override the base
+    # package, then sort by skill/support name for deterministic plans.
+    awk -F'|' '{row[$2]=$0} END {for (name in row) print row[name]}' "$tmp" | sort -t'|' -k2,2 > "$out"
+    rm -f "$tmp"
+}
+
+load_manifest() {
+    local path="$1" out="$2"
+    : > "$out"
+    [[ -f "$path" ]] || return 0
+    local ver
+    ver="$(awk -F'\t' '$1=="version"{print $2}' "$path" | head -1)"
+    [[ "$ver" == "$MANIFEST_VERSION" ]] || die "manifest version mismatch (got: ${ver:-none}, expected: $MANIFEST_VERSION)"
+    awk -F'\t' '
+        BEGIN { in_body=0 }
+        /^kind\tname\tsource_rel\ttarget_rel\tmode$/ { in_body=1; next }
+        in_body && NF==5 { print }
+    ' "$path" > "$out"
+}
+
+manifest_lookup_target() { awk -F'\t' -v n="$2" '$2==n {print $4; exit}' "$1"; }
+manifest_lookup_source() { awk -F'\t' -v n="$2" '$2==n {print $3; exit}' "$1"; }
+manifest_repo_root() { awk -F'\t' '$1=="repo_root" {print $2; exit}' "$1"; }
+
+PROJECT_PATH="${PROJECT_PATH:-$(pwd)}"
+[[ -d "$PROJECT_PATH" ]] || die "project path does not exist: $PROJECT_PATH"
+PROJECT_PATH="$(abs_path "$PROJECT_PATH")"
+ARIS_REPO="$(resolve_aris_repo)"
+PROJECT_SKILLS_DIR="$PROJECT_PATH/$SKILLS_REL"
+PROJECT_ARIS_DIR="$PROJECT_PATH/$ARIS_DIR_NAME"
+MANIFEST_PATH="$PROJECT_ARIS_DIR/$MANIFEST_NAME"
+MANIFEST_PREV="$PROJECT_ARIS_DIR/$MANIFEST_PREV_NAME"
+LOCK_DIR="$PROJECT_ARIS_DIR/$LOCK_DIR_NAME"
+DOC_FILE="$PROJECT_PATH/$DOC_FILE_NAME"
+LEGACY_NESTED="$PROJECT_PATH/.agents/skills/aris"
+
+check_no_symlinked_parents() {
+    local p
+    for p in "$PROJECT_ARIS_DIR" "$PROJECT_PATH/.agents" "$PROJECT_SKILLS_DIR"; do
+        if is_symlink "$p"; then
+            die "$p is a symlink; refusing to mutate symlinked parent directories"
+        fi
+    done
+}
+
+check_legacy_nested_install() {
+    if [[ -e "$LEGACY_NESTED" || -L "$LEGACY_NESTED" ]]; then
+        die "legacy nested Codex install detected at $LEGACY_NESTED. Remove or migrate it before using the flat .agents/skills/<name> layout."
+    fi
+}
+
+write_lock_metadata() {
+    cat > "$LOCK_DIR/owner.json" <<EOF
+{"host":"$(hostname)","pid":$$,"started_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","tool":"install_aris_codex.sh"}
+EOF
+    echo "$$" > "$LOCK_DIR/owner.pid"
+    echo "$(hostname)" > "$LOCK_DIR/owner.host"
+}
+
+release_lock() {
+    [[ -d "$LOCK_DIR" ]] || return 0
+    if [[ -f "$LOCK_DIR/owner.pid" && -f "$LOCK_DIR/owner.host" ]]; then
+        local pid host
+        pid="$(cat "$LOCK_DIR/owner.pid" 2>/dev/null || echo "")"
+        host="$(cat "$LOCK_DIR/owner.host" 2>/dev/null || echo "")"
+        if [[ "$pid" == "$$" && "$host" == "$(hostname)" ]]; then
+            rm -rf "$LOCK_DIR"
+        fi
+    fi
+}
+
+acquire_lock() {
+    mkdir -p "$PROJECT_ARIS_DIR"
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        write_lock_metadata
+        trap release_lock EXIT INT TERM
+        return 0
+    fi
+    if $CLEAR_STALE_LOCK; then
+        warn "removing stale lock: $LOCK_DIR"
+        rm -rf "$LOCK_DIR"
+        mkdir "$LOCK_DIR" || die "cannot acquire lock after stale clear"
+        write_lock_metadata
+        trap release_lock EXIT INT TERM
+        return 0
+    fi
+    local owner=""
+    [[ -f "$LOCK_DIR/owner.json" ]] && owner="$(cat "$LOCK_DIR/owner.json")"
+    die "another install_aris_codex.sh appears to be running (lock: $LOCK_DIR, owner: $owner)"
+}
+
+compute_plan() {
+    local upstream_file="$1" manifest_data="$2" out="$3"
+    local kind name source_rel target_path expected_target current_target in_manifest
+    : > "$out"
+
+    while IFS='|' read -r kind name source_rel; do
+        [[ -z "$name" ]] && continue
+        target_path="$PROJECT_SKILLS_DIR/$name"
+        expected_target="$ARIS_REPO/$source_rel"
+        in_manifest=false
+        [[ -n "$(manifest_lookup_target "$manifest_data" "$name")" ]] && in_manifest=true
+
+        if [[ -L "$target_path" ]]; then
+            current_target="$(read_link_target "$target_path")"
+            [[ "$current_target" != /* ]] && current_target="$(canonicalize "$(dirname "$target_path")/$current_target")"
+            if [[ "$current_target" == "$expected_target" ]]; then
+                if $in_manifest; then
+                    printf "REUSE|%s|%s|%s|\n" "$kind" "$name" "$source_rel" >> "$out"
+                else
+                    printf "ADOPT|%s|%s|%s|\n" "$kind" "$name" "$source_rel" >> "$out"
+                fi
+            elif $in_manifest || name_in_replace_allowlist "$name"; then
+                printf "UPDATE_TARGET|%s|%s|%s|%s\n" "$kind" "$name" "$source_rel" "$current_target" >> "$out"
+            else
+                printf "CONFLICT|%s|%s|%s|symlink_to:%s\n" "$kind" "$name" "$source_rel" "$current_target" >> "$out"
+            fi
+        elif [[ -e "$target_path" ]]; then
+            printf "CONFLICT|%s|%s|%s|real_path\n" "$kind" "$name" "$source_rel" >> "$out"
+        else
+            printf "CREATE|%s|%s|%s|\n" "$kind" "$name" "$source_rel" >> "$out"
+        fi
+    done < "$upstream_file"
+
+    local recorded_repo_root
+    recorded_repo_root="$(manifest_repo_root "$MANIFEST_PATH" 2>/dev/null || true)"
+    local mkind mname msource mtarget mmode
+    while IFS=$'\t' read -r mkind mname msource mtarget mmode; do
+        [[ -z "$mname" ]] && continue
+        if awk -F'|' -v n="$mname" '$2==n {found=1} END{exit found?0:1}' "$upstream_file"; then
+            continue
+        fi
+        [[ -n "$recorded_repo_root" ]] || die "manifest missing repo_root: $MANIFEST_PATH"
+        printf "REMOVE|%s|%s|%s|%s/%s\n" "$mkind" "$mname" "$msource" "$recorded_repo_root" "$msource" >> "$out"
+    done < "$manifest_data"
+}
+
+print_plan() {
+    local plan="$1"
+    local action
+    log ""
+    log "Plan summary:"
+    for action in CREATE ADOPT UPDATE_TARGET REUSE REMOVE CONFLICT; do
+        log "  $action: $(grep -c "^$action|" "$plan" || true)"
+    done
+    if grep -q '^CONFLICT|' "$plan"; then
+        log ""
+        log "Conflicts:"
+        while IFS='|' read -r _ kind name _source extra; do
+            log "  - $name ($kind): $extra"
+        done < <(grep '^CONFLICT|' "$plan")
+    fi
+}
+
+write_manifest_tmp() {
+    local plan="$1" out="$2"
+    {
+        printf "version\t%s\n" "$MANIFEST_VERSION"
+        printf "repo_root\t%s\n" "$ARIS_REPO"
+        printf "project_root\t%s\n" "$PROJECT_PATH"
+        printf "generated\t%s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        printf "packages\t%s\n" "$(selected_packages | paste -sd, -)"
+        printf "kind\tname\tsource_rel\ttarget_rel\tmode\n"
+        awk -F'|' '$1=="REUSE"||$1=="ADOPT"||$1=="CREATE"||$1=="UPDATE_TARGET"{print}' "$plan" \
+        | while IFS='|' read -r _ kind name source_rel _extra; do
+            printf "%s\t%s\t%s\t%s/%s\tsymlink\n" "$kind" "$name" "$source_rel" "$SKILLS_REL" "$name"
+        done
+    } > "$out"
+}
+
+apply_plan() {
+    local plan="$1"
+    local action kind name source_rel extra target_path expected_target current_target
+    mkdir -p "$PROJECT_SKILLS_DIR"
+    while IFS='|' read -r action kind name source_rel extra; do
+        [[ -z "$name" ]] && continue
+        target_path="$PROJECT_SKILLS_DIR/$name"
+        expected_target="$ARIS_REPO/$source_rel"
+        case "$action" in
+            REUSE|ADOPT)
+                :
+                ;;
+            CREATE)
+                if [[ -e "$target_path" || -L "$target_path" ]]; then
+                    die "path appeared during install: $target_path"
+                fi
+                if $DRY_RUN; then
+                    log "  (dry-run) ln -s $expected_target $target_path"
+                else
+                    ln -s "$expected_target" "$target_path"
+                    log "  + $name"
+                fi
+                ;;
+            UPDATE_TARGET)
+                if [[ -L "$target_path" ]]; then
+                    current_target="$(read_link_target "$target_path")"
+                    [[ "$current_target" != /* ]] && current_target="$(canonicalize "$(dirname "$target_path")/$current_target")"
+                else
+                    current_target=""
+                fi
+                if [[ "$current_target" != "$extra" ]]; then
+                    die "symlink target changed during install for $name (expected: $extra, got: ${current_target:-missing})"
+                fi
+                if $DRY_RUN; then
+                    log "  (dry-run) relink $target_path -> $expected_target"
+                else
+                    rm -f "$target_path"
+                    ln -s "$expected_target" "$target_path"
+                    log "  ↻ $name"
+                fi
+                ;;
+            REMOVE)
+                [[ -n "$extra" ]] || die "remove action missing recorded target for $name"
+                if [[ -L "$target_path" ]]; then
+                    current_target="$(read_link_target "$target_path")"
+                    [[ "$current_target" != /* ]] && current_target="$(canonicalize "$(dirname "$target_path")/$current_target")"
+                    if [[ "$current_target" == "$extra" ]]; then
+                        if $DRY_RUN; then
+                            log "  (dry-run) rm $target_path"
+                        else
+                            rm -f "$target_path"
+                            log "  - $name"
+                        fi
+                    else
+                        die "refusing to remove $name; target changed during reconcile (expected: $extra, got: $current_target)"
+                    fi
+                elif [[ -e "$target_path" ]]; then
+                    die "refusing to remove $name; target path is no longer a symlink"
+                else
+                    log "  - $name (already removed)"
+                fi
+                ;;
+            CONFLICT)
+                die "conflict reached apply phase for $name"
+                ;;
+        esac
+    done < "$plan"
+}
+
+commit_manifest() {
+    local manifest_tmp="$1"
+    if $DRY_RUN; then
+        log "  (dry-run) would commit manifest"
+        return 0
+    fi
+    mkdir -p "$PROJECT_ARIS_DIR"
+    if [[ -f "$MANIFEST_PATH" ]]; then
+        cp -p "$MANIFEST_PATH" "$MANIFEST_PREV.tmp"
+        mv -f "$MANIFEST_PREV.tmp" "$MANIFEST_PREV"
+    fi
+    mv -f "$manifest_tmp" "$MANIFEST_PATH"
+}
+
+update_agents_doc() {
+    local installed_names_file="$1"
+    $NO_DOC && return 0
+    local original=""
+    [[ -f "$DOC_FILE" ]] && original="$(cat "$DOC_FILE")"
+    local count packages_csv new_block new_content tmp current
+    count="$(wc -l < "$installed_names_file" | tr -d ' ')"
+    packages_csv="$(selected_packages | paste -sd, -)"
+    local repo_lookup_cmd
+    repo_lookup_cmd="ARIS_REPO=\$(awk -F'\\t' '\$1==\"repo_root\"{print \$2; exit}' \"$PROJECT_PATH/$ARIS_DIR_NAME/$MANIFEST_NAME\")"
+    new_block="$BLOCK_BEGIN
+## ARIS Codex Skill Scope
+ARIS Codex packages installed in this project: $packages_csv
+Managed entries: $count
+Manifest: \`$ARIS_DIR_NAME/$MANIFEST_NAME\`
+ARIS repo root: \`$ARIS_REPO\`
+Project skill path: \`$SKILLS_REL/<skill-name>\`
+For ARIS Codex workflows, prefer the project-local skills under \`$SKILLS_REL/\`.
+When a skill needs ARIS helper scripts, resolve the repo root from the manifest or set it explicitly:
+\`$repo_lookup_cmd\`
+Do not edit or delete symlinked skills in place; update upstream or rerun:
+\`bash $ARIS_REPO/tools/install_aris_codex.sh \"$PROJECT_PATH\" --reconcile\`
+For copied Codex installs, use:
+\`bash $ARIS_REPO/tools/smart_update_codex.sh --project \"$PROJECT_PATH\"\`
+$BLOCK_END"
+
+    if printf '%s' "$original" | grep -qF "$BLOCK_BEGIN"; then
+        new_content="$(python3 - "$DOC_FILE" "$BLOCK_BEGIN" "$BLOCK_END" "$new_block" <<'PYEOF'
+import pathlib
+import re
+import sys
+
+path, begin, end, body = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+text = pathlib.Path(path).read_text() if pathlib.Path(path).exists() else ""
+pattern = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+matches = pattern.findall(text)
+if len(matches) > 1:
+    sys.stderr.write("ARIS-CODEX:WARN multiple managed blocks found; skipping update\n")
+    sys.stdout.write(text)
+else:
+    sys.stdout.write(pattern.sub(body, text))
+PYEOF
+        )" || { warn "AGENTS.md update failed; continuing"; return 0; }
+    else
+        new_content="$original"
+        [[ -n "$new_content" && "${new_content: -1}" != $'\n' ]] && new_content="${new_content}"$'\n'
+        new_content="${new_content}${new_block}"$'\n'
+    fi
+
+    if $DRY_RUN; then
+        log "  (dry-run) would update AGENTS.md managed block"
+        return 0
+    fi
+
+    tmp="$DOC_FILE.aris-codex-tmp.$$"
+    printf '%s' "$new_content" > "$tmp"
+    current=""
+    [[ -f "$DOC_FILE" ]] && current="$(cat "$DOC_FILE")"
+    if [[ "$current" != "$original" ]]; then
+        rm -f "$tmp"
+        warn "AGENTS.md changed during install; skipping managed block update"
+        return 0
+    fi
+    mv -f "$tmp" "$DOC_FILE"
+    log "  ✓ updated AGENTS.md"
+}
+
+remove_agents_doc_block() {
+    $NO_DOC && return 0
+    [[ -f "$DOC_FILE" ]] || return 0
+
+    local original new_content tmp current
+    original="$(cat "$DOC_FILE")"
+    if ! printf '%s' "$original" | grep -qF "$BLOCK_BEGIN"; then
+        return 0
+    fi
+
+    new_content="$(python3 - "$DOC_FILE" "$BLOCK_BEGIN" "$BLOCK_END" <<'PYEOF'
+import pathlib
+import re
+import sys
+
+path, begin, end = sys.argv[1], sys.argv[2], sys.argv[3]
+text = pathlib.Path(path).read_text()
+pattern = re.compile(r"\n?" + re.escape(begin) + r".*?" + re.escape(end) + r"\n?", re.DOTALL)
+matches = pattern.findall(text)
+if len(matches) > 1:
+    sys.stderr.write("ARIS-CODEX:WARN multiple managed blocks found; skipping removal\n")
+    sys.stdout.write(text)
+else:
+    updated = pattern.sub("\n", text)
+    sys.stdout.write(updated.lstrip("\n"))
+PYEOF
+    )" || { warn "AGENTS.md managed block removal failed; continuing"; return 0; }
+
+    if $DRY_RUN; then
+        log "  (dry-run) would remove AGENTS.md managed block"
+        return 0
+    fi
+
+    tmp="$DOC_FILE.aris-codex-tmp.$$"
+    printf '%s' "$new_content" > "$tmp"
+    current="$(cat "$DOC_FILE")"
+    if [[ "$current" != "$original" ]]; then
+        rm -f "$tmp"
+        warn "AGENTS.md changed during uninstall; skipping managed block removal"
+        return 0
+    fi
+    mv -f "$tmp" "$DOC_FILE"
+    log "  ✓ removed AGENTS.md managed block"
+}
+
+do_uninstall() {
+    [[ -f "$MANIFEST_PATH" ]] || die "no manifest at $MANIFEST_PATH; nothing to uninstall"
+    local manifest_data
+    manifest_data="$(mktemp -t aris-codex-manifest.XXXX)"
+    load_manifest "$MANIFEST_PATH" "$manifest_data"
+    log ""
+    log "Uninstall plan:"
+    while IFS=$'\t' read -r kind name _source _target _mode; do
+        [[ -z "$name" ]] && continue
+        log "  - $name ($kind)"
+    done < "$manifest_data"
+    if ! $DRY_RUN; then
+        prompt "Proceed?" || { log "aborted"; exit 0; }
+    fi
+    local kind name source_rel target_rel mode target_path expected_target current_target
+    local recorded_repo_root
+    recorded_repo_root="$(manifest_repo_root "$MANIFEST_PATH")"
+    [[ -n "$recorded_repo_root" ]] || die "manifest missing repo_root: $MANIFEST_PATH"
+    while IFS=$'\t' read -r kind name source_rel target_rel mode; do
+        [[ -z "$name" ]] && continue
+        target_path="$PROJECT_PATH/$target_rel"
+        expected_target="$recorded_repo_root/$source_rel"
+        if [[ -L "$target_path" ]]; then
+            current_target="$(read_link_target "$target_path")"
+            [[ "$current_target" != /* ]] && current_target="$(canonicalize "$(dirname "$target_path")/$current_target")"
+            if [[ "$current_target" == "$expected_target" ]]; then
+                if $DRY_RUN; then
+                    log "  (dry-run) rm $target_path"
+                else
+                    rm -f "$target_path"
+                    log "  - removed $name"
+                fi
+            else
+                warn "skipping $name during uninstall; target changed to $current_target"
+            fi
+        else
+            warn "skipping $name during uninstall; not a symlink"
+        fi
+    done < "$manifest_data"
+    rm -f "$manifest_data"
+    if ! $DRY_RUN; then
+        mv -f "$MANIFEST_PATH" "$MANIFEST_PREV"
+        log "  ✓ uninstalled (manifest preserved as $MANIFEST_PREV)"
+    fi
+    remove_agents_doc_block
+}
+
+log ""
+log "ARIS Codex Project Install"
+log "  Project:   $PROJECT_PATH"
+log "  Repo:      $ARIS_REPO"
+log "  Packages:  $(selected_packages | paste -sd, -)"
+log "  Action:    $ACTION$($DRY_RUN && echo ' (dry-run)')"
+log ""
+
+check_no_symlinked_parents
+check_legacy_nested_install
+if ! $DRY_RUN; then
+    acquire_lock
+fi
+
+if [[ "$ACTION" == "uninstall" ]]; then
+    do_uninstall
+    exit 0
+fi
+
+if [[ "$ACTION" == "reconcile" && ! -f "$MANIFEST_PATH" ]]; then
+    die "--reconcile requires existing manifest; none found at $MANIFEST_PATH"
+fi
+
+UPSTREAM_FILE="$(mktemp -t aris-codex-upstream.XXXX)"
+build_upstream_inventory "$ARIS_REPO" "$UPSTREAM_FILE"
+
+MANIFEST_DATA="$(mktemp -t aris-codex-manifest.XXXX)"
+load_manifest "$MANIFEST_PATH" "$MANIFEST_DATA"
+
+PLAN_FILE="$(mktemp -t aris-codex-plan.XXXX)"
+compute_plan "$UPSTREAM_FILE" "$MANIFEST_DATA" "$PLAN_FILE"
+print_plan "$PLAN_FILE"
+
+if grep -q '^CONFLICT|' "$PLAN_FILE"; then
+    log ""
+    log "Aborting due to unresolved conflicts."
+    log "Use --replace-link NAME for a symlink you intentionally want to replace."
+    exit 1
+fi
+
+if $DRY_RUN; then
+    log ""
+    log "(dry-run) no changes made"
+    rm -f "$UPSTREAM_FILE" "$MANIFEST_DATA" "$PLAN_FILE"
+    exit 0
+fi
+
+N_CHANGES="$(awk -F'|' '$1=="CREATE"||$1=="UPDATE_TARGET"||$1=="REMOVE"{n++} END{print n+0}' "$PLAN_FILE")"
+if (( N_CHANGES > 0 )); then
+    prompt "Apply these $N_CHANGES changes?" || { log "aborted"; exit 0; }
+fi
+
+MANIFEST_TMP="$MANIFEST_PATH.tmp.$$"
+write_manifest_tmp "$PLAN_FILE" "$MANIFEST_TMP"
+log ""
+log "Applying:"
+apply_plan "$PLAN_FILE"
+commit_manifest "$MANIFEST_TMP"
+
+INSTALLED_NAMES="$(mktemp -t aris-codex-names.XXXX)"
+awk -F'|' '$1=="REUSE"||$1=="ADOPT"||$1=="CREATE"||$1=="UPDATE_TARGET"{print $3}' "$PLAN_FILE" > "$INSTALLED_NAMES"
+update_agents_doc "$INSTALLED_NAMES"
+
+if ! $DRY_RUN; then
+    local_bad=0
+    while IFS=$'\t' read -r kind name source_rel target_rel mode; do
+        [[ -z "$name" ]] && continue
+        target_path="$PROJECT_PATH/$target_rel"
+        expected_target="$ARIS_REPO/$source_rel"
+        if [[ ! -L "$target_path" ]]; then
+            warn "verify: missing symlink $target_path"
+            local_bad=$((local_bad + 1))
+            continue
+        fi
+        current_target="$(read_link_target "$target_path")"
+        [[ "$current_target" != /* ]] && current_target="$(canonicalize "$(dirname "$target_path")/$current_target")"
+        if [[ "$current_target" != "$expected_target" ]]; then
+            warn "verify: wrong target for $target_path -> $current_target"
+            local_bad=$((local_bad + 1))
+        fi
+    done < <(awk -F'\t' '
+        BEGIN { in_body=0 }
+        /^kind\tname\tsource_rel\ttarget_rel\tmode$/ { in_body=1; next }
+        in_body && NF==5 { print }
+    ' "$MANIFEST_PATH")
+    (( local_bad == 0 )) && log "" && log "✓ Codex install complete. $N_CHANGES changes applied."
+fi
+
+rm -f "$UPSTREAM_FILE" "$MANIFEST_DATA" "$PLAN_FILE" "$INSTALLED_NAMES"

--- a/tools/smart_update_codex.sh
+++ b/tools/smart_update_codex.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# smart_update_codex.sh -- update copied ARIS Codex skills safely.
+#
+# Default upstream:
+#   repo/skills/skills-codex
+#
+# Optional overlays:
+#   --overlay claude-review
+#   --overlay gemini-review
+#
+# Default local targets:
+#   global:  ~/.codex/skills
+#   project: <project>/.agents/skills
+#
+# This tool is for copied installs only. If the target is managed by
+# install_aris_codex.sh (manifest + symlinks), it refuses and points to:
+#   git pull + install_aris_codex.sh --reconcile
+
+set -euo pipefail
+
+APPLY=false
+MODE="global"
+PROJECT_PATH=""
+CUSTOM_UPSTREAM=""
+CUSTOM_LOCAL=""
+HAS_CUSTOM_UPSTREAM=false
+HAS_CUSTOM_LOCAL=false
+OVERLAYS=()
+
+usage() { sed -n '2,24p' "$0" | sed 's/^# \?//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply) APPLY=true; shift ;;
+        --project) MODE="project"; PROJECT_PATH="${2:?--project requires path}"; shift 2 ;;
+        --upstream) MODE="explicit"; HAS_CUSTOM_UPSTREAM=true; CUSTOM_UPSTREAM="${2:?--upstream requires path}"; shift 2 ;;
+        --local) MODE="explicit"; HAS_CUSTOM_LOCAL=true; CUSTOM_LOCAL="${2:?--local requires path}"; shift 2 ;;
+        --overlay) OVERLAYS+=("${2:?--overlay requires claude-review or gemini-review}"); shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        --*) echo "Unknown option: $1" >&2; exit 2 ;;
+        *) echo "Unexpected positional argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "$@"; }
+die() { echo "error: $*" >&2; exit 1; }
+warn() { echo "warning: $*" >&2; }
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_UPSTREAM="$REPO_ROOT/skills/skills-codex"
+DEFAULT_GLOBAL_LOCAL="$HOME/.codex/skills"
+
+for overlay in "${OVERLAYS[@]}"; do
+    case "$overlay" in
+        claude-review|gemini-review) ;;
+        *) die "--overlay must be claude-review or gemini-review (got: $overlay)" ;;
+    esac
+done
+
+case "$MODE" in
+    explicit)
+        $HAS_CUSTOM_LOCAL || die "--local must be provided when using --upstream"
+        if $HAS_CUSTOM_UPSTREAM; then
+            [[ ${#OVERLAYS[@]} -eq 0 ]] || die "--overlay is only supported with repo-default upstream"
+            UPSTREAM_DIR="$CUSTOM_UPSTREAM"
+        else
+            UPSTREAM_DIR="$BASE_UPSTREAM"
+        fi
+        LOCAL_DIR="$CUSTOM_LOCAL"
+        SCOPE="local:$CUSTOM_LOCAL"
+        PROJECT_ROOT=""
+        ;;
+    project)
+        [[ -n "$PROJECT_PATH" ]] || die "--project requires a path"
+        PROJECT_ROOT="$(cd "$PROJECT_PATH" && pwd)"
+        UPSTREAM_DIR="$BASE_UPSTREAM"
+        LOCAL_DIR="$PROJECT_ROOT/.agents/skills"
+        SCOPE="project:$PROJECT_ROOT"
+        ;;
+    *)
+        PROJECT_ROOT=""
+        UPSTREAM_DIR="$BASE_UPSTREAM"
+        LOCAL_DIR="$DEFAULT_GLOBAL_LOCAL"
+        SCOPE="global"
+        ;;
+esac
+
+[[ -d "$UPSTREAM_DIR" ]] || die "upstream directory not found: $UPSTREAM_DIR"
+[[ -d "$LOCAL_DIR" ]] || die "local directory not found: $LOCAL_DIR"
+
+MANAGED_MANIFEST=""
+if [[ -n "$PROJECT_ROOT" ]]; then
+    MANAGED_MANIFEST="$PROJECT_ROOT/.aris/installed-skills-codex.txt"
+fi
+if [[ -n "$MANAGED_MANIFEST" && -f "$MANAGED_MANIFEST" ]]; then
+    die "target project is managed by install_aris_codex.sh. Use: git pull && bash $REPO_ROOT/tools/install_aris_codex.sh \"$PROJECT_ROOT\" --reconcile"
+fi
+if [[ -L "$LOCAL_DIR" ]]; then
+    die "local skill directory is a symlink. Use: git pull && bash $REPO_ROOT/tools/install_aris_codex.sh \"${PROJECT_ROOT:-<project>}\" --reconcile"
+fi
+while IFS= read -r link_entry; do
+    link_name="$(basename "$link_entry")"
+    if [[ "$link_name" == "shared-references" || -d "$UPSTREAM_DIR/$link_name" ]]; then
+        die "local skill directory contains symlink-managed ARIS entry '$link_name'. Use: git pull && bash $REPO_ROOT/tools/install_aris_codex.sh \"${PROJECT_ROOT:-<project>}\" --reconcile"
+    fi
+    for overlay in "${OVERLAYS[@]}"; do
+        if [[ -d "$REPO_ROOT/skills/skills-codex-$overlay/$link_name" ]]; then
+            die "local skill directory contains symlink-managed ARIS overlay entry '$link_name'. Use: git pull && bash $REPO_ROOT/tools/install_aris_codex.sh \"${PROJECT_ROOT:-<project>}\" --reconcile"
+        fi
+    done
+done < <(find "$LOCAL_DIR" -mindepth 1 -maxdepth 1 -type l)
+
+TMP_ROOT=""
+MERGED_UPSTREAM="$UPSTREAM_DIR"
+cleanup() {
+    if [[ -n "$TMP_ROOT" ]]; then
+        rm -rf "$TMP_ROOT"
+    fi
+    return 0
+}
+trap cleanup EXIT INT TERM
+
+if [[ ${#OVERLAYS[@]} -gt 0 ]]; then
+    TMP_ROOT="$(mktemp -d /tmp/aris-codex-update.XXXXXX)"
+    MERGED_UPSTREAM="$TMP_ROOT/upstream"
+    mkdir -p "$MERGED_UPSTREAM"
+    cp -a "$BASE_UPSTREAM/." "$MERGED_UPSTREAM/"
+    for overlay in "${OVERLAYS[@]}"; do
+        cp -a "$REPO_ROOT/skills/skills-codex-$overlay/." "$MERGED_UPSTREAM/"
+    done
+fi
+
+UPSTREAM_DIR="$MERGED_UPSTREAM"
+
+list_entries() {
+    local root="$1"
+    local entry name
+    for entry in "$root"/*; do
+        [[ -e "$entry" ]] || continue
+        [[ -d "$entry" ]] || continue
+        name="$(basename "$entry")"
+        if [[ "$name" == "shared-references" || -f "$entry/SKILL.md" ]]; then
+            printf "%s\n" "$name"
+        fi
+    done | sort
+}
+
+NEW=0
+IDENTICAL=0
+SAFE_UPDATE=0
+NEEDS_MERGE=0
+LOCAL_ONLY=0
+
+declare -a NEW_SKILLS=()
+declare -a IDENTICAL_SKILLS=()
+declare -a SAFE_SKILLS=()
+declare -a MERGE_SKILLS=()
+declare -a LOCAL_SKILLS=()
+declare -a UPSTREAM_NAMES=()
+declare -a NEW_SHARED_REFERENCES=()
+
+while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    UPSTREAM_NAMES+=("$name")
+    upstream_entry="$UPSTREAM_DIR/$name"
+    local_entry="$LOCAL_DIR/$name"
+    if [[ ! -d "$local_entry" ]]; then
+        NEW=$((NEW + 1))
+        NEW_SKILLS+=("$name")
+        continue
+    fi
+    if diff -qr "$upstream_entry" "$local_entry" >/dev/null 2>&1; then
+        IDENTICAL=$((IDENTICAL + 1))
+        IDENTICAL_SKILLS+=("$name")
+        continue
+    fi
+    if [[ ${#OVERLAYS[@]} -gt 0 && -d "$BASE_UPSTREAM/$name" ]] && diff -qr "$BASE_UPSTREAM/$name" "$local_entry" >/dev/null 2>&1; then
+        SAFE_UPDATE=$((SAFE_UPDATE + 1))
+        SAFE_SKILLS+=("$name")
+        continue
+    fi
+    # Unlike managed installs, copied installs have no manifest/baseline telling us
+    # whether a diff is upstream-only or includes local edits. Be conservative:
+    # any non-identical local entry requires manual merge instead of replacement.
+    NEEDS_MERGE=$((NEEDS_MERGE + 1))
+    MERGE_SKILLS+=("$name")
+done < <(list_entries "$UPSTREAM_DIR")
+
+while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    found=false
+    for upstream_name in "${UPSTREAM_NAMES[@]}"; do
+        if [[ "$upstream_name" == "$name" ]]; then
+            found=true
+            break
+        fi
+    done
+    if ! $found; then
+        LOCAL_ONLY=$((LOCAL_ONLY + 1))
+        LOCAL_SKILLS+=("$name")
+    fi
+done < <(list_entries "$LOCAL_DIR")
+
+if [[ -d "$UPSTREAM_DIR/shared-references" ]]; then
+    while IFS= read -r ref_file; do
+        rel_ref="${ref_file#"$UPSTREAM_DIR/shared-references/"}"
+        local_ref="$LOCAL_DIR/shared-references/$rel_ref"
+        if [[ ! -e "$local_ref" ]]; then
+            NEW_SHARED_REFERENCES+=("$rel_ref")
+        fi
+    done < <(find "$UPSTREAM_DIR/shared-references" -type f | sort)
+fi
+
+log "ARIS Codex Smart Update"
+log "  Scope:    $SCOPE"
+log "  Upstream: $UPSTREAM_DIR"
+log "  Local:    $LOCAL_DIR"
+if [[ ${#OVERLAYS[@]} -gt 0 ]]; then
+    log "  Overlays: ${OVERLAYS[*]}"
+fi
+log ""
+
+log "Identical: $IDENTICAL"
+for s in "${IDENTICAL_SKILLS[@]:-}"; do [[ -n "$s" ]] && log "  $s"; done
+log ""
+log "New: $NEW"
+for s in "${NEW_SKILLS[@]:-}"; do [[ -n "$s" ]] && log "  $s"; done
+log ""
+log "Safe update: $SAFE_UPDATE"
+for s in "${SAFE_SKILLS[@]:-}"; do [[ -n "$s" ]] && log "  $s"; done
+log ""
+log "Needs merge: $NEEDS_MERGE"
+for s in "${MERGE_SKILLS[@]:-}"; do [[ -n "$s" ]] && log "  $s"; done
+log ""
+log "Local only: $LOCAL_ONLY"
+for s in "${LOCAL_SKILLS[@]:-}"; do [[ -n "$s" ]] && log "  $s"; done
+log ""
+log "New shared references: ${#NEW_SHARED_REFERENCES[@]}"
+for s in "${NEW_SHARED_REFERENCES[@]:-}"; do [[ -n "$s" ]] && log "  shared-references/$s"; done
+log ""
+
+if ! $APPLY; then
+    log "Dry-run only. Re-run with --apply to copy new entries, new shared references, and replace safe-update entries."
+    exit 0
+fi
+
+for name in "${NEW_SKILLS[@]:-}"; do
+    [[ -n "$name" ]] || continue
+    mkdir -p "$LOCAL_DIR"
+    cp -a "$UPSTREAM_DIR/$name" "$LOCAL_DIR/$name"
+    log "  + added $name"
+done
+
+for name in "${SAFE_SKILLS[@]:-}"; do
+    [[ -n "$name" ]] || continue
+    rm -rf "$LOCAL_DIR/$name"
+    cp -a "$UPSTREAM_DIR/$name" "$LOCAL_DIR/$name"
+    log "  ↻ updated $name"
+done
+
+for rel_ref in "${NEW_SHARED_REFERENCES[@]:-}"; do
+    [[ -n "$rel_ref" ]] || continue
+    mkdir -p "$(dirname "$LOCAL_DIR/shared-references/$rel_ref")"
+    cp -a "$UPSTREAM_DIR/shared-references/$rel_ref" "$LOCAL_DIR/shared-references/$rel_ref"
+    log "  + added shared-references/$rel_ref"
+done
+
+validate_shared_references() {
+    local root="$1"
+    local failures=0
+    local name skill_file ref
+    for name in "${UPSTREAM_NAMES[@]:-}"; do
+        [[ -n "$name" && "$name" != "shared-references" ]] || continue
+        skill_file="$root/$name/SKILL.md"
+        [[ -f "$skill_file" ]] || continue
+        while IFS= read -r ref; do
+            [[ -n "$ref" ]] || continue
+            if [[ ! -f "$root/shared-references/$ref" ]]; then
+                warn "missing shared reference: $(basename "$(dirname "$skill_file")") -> shared-references/$ref"
+                failures=$((failures + 1))
+            fi
+        done < <(grep -Eo '\.\./shared-references/[A-Za-z0-9._-]+\.md' "$skill_file" 2>/dev/null | sed 's|../shared-references/||' | sort -u)
+    done
+    return "$failures"
+}
+
+log ""
+log "Apply complete."
+if (( NEEDS_MERGE > 0 )); then
+    warn "$NEEDS_MERGE entries still need manual merge"
+fi
+if ! validate_shared_references "$LOCAL_DIR"; then
+    die "copied install has missing shared references after update; merge or copy the reported files before using affected skills"
+fi


### PR DESCRIPTION
## Summary

This PR rebuilds the Codex route as a Claude-mainline mirror/adaptation layer rather than a separate product line.

Key changes:

- Completes `skills/skills-codex/` coverage to match all 67 mainline `skills/` entries.
- Aligns Codex skill content with Claude mainline semantics while preserving Codex-specific execution paths.
- Standardizes Codex reviewer-heavy skills around Codex-native reviewer routing (`spawn_agent` for initial review and `send_input` for continuation where applicable).
- Keeps Codex base free of the old `mcp__codex__codex` / `mcp__codex__codex-reply` reviewer path.
- Reworks `training-check` as an interactive current-session Codex monitoring skill instead of Cron/tmux/codex-exec runtime.
- Adds Codex-specific project install and copied-install update tooling:
  - `tools/install_aris_codex.sh`
  - `tools/smart_update_codex.sh`
- Updates Codex and overlay documentation to describe Codex as a mirror/adaptation layer and to point users at the Codex-specific install/update chain.
- Mirrors required `shared-references` into `skills/skills-codex/shared-references/`.

## Codex install/update behavior

`install_aris_codex.sh` provides managed project-local installs:

- Installs flat symlinks under `.agents/skills/<skill-name>`.
- Tracks managed entries in `.aris/installed-skills-codex.txt`.
- Supports install, reconcile, uninstall, dry-run, quiet mode, lock handling, and AGENTS.md managed block updates.
- Supports optional Claude/Gemini reviewer overlays via install-time flags.

`smart_update_codex.sh` provides copied-install updates:

- Defaults to dry-run; `--apply` is required to write.
- Supports global/local copied installs and project `.agents/skills` copied installs.
- Supports optional overlay merging for copied installs.
- Refuses manifest/symlink-managed ARIS installs and directs users to `install_aris_codex.sh --reconcile`.
- Avoids silently overwriting local customizations; non-identical copied entries are marked `Needs merge`.
- Allows unrelated third-party symlinked skills in shared skill directories.
- Restricts shared-reference validation to ARIS-managed skill names.

## Important intentional differences from Claude mainline

These are deliberate Codex adaptations, not missed migrations:

- Reviewer routing uses Codex-native `spawn_agent` / `send_input` instead of Codex MCP calls.
- Codex skills use `AGENTS.md`, `.agents/skills`, `.aris/installed-skills-codex.txt`, and `~/.codex/...` where appropriate.
- `training-check` is interactive current-session monitoring for Codex, not the Claude Cron/Watchdog setup.
- Helper script references resolve through the ARIS repo root/manifest rather than assuming helper scripts exist in the user's project.

## Validation

Automated checks run:

- `pytest -q tests/test_codex_install_update.py tests/test_codex_skill_mirror.py`
  - `26 passed`
- `pytest -q`
  - `183 passed, 3 skipped`
- `bash -n tools/install_aris_codex.sh tools/smart_update_codex.sh`
  - passed

Manual temporary-directory end-to-end check run under `/tmp/aris-codex-e2e.*`:

- `install_aris_codex.sh --dry-run` produced no project writes.
- Base managed install created `.aris/installed-skills-codex.txt`, `AGENTS.md`, and 68 symlinks (67 skills + `shared-references`).
- Claude overlay reconcile retargeted only overlay-covered skills and kept uncovered skills on the base package.
- Gemini overlay reconcile behaved the same for its overlay set.
- Managed uninstall removed only managed entries, preserved a local-only skill, moved manifest to `.prev`, and removed the AGENTS.md managed block.
- `smart_update_codex.sh --local ... --apply` installed the copied base package and shared references.
- Copied base install upgraded safely to Claude overlay.
- Overlay update preserved a local customization and reported affected entries as `Needs merge`.
- Unrelated third-party symlinked skills were allowed.
- ARIS symlink-managed entries in copied installs were refused with the expected guidance.

## Notes

The Codex install/update scripts are not a byte-for-byte port of the Claude scripts. They preserve the core lifecycle expected for Codex v1 while avoiding Claude legacy migration paths that are not part of this Codex-specific route.