### PR TITLE
fix: Thinking block support + multi-tool fix + DeepSeek /setup integration

### DIFF
--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -192,6 +192,10 @@ pub enum OutputContentBlock {
         name: String,
         input: Value,
     },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -247,6 +251,8 @@ pub struct ContentBlockDeltaEvent {
 pub enum ContentBlockDelta {
     TextDelta { text: String },
     InputJsonDelta { partial_json: String },
+    ThinkingDelta { thinking: String },
+    SignatureDelta { signature: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -132,6 +132,10 @@ pub enum InputContentBlock {
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         is_error: bool,
     },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -233,6 +233,11 @@ impl ArisConfig {
                             std::env::set_var("ARIS_REVIEWER_AUTH_TOKEN", key);
                         }
                     }
+                    "deepseek" => {
+                        if force_reviewer || std::env::var("ARIS_REVIEWER_AUTH_TOKEN").is_err() {
+                            std::env::set_var("ARIS_REVIEWER_AUTH_TOKEN", key);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -297,9 +302,14 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     println!("  4. GLM         (GLM-5)");
     println!("  5. MiniMax     (MiniMax-M2.7)");
     println!("  6. Kimi        (kimi-k2.5)");
+    println!("  7. DeepSeek    (deepseek-chat)");
 
     let default_executor = match config.executor_provider.as_deref() {
-        Some("anthropic") | Some("anthropic-compat") => "1",
+        Some("anthropic") => "1",
+        Some("anthropic-compat") => match config.executor_base_url.as_deref() {
+            Some(u) if u.contains("deepseek") => "7",
+            _ => "1",
+        },
         Some("openai") => match config.executor_base_url.as_deref() {
             Some(u) if u.contains("googleapis") => "3",
             Some(u) if u.contains("bigmodel") => "4",
@@ -309,7 +319,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         },
         _ => "1",
     };
-    let exec_choice_raw = prompt_with_default("  Choose [1-6]", default_executor)?;
+    let exec_choice_raw = prompt_with_default("  Choose [1-7]", default_executor)?;
     let exec_choice = exec_choice_raw.trim();
     // Detect real menu change, not just provider-string change. OpenAI / Gemini /
     // GLM / MiniMax / Kimi all serialize to provider="openai" so we must compare
@@ -323,6 +333,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         "4" => ("openai", "EXECUTOR_API_KEY", "GLM API key", Some("https://open.bigmodel.cn/api/paas/v4"), "GLM-5"),
         "5" => ("openai", "EXECUTOR_API_KEY", "MiniMax API key", Some("https://api.minimax.chat/v1"), "MiniMax-M2.7"),
         "6" => ("openai", "EXECUTOR_API_KEY", "Kimi API key", Some("https://api.moonshot.cn/v1"), "kimi-k2.5"),
+        "7" => ("anthropic-compat", "ANTHROPIC_AUTH_TOKEN", "DeepSeek API key", Some("https://api.deepseek.com/anthropic"), "deepseek-v4-pro"),
         _ => ("anthropic", "ANTHROPIC_API_KEY", "Anthropic API key", None, "claude-opus-4-6"),
     };
 
@@ -405,7 +416,8 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     println!("  4. MiniMax         (MiniMax-M2.7)");
     println!("  5. Kimi            (kimi-k2.5)");
     println!("  6. Anthropic Proxy (claude via proxy)");
-    println!("  7. Skip (no reviewer)");
+    println!("  7. DeepSeek         (deepseek-chat)");
+    println!("  8. Skip (no reviewer)");
     let default_reviewer = match config.reviewer_provider.as_deref() {
         Some("openai") => "1",
         Some("gemini") => "2",
@@ -413,10 +425,11 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         Some("minimax") => "4",
         Some("kimi") => "5",
         Some("anthropic-compat") => "6",
+        Some("deepseek") => "7",
         None => "1",
-        _ => "7",
+        _ => "8",
     };
-    let reviewer_choice_raw = prompt_with_default("  Choose [1-7]", default_reviewer)?;
+    let reviewer_choice_raw = prompt_with_default("  Choose [1-8]", default_reviewer)?;
     let reviewer_choice = reviewer_choice_raw.trim();
     let switched_reviewer = reviewer_choice != default_reviewer;
 
@@ -428,6 +441,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         "4" => Some(("minimax", "MINIMAX_API_KEY", "MiniMax API key", "MiniMax-M2.7")),
         "5" => Some(("kimi", "KIMI_API_KEY", "Kimi API key", "kimi-k2.5")),
         "6" => Some(("anthropic-compat", "ARIS_REVIEWER_AUTH_TOKEN", "Reviewer auth token", "claude-sonnet-4-6")),
+        "7" => Some(("deepseek", "ARIS_REVIEWER_AUTH_TOKEN", "DeepSeek API key", "deepseek-v4-pro")),
         _ => None,
     };
 
@@ -532,10 +546,12 @@ fn print_executor_url_hints(exec_choice: &str) {
             println!("    \x1b[2m• https://api.deepseek.com/v1                         (DeepSeek)\x1b[0m");
             println!("    \x1b[2m• https://dashscope.aliyuncs.com/compatible-mode/v1   (阿里云百练 OpenAI-compat)\x1b[0m");
         }
-        _ => {
-            // Options 3-6 are provider-specific (Gemini/GLM/MiniMax/Kimi) with
-            // their own defaults already populated. No hints needed.
+        "7" => {
+            // DeepSeek via Anthropic-compatible API (supports extended thinking).
+            println!("  \x1b[2mDeepSeek Anthropic-compatible endpoint:\x1b[0m");
+            println!("    \x1b[2m• https://api.deepseek.com/anthropic                       (official)\x1b[0m");
         }
+        _ => {}
     }
 }
 
@@ -550,6 +566,10 @@ fn print_reviewer_url_hints(reviewer_choice: &str) {
             println!("    \x1b[2m• https://openrouter.ai/api/v1                        (OpenRouter)\x1b[0m");
             println!("    \x1b[2m• https://api.deepseek.com/v1                         (DeepSeek)\x1b[0m");
             println!("    \x1b[2m• https://dashscope.aliyuncs.com/compatible-mode/v1   (阿里云百练 OpenAI-compat)\x1b[0m");
+        }
+        "7" => {
+            println!("  \x1b[2mDeepSeek Anthropic-compatible endpoint:\x1b[0m");
+            println!("    \x1b[2m• https://api.deepseek.com/anthropic                       (official)\x1b[0m");
         }
         _ => {}
     }

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -3572,6 +3572,8 @@ impl ApiClient for AnthropicRuntimeClient {
                                 input.push_str(&partial_json);
                             }
                         }
+                        ContentBlockDelta::ThinkingDelta { .. } => {},
+                        ContentBlockDelta::SignatureDelta { .. } => {},
                     },
                     ApiStreamEvent::ContentBlockStop(_) => {
                         if let Some(rendered) = markdown_stream.flush(&renderer) {
@@ -4134,6 +4136,7 @@ fn push_output_block(
             };
             *pending_tool = Some((id, name, initial_input));
         }
+        OutputContentBlock::Thinking { .. } => {},
     }
     Ok(())
 }

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -3109,6 +3109,9 @@ fn render_export_text(session: &Session) -> String {
                         "[tool_result id={tool_use_id} name={tool_name} error={is_error}] {output}"
                     ));
                 }
+                ContentBlock::Thinking { thinking, .. } => {
+                    lines.push(format!("[thinking] {thinking}"));
+                }
             }
         }
         lines.push(String::new());
@@ -3529,6 +3532,7 @@ impl ApiClient for AnthropicRuntimeClient {
             let mut markdown_stream = MarkdownStreamState::default();
             let mut events = Vec::new();
             let mut pending_tool: Option<(String, String, String)> = None;
+        let mut pending_thinking: Option<(String, String)> = None;
             let mut saw_stop = false;
 
             while let Some(event) = stream
@@ -3548,13 +3552,22 @@ impl ApiClient for AnthropicRuntimeClient {
                         }
                     }
                     ApiStreamEvent::ContentBlockStart(start) => {
-                        push_output_block(
-                            start.content_block,
-                            out,
-                            &mut events,
-                            &mut pending_tool,
-                            true,
-                        )?;
+                        if let OutputContentBlock::Thinking {
+                            thinking,
+                            signature,
+                        } = &start.content_block
+                        {
+                            pending_thinking =
+                                Some((thinking.clone(), signature.clone()));
+                        } else {
+                            push_output_block(
+                                start.content_block,
+                                out,
+                                &mut events,
+                                &mut pending_tool,
+                                true,
+                            )?;
+                        }
                     }
                     ApiStreamEvent::ContentBlockDelta(delta) => match delta.delta {
                         ContentBlockDelta::TextDelta { text } => {
@@ -3572,8 +3585,16 @@ impl ApiClient for AnthropicRuntimeClient {
                                 input.push_str(&partial_json);
                             }
                         }
-                        ContentBlockDelta::ThinkingDelta { .. } => {},
-                        ContentBlockDelta::SignatureDelta { .. } => {},
+                        ContentBlockDelta::ThinkingDelta { thinking } => {
+                            if let Some((ref mut t, _)) = pending_thinking {
+                                t.push_str(&thinking);
+                            }
+                        }
+                        ContentBlockDelta::SignatureDelta { signature } => {
+                            if let Some((_, ref mut s)) = pending_thinking {
+                                *s = signature;
+                            }
+                        },
                     },
                     ApiStreamEvent::ContentBlockStop(_) => {
                         if let Some(rendered) = markdown_stream.flush(&renderer) {
@@ -3587,6 +3608,12 @@ impl ApiClient for AnthropicRuntimeClient {
                                 .and_then(|()| out.flush())
                                 .map_err(|error| RuntimeError::new(error.to_string()))?;
                             events.push(AssistantEvent::ToolUse { id, name, input });
+                        }
+                        if let Some((thinking, signature)) = pending_thinking.take() {
+                            events.push(AssistantEvent::Thinking {
+                                thinking,
+                                signature,
+                            });
                         }
                     }
                     ApiStreamEvent::MessageDelta(delta) => {
@@ -4136,7 +4163,15 @@ fn push_output_block(
             };
             *pending_tool = Some((id, name, initial_input));
         }
-        OutputContentBlock::Thinking { .. } => {},
+        OutputContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            events.push(AssistantEvent::Thinking {
+                thinking,
+                signature,
+            });
+        }
     }
     Ok(())
 }
@@ -4260,6 +4295,13 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
                         }],
                         is_error: *is_error,
                     },
+                    ContentBlock::Thinking {
+                        thinking,
+                        signature,
+                    } => InputContentBlock::Thinking {
+                        thinking: thinking.clone(),
+                        signature: signature.clone(),
+                    },
                 })
                 .collect::<Vec<_>>();
             (!content.is_empty()).then(|| InputMessage {
@@ -4340,7 +4382,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
-        "  DeepSeek:  EXECUTOR_PROVIDER=openai EXECUTOR_BASE_URL=https://api.deepseek.com EXECUTOR_API_KEY=xxx aris --model deepseek-chat"
+        "  DeepSeek:  EXECUTOR_PROVIDER=anthropic-compat EXECUTOR_BASE_URL=https://api.deepseek.com/anthropic EXECUTOR_API_KEY=xxx aris --model deepseek-v4-pro"
     )?;
     writeln!(
         out,

--- a/crates/aris-cli/src/openai_executor.rs
+++ b/crates/aris-cli/src/openai_executor.rs
@@ -524,6 +524,7 @@ fn convert_messages_openai(
                             }));
                         }
                         ContentBlock::ToolResult { .. } => {}
+                        ContentBlock::Thinking { .. } => {}
                     }
                 }
 

--- a/crates/runtime/src/compact.rs
+++ b/crates/runtime/src/compact.rs
@@ -159,7 +159,7 @@ fn summarize_messages(messages: &[ConversationMessage]) -> String {
         .filter_map(|block| match block {
             ContentBlock::ToolUse { name, .. } => Some(name.as_str()),
             ContentBlock::ToolResult { tool_name, .. } => Some(tool_name.as_str()),
-            ContentBlock::Text { .. } => None,
+            ContentBlock::Text { .. } | ContentBlock::Thinking { .. } => None,
         })
         .collect::<Vec<_>>();
     tool_names.sort_unstable();
@@ -239,6 +239,7 @@ fn summarize_block(block: &ContentBlock) -> String {
             "tool_result {tool_name}: {}{output}",
             if *is_error { "error " } else { "" }
         ),
+        ContentBlock::Thinking { thinking, .. } => thinking.clone(),
     };
     truncate_summary(&raw, 160)
 }
@@ -290,6 +291,7 @@ fn collect_key_files(messages: &[ConversationMessage]) -> Vec<String> {
             ContentBlock::Text { text } => text.as_str(),
             ContentBlock::ToolUse { input, .. } => input.as_str(),
             ContentBlock::ToolResult { output, .. } => output.as_str(),
+            ContentBlock::Thinking { thinking, .. } => thinking.as_str(),
         })
         .flat_map(extract_file_candidates)
         .collect::<Vec<_>>();
@@ -312,7 +314,8 @@ fn first_text_block(message: &ConversationMessage) -> Option<&str> {
         ContentBlock::Text { text } if !text.trim().is_empty() => Some(text.as_str()),
         ContentBlock::ToolUse { .. }
         | ContentBlock::ToolResult { .. }
-        | ContentBlock::Text { .. } => None,
+        | ContentBlock::Text { .. }
+        | ContentBlock::Thinking { .. } => None,
     })
 }
 
@@ -362,6 +365,9 @@ fn estimate_message_tokens(message: &ConversationMessage) -> usize {
             ContentBlock::ToolResult {
                 tool_name, output, ..
             } => (tool_name.len() + output.len()) / 4 + 1,
+            ContentBlock::Thinking {
+                thinking, signature,
+            } => (thinking.len() + signature.len()) / 4 + 1,
         })
         .sum()
 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -8,7 +8,7 @@ use crate::config::RuntimeFeatureConfig;
 use crate::event_sink::{EventSink, EventType, NoopEventSink, RuntimeEvent, now_iso8601};
 use crate::hooks::{HookRunResult, HookRunner};
 use crate::permissions::{PermissionOutcome, PermissionPolicy, PermissionPrompter};
-use crate::session::{ContentBlock, ConversationMessage, Session};
+use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
 use crate::usage::{TokenUsage, UsageTracker};
 
 const DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD: u32 = 200_000;
@@ -27,6 +27,10 @@ pub enum AssistantEvent {
         id: String,
         name: String,
         input: String,
+    },
+    Thinking {
+        thinking: String,
+        signature: String,
     },
     Usage(TokenUsage),
     MessageStop,
@@ -242,6 +246,7 @@ where
                 break;
             }
 
+            let mut turn_tool_results = Vec::new();
             for (tool_use_id, tool_name, input) in pending_tool_uses {
                 let permission_outcome = if let Some(prompt) = prompter.as_mut() {
                     self.permission_policy
@@ -250,17 +255,17 @@ where
                     self.permission_policy.authorize(&tool_name, &input, None)
                 };
 
-                let result_message = match permission_outcome {
+                let result_blocks = match permission_outcome {
                     PermissionOutcome::Allow => {
                         let pre_hook_result = self.hook_runner.run_pre_tool_use(&tool_name, &input);
                         if pre_hook_result.is_denied() {
                             let deny_message = format!("PreToolUse hook denied tool `{tool_name}`");
-                            ConversationMessage::tool_result(
+                            vec![ContentBlock::ToolResult {
                                 tool_use_id,
                                 tool_name,
-                                format_hook_message(&pre_hook_result, &deny_message),
-                                true,
-                            )
+                                output: format_hook_message(&pre_hook_result, &deny_message),
+                                is_error: true,
+                            }]
                         } else {
                             let (mut output, mut is_error) =
                                 match self.tool_executor.execute(&tool_name, &input) {
@@ -311,17 +316,30 @@ where
                                 },
                             });
 
-                            ConversationMessage::tool_result(
+                            vec![ContentBlock::ToolResult {
                                 tool_use_id,
                                 tool_name,
                                 output,
                                 is_error,
-                            )
+                            }]
                         }
                     }
                     PermissionOutcome::Deny { reason } => {
-                        ConversationMessage::tool_result(tool_use_id, tool_name, reason, true)
+                        vec![ContentBlock::ToolResult {
+                            tool_use_id,
+                            tool_name,
+                            output: reason,
+                            is_error: true,
+                        }]
                     }
+                };
+                turn_tool_results.extend(result_blocks);
+            }
+            if !turn_tool_results.is_empty() {
+                let result_message = ConversationMessage {
+                    role: MessageRole::User,
+                    blocks: turn_tool_results,
+                    usage: None,
                 };
                 self.session.messages.push(result_message.clone());
                 tool_results.push(result_message);
@@ -421,6 +439,10 @@ fn build_assistant_message(
             AssistantEvent::ToolUse { id, name, input } => {
                 flush_text_block(&mut text, &mut blocks);
                 blocks.push(ContentBlock::ToolUse { id, name, input });
+            }
+            AssistantEvent::Thinking { thinking, signature } => {
+                flush_text_block(&mut text, &mut blocks);
+                blocks.push(ContentBlock::Thinking { thinking, signature });
             }
             AssistantEvent::Usage(value) => usage = Some(value),
             AssistantEvent::MessageStop => {

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -337,7 +337,7 @@ where
             }
             if !turn_tool_results.is_empty() {
                 let result_message = ConversationMessage {
-                    role: MessageRole::User,
+                    role: MessageRole::Tool,
                     blocks: turn_tool_results,
                     usage: None,
                 };

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -30,6 +30,10 @@ pub enum ContentBlock {
         output: String,
         is_error: bool,
     },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -315,6 +319,23 @@ impl ContentBlock {
                 object.insert("output".to_string(), JsonValue::String(output.clone()));
                 object.insert("is_error".to_string(), JsonValue::Bool(*is_error));
             }
+            Self::Thinking {
+                thinking,
+                signature,
+            } => {
+                object.insert(
+                    "type".to_string(),
+                    JsonValue::String("thinking".to_string()),
+                );
+                object.insert(
+                    "thinking".to_string(),
+                    JsonValue::String(thinking.clone()),
+                );
+                object.insert(
+                    "signature".to_string(),
+                    JsonValue::String(signature.clone()),
+                );
+            }
         }
         JsonValue::Object(object)
     }
@@ -344,6 +365,10 @@ impl ContentBlock {
                     .get("is_error")
                     .and_then(JsonValue::as_bool)
                     .ok_or_else(|| SessionError::Format("missing is_error".to_string()))?,
+            }),
+            "thinking" => Ok(Self::Thinking {
+                thinking: required_string(object, "thinking")?,
+                signature: required_string(object, "signature")?,
             }),
             other => Err(SessionError::Format(format!(
                 "unsupported block type: {other}"

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1980,6 +1980,8 @@ impl ApiClient for AnthropicRuntimeClient {
                                 input.push_str(&partial_json);
                             }
                         }
+                        ContentBlockDelta::ThinkingDelta { .. } => {},
+                        ContentBlockDelta::SignatureDelta { .. } => {},
                     },
                     ApiStreamEvent::ContentBlockStop(_) => {
                         if let Some((id, name, input)) = pending_tool.take() {
@@ -2128,6 +2130,7 @@ fn push_output_block(
             };
             *pending_tool = Some((id, name, initial_input));
         }
+        OutputContentBlock::Thinking { .. } => {}
     }
 }
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -2097,6 +2097,13 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
                         }],
                         is_error: *is_error,
                     },
+                    ContentBlock::Thinking {
+                        thinking,
+                        signature,
+                    } => InputContentBlock::Thinking {
+                        thinking: thinking.clone(),
+                        signature: signature.clone(),
+                    },
                 })
                 .collect::<Vec<_>>();
             (!content.is_empty()).then(|| InputMessage {
@@ -2130,7 +2137,15 @@ fn push_output_block(
             };
             *pending_tool = Some((id, name, initial_input));
         }
-        OutputContentBlock::Thinking { .. } => {}
+        OutputContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            events.push(AssistantEvent::Thinking {
+                thinking,
+                signature,
+            });
+        }
     }
 }
 
@@ -3183,8 +3198,10 @@ fn route_openai_compat_model(model: &str) -> (&'static str, &'static str, &'stat
         ("MINIMAX_API_KEY", "https://api.minimax.chat/v1/chat/completions", "minimax")
     } else if model.contains("kimi") || model.contains("moonshot") {
         ("KIMI_API_KEY", "https://api.moonshot.cn/v1/chat/completions", "kimi")
+    } else if model.contains("deepseek") {
+        ("DEEPSEEK_API_KEY", "https://api.deepseek.com/v1/chat/completions", "deepseek")
     } else {
-        // Default: OpenAI (also covers gpt, o3, o4, deepseek via OPENAI_API_KEY)
+        // Default: OpenAI (also covers gpt, o3, o4)
         ("OPENAI_API_KEY", "https://api.openai.com/v1/chat/completions", "openai")
     }
 }
@@ -3244,11 +3261,13 @@ fn run_llm_review(input: LlmReviewInput) -> Result<String, String> {
     let reviewer_provider = std::env::var("ARIS_REVIEWER_PROVIDER").ok().filter(|s| !s.is_empty());
     let custom_base_url = std::env::var("ARIS_REVIEWER_BASE_URL").ok().filter(|s| !s.is_empty());
 
-    // Anthropic-compatible reviewer mode (e.g., Claude via proxy, Kimi coding endpoint).
+    // Anthropic-compatible reviewer mode (e.g., Claude via proxy, DeepSeek).
     // This path uses ARIS_REVIEWER_AUTH_TOKEN (Bearer) and ignores the openai-compat
     // key routing. We still honor an explicit input.model override here because
     // the target endpoint decides which Anthropic-format model name it accepts.
-    if reviewer_provider.as_deref() == Some("anthropic-compat") {
+    if reviewer_provider.as_deref() == Some("anthropic-compat")
+        || reviewer_provider.as_deref() == Some("deepseek")
+    {
         let key = std::env::var("ARIS_REVIEWER_AUTH_TOKEN")
             .or_else(|_| std::env::var("ANTHROPIC_AUTH_TOKEN"))
             .ok()
@@ -3259,7 +3278,12 @@ fn run_llm_review(input: LlmReviewInput) -> Result<String, String> {
             .as_deref()
             .filter(|s| !s.is_empty())
             .unwrap_or(configured_model);
-        let base = custom_base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string());
+        let default_base = if reviewer_provider.as_deref() == Some("deepseek") {
+            "https://api.deepseek.com/anthropic"
+        } else {
+            "https://api.anthropic.com"
+        };
+        let base = custom_base_url.unwrap_or_else(|| default_base.to_string());
         let endpoint = format!("{}/v1/messages", base.trim_end_matches('/'));
         return call_anthropic_compat_reviewer(&key, &endpoint, model, &input.prompt);
     }
@@ -4896,8 +4920,8 @@ printf 'pwsh:%s' "$1"
         assert_eq!(route_openai_compat_model("MiniMax-M2.7").0, "MINIMAX_API_KEY");
         assert_eq!(route_openai_compat_model("kimi-k2.5").0, "KIMI_API_KEY");
         assert_eq!(route_openai_compat_model("moonshot-v1").0, "KIMI_API_KEY");
-        // Unknown model → OpenAI fallback (matches OpenRouter / DeepSeek convention).
-        assert_eq!(route_openai_compat_model("deepseek-chat").0, "OPENAI_API_KEY");
+        // DeepSeek models route to their own API key.
+        assert_eq!(route_openai_compat_model("deepseek-chat").0, "DEEPSEEK_API_KEY");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three-fold fix to fully enable **DeepSeek V4 Pro** (and other reasoning models
that return extended thinking) via the `anthropic-compat` provider.

### 1. Parse and preserve thinking blocks
- Add Thinking variant to OutputContentBlock, InputContentBlock, ContentBlockDelta
- Add Thinking variant to ContentBlock (session) with JSON serialization
- Fixes: unknown variant thinking deserialization error
- Fixes: thinking must be passed back to the API (400 Bad Request)

### 2. Fix multi-tool result grouping (CRITICAL)
- Accumulate all tool results from one assistant turn into a SINGLE message
- Fixes: tool_use_ids_without_tool_result error with parallel tool calls

### 3. Add DeepSeek to /setup interactive menu
- Executor option 7: DeepSeek (deepseek-v4-pro) via anthropic-compat
- Reviewer option 7: DeepSeek (deepseek-v4-pro), Skip shifted to 8
- Add deepseek model routing for reviewer fallback
- Update help text and URL hints

## Files changed (8 source files)

| File | Change |
|------|--------|
| crates/api/src/types.rs | Add Thinking variants |
| crates/runtime/src/session.rs | Add Thinking ContentBlock + JSON |
| crates/runtime/src/conversation.rs | Thinking + multi-tool grouping fix |
| crates/runtime/src/compact.rs | Thinking in 5 match arms |
| crates/aris-cli/src/main.rs | Stream thinking + help text |
| crates/aris-cli/src/config.rs | DeepSeek in /setup menus |
| crates/aris-cli/src/openai_executor.rs | Skip Thinking for OpenAI |
| crates/tools/src/lib.rs | Thinking + deepseek routing |

## Test plan

- [x] cargo build --release compiles 0 errors
- [x] cargo test -p tools --lib: 29/34 pass (5 pre-existing env failures)
- [x] DeepSeek V4 Pro single-turn: thinking blocks parsed
- [x] DeepSeek V4 Pro multi-turn: no thinking must be passed back error
- [x] DeepSeek V4 Pro multi-tool parallel calls: no tool_use error
- [x] /setup integration: help text shows correct endpoint and model

Fixes #161