### PR TITLE
feat(citation-audit): add opt-in --uncited flag for unused bib entries

### DIFF
--- a/skills/citation-audit/SKILL.md
+++ b/skills/citation-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: citation-audit
 description: "Zero-context verification that every bibliographic entry in the paper is real, correctly attributed, and used in a context the cited paper actually supports. Uses a fresh cross-model reviewer with web/DBLP/arXiv lookup to catch hallucinated authors, wrong years, fabricated venues, version mismatches, and wrong-context citations (cite present but the cited paper does not establish the claim). Use when user says \"审查引用\", \"check citations\", \"citation audit\", \"verify references\", \"引用核对\", or before submission to ensure bibliography integrity."
-argument-hint: [paper-directory-or-bib-file]
+argument-hint: [paper-directory-or-bib-file] [--uncited]
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent, mcp__codex__codex, WebSearch, WebFetch
 ---
 
@@ -65,11 +65,13 @@ Output a flat list of `(key, file, line, surrounding_sentence)` tuples.
 
 Also build the inverse: for each bib entry, the list of all places it is cited.
 
+If the user passed `--uncited`, also compute the set difference `bib_keys \ cited_keys` here and stash it for use in Steps 5 and the JSON aggregation; see "Uncited Entry Detection (opt-in)" below for the protocol. The set-diff is a string operation only and does not consume reviewer budget.
+
 Save the extracted contexts to `paper/.aris/citation-audit/contexts.txt` so the reviewer can read it directly. Use the paper-dir-relative path `.aris/citation-audit/contexts.txt` when recording the file in `audited_input_hashes`; do not stage under `/tmp` or other transient locations that the verifier cannot rehash later.
 
 ### Step 3: Send each entry to fresh cross-model reviewer
 
-For each bib entry, invoke `mcp__codex__codex` (NOT `codex-reply` — fresh thread per entry, or batch with explicit per-entry isolation):
+For each **cited** bib entry — i.e., each key in `cited_keys` with at least one extracted citation context — invoke `mcp__codex__codex` (NOT `codex-reply` — fresh thread per entry, or batch with explicit per-entry isolation). Do **not** send entries in `bib_keys \ cited_keys` to the reviewer; those are detect-only and surface only when `--uncited` is explicitly enabled (see "Uncited Entry Detection" below).
 
 ```
 mcp__codex__codex:
@@ -159,7 +161,7 @@ Write `CITATION_AUDIT.md`:
 # Citation Audit Report
 
 **Date**: 2026-04-19
-**Bib file**: references.bib
+**Bib file(s)**: references.bib
 **Total entries**: 29
 
 ## Summary
@@ -189,6 +191,20 @@ Write `CITATION_AUDIT.md`:
 [list of KEEP keys]
 ```
 
+When `--uncited` is set, append the following section after "All-Clean Entries":
+
+```markdown
+## Uncited Entries (opt-in)
+
+The following bib entries are present in the audited bib file(s) but are not referenced by any `\cite{...}` in the paper body:
+
+- `wainwright2008` — suggestion: prune (uncited; no local evidence of intent)
+- `lafferty2001` — suggestion: prune (uncited; no local evidence of intent)
+- `figueroa2024` — suggestion: check (a `% TODO: cite figueroa2024` comment was found in `sections/3.related.tex`)
+
+This section is detect-only; it does not change the top-level verdict.
+```
+
 ### Step 6: Apply fixes (interactive)
 
 For each FIX/REPLACE/REMOVE verdict, prompt the user:
@@ -213,6 +229,41 @@ Confirm:
 - No `Reference undefined` warnings
 - Page count unchanged or only minimally affected by metadata fixes
 
+## Uncited Entry Detection (opt-in)
+
+**Default**: disabled. Existing users see no behavior change — only `\cite{...}` keys are audited, and bib entries with no `\cite` reference in the manuscript are silently ignored.
+
+**Opt-in**: pass `--uncited` on invocation. The skill then performs a set-diff after Step 2 and reports bib entries that appear in any audited bib file(s) but are not cited anywhere in the paper. Detect-only — uncited entries are **not** sent to the cross-model reviewer, so there is no extra reviewer/web-lookup cost.
+
+### Why opt-in
+This skill's headline output is the three-axis audit on cited entries. Surfacing uncited bib entries by default would (a) change long-form output for every existing run, and (b) noise up the verdict for users who intentionally maintain a superset bib file (e.g., shared lab bib, in-progress section reorder where the cite has been removed but the entry intentionally retained). The flag preserves zero behavior change for existing callers.
+
+### Effect when enabled
+
+When `--uncited` is set:
+
+- `CITATION_AUDIT.md` gains a `## Uncited Entries (opt-in)` section listing the keys with a one-line suggestion each: `prune` (entry is dead weight; recommend deleting) or `check` (entry might be intentional; flag for user review). Default suggestion is `prune`; only emit `check` when there is concrete local evidence (e.g., a TODO comment in a `.tex` file mentioning the key, or a recently removed `\cite` visible in `git diff`). Do not infer intent from the bib key string alone.
+- `CITATION_AUDIT.json` `details` gains an `uncited_entries` array; see "Submission Artifact Emission" below for the schema.
+- The top-level `verdict` is **unchanged**: uncited entries do not upgrade or downgrade the PASS / WARN / FAIL / etc. classification. The `reason_code` and `summary` are likewise unchanged in shape; only the `details.uncited_entries` field appears.
+- Verifier gates and downstream skills (`paper-writing` Phase 6, `tools/verify_paper_audits.sh`) MUST NOT treat the presence of `uncited_entries` as a blocking signal.
+
+### When opt-in is appropriate
+
+- Pre-submission cleanup (drop dead bib entries before sharing camera-ready ZIP).
+- Shared lab bib file where the paper uses a subset and the user wants to confirm what is in scope.
+- Recurring audits where the user has previously seen the uncited count and wants to track whether it changed.
+
+### Fallback when bib enumeration fails
+
+If `--uncited` is enabled but full bib-key enumeration fails (e.g., malformed bib syntax that the parser cannot recover), the cited-entry audit must still proceed if at all possible. In that case:
+
+- Do **not** alter the top-level `verdict`, `reason_code`, or `summary`.
+- Emit `details.uncited_entries` as an empty array `[]`.
+- Add `details.uncited_entries_status: "unavailable"` plus a one-line note explaining why (e.g., `"bib parser could not enumerate keys; cited-entry audit completed normally"`).
+- Verifier gates and downstream skills MUST treat `unavailable` the same as the field being absent: not blocking.
+
+If the bib file cannot be read well enough to audit even the cited entries, fall back to the existing `BLOCKED` / `bib_unreadable` path defined in the verdict decision table; this is the same behavior as the no-flag default.
+
 ## Key Rules
 
 - **Fresh reviewer thread per audit run** — never reuse prior review context
@@ -221,6 +272,7 @@ Confirm:
 - **REPLACE/REMOVE require human approval** — never auto-modify content claims
 - **Always emit, never block** — this skill always writes `CITATION_AUDIT.json` with a verdict; the decision to block finalization lives in `paper-writing` Phase 6 + `tools/verify_paper_audits.sh`, driven by the `assurance` level. See "Submission Artifact Emission" below.
 - **Run once per submission** — the audit is wall-clock expensive (web lookups for each entry); not for every save
+- **Uncited detection is opt-in only** — never auto-enable; never block on uncited entries; existing callers must observe identical output if they do not pass `--uncited`
 
 ## Comparison with Other Audit Skills
 
@@ -249,7 +301,8 @@ After each `mcp__codex__codex` reviewer call, save the trace following `shared-r
 - `CITATION_AUDIT.md` (human-readable report) at paper root
 - `CITATION_AUDIT.json` (machine-readable ledger; schema below) at paper root
 - `.aris/traces/citation-audit/<date>_runNN/` (per-entry review traces)
-- Optional: applied fixes to `references.bib` + `sec/*.tex` (with --apply flag)
+- Optional: applied fixes to `references.bib` + `sec/*.tex` (with `--apply` flag)
+- Optional: `details.uncited_entries` field in JSON + `## Uncited Entries (opt-in)` MD section (with `--uncited` flag; field absent and section omitted when flag is unset)
 
 ## Submission Artifact Emission
 
@@ -287,6 +340,25 @@ The artifact conforms to the schema in `shared-references/assurance-contract.md`
 }
 ```
 
+### Optional: `details.uncited_entries` (only when `--uncited` is set)
+
+```json
+"details": {
+  ...
+  "uncited_entries": [
+    {"key": "<bibkey>", "suggestion": "prune" | "check", "note": "..."}
+  ],
+  "uncited_entries_status": "ok" | "unavailable"
+}
+```
+
+Field semantics:
+- Both fields are **omitted entirely** when the flag is not set. The default schema does not include either key.
+- When the flag is set and the set-diff completes normally, `uncited_entries_status` is `"ok"` and `uncited_entries` lists the detected keys (possibly empty if every bib entry is cited).
+- When the flag is set but bib-key enumeration fails (per "Fallback when bib enumeration fails" above), `uncited_entries_status` is `"unavailable"` and `uncited_entries` is `[]`. Downstream consumers MUST treat `"unavailable"` identically to the field being absent: not blocking.
+- Downstream consumers MUST treat absence of either field as the only valid default state and MUST NOT raise on missing.
+- `suggestion` is advisory only; the verifier and `paper-writing` Phase 6 do not block on it.
+
 ### `audited_input_hashes` scope
 
 Hash the **declared input set** actually passed to this audit: the `.bib`
@@ -312,6 +384,8 @@ any file outside the paper dir.
 | Only FIX verdicts (metadata drift, no context errors)          | `WARN`           | `metadata_drift`      |
 | Any REPLACE or REMOVE (wrong-context or hallucinated entry)    | `FAIL`           | `wrong_context`       |
 | Web lookups timed out / reviewer invocation failed             | `ERROR`          | `reviewer_error`      |
+
+The `--uncited` flag does **not** appear in this table: uncited entries are advisory only and never alter the top-level verdict or reason_code. They surface exclusively through `details.uncited_entries` and the optional MD section.
 
 ### Thread independence
 

--- a/skills/citation-audit/SKILL.md
+++ b/skills/citation-audit/SKILL.md
@@ -65,6 +65,8 @@ Output a flat list of `(key, file, line, surrounding_sentence)` tuples.
 
 Also build the inverse: for each bib entry, the list of all places it is cited.
 
+Define two protocol sets used throughout the rest of the workflow: `cited_keys` is the set of unique cite keys appearing in any `\cite{...}` invocation across the audited `*.tex` files (de-duplicated), and `bib_keys` is the set of keys parsed from the audited bib file(s). `cited_keys` drives Step 3 (audit only cited entries); `bib_keys \ cited_keys` is the uncited residual surfaced by the `--uncited` opt-in.
+
 If the user passed `--uncited`, also compute the set difference `bib_keys \ cited_keys` here and stash it for use in Steps 5 and the JSON aggregation; see "Uncited Entry Detection (opt-in)" below for the protocol. The set-diff is a string operation only and does not consume reviewer budget.
 
 Save the extracted contexts to `paper/.aris/citation-audit/contexts.txt` so the reviewer can read it directly. Use the paper-dir-relative path `.aris/citation-audit/contexts.txt` when recording the file in `audited_input_hashes`; do not stage under `/tmp` or other transient locations that the verifier cannot rehash later.
@@ -331,7 +333,7 @@ The artifact conforms to the schema in `shared-references/assurance-contract.md`
   "reviewer_reasoning": "xhigh",
   "generated_at":     "<UTC ISO-8601>",
   "details": {
-    "total_entries":  <int>,
+    "total_entries":  <int>,                 // count of audited cited entries (= |cited_keys|), NOT the bib-file size
     "per_entry":      [ { "key": "madaan2023selfrefine",
                           "verdict": "KEEP | FIX | REPLACE | REMOVE",
                           "axis_failures": [ "CONTEXT" | "METADATA" | "EXISTENCE" ],

--- a/skills/skills-codex/citation-audit/SKILL.md
+++ b/skills/skills-codex/citation-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: citation-audit
 description: "Zero-context verification that every bibliographic entry in the paper is real, correctly attributed, and used in a context the cited paper actually supports. Uses a fresh cross-model reviewer with web/DBLP/arXiv lookup to catch hallucinated authors, wrong years, fabricated venues, version mismatches, and wrong-context citations (cite present but the cited paper does not establish the claim). Use when user says \"审查引用\", \"check citations\", \"citation audit\", \"verify references\", \"引用核对\", or before submission to ensure bibliography integrity."
-argument-hint: [paper-directory-or-bib-file]
+argument-hint: [paper-directory-or-bib-file] [--uncited]
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent, WebSearch, WebFetch
 ---
 
@@ -65,11 +65,15 @@ Output a flat list of `(key, file, line, surrounding_sentence)` tuples.
 
 Also build the inverse: for each bib entry, the list of all places it is cited.
 
+Define two protocol sets used throughout the rest of the workflow: `cited_keys` is the set of unique cite keys appearing in any `\cite{...}` invocation across the audited `*.tex` files (de-duplicated), and `bib_keys` is the set of keys parsed from the audited bib file(s). `cited_keys` drives Step 3 (audit only cited entries); `bib_keys \ cited_keys` is the uncited residual surfaced by the `--uncited` opt-in.
+
+If the user passed `--uncited`, also compute the set difference `bib_keys \ cited_keys` here and stash it for use in Steps 5 and the JSON aggregation; see "Uncited Entry Detection (opt-in)" below for the protocol. The set-diff is a string operation only and does not consume reviewer budget.
+
 Save the extracted contexts to `paper/.aris/citation-audit/contexts.txt` so the reviewer can read it directly. Use the paper-dir-relative path `.aris/citation-audit/contexts.txt` when recording the file in `audited_input_hashes`; do not stage under `/tmp` or other transient locations that the verifier cannot rehash later.
 
 ### Step 3: Send each entry to fresh cross-model reviewer
 
-For each bib entry, launch a fresh Codex reviewer agent. Do not reuse the same reviewer across entries.
+For each **cited** bib entry — i.e., each key in `cited_keys` with at least one extracted citation context — launch a fresh Codex reviewer agent. Do not reuse the same reviewer across entries. Do **not** spawn an agent for entries in `bib_keys \ cited_keys`; those are detect-only and surface only when `--uncited` is explicitly enabled (see "Uncited Entry Detection" below).
 
 ```
 spawn_agent:
@@ -158,7 +162,7 @@ Write `CITATION_AUDIT.md`:
 # Citation Audit Report
 
 **Date**: 2026-04-19
-**Bib file**: references.bib
+**Bib file(s)**: references.bib
 **Total entries**: 29
 
 ## Summary
@@ -188,6 +192,20 @@ Write `CITATION_AUDIT.md`:
 [list of KEEP keys]
 ```
 
+When `--uncited` is set, append the following section after "All-Clean Entries":
+
+```markdown
+## Uncited Entries (opt-in)
+
+The following bib entries are present in the audited bib file(s) but are not referenced by any `\cite{...}` in the paper body:
+
+- `wainwright2008` — suggestion: prune (uncited; no local evidence of intent)
+- `lafferty2001` — suggestion: prune (uncited; no local evidence of intent)
+- `figueroa2024` — suggestion: check (a `% TODO: cite figueroa2024` comment was found in `sections/3.related.tex`)
+
+This section is detect-only; it does not change the top-level verdict.
+```
+
 ### Step 6: Apply fixes (interactive)
 
 For each FIX/REPLACE/REMOVE verdict, prompt the user:
@@ -212,6 +230,41 @@ Confirm:
 - No `Reference undefined` warnings
 - Page count unchanged or only minimally affected by metadata fixes
 
+## Uncited Entry Detection (opt-in)
+
+**Default**: disabled. Existing users see no behavior change — only `\cite{...}` keys are audited, and bib entries with no `\cite` reference in the manuscript are silently ignored.
+
+**Opt-in**: pass `--uncited` on invocation. The skill then performs a set-diff after Step 2 and reports bib entries that appear in any audited bib file(s) but are not cited anywhere in the paper. Detect-only — uncited entries are **not** sent to the reviewer agent, so there is no extra reviewer/web-lookup cost.
+
+### Why opt-in
+This skill's headline output is the three-axis audit on cited entries. Surfacing uncited bib entries by default would (a) change long-form output for every existing run, and (b) noise up the verdict for users who intentionally maintain a superset bib file (e.g., shared lab bib, in-progress section reorder where the cite has been removed but the entry intentionally retained). The flag preserves zero behavior change for existing callers.
+
+### Effect when enabled
+
+When `--uncited` is set:
+
+- `CITATION_AUDIT.md` gains a `## Uncited Entries (opt-in)` section listing the keys with a one-line suggestion each: `prune` (entry is dead weight; recommend deleting) or `check` (entry might be intentional; flag for user review). Default suggestion is `prune`; only emit `check` when there is concrete local evidence (e.g., a TODO comment in a `.tex` file mentioning the key, or a recently removed `\cite` visible in `git diff`). Do not infer intent from the bib key string alone.
+- `CITATION_AUDIT.json` `details` gains an `uncited_entries` array; see "Submission Artifact Emission" below for the schema.
+- The top-level `verdict` is **unchanged**: uncited entries do not upgrade or downgrade the PASS / WARN / FAIL / etc. classification. The `reason_code` and `summary` are likewise unchanged in shape; only the `details.uncited_entries` field appears.
+- Verifier gates and downstream skills (`paper-writing` Phase 6, `tools/verify_paper_audits.sh`) MUST NOT treat the presence of `uncited_entries` as a blocking signal.
+
+### When opt-in is appropriate
+
+- Pre-submission cleanup (drop dead bib entries before sharing camera-ready ZIP).
+- Shared lab bib file where the paper uses a subset and the user wants to confirm what is in scope.
+- Recurring audits where the user has previously seen the uncited count and wants to track whether it changed.
+
+### Fallback when bib enumeration fails
+
+If `--uncited` is enabled but full bib-key enumeration fails (e.g., malformed bib syntax that the parser cannot recover), the cited-entry audit must still proceed if at all possible. In that case:
+
+- Do **not** alter the top-level `verdict`, `reason_code`, or `summary`.
+- Emit `details.uncited_entries` as an empty array `[]`.
+- Add `details.uncited_entries_status: "unavailable"` plus a one-line note explaining why (e.g., `"bib parser could not enumerate keys; cited-entry audit completed normally"`).
+- Verifier gates and downstream skills MUST treat `unavailable` the same as the field being absent: not blocking.
+
+If the bib file cannot be read well enough to audit even the cited entries, fall back to the existing `BLOCKED` / `bib_unreadable` path defined in the verdict decision table; this is the same behavior as the no-flag default.
+
 ## Key Rules
 
 - **Fresh reviewer thread per audit run** — never reuse prior review context
@@ -220,6 +273,7 @@ Confirm:
 - **REPLACE/REMOVE require human approval** — never auto-modify content claims
 - **Always emit, never block** — this skill always writes `CITATION_AUDIT.json` with a verdict; the decision to block finalization lives in `paper-writing` Phase 6 + `tools/verify_paper_audits.sh`, driven by the `assurance` level. See "Submission Artifact Emission" below.
 - **Run once per submission** — the audit is wall-clock expensive (web lookups for each entry); not for every save
+- **Uncited detection is opt-in only** — never auto-enable; never block on uncited entries; existing callers must observe identical output if they do not pass `--uncited`
 
 ## Comparison with Other Audit Skills
 
@@ -248,7 +302,8 @@ After each reviewer agent call, save the trace following `shared-references/revi
 - `CITATION_AUDIT.md` (human-readable report) at paper root
 - `CITATION_AUDIT.json` (machine-readable ledger; schema below) at paper root
 - `.aris/traces/citation-audit/<date>_runNN/` (per-entry review traces)
-- Optional: applied fixes to `references.bib` + `sec/*.tex` (with --apply flag)
+- Optional: applied fixes to `references.bib` + `sec/*.tex` (with `--apply` flag)
+- Optional: `details.uncited_entries` field in JSON + `## Uncited Entries (opt-in)` MD section (with `--uncited` flag; field absent and section omitted when flag is unset)
 
 ## Submission Artifact Emission
 
@@ -277,7 +332,7 @@ The artifact conforms to the schema in `shared-references/assurance-contract.md`
   "reviewer_reasoning": "xhigh",
   "generated_at":     "<UTC ISO-8601>",
   "details": {
-    "total_entries":  <int>,
+    "total_entries":  <int>,                 // count of audited cited entries (= |cited_keys|), NOT the bib-file size
     "per_entry":      [ { "key": "madaan2023selfrefine",
                           "verdict": "KEEP | FIX | REPLACE | REMOVE",
                           "axis_failures": [ "CONTEXT" | "METADATA" | "EXISTENCE" ],
@@ -285,6 +340,25 @@ The artifact conforms to the schema in `shared-references/assurance-contract.md`
   }
 }
 ```
+
+### Optional: `details.uncited_entries` (only when `--uncited` is set)
+
+```json
+"details": {
+  ...
+  "uncited_entries": [
+    {"key": "<bibkey>", "suggestion": "prune" | "check", "note": "..."}
+  ],
+  "uncited_entries_status": "ok" | "unavailable"
+}
+```
+
+Field semantics:
+- Both fields are **omitted entirely** when the flag is not set. The default schema does not include either key.
+- When the flag is set and the set-diff completes normally, `uncited_entries_status` is `"ok"` and `uncited_entries` lists the detected keys (possibly empty if every bib entry is cited).
+- When the flag is set but bib-key enumeration fails (per "Fallback when bib enumeration fails" above), `uncited_entries_status` is `"unavailable"` and `uncited_entries` is `[]`. Downstream consumers MUST treat `"unavailable"` identically to the field being absent: not blocking.
+- Downstream consumers MUST treat absence of either field as the only valid default state and MUST NOT raise on missing.
+- `suggestion` is advisory only; the verifier and `paper-writing` Phase 6 do not block on it.
 
 ### `audited_input_hashes` scope
 
@@ -311,6 +385,8 @@ any file outside the paper dir.
 | Only FIX verdicts (metadata drift, no context errors)          | `WARN`           | `metadata_drift`      |
 | Any REPLACE or REMOVE (wrong-context or hallucinated entry)    | `FAIL`           | `wrong_context`       |
 | Web lookups timed out / reviewer invocation failed             | `ERROR`          | `reviewer_error`      |
+
+The `--uncited` flag does **not** appear in this table: uncited entries are advisory only and never alter the top-level verdict or reason_code. They surface exclusively through `details.uncited_entries` and the optional MD section.
 
 ### Thread independence
 


### PR DESCRIPTION
## Summary

Adds an opt-in `--uncited` flag to `/citation-audit` that surfaces bib entries present in the audited bib file(s) but not referenced by any `\cite{...}` in the paper body. Detect-only — uncited entries are never sent to the cross-model reviewer (no extra web-lookup cost).

**Default behavior preserved**: zero output change for existing callers running `/citation-audit "paper/"` without the flag. The optional `details.uncited_entries` JSON field and `## Uncited Entries (opt-in)` MD section are omitted entirely when the flag is unset; downstream consumers (`paper-writing` Phase 6, `tools/verify_paper_audits.sh`) MUST treat field absence as the only valid default state and never block on uncited entries.

## How it was built

Delegated agent (Claude Code session) implemented the opt-in in `f37ee09` against the briefing in `~/Desktop/aris_paper_discussion/aris_skill_dev_brief.md`. The delegated agent ran two rounds of cross-model review via `mcp__codex__codex` (gpt-5.5 xhigh, threads `019de48c` + `019de490`) and applied two A/C-blocker fixes (Step 3 prose contradiction with the new cited-only invariant; missing fallback when bib enumeration fails) plus several style nits.

Maintainer review (independent codex MCP audit, gpt-5.5 xhigh, thread `019de499`) flagged 4 additional required fixes, addressed in the fixup commit `4e9908e`:

1. **`skills/skills-codex/citation-audit/SKILL.md` mirror sync** — agent declined as "different architecture", but the architecture differs only in reviewer-invocation (`spawn_agent` vs `mcp__codex__codex`); skill semantics, output contract, verdict decision table, and verifier interaction are identical. Ported the entire `--uncited` opt-in (argument-hint, Step 2 set-diff stash, Step 3 cited-only restriction, Step 5 MD section, "Uncited Entry Detection (opt-in)" subsection, Output Contract additions, Key Rules bullet, JSON schema "Optional: details.uncited_entries" block, verdict-table footnote) using the spawn_agent idiom. Mainline + mirror now have keyword parity (`cited_keys` / `bib_keys` / `uncited_entries_status` / `details.uncited_entries` counts match).
2. **Define `cited_keys` / `bib_keys` as named protocol sets** in Step 2 of both files, so an executing agent has a precise referent for the cited-only restriction in Step 3 and the set-difference in the `--uncited` path.
3. **Clarify `details.total_entries` semantics** — inline comment in JSON schema noting the count is `|cited_keys|` (audited cited entries), not the bib-file size, since the cited-only Step 3 restriction makes the prior wording ambiguous.

### Subtle default-behavior note (Concern 1, intentional)

Step 3 changed from "For each bib entry, invoke ..." to "For each **cited** bib entry, invoke ..." — see commit `f37ee09` and the maintainer audit. Technically a behavior change for any user previously running `citation-audit` on a bib file containing uncited entries (those entries would have been audited under the old prose; they are now silent unless `--uncited` is passed). Kept as-is because the skill's existing description has always said it audits "a context the cited paper actually supports", which already implies cited-only semantics. The prior Step 3 wording was misleading; the new wording matches the headline contract.

## Files changed

- `skills/citation-audit/SKILL.md` (+82 / -4) — opt-in implementation + cited_keys/bib_keys definition + total_entries comment
- `skills/skills-codex/citation-audit/SKILL.md` (+86 / -4) — mirror sync (Codex CLI variant)

No `tools/` or shared-references/ changes; pure prose-driven flag.

## Test plan

- [ ] Default invocation regression: run `/citation-audit paper/` without flag on a paper with known unused bib entries; verify `CITATION_AUDIT.json` schema and `CITATION_AUDIT.md` output are byte-identical to a pre-merge baseline (no `details.uncited_entries`, no `## Uncited Entries (opt-in)` section).
- [ ] Opt-in basic: run `/citation-audit paper/ --uncited` on the same paper; verify `details.uncited_entries` lists the unused keys with `suggestion: prune` and `uncited_entries_status: "ok"`.
- [ ] Opt-in fallback: corrupt one bib entry (malformed syntax); verify `uncited_entries: []` + `uncited_entries_status: "unavailable"` and that the top-level verdict is unchanged.
- [ ] `paper-writing` Phase 6 chain: run the full paper-writing pipeline; verify it still calls `/citation-audit "paper/"` without `--uncited` and the artifact is byte-identical to a pre-merge baseline.
- [ ] `tools/verify_paper_audits.sh`: on a paper whose CITATION_AUDIT.json contains the optional `details.uncited_entries` field, the verifier MUST PASS (no rejection of unknown details keys).

## Known limitations / follow-ups

1. `--uncited` is detect-only; no auto-prune (prune still goes through Step 6 interactive flow with human approval).
2. The `suggestion: check` heuristic relies on local evidence (TODO comment, recent `git diff`); the SKILL.md describes the policy but the scan itself is agent-side.
3. Multi-bib-file singular-wording cleanup (4 remaining places say "references.bib" rather than "the bib file(s)") deferred as scope-control; Step 1 already handles multiple bib files explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)