### PR TITLE
docs(proof-checker): clarify thread-policy split between within-run and across-run

### DIFF
--- a/skills/proof-checker/SKILL.md
+++ b/skills/proof-checker/SKILL.md
@@ -521,7 +521,7 @@ If the augmented Phase 1 call fails so badly that the normal proof review cannot
 - **Claude analyzes, Codex reviews**: Claude reads proof, formulates questions, implements fixes. Codex provides adversarial review.
 - **Codex reasoning always xhigh**: Never downgrade.
 - **Send full content**: Don't summarize — send actual math for line-by-line checking.
-- **Preserve threadId**: Use `codex-reply` for follow-up rounds.
+- **Preserve threadId within a single run**: Use `codex-reply` for Phase 3 follow-up rounds within the same top-level `/proof-checker` invocation, so the reviewer keeps prior-issue context when judging whether a fix closed the gap. Across separate top-level invocations, always start a fresh thread (see "Thread independence" below).
 
 ### Fix quality
 - **Minimal fixes**: Fix exactly what's broken, nothing more.
@@ -690,11 +690,9 @@ must carry an explicit justification in `summary` + `details.issues`.
 
 ### Thread independence
 
-Every invocation uses a fresh `mcp__codex__codex` thread. Never
-`codex-reply` across proof-checker runs. Do not accept prior audit outputs
-(PAPER_CLAIM_AUDIT, CITATION_AUDIT, EXPERIMENT_LOG) as input — the fresh
-thread preserves reviewer independence per
-`shared-references/reviewer-independence.md`.
+Every **top-level** `/proof-checker` invocation starts a fresh `mcp__codex__codex` thread; do not reuse a saved threadId across separate invocations of this skill. Within a single top-level invocation, `codex-reply` is the correct primitive to thread the Phase 3 follow-up rounds — the reviewer needs prior-issue context to judge whether a fix actually closed the gap, and the Phase 1→3 flow above explicitly relies on this. The Phase 3.5 "Independent second review for FATAL/CRITICAL fixes" sub-step is the deliberate exception inside a single run: it must spawn a fresh thread so the blind reviewer has no exposure to the original critique.
+
+Do not accept prior audit outputs (PAPER_CLAIM_AUDIT, CITATION_AUDIT, EXPERIMENT_LOG) as input across separate invocations — the cross-run freshness is what preserves reviewer independence per `shared-references/reviewer-independence.md`.
 
 This skill never blocks by itself; `paper-writing` Phase 6 plus the
 verifier decide whether the verdict blocks finalization based on the


### PR DESCRIPTION
## Summary

Pure prose clarification of the thread-policy text in `skills/proof-checker/SKILL.md`. **No flags, no schema changes, no allowed-tools changes, no behavior change.**

The OLD prose was inconsistent with implementation:
- "Cross-model protocol" rule said "Use `codex-reply` for follow-up rounds" without scoping (within-run vs across-run).
- "Thread independence" section said "Never `codex-reply` across proof-checker runs" — correct but ambiguous about whether within-run `codex-reply` is OK.

In actual implementation:
- **Phase 3** (line 352): always uses `codex-reply` with saved threadId for re-review within the same run.
- **Phase 3.5** (line 357+): always spawns a fresh `mcp__codex__codex` thread for the blind FATAL/CRITICAL second-review sub-step.

So the prose was lagging behind code. This PR makes the two-level distinction explicit.

## What changed

- **`Cross-model protocol` rule** (line 521): "Preserve threadId" → "Preserve threadId within a single run" with explicit reason (reviewer needs prior-issue context to judge whether a fix closed the gap), and explicit pointer to "Thread independence" for the across-run rule.
- **`Thread independence` section** (line 690): Two-level rule:
  - Top-level invocations always start fresh (cross-run independence per `shared-references/reviewer-independence.md`).
  - Within a single invocation, `codex-reply` is the correct primitive for Phase 3 follow-up rounds.
  - Phase 3.5 blind review is the deliberate in-run exception (fresh thread, no critique exposure).

## Reviewer audit

Reviewer-side codex MCP audit (gpt-5.5 xhigh, thread `019de4c8`) — GREEN-LIGHT, no pre-merge fixes.

- Default contamination: No. New prose matches existing Phase 3 / Phase 3.5 implementation; pure clarification.
- Cross-skill side effects: No sibling updates required. `paper-claim-audit` / `citation-audit` are fresh-thread-only, do not need the split. `auto-paper-improvement-loop` has its own stronger fresh-every-round policy.
- Hard-fail dependency: N/A (prose-only). Phase 3.5 fresh-thread failure already maps to top-level `ERROR` / `reviewer_error` per the existing verdict table; no new fallback needed.
- 3-way merge sanity: Clean — branch is one commit on top of main `c93243c` (post YAML quote fix), no conflicts.

## Files changed

- `skills/proof-checker/SKILL.md` (+4 / -6) — prose only

## Test plan

- [ ] Default invocation regression: run `/proof-checker paper.tex` end-to-end on a paper with one CRITICAL issue; verify Phase 3 still uses `codex-reply` (saved threadId persists across rounds) and Phase 3.5 still spawns a fresh thread for the blind second-review on that issue.
- [ ] Cross-run independence: run `/proof-checker` twice in sequence; verify the second run starts a fresh thread (does not call `codex-reply` against the first run's thread).
- [ ] No silent behavior change: verify `PROOF_CHECK_STATE.json` schema and per-issue verdicts are identical between pre-PR and post-PR runs on the same input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)