### PR TITLE
docs(auto-paper-improvement-loop): cross-reference /proof-checker --restatement-check

### DIFF
--- a/skills/auto-paper-improvement-loop/SKILL.md
+++ b/skills/auto-paper-improvement-loop/SKILL.md
@@ -209,6 +209,16 @@ PY
 
 **Empirical motivation:** in our April 2026 NeurIPS run, `thm:dsm-oracle` had a 3-case split (w=0/1/>1) in main but no case split in appendix; `nu_T` was named "stationary" in main and "terminal" in appendix. These drifted multiple times across fix rounds because no automated check caught regression.
 
+**Optional deeper check: `/proof-checker --restatement-check`**
+
+The inline Python check above is the default and is sufficient for routine main-vs-appendix consistency. For broader coverage, you may additionally invoke `/proof-checker --restatement-check` (added in PR #189), which extends the comparison to:
+
+- Restatements in summary tables, abstract, "Key Contributions" lists, and discussion sections (not just main vs appendix).
+- Six named drift signatures classified by reviewer: `conditional_loss`, `scope_change`, `quantifier_loss`, `regime_envelope_change`, `constant_change`, `variable_rename`.
+- Structured findings emitted as `details.restatement_drift[]` in `PROOF_AUDIT.json`, suitable for downstream tooling or audit trails.
+
+This is advisory only — the inline Step 4.5 check remains the default and continues to run on every loop round. Consider invoking `/proof-checker --restatement-check` when (a) you suspect cross-location drift outside the main↔appendix axis (e.g., abstract overclaim relative to theorem statement), or (b) you want reviewer-graded drift signatures rather than raw string mismatches. Running both is supported and they are independent: the inline check fails fast on string drift, the proof-checker pass surfaces semantic-class drift.
+
 ### Step 5: Round 2 Review
 
 If `REVIEWER_BIAS_GUARD = true` (default), use a **fresh** `mcp__codex__codex` thread for Round 2. Do not reuse the Round 1 threadId for prompting. Save the returned threadId only for recovery bookkeeping.


### PR DESCRIPTION
## Summary

10-line advisory prose addition to `skills/auto-paper-improvement-loop/SKILL.md` Step 4.5, cross-referencing `/proof-checker --restatement-check` (PR #189) as an **optional** deeper check that complements the existing inline Python main-vs-appendix consistency check.

**Default behavior preserved**: the inline Step 4.5 Python check is still the default and continues to run on every loop round; `--restatement-check` is documented as opt-in for users who want broader coverage (summary tables / abstract / "Key Contributions" / discussion) and reviewer-graded drift signatures (the 6 named drift types from PR #189).

## What this PR is and is not

**Is**: a documentation cross-reference. The two checks are independent and the prose explicitly says so. Running both is supported.

**Is NOT**: a real delegation. Auto-paper-improvement-loop will not auto-invoke `/proof-checker --restatement-check`. If the maintainer later wants real delegation (drop the inline Python and call proof-checker directly), that is a medium-path refactor outside this PR's scope.

## Files changed

- `skills/auto-paper-improvement-loop/SKILL.md` (+10 / -0) — pure prose under Step 4.5, after the existing "Empirical motivation" block

## Test plan

- [ ] Default invocation regression: run `/auto-paper-improvement-loop` end-to-end on a paper with known main↔appendix theorem-statement drift; verify the inline Python check still runs every round and produces the same `STEP4.5_DRIFT.txt` output as before.
- [ ] Cross-reference rendering: view the new section on GitHub; verify the link to PR #189 resolves and the drift-signature list matches what `/proof-checker --restatement-check` actually emits.
- [ ] No interaction with `--restatement-check`: verify that NOT invoking `/proof-checker --restatement-check` produces identical pre-PR behavior (the cross-reference is text-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)