### PR TITLE
feat(install): add optional .aris/tools symlink during install (#174 Phase 0)

### DIFF
--- a/tests/test_install_aris_tools_symlink.py
+++ b/tests/test_install_aris_tools_symlink.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Regression test for install_aris.sh #174: project-local .aris/tools symlink.
+
+Covers:
+  install: fresh project gets `.aris/tools -> <repo>/tools`
+  install: idempotent on rerun
+  install: warns and leaves alone if `.aris/tools` already exists with
+           a different target / as a non-symlink path
+  uninstall: removes the managed symlink
+  uninstall: preserves non-managed `.aris/tools` (different target / real dir)
+  dry-run: prints planned action without writing anything
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SCRIPT = REPO_ROOT / "tools" / "install_aris.sh"
+
+
+class InstallTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="aris-174-"))
+        self.project = self.tmp / "project"
+        self.project.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run(self, *extra_args):
+        result = subprocess.run(
+            [
+                "bash",
+                str(INSTALL_SCRIPT),
+                str(self.project),
+                "--aris-repo",
+                str(REPO_ROOT),
+                "--quiet",
+                "--no-doc",
+                *extra_args,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    # ─── install behaviour ────────────────────────────────────────────────
+
+    def test_install_creates_tools_symlink(self):
+        result = self._run()
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        link = self.project / ".aris" / "tools"
+        self.assertTrue(link.is_symlink(), f"expected {link} to be a symlink")
+        self.assertEqual(
+            os.readlink(link),
+            str(REPO_ROOT / "tools"),
+            "managed symlink must point to the canonical aris-repo tools dir",
+        )
+
+    def test_install_dry_run_does_not_create_symlink(self):
+        # Run without --quiet so log() output reaches stdout for assertion
+        result = subprocess.run(
+            [
+                "bash",
+                str(INSTALL_SCRIPT),
+                str(self.project),
+                "--aris-repo",
+                str(REPO_ROOT),
+                "--no-doc",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        link = self.project / ".aris" / "tools"
+        self.assertFalse(link.exists(), "dry-run must not create the symlink")
+        self.assertIn(".aris/tools", result.stdout, "dry-run output must mention .aris/tools")
+
+    def test_install_is_idempotent(self):
+        # Run twice; second run should be a no-op for the tools symlink
+        self._run()
+        result = self._run()
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        link = self.project / ".aris" / "tools"
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(os.readlink(link), str(REPO_ROOT / "tools"))
+
+    def test_install_does_not_replace_existing_dir(self):
+        # User already has a real .aris/tools dir; installer must leave it alone
+        (self.project / ".aris").mkdir()
+        existing_dir = self.project / ".aris" / "tools"
+        existing_dir.mkdir()
+        marker = existing_dir / "user_file.txt"
+        marker.write_text("user content")
+
+        result = self._run()
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertFalse((self.project / ".aris" / "tools").is_symlink())
+        self.assertTrue(marker.exists(), "user-created content must be preserved")
+        self.assertEqual(marker.read_text(), "user content")
+
+    def test_install_does_not_replace_different_symlink(self):
+        # User already has .aris/tools pointing somewhere else
+        (self.project / ".aris").mkdir()
+        elsewhere = self.tmp / "elsewhere"
+        elsewhere.mkdir()
+        os.symlink(str(elsewhere), str(self.project / ".aris" / "tools"))
+
+        result = self._run()
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            os.readlink(self.project / ".aris" / "tools"),
+            str(elsewhere),
+            "non-managed symlink must be preserved",
+        )
+
+    # ─── uninstall behaviour ──────────────────────────────────────────────
+
+    def test_uninstall_removes_managed_symlink(self):
+        self._run()  # install
+        self.assertTrue((self.project / ".aris" / "tools").is_symlink())
+        result = self._run("--uninstall")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertFalse(
+            (self.project / ".aris" / "tools").exists(),
+            "uninstall must remove the managed symlink",
+        )
+
+    def test_uninstall_preserves_non_managed_dir(self):
+        # First install, then replace tools symlink with a user dir, then uninstall
+        self._run()
+        link = self.project / ".aris" / "tools"
+        link.unlink()
+        link.mkdir()
+        marker = link / "preserved.txt"
+        marker.write_text("preserved")
+
+        result = self._run("--uninstall")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertTrue(link.is_dir(), "user-created dir must be preserved by uninstall")
+        self.assertEqual(marker.read_text(), "preserved")
+
+    def test_uninstall_preserves_non_managed_symlink(self):
+        # Install creates managed symlink, user replaces with custom symlink, uninstall must skip
+        self._run()
+        link = self.project / ".aris" / "tools"
+        link.unlink()
+        elsewhere = self.tmp / "elsewhere"
+        elsewhere.mkdir()
+        os.symlink(str(elsewhere), str(link))
+
+        result = self._run("--uninstall")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertTrue(link.is_symlink(), "user-created symlink must be preserved")
+        self.assertEqual(os.readlink(link), str(elsewhere))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/install_aris.sh
+++ b/tools/install_aris.sh
@@ -44,6 +44,10 @@
 #   S9  If .aris/, .claude/, or .claude/skills/ is itself a symlink, abort.
 #   S10 Reject upstream entries that are symlinks to outside aris-repo.
 #   S11 Revalidate exact target match (lstat + readlink) before every mutation.
+#   S12 The optional `.aris/tools` symlink (added in #174) is the only managed
+#       artifact NOT tracked in the manifest. It is identified at uninstall
+#       time by exact target match against `<aris-repo>/tools`. Any other
+#       path or differently-targeted symlink at `.aris/tools` is left alone.
 #   S12 Temp files live in the same directory as the destination.
 #   S13 Skill names must match ^[A-Za-z0-9][A-Za-z0-9._-]*$ (slug regex).
 
@@ -526,6 +530,65 @@ apply_plan() {
     done < "$plan"
 }
 
+# Phase 0 (#174): ensure project-local `.aris/tools` symlink exists, pointing
+# to the canonical aris-repo `tools/` dir. Pure-additive: existing users who
+# don't rerun the installer never see this. The symlink is currently inert
+# (no SKILL.md references it); it sets up future #177 path-rewrites.
+#
+# Idempotent. If `.aris/tools` already exists with a different target (or as
+# a real file/dir), warn and leave it alone — never replace user content.
+# Membership in the "managed" set is determined by exact target match against
+# `$ARIS_REPO/tools`, not via the manifest, so we don't need to bump the
+# manifest format for this single-link addition (per #174 non-goals).
+ensure_tools_symlink() {
+    local link_path="$PROJECT_ARIS_DIR/tools"
+    local expected_target="$ARIS_REPO/tools"
+
+    if is_symlink "$link_path"; then
+        local cur; cur="$(read_link_target "$link_path")"
+        [[ "$cur" != /* ]] && cur="$(canonicalize "$(dirname "$link_path")/$cur")"
+        if [[ "$cur" == "$expected_target" ]]; then
+            return 0
+        fi
+        warn ".aris/tools already exists with different target ($cur); leaving alone (#174)"
+        return 0
+    fi
+
+    if [[ -e "$link_path" ]]; then
+        warn ".aris/tools already exists as a non-symlink path; leaving alone (#174)"
+        return 0
+    fi
+
+    if $DRY_RUN; then
+        log "  (dry-run) ln -s $expected_target $link_path"
+    else
+        ln -s "$expected_target" "$link_path"
+        log "  + .aris/tools -> tools/ (Phase 0, #174)"
+    fi
+}
+
+# Counterpart for uninstall: only remove `.aris/tools` if it is exactly the
+# managed symlink (target == $ARIS_REPO/tools). User-created directories /
+# files / different symlinks are untouched.
+remove_tools_symlink() {
+    local link_path="$PROJECT_ARIS_DIR/tools"
+    local expected_target="$ARIS_REPO/tools"
+
+    is_symlink "$link_path" || return 0
+    local cur; cur="$(read_link_target "$link_path")"
+    [[ "$cur" != /* ]] && cur="$(canonicalize "$(dirname "$link_path")/$cur")"
+    if [[ "$cur" != "$expected_target" ]]; then
+        return 0
+    fi
+
+    if $DRY_RUN; then
+        log "  (dry-run) rm $link_path"
+    else
+        rm -f "$link_path"
+        log "  - .aris/tools (managed symlink)"
+    fi
+}
+
 commit_manifest() {
     local manifest_tmp="$1"
     if $DRY_RUN; then log "  (dry-run) would commit manifest"; return; fi
@@ -625,6 +688,10 @@ do_uninstall() {
         fi
     done < "$manifest_data"
     rm -f "$manifest_data"
+    # #174 Phase 0: best-effort cleanup of `.aris/tools` symlink, only if it
+    # is exactly the managed symlink. Anything else (user-created dir, custom
+    # symlink target) is left alone.
+    remove_tools_symlink
     if ! $DRY_RUN; then
         # Keep .prev for forensics, remove current manifest
         [[ -f "$MANIFEST_PATH" ]] && mv -f "$MANIFEST_PATH" "$MANIFEST_PREV"
@@ -701,6 +768,9 @@ if (( N_CONFLICT > 0 )); then
 fi
 
 if $DRY_RUN; then
+    # #174 preview: print the planned `.aris/tools` symlink action (function
+    # is idempotent + DRY_RUN-aware, so it just logs in this mode)
+    ensure_tools_symlink
     log ""
     log "(dry-run) no changes made"
     exit 0
@@ -720,6 +790,10 @@ log ""
 log "Applying:"
 apply_plan "$PLAN_FILE" "$MANIFEST_TMP"
 commit_manifest "$MANIFEST_TMP"
+
+# #174 Phase 0: ensure project-local .aris/tools symlink (purely additive).
+# Runs after manifest commit so a failure here doesn't roll back skill links.
+ensure_tools_symlink
 
 # Handle prefer-upstream legacy archive AFTER successful apply
 if [[ "$LEGACY_KIND" == "real_dir" && "$MIGRATE_COPY" == "prefer-upstream" ]]; then


### PR DESCRIPTION
Closes #174.

## Summary

Phase 0 of the four-step tools-stability migration plan (#174 → #176 → #177 → #178). Pure-additive installer change: on every install / reconcile run, `install_aris.sh` now creates `.aris/tools -> <aris-repo>/tools` as a project-local convenience alias.

**Zero blast radius for existing users**: the symlink is only created when a user reruns `install_aris.sh`. Existing installations are not retroactively modified; no SKILL.md currently references `.aris/tools/*` so the symlink is currently inert (it sets up #177 path-rewrites).

## What this PR does

- **Install / reconcile**: creates `.aris/tools` symlink targeting `$ARIS_REPO/tools` after manifest commit.
- **Idempotent**: rerunning with the correct symlink already in place is a no-op.
- **Safe collisions**: if `.aris/tools` exists as a non-managed path (different symlink target, real directory, or regular file), the installer warns and continues without replacing user content.
- **Dry-run preview**: `--dry-run` prints the planned symlink action.
- **Uninstall**: removes the symlink only if it is exactly the managed symlink (target match against `$ARIS_REPO/tools`); any other path is preserved.

## What this PR does NOT do (per #174 non-goals)

- No SKILL.md changes (path rewrites land in #177).
- No stability-policy doc (lands in #176).
- No manifest format change. Membership in the "managed" set is determined by exact target match against `$ARIS_REPO/tools`, not via manifest tracking. New safety rule S12 documents this carve-out.

## Tests

`tests/test_install_aris_tools_symlink.py` — 8 cases, all passing locally:

1. Fresh install creates the symlink with the expected target.
2. Dry-run prints the planned action without writing.
3. Idempotent on rerun.
4. Existing user-created `.aris/tools` directory is preserved (with marker file).
5. Existing user symlink with a different target is preserved.
6. Uninstall removes the managed symlink.
7. Uninstall preserves a user-created `.aris/tools` directory.
8. Uninstall preserves a user-created `.aris/tools` symlink with a different target.

## Risk

🟢 **low**. If something goes wrong: only users who rerun `install_aris.sh` are affected, and the worst case is an extra inert symlink or a warning. Single `git revert` stops future creation.

## Known limitations

1. **Windows**: `install_aris.ps1` is NOT updated in this PR. Windows users will not get the `.aris/tools` symlink (or junction) until a follow-up PR. Tracked under the same issue series.
2. **Manifest tracking**: deliberately not added (per #174 non-goals). The trade-off is that uninstall must use target match instead of manifest lookup; the new safety rule S12 documents this exception.
3. **Inert until #177**: this PR alone doesn't make any skill use `.aris/tools/*`. Follow-up #177 incrementally rewrites SKILL.md tool references with multi-path resolver fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)