### PR TITLE
fix(experiment-queue): repair orchestration paths so queue actually launches

### DIFF
--- a/skills/experiment-queue/SKILL.md
+++ b/skills/experiment-queue/SKILL.md
@@ -101,7 +101,17 @@ Input can be:
 - **Grid spec** (Cartesian product of param values, e.g., `N=[64,128,256] × n=[50K,150K,500K,652K]`)
 - **Natural language description** (Claude parses into manifest)
 
-Save the built manifest to `<project>/experiment_queue/<timestamp>/manifest.json` for reproducibility.
+Bind the run identifiers once so every later step (manifest save, scp, launch, monitor, resume) refers to the same paths. Set these as local shell variables before generating the manifest:
+
+```bash
+# REPLACE the placeholder path before running, or pre-export PROJECT_DIR:
+PROJECT_DIR="${PROJECT_DIR:?set PROJECT_DIR to the local project root}"
+RUN_TS=$(date -u +%Y%m%dT%H%M%SZ)             # one timestamp per run, reused everywhere
+LOCAL_RUN_DIR="$PROJECT_DIR/experiment_queue/$RUN_TS"
+mkdir -p "$LOCAL_RUN_DIR"
+```
+
+Save the built manifest to `$LOCAL_RUN_DIR/manifest.json` for reproducibility.
 
 ### Step 2: Pre-flight
 
@@ -115,14 +125,66 @@ If any precondition fails, show user which jobs are blocked and why.
 
 ### Step 3: Launch Scheduler
 
-Run `tools/queue_manager.py` (bundled with this skill) as a detached `nohup` process on the SSH host:
+The scheduler implementation lives in `tools/experiment_queue/queue_manager.py`. Three preliminaries before launch.
+
+**3a. Resolve the local helper directory.** The two helpers (`queue_manager.py`, `build_manifest.py`) sit under `tools/experiment_queue/` in the ARIS repo. Use this fallback chain so the skill works from any project layout:
 
 ```bash
-ssh <server> 'nohup python3 ~/.aris_queue/queue_manager.py \
-  --manifest /tmp/manifest.json \
-  --state /tmp/queue_state.json \
-  --log /tmp/queue.log \
-  > /tmp/queue_mgr.log 2>&1 &'
+QUEUE_TOOLS=".aris/tools/experiment_queue"
+[ -f "$QUEUE_TOOLS/queue_manager.py" ] || QUEUE_TOOLS="tools/experiment_queue"
+[ -f "$QUEUE_TOOLS/queue_manager.py" ] || QUEUE_TOOLS="${ARIS_REPO:-}/tools/experiment_queue"
+[ -f "$QUEUE_TOOLS/queue_manager.py" ] || { echo "ERROR: experiment_queue helpers not found; rerun install_aris.sh or set ARIS_REPO" >&2; exit 1; }
+```
+
+The `.aris/tools` symlink is set up by `install_aris.sh` (#174). Older installs without that symlink fall through to `tools/experiment_queue` (works if invoked from inside the ARIS repo) or `$ARIS_REPO/tools/experiment_queue`.
+
+**3b. Compute remote paths.** Use both a remote-relative form (for `scp` destinations — modern `scp` runs in SFTP mode and does NOT reliably expand `$HOME` in destination paths) and a `$HOME`-prefixed form (for `ssh ... command` strings, where remote bash WILL expand `$HOME`):
+
+```bash
+REMOTE_RUN_REL=".aris_queue/runs/$RUN_TS"          # for scp destinations (relative to remote home)
+REMOTE_RUN_DIR="\$HOME/$REMOTE_RUN_REL"            # for ssh command strings (literal $HOME, expanded on remote)
+```
+
+**3c. Bootstrap the remote run directory and copy helpers + manifest.** Per-invocation and idempotent. Use a unique run directory rather than `/tmp` so concurrent queues do not collide and so resume-after-crash is reproducible.
+
+```bash
+ssh <server> "mkdir -p \"$REMOTE_RUN_DIR/logs\" \"\$HOME/.aris_queue\""
+scp "$QUEUE_TOOLS/queue_manager.py" "$QUEUE_TOOLS/build_manifest.py" <server>:.aris_queue/
+scp "$LOCAL_RUN_DIR/manifest.json" <server>:"$REMOTE_RUN_REL/manifest.json"
+```
+
+**3d. Launch the scheduler as a detached `nohup` process on the SSH host:**
+
+```bash
+ssh <server> "nohup python3 \"\$HOME/.aris_queue/queue_manager.py\" \\
+  --manifest \"$REMOTE_RUN_DIR/manifest.json\" \\
+  --state    \"$REMOTE_RUN_DIR/queue_state.json\" \\
+  --log-dir  \"$REMOTE_RUN_DIR/logs\" \\
+  > \"$REMOTE_RUN_DIR/queue_mgr.log\" 2>&1 &"
+```
+
+Notes for callers:
+- `--log-dir` is what `queue_manager.py` actually consumes (per-job log files for OOM detection). Do NOT pass `--log <path>` — that flag is declared but unused, and a single combined log breaks the per-job stale-screen / OOM heuristics.
+- Persist `RUN_TS` / `REMOTE_RUN_REL` / `REMOTE_RUN_DIR` to disk so monitoring and resume can reload them without regenerating:
+
+  ```bash
+  {
+    printf 'PROJECT_DIR=%q\n'    "$PROJECT_DIR"
+    printf 'RUN_TS=%q\n'         "$RUN_TS"
+    printf 'LOCAL_RUN_DIR=%q\n'  "$LOCAL_RUN_DIR"
+    printf 'REMOTE_RUN_REL=%q\n' "$REMOTE_RUN_REL"
+    printf 'REMOTE_RUN_DIR=%q\n' "$REMOTE_RUN_DIR"
+  } > "$LOCAL_RUN_DIR/run_meta.txt"
+  ```
+
+  `%q` shell-escapes the values so the file is safely sourceable later. Note that `REMOTE_RUN_DIR` keeps a literal `$HOME` (do not expand it locally), which is the right form for re-use inside `ssh "..."` strings later.
+
+**3e. Resume an existing queue (only when the user asks).** A fresh `RUN_TS` per invocation is correct for *new* queues. To resume a crashed queue, do NOT regenerate `RUN_TS` — reload the recorded values and re-run only the launch command (Step 3d), not the bootstrap (Step 3c):
+
+```bash
+LOCAL_RUN_DIR="/abs/path/to/project/experiment_queue/<existing-run-ts>"   # the run dir to resume
+. "$LOCAL_RUN_DIR/run_meta.txt"                                            # reloads PROJECT_DIR / RUN_TS / REMOTE_RUN_REL / REMOTE_RUN_DIR
+# Then re-run Step 3d verbatim. Do NOT re-run Step 3c (would overwrite manifest.json + state.json).
 ```
 
 The scheduler:
@@ -137,20 +199,21 @@ The scheduler:
 
 ### Step 4: Monitoring
 
-User can check state anytime:
+User can check state anytime, using `$REMOTE_RUN_DIR` from Step 3b (or reload from `$LOCAL_RUN_DIR/run_meta.txt` for an older run):
 
 ```bash
-ssh <server> cat /tmp/queue_state.json | jq '.jobs | group_by(.status) | map({(.[0].status): length}) | add'
+ssh <server> "cat \"$REMOTE_RUN_DIR/queue_state.json\"" \
+  | jq '.jobs | group_by(.status) | map({(.[0].status): length}) | add'
 ```
 
-Or invoke `/monitor-experiment` which reads the state file.
+Note: `/monitor-experiment` is currently focused on screen sessions, result JSONs, and W&B; it does not yet read `queue_state.json` directly. For queue-state monitoring, use the literal command above against the recorded `REMOTE_RUN_DIR`. (Tracking `/monitor-experiment` queue-state integration as a follow-up.)
 
 ### Step 5: Post-completion
 
 When all jobs in `manifest.json` are `completed` or `stuck`:
-- Scheduler exits cleanly
-- Write final summary to `<project>/experiment_queue/<timestamp>/summary.md`
-- Invoke `/analyze-results` if `analyze_on_complete: true`
+- The remote scheduler (`queue_manager.py`) exits cleanly with `All jobs done` to its own stdout (captured in `$REMOTE_RUN_DIR/queue_mgr.log`). It does NOT write the local summary.
+- The **local** skill agent then aggregates state into `$LOCAL_RUN_DIR/summary.md` (read `$REMOTE_RUN_DIR/queue_state.json`, group by status, optionally pull per-job logs).
+- Local skill agent invokes `/analyze-results` if `analyze_on_complete: true`.
 
 ## Grid Spec Syntax
 
@@ -301,8 +364,8 @@ Then user can check anytime or wait for summary report.
 - `/run-experiment` — single experiment deployment
 - `/monitor-experiment` — check progress (now reads from queue_state.json)
 - `/analyze-results` — post-hoc analysis
-- `tools/queue_manager.py` (bundled) — the scheduler implementation
-- `tools/build_manifest.py` (bundled) — build manifest from grid spec
+- `tools/experiment_queue/queue_manager.py` (bundled) — the scheduler implementation; resolved at runtime via the fallback chain in Step 3a
+- `tools/experiment_queue/build_manifest.py` (bundled) — build manifest from grid spec; same resolution chain
 
 ## Rationale / Source
 

--- a/skills/skills-codex/experiment-queue/SKILL.md
+++ b/skills/skills-codex/experiment-queue/SKILL.md
@@ -101,7 +101,17 @@ Input can be:
 - **Grid spec** (Cartesian product of param values, e.g., `N=[64,128,256] × n=[50K,150K,500K,652K]`)
 - **Natural language description** (Claude parses into manifest)
 
-Save the built manifest to `<project>/experiment_queue/<timestamp>/manifest.json` for reproducibility.
+Bind run identifiers once so every later step refers to the same paths:
+
+```bash
+# REPLACE the placeholder path before running, or pre-export PROJECT_DIR:
+PROJECT_DIR="${PROJECT_DIR:?set PROJECT_DIR to the local project root}"
+RUN_TS=$(date -u +%Y%m%dT%H%M%SZ)
+LOCAL_RUN_DIR="$PROJECT_DIR/experiment_queue/$RUN_TS"
+mkdir -p "$LOCAL_RUN_DIR"
+```
+
+Save the built manifest to `$LOCAL_RUN_DIR/manifest.json` for reproducibility.
 
 ### Step 2: Pre-flight
 
@@ -115,25 +125,62 @@ If any precondition fails, show user which jobs are blocked and why.
 
 ### Step 3: Launch Scheduler
 
-Resolve the bundled helper directory from the managed Codex install manifest or from `ARIS_REPO`, then copy the helpers to the SSH host:
+Resolve the bundled helper directory (`$PROJECT_DIR` / `$RUN_TS` / `$LOCAL_RUN_DIR` already set in Step 1):
 
 ```bash
 ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
 [ -n "$ARIS_REPO" ] || { echo "ERROR: ARIS_REPO not set. Use install_aris_codex.sh managed install or export ARIS_REPO=/path/to/ARIS."; exit 1; }
 QUEUE_TOOLS="$ARIS_REPO/tools/experiment_queue"
 [ -f "$QUEUE_TOOLS/queue_manager.py" ] || { echo "ERROR: queue_manager.py not found under $QUEUE_TOOLS"; exit 1; }
-ssh <server> 'mkdir -p ~/.aris_queue'
-scp "$QUEUE_TOOLS/queue_manager.py" "$QUEUE_TOOLS/build_manifest.py" <server>:~/.aris_queue/
 ```
 
-Run `tools/experiment_queue/queue_manager.py` as a detached `nohup` process on the SSH host:
+Compute remote paths (note: modern `scp` runs in SFTP mode and does NOT reliably expand `$HOME` in destination paths — use remote-relative for `scp`, `$HOME`-prefixed for `ssh` command strings):
 
 ```bash
-ssh <server> 'nohup python3 ~/.aris_queue/queue_manager.py \
-  --manifest /tmp/manifest.json \
-  --state /tmp/queue_state.json \
-  --log /tmp/queue.log \
-  > /tmp/queue_mgr.log 2>&1 &'
+REMOTE_RUN_REL=".aris_queue/runs/$RUN_TS"
+REMOTE_RUN_DIR="\$HOME/$REMOTE_RUN_REL"
+```
+
+Bootstrap remote run dir + copy helpers + copy manifest. Per-invocation, idempotent:
+
+```bash
+ssh <server> "mkdir -p \"$REMOTE_RUN_DIR/logs\" \"\$HOME/.aris_queue\""
+scp "$QUEUE_TOOLS/queue_manager.py" "$QUEUE_TOOLS/build_manifest.py" <server>:.aris_queue/
+scp "$LOCAL_RUN_DIR/manifest.json" <server>:"$REMOTE_RUN_REL/manifest.json"
+```
+
+Launch the scheduler as a detached `nohup` process:
+
+```bash
+ssh <server> "nohup python3 \"\$HOME/.aris_queue/queue_manager.py\" \\
+  --manifest \"$REMOTE_RUN_DIR/manifest.json\" \\
+  --state    \"$REMOTE_RUN_DIR/queue_state.json\" \\
+  --log-dir  \"$REMOTE_RUN_DIR/logs\" \\
+  > \"$REMOTE_RUN_DIR/queue_mgr.log\" 2>&1 &"
+```
+
+Notes: `--log-dir` is what `queue_manager.py` actually consumes (per-job log files for OOM detection). Do NOT pass `--log <path>` — that flag is declared but unused.
+
+Persist run identifiers for monitoring + resume (sourceable later):
+
+```bash
+{
+  printf 'PROJECT_DIR=%q\n'    "$PROJECT_DIR"
+  printf 'RUN_TS=%q\n'         "$RUN_TS"
+  printf 'LOCAL_RUN_DIR=%q\n'  "$LOCAL_RUN_DIR"
+  printf 'REMOTE_RUN_REL=%q\n' "$REMOTE_RUN_REL"
+  printf 'REMOTE_RUN_DIR=%q\n' "$REMOTE_RUN_DIR"
+} > "$LOCAL_RUN_DIR/run_meta.txt"
+```
+
+`%q` shell-escapes values; `REMOTE_RUN_DIR` keeps a literal `$HOME` (correct for later reuse inside `ssh "..."`).
+
+**Resume an existing queue.** Do NOT regenerate `RUN_TS`. Reload from `run_meta.txt` and re-run only the launch command above (not the bootstrap):
+
+```bash
+LOCAL_RUN_DIR="/abs/path/to/project/experiment_queue/<existing-run-ts>"
+. "$LOCAL_RUN_DIR/run_meta.txt"
+# Then re-run the launch command verbatim; do NOT re-run mkdir/scp.
 ```
 
 The scheduler:
@@ -148,20 +195,21 @@ The scheduler:
 
 ### Step 4: Monitoring
 
-User can check state anytime:
+User can check state anytime, using `$REMOTE_RUN_DIR` from Step 3 (or reload it from `$LOCAL_RUN_DIR/run_meta.txt`):
 
 ```bash
-ssh <server> cat /tmp/queue_state.json | jq '.jobs | group_by(.status) | map({(.[0].status): length}) | add'
+ssh <server> "cat \"$REMOTE_RUN_DIR/queue_state.json\"" \
+  | jq '.jobs | group_by(.status) | map({(.[0].status): length}) | add'
 ```
 
-Or invoke `/monitor-experiment` which reads the state file.
+Note: `/monitor-experiment` is currently focused on screen sessions, result JSONs, and W&B; it does not yet read `queue_state.json` directly. For queue-state monitoring, use the literal command above.
 
 ### Step 5: Post-completion
 
 When all jobs in `manifest.json` are `completed` or `stuck`:
-- Scheduler exits cleanly
-- Write final summary to `<project>/experiment_queue/<timestamp>/summary.md`
-- Invoke `/analyze-results` if `analyze_on_complete: true`
+- The remote scheduler (`queue_manager.py`) exits cleanly with `All jobs done` to its own stdout (captured in `$REMOTE_RUN_DIR/queue_mgr.log`). It does NOT write the local summary.
+- The **local** skill agent then aggregates state into `$LOCAL_RUN_DIR/summary.md` (read `$REMOTE_RUN_DIR/queue_state.json`, group by status, optionally pull per-job logs).
+- Local skill agent invokes `/analyze-results` if `analyze_on_complete: true`.
 
 ## Grid Spec Syntax
 

--- a/tools/experiment_queue/README.md
+++ b/tools/experiment_queue/README.md
@@ -9,11 +9,15 @@ Scheduler and manifest builder for `/experiment-queue` skill.
 
 ## Install on Remote
 
-The skill auto-installs these on the SSH host under `~/.aris_queue/`:
+The `/experiment-queue` skill auto-installs these on the SSH host under `~/.aris_queue/` per invocation (idempotent). The skill resolves the local helpers via a fallback chain (`.aris/tools/experiment_queue/` → `tools/experiment_queue/` → `$ARIS_REPO/tools/experiment_queue/`) so it works from any project layout.
+
+For manual install (run from anywhere; `$ARIS_REPO` points at the cloned ARIS repo root):
 
 ```bash
 ssh <server> 'mkdir -p ~/.aris_queue'
-scp queue_manager.py build_manifest.py <server>:~/.aris_queue/
+scp "$ARIS_REPO/tools/experiment_queue/queue_manager.py" \
+    "$ARIS_REPO/tools/experiment_queue/build_manifest.py" \
+    <server>:~/.aris_queue/
 ```
 
 ## Example
@@ -53,18 +57,29 @@ python3 build_manifest.py --config grid_spec.yaml --output manifest.json
 
 ### 3. Launch scheduler
 
+Use a per-run directory under `~/.aris_queue/runs/` so concurrent queues don't collide and crash-resume is reproducible. Note that `scp` runs in SFTP mode in modern OpenSSH and does NOT reliably expand `$HOME` in destination paths — use remote-relative paths for `scp` destinations and `$HOME`-prefixed paths only inside `ssh` command strings (where remote bash expands them):
+
 ```bash
-ssh <server> 'nohup python3 ~/.aris_queue/queue_manager.py \
-    --manifest /tmp/manifest.json \
-    --state /tmp/queue_state.json \
-    --log-dir /home/rfyang/rfyang_code/dllm_experiments_torch \
-    > /tmp/queue_mgr.log 2>&1 &'
+RUN_TS=$(date -u +%Y%m%dT%H%M%SZ)
+REMOTE_RUN_REL=".aris_queue/runs/$RUN_TS"          # for scp (relative to remote home)
+REMOTE_RUN_DIR="\$HOME/$REMOTE_RUN_REL"            # for ssh commands (expanded remotely)
+
+ssh <server> "mkdir -p \"$REMOTE_RUN_DIR/logs\" \"\$HOME/.aris_queue\""
+scp manifest.json <server>:"$REMOTE_RUN_REL/manifest.json"
+
+ssh <server> "nohup python3 \"\$HOME/.aris_queue/queue_manager.py\" \\
+    --manifest \"$REMOTE_RUN_DIR/manifest.json\" \\
+    --state    \"$REMOTE_RUN_DIR/queue_state.json\" \\
+    --log-dir  \"$REMOTE_RUN_DIR/logs\" \\
+    > \"$REMOTE_RUN_DIR/queue_mgr.log\" 2>&1 &"
 ```
+
+> Note: `--log-dir` is the per-job log directory the scheduler reads for OOM detection. The flag `--log` is declared by argparse but unused; do not pass it.
 
 ### 4. Monitor
 
 ```bash
-ssh <server> 'jq ".jobs | group_by(.status) | map({(.[0].status): length}) | add" /tmp/queue_state.json'
+ssh <server> "jq '.jobs | group_by(.status) | map({(.[0].status): length}) | add' \"$REMOTE_RUN_DIR/queue_state.json\""
 ```
 
 Returns:

--- a/tools/experiment_queue/queue_manager.py
+++ b/tools/experiment_queue/queue_manager.py
@@ -9,8 +9,11 @@ Usage (on remote):
     nohup python3 queue_manager.py \\
         --manifest manifest.json \\
         --state queue_state.json \\
-        --log queue.log \\
+        --log-dir ./logs \\
         > queue_mgr.log 2>&1 &
+
+(Pass --log-dir, NOT --log: --log is declared but unused; per-job log
+files in --log-dir drive OOM detection and stale-screen cleanup.)
 
 The manifest.json is either produced manually or by `build_manifest.py`.
 


### PR DESCRIPTION
User-reported regression: `/experiment-queue` could not find its orchestration scripts or set up the remote run directory at runtime, making the skill unusable for fresh installs.

## Root causes (4 user-visible + 3 surfaced during audit)

1. **Local helper path wrong**: SKILL.md referenced `tools/queue_manager.py` and `tools/build_manifest.py`, but the real files live under `tools/experiment_queue/`. The `experiment_queue/` subdir was silently missing from all skill references.
2. **Remote bootstrap missing**: launch command assumed `~/.aris_queue/queue_manager.py` existed on the remote host, but the workflow never described how to put it there. Fresh users had no `scp` / `rsync` step.
3. **`scp` + `$HOME` unreliable**: modern OpenSSH `scp` runs in SFTP mode and does NOT expand `$HOME` in destination paths. The example `scp ... <server>:$HOME/.aris_queue/` would silently drop files or write them to a literal `$HOME` directory name.
4. **`--log` flag unused**: launch invocation passed `--log /tmp/queue.log`, but `queue_manager.py` declares `--log-dir` (not `--log`) and relies on per-job log files in `--log-dir` for OOM detection. The flag was silently ignored and OOM-aware retry could not find the per-job logs.

Surfaced during cross-model audit:
5. Manifest never copied to remote (only saved locally).
6. `<project>` placeholder embedded inside executable bash blocks.
7. Step 5 implied the remote scheduler writes the local `summary.md` (it does not).

## Cross-model audit

Three rounds of Codex MCP `gpt-5.5` xhigh review (threads `019de7b4` + `019de7b8` + `019de7bf`):
- **Round 1**: confirmed 3 user-reported bugs, surfaced 4 more.
- **Round 2**: verified prose fix and surfaced 6 follow-ups (scp+`$HOME`, `RUN_TS` drift, executable placeholder, Step 4 monitor overclaim, missing resume guidance, Codex mirror staleness).
- **Round 3**: verified those fixes, surfaced 4 more (`run_meta.txt` write missing, resume reload underspecified, mirror Step 1 forward reference, Step 5 author ambiguity).
- **Round 4**: maintainer self-audit (all round-3 fixes verified in place).

## What changed

**`skills/experiment-queue/SKILL.md`** — Step 1 binds `PROJECT_DIR` / `RUN_TS` / `LOCAL_RUN_DIR` once with a `${PROJECT_DIR:?...}` placeholder trap. Step 3 splits into:
- 3a: helper resolution with `.aris/tools/experiment_queue` → `tools/experiment_queue` → `$ARIS_REPO/tools/experiment_queue` fallback (uses the `.aris/tools` symlink from PR #192).
- 3b: compute `REMOTE_RUN_REL` (relative for `scp`) + `REMOTE_RUN_DIR` (with literal `$HOME` for `ssh` command strings).
- 3c: `mkdir` + `scp` helpers + `scp` manifest, all using remote-relative paths.
- 3d: launch with `--log-dir` (not `--log`); persist `run_meta.txt` with `printf '%q'` so values are sourceable later.
- 3e: resume an existing queue — source `run_meta.txt` and rerun only the launch command.

Step 5 now explicitly states the remote scheduler does NOT write the local summary; the local skill agent does.

**`tools/experiment_queue/README.md`** — parallel fixes for the manual example.

**`tools/experiment_queue/queue_manager.py`** — docstring `--log queue.log` → `--log-dir ./logs` with explicit anti-trap note (`--log` is declared by argparse but unused).

**`skills/skills-codex/experiment-queue/SKILL.md`** — parallel updates for the Codex CLI mirror with mirror-specific helper resolution preserved.

## What was NOT changed

- `queue_manager.py` logic. No change to OOM-aware retry, stale-screen cleanup, wave gating, screen naming, state machine, or resume behavior.
- Manifest format.
- The remote install location (`~/.aris_queue/`) — kept stable for backward compatibility with anyone who manually `scp`'d helpers before.

## Files changed

- `skills/experiment-queue/SKILL.md` (+89 / -19)
- `skills/skills-codex/experiment-queue/SKILL.md` (+57 / -16)
- `tools/experiment_queue/README.md` (+18 / -5)
- `tools/experiment_queue/queue_manager.py` (+5 / -1)

## Test plan

- [ ] Fresh-install regression: clone ARIS into `~/Desktop/test-aris`, install via `bash tools/install_aris.sh /tmp/test-project --aris-repo ~/Desktop/test-aris`, then in `/tmp/test-project` invoke `/experiment-queue` with a 2-job test grid; verify the helpers get scp'd to remote and the scheduler launches without `--log` warnings.
- [ ] Resume test: kill the scheduler mid-run, source `$LOCAL_RUN_DIR/run_meta.txt`, rerun only Step 3d; verify `queue_state.json` is preserved and the scheduler picks up where it left off.
- [ ] Concurrent queues: launch two `/experiment-queue` invocations from the same project within seconds of each other; verify they get different `RUN_TS` and do not collide.
- [ ] OOM detection: trigger a CUDA OOM in one job; verify it gets marked `failed_oom` and retried (this exercises the `--log-dir` per-job log path).

## Risk

🟡 **medium**. Pure prose / docstring change, no Python logic touched, no scheduler-behavior change, no schema change. Worst case: a downstream caller still hardcodes the old paths and needs separate update. Mitigated by keeping `~/.aris_queue/` as the stable remote install location and documenting fallback resolution for older installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)