### PR TITLE
feat(idea-discovery): include gemini in Phase 1 literature survey by default

### DIFF
--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -111,14 +111,22 @@ Phase 1 and Phase 2 will use `idea-stage/REF_PAPER_SUMMARY.md` as additional con
 
 ### Phase 1: Literature Survey
 
-Invoke `/research-lit` to map the research landscape:
+Invoke `/research-lit` to map the research landscape. Idea discovery is exactly the place where Gemini's AI-driven broad coverage adds value, so include `gemini` as a source by default unless the user already specified an explicit `— sources:` directive in their idea-discovery invocation:
 
 ```
+# If $ARGUMENTS already contains "— sources:", pass through unchanged
+# (the user is in control of source selection):
 /research-lit "$ARGUMENTS"
+
+# Otherwise (the common case), include gemini explicitly for broader discovery:
+/research-lit "$ARGUMENTS" — sources: all, gemini
 ```
+
+If `gemini-cli` is not installed, `/research-lit` skips the Gemini source gracefully with a warning — no break to the pipeline. Users who want to force-disable Gemini in idea-discovery can pass `/idea-discovery "topic" — sources: all` explicitly (which becomes the literal source list, no auto-injection).
 
 **What this does:**
 - Search arXiv, Google Scholar, Semantic Scholar for recent papers
+- Plus Gemini-driven broad discovery (sub-problem decomposition, naming variants, alias coverage) when `gemini-cli` is available
 - Build a landscape map: sub-directions, approaches, open problems
 - Identify structural gaps and recurring limitations
 - Output a literature summary (saved to working notes)


### PR DESCRIPTION
Phase 1 of `/idea-discovery` now passes `— sources: all, gemini` to `/research-lit` by default, so the workflow benefits from Gemini's AI-driven broad coverage in addition to the existing default sources.

Opt-out: `/idea-discovery "topic" — sources: all` (or any explicit `— sources:`) bypasses the auto-injection. Graceful skip when `gemini-cli` is not installed.

Reviewer audit: Codex MCP `gpt-5.5` xhigh GREEN-LIGHT (thread `019de87f`).

Follow-up tracked: `/research-lit`'s internal gemini block still pins `gemini-2.5-pro`, while `/gemini-search` standalone now defaults to `gemini-3-pro-preview` (PR #195). Aligning the two would make `/idea-discovery` and `/gemini-search` use the same model. Logged in TODO_aris_post_paper.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)