### PR TITLE
feat(kill-argument): standalone Attack-Adjudication skill + W3 integration + assurance-schema upgrade

### DIFF
--- a/skills/auto-paper-improvement-loop/SKILL.md
+++ b/skills/auto-paper-improvement-loop/SKILL.md
@@ -289,29 +289,37 @@ mcp__codex__codex:
 
 If `REVIEWER_BIAS_GUARD = false` (legacy debugging only), use `mcp__codex__codex-reply` with the saved threadId; this is **not** the recommended path.
 
-### Step 5.5: Kill Argument Exercise (theory papers only)
+### Step 5.5: Kill Argument Exercise (theory / scope-heavy papers only)
 
-Run this only if the paper is theory-heavy (≥5 `\begin{theorem}|\begin{lemma}|\begin{proposition}|\begin{corollary}` environments in the source) and only on the final scheduled round (`current_round == MAX_ROUNDS`).
+Run this only if the paper is theory-heavy (≥5 `\begin{theorem}|\begin{lemma}|\begin{proposition}|\begin{corollary}` environments in the source) or has explicit scope/generality claims in title/abstract, and only on the final scheduled round (`current_round == MAX_ROUNDS`).
 
-This is a late-stage adversarial check. It must always use **fresh** `mcp__codex__codex` threads, never `codex-reply`, and it must not reuse any prior review context.
+**Delegate to `/kill-argument`** — the canonical implementation lives at `skills/kill-argument/SKILL.md` (extracted in May 2026). This step does NOT re-implement the Attack-and-Adjudication prompt template; instead, invoke the skill and read its output:
 
-**Thread 1: Attack**
-- Use a fresh thread with only the current paper files.
-- Prompt: "Construct the single best argument to reject this paper in 200 words. Focus on theorem validity, assumption mismatch, missing proof obligations, limit-order ambiguity, and claim/evidence gaps. Do not reference prior rounds or fixes."
+```bash
+# Invoke the canonical adversarial-review primitive on the current paper.
+# /kill-argument runs two fresh-thread codex 5.5 xhigh calls and writes
+# KILL_ARGUMENT.{md,json} into the paper directory. It is detect-only —
+# it never edits the paper itself.
+/kill-argument "$PAPER_DIR"
 
-**Thread 2: Defense**
-- Use a second fresh thread with the current paper files plus the attack memo.
-- Prompt: "Now defend the paper against the attack memo. For each rejection point, classify it as already fixed, partially fixed, or still unresolved, and cite the current files. Do not reuse prior review context."
+# Read the structured verdict.
+KILL_VERDICT=$(jq -r '.verdict' "$PAPER_DIR/KILL_ARGUMENT.json")
+KILL_REASON=$(jq -r '.reason_code' "$PAPER_DIR/KILL_ARGUMENT.json")
+```
 
-**Merge rule**
-- Dedupe attack points against the Round 2 weakness list by semantic overlap.
-- Append any novel unresolved attack point to the Step 6 fix list before implementation.
-- If the defense cannot refute a point, keep it at the original severity or raise it by one level if it exposes a main-theorem or core-assumption failure.
-- If the defense shows the issue is already fixed in the current files, only downgrade after verifying the file evidence.
-- Record both memos in `PAPER_IMPROVEMENT_LOG.md`.
+**Merge rule** (auto-loop's responsibility — `/kill-argument` itself is detect-only):
+
+- Read `details.decomposed_points` from `KILL_ARGUMENT.json`.
+- For each point with `verdict == "still_unresolved"` or `verdict == "partially_answered"` at `severity_if_unresolved == "critical"`:
+  - Dedupe against the Round 2 weakness list by semantic overlap (~85% similarity threshold).
+  - If novel, append it to the Step 6 fix list with the recommended_fix as the action description.
+- If the adjudication shows the issue is `answered_by_current_text`, only downgrade an existing weakness item after verifying the cited file:line evidence yourself.
+- Record both `KILL_ARGUMENT.md` and the merge decision in `PAPER_IMPROVEMENT_LOG.md`.
 - If `HUMAN_CHECKPOINT = true`, include the merged findings in the checkpoint summary before asking the user to proceed.
 
-This phase feeds directly into Step 6. The attack/defense findings must be merged before the final recompile.
+This phase feeds directly into Step 6. The merged findings must land before the final recompile.
+
+If `/kill-argument` returns `verdict: NOT_APPLICABLE` (paper isn't theory- or scope-heavy enough to need this check), skip Step 5.5 entirely and proceed to Step 6. If it returns `BLOCKED` or `ERROR`, log the reason in `PAPER_IMPROVEMENT_LOG.md` and proceed without merging — the loop should not stall on an adversarial check that cannot run.
 
 **Empirical motivation:** in a real submission run, after several rounds of standard improvement (score 7-8/10), the kill-argument exercise surfaced framing weaknesses that no prior review caught (e.g., a setting being mostly conditional rather than truly general, or a baseline being irrelevant to real systems). Author rebuttal forced explicit scope qualifications in abstract and discussion.
 
@@ -488,7 +496,7 @@ paper/
 
 ## Typical Score Progression
 
-Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
+Based on end-to-end testing on a real theory-paper run:
 
 | Round | Score | Key Improvements |
 |-------|-------|-----------------|
@@ -497,7 +505,7 @@ Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
 | Round 2 | 7/10 (content) | Added synthetic validation, formal truncation proposition, stronger limitations |
 | Round 3 | 5→8.5/10 (format) | Removed hero fig, appendix, compressed conclusion, fixed overfull hbox |
 
-**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final: 8 pages main body, 0 overfull hbox, ICLR-compliant.
+**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final state at submission: clean overfull-hbox count and venue-format-compliant length.
 
 ## Review Tracing
 

--- a/skills/kill-argument/SKILL.md
+++ b/skills/kill-argument/SKILL.md
@@ -17,7 +17,7 @@ A balanced reviewer might list "scope-overclaim risk" as MAJOR alongside 3-5 oth
 
 This skill runs that adversarial pass deliberately, then forces a second fresh reviewer to defend point-by-point, classify each rejection as already-fixed / partially-fixed / still-unresolved, and surface what's actually load-bearing.
 
-**Empirical motivation** (NeurIPS 2026 D-LLM theory paper, April 2026): after 5 standard improvement rounds settling at score 7-8/10, kill-argument surfaced two framing weaknesses no prior review caught — "width-w is mostly conditional" and "CRF irrelevant to real D-LLMs".  Author rebuttal forced explicit scope qualifications in abstract and discussion that weren't visible from the score-based reviews alone.
+**Empirical motivation:** in a real submission run, after several rounds of standard improvement (score 7-8/10), the kill-argument exercise surfaced framing weaknesses that no prior review caught (e.g., a setting being mostly conditional rather than truly general, or a baseline being irrelevant to real systems).  Author rebuttal forced explicit scope qualifications in abstract and discussion that weren't visible from the score-based reviews alone.
 
 ## How This Differs From Other Review Skills
 
@@ -47,7 +47,7 @@ This skill is most valuable for **theory papers** with ≥5 theorem-class enviro
 - **CONTEXT_POLICY** = `fresh` (REVIEWER_BIAS_GUARD).  Each thread is a fresh `mcp__codex__codex` call.  **Never** use `mcp__codex__codex-reply`.  No prior review summary, fix list, or executor explanation enters either prompt.
 - **ATTACK_LENGTH** = approximately 200 words (do not exceed 250).  Single coherent argument, not a list.
 - **DEFENSE_DECOMPOSITION** = 3-7 atomic rejection points extracted from the attack memo.  Each gets its own classification.
-- **CLASSIFICATION** = `already_fixed` / `partially_fixed` / `still_unresolved`.
+- **CLASSIFICATION** = `answered_by_current_text` / `partially_answered` / `still_unresolved`.  (Names chosen so the adjudicator does not assume "fixed" implies prior history of patching — they read the paper as a fresh reviewer would.)
 - **OUTPUT** = `KILL_ARGUMENT.md` (human-readable) + `KILL_ARGUMENT.json` (machine-readable) in the paper directory.
 
 ## Workflow
@@ -133,7 +133,7 @@ mcp__codex__codex:
 
 Save the returned `threadId` for the trace; do NOT pass it to Thread 2.  Save the attack memo verbatim — both Thread 2 and the human-readable report use it.
 
-### Step 3: Defense memo (Thread 2, fresh codex with attack + paper)
+### Step 3: Adjudication memo (Thread 2, fresh codex with attack + paper)
 
 Invoke a second `mcp__codex__codex` call (still NOT `codex-reply` — Thread 2 is independent of Thread 1's codex history):
 
@@ -144,9 +144,12 @@ mcp__codex__codex:
   sandbox: read-only
   cwd: <paper directory>
   prompt: |
-    You are defending a paper against a hostile reviewer's rejection memo.
-    This is the defense pass of a kill-argument adversarial check. Fresh,
-    zero-context defense; do not reference any prior reviews / fix lists.
+    You are an independent area-chair adjudicator examining whether the
+    current paper text answers a hostile reviewer's rejection memo.
+    You are NOT the paper's defender — your job is to read the attack
+    point-by-point and rule, from the current source files alone,
+    whether each point stands or falls. Fresh, zero-context adjudication;
+    do not reference any prior reviews / fix lists.
 
     ## Paper files
     [list paths same as Step 2]
@@ -156,21 +159,25 @@ mcp__codex__codex:
 
     ## Your task
     The attack is one continuous argument, but it makes multiple distinct
-    rejection points that you must defend separately. Decompose the attack
-    into its atomic rejection points (3-7 of them), then for each point
-    classify it:
+    rejection points that you must adjudicate separately. Decompose the
+    attack into its atomic rejection points (3-7 of them), then for each
+    point classify it:
 
-    - already_fixed: the current paper text already mitigates this point
-      (cite specific file:line evidence)
-    - partially_fixed: paper has some response but not enough to refute
+    - answered_by_current_text: the current paper source already mitigates
+      this point (cite specific file:line evidence)
+    - partially_answered: paper has some response but not enough to refute
       the attack as written
     - still_unresolved: paper has no effective response
+
+    The label `answered_by_current_text` is intentional — "fixed" implies
+    history of patching and biases toward optimism. You are reading the
+    paper as a reviewer would, with no knowledge of prior round drafts.
 
     For each rejection point, output:
     ### Point P_n: <short label>
     **Attack claim**: <the specific accusation, ~30 words>
-    **Verdict**: already_fixed | partially_fixed | still_unresolved
-    **Defense evidence**: <cite file:line, ~50 words>
+    **Verdict**: answered_by_current_text | partially_answered | still_unresolved
+    **Evidence (or lack of)**: <cite file:line, ~50 words>
     **Severity if unresolved**: critical | major | minor
     **If unresolved, recommended fix**: <one specific actionable sentence>
 
@@ -178,14 +185,14 @@ mcp__codex__codex:
 
     ## Summary
     Total rejection points: N
-    - already_fixed: X
-    - partially_fixed: Y
+    - answered_by_current_text: X
+    - partially_answered: Y
     - still_unresolved: Z
 
     ## Net assessment
-    <one short paragraph: does the defense as a whole survive the attack,
-    or is the attack effective at the headline level? Be honest — if Y or Z
-    > 0 and they hit the headline, say so.>
+    <one short paragraph: would this paper survive a senior area-chair read
+    of the attack memo, given only what is in the current source? Be honest —
+    if Y or Z > 0 and they hit the headline, say so.>
 
     ## Top action items (in priority order, max 3)
     1. ...
@@ -193,15 +200,17 @@ mcp__codex__codex:
     3. ...
 
     ## Constraints
-    - Do NOT consult any prior round reviews or fix lists. Defense must be
-      made strictly from current paper files.
-    - If the defense cannot refute a point, do NOT minimize — keep severity
+    - Do NOT consult any prior round reviews or fix lists. Adjudication must
+      be made strictly from current paper files.
+    - If the paper cannot refute a point, do NOT minimize — keep severity
       honest.
     - If a point reflects an author-chosen position (e.g., conscious title
-      scope decision), classify as partially_fixed with a note that the
-      position is intentional, but say whether this position is sustainable
-      under the attack.
-    - Be specific. No flattery, no hedging.
+      scope decision), classify as `partially_answered` with a note that the
+      position is intentional, AND say whether this position is sustainable
+      under the attack — do NOT auto-grade as `answered_by_current_text`
+      just because it is intentional.
+    - Be specific. No flattery, no hedging, no rationalizing on the paper's
+      behalf.
 ```
 
 Save the returned `threadId`.
@@ -216,19 +225,20 @@ Compose the human-readable report `<paper-dir>/KILL_ARGUMENT.md`:
 **Date**: <YYYY-MM-DD>
 **Reviewer model**: gpt-5.5 xhigh, fresh threads (no codex-reply)
 **Attack thread**: <threadId 1>
-**Defense thread**: <threadId 2>
+**Adjudicator thread**: <threadId 2>
+**Verdict**: <PASS / WARN / FAIL / NOT_APPLICABLE / BLOCKED / ERROR> (`reason_code: <...>`)
 
-## Net verdict
+## Net assessment
 
-<paragraph from defense memo's "Net assessment">
+<paragraph from adjudicator memo's "Net assessment">
 
 ## Attack memo (verbatim)
 
 > <attack memo from Thread 1>
 
-## Defense memo (per-point)
+## Adjudication (per-point)
 
-<copy verbatim from Thread 2>
+<copy verbatim from Thread 2 — uses labels answered_by_current_text / partially_answered / still_unresolved>
 
 ## Top action items
 
@@ -241,46 +251,82 @@ it as a known open problem in the conclusion / limitations. If it is
 writing-level, queue for next /auto-paper-improvement-loop round.
 ```
 
-Compose the machine-readable `<paper-dir>/KILL_ARGUMENT.json`:
+Compose the machine-readable `<paper-dir>/KILL_ARGUMENT.json` per the
+ARIS Audit Artifact Schema (`shared-references/assurance-contract.md`):
 
 ```json
 {
-  "skill": "kill-argument",
-  "verdict": "PASS | WARN | FAIL",
-  "summary": "<one-line summary>",
-  "attack_thread_id": "<...>",
-  "defense_thread_id": "<...>",
+  "audit_skill": "kill-argument",
+  "verdict": "PASS | WARN | FAIL | NOT_APPLICABLE | BLOCKED | ERROR",
+  "reason_code": "<see verdict mapping below>",
+  "summary": "<one-line summary, ~80 chars>",
+  "audited_input_hashes": {
+    "main.tex":                          "sha256:<...>",
+    "sec/0.abstract.tex":                "sha256:<...>",
+    "sec/<each-section>.tex":            "sha256:<...>",
+    "references.bib":                    "sha256:<...>",
+    "main.pdf":                          "sha256:<...>"
+  },
+  "trace_path": ".aris/traces/kill-argument/<date>_run<NN>/",
+  "thread_id": "<defense threadId — primary; attack threadId in details>",
   "reviewer_model": "gpt-5.5",
   "reviewer_reasoning": "xhigh",
   "generated_at": "<UTC ISO-8601>",
   "details": {
+    "attack_thread_id": "<threadId 1>",
+    "defense_thread_id": "<threadId 2 — same as top-level thread_id>",
     "attack_memo": "<verbatim>",
     "decomposed_points": [
       {
         "id": "P_1",
         "label": "<short label>",
         "attack_claim": "<...>",
-        "verdict": "already_fixed | partially_fixed | still_unresolved",
-        "defense_evidence": "<file:line citation>",
+        "verdict": "answered_by_current_text | partially_answered | still_unresolved",
+        "evidence": "<file:line citation>",
         "severity_if_unresolved": "critical | major | minor",
         "recommended_fix": "<...>"
       }
     ],
     "counts": {
-      "already_fixed": <int>,
-      "partially_fixed": <int>,
-      "still_unresolved": <int>
+      "answered_by_current_text": <int>,
+      "partially_answered":       <int>,
+      "still_unresolved":         <int>
     },
-    "net_assessment": "<defense memo's net assessment>",
+    "net_assessment": "<adjudicator memo's net assessment>",
     "top_action_items": ["...", "...", "..."]
   }
 }
 ```
 
-Verdict mapping:
-- `PASS`: 0 still_unresolved AND ≤1 partially_fixed at critical severity → defense fully survives.
-- `WARN`: ≥1 partially_fixed at critical, OR ≥1 still_unresolved at major.
-- `FAIL`: ≥1 still_unresolved at critical → headline attack effective; defense does not survive.
+**Hash inputs** (`audited_input_hashes`): use paper-relative paths,
+`sha256` of every `.tex` consumed plus `references.bib` and the
+compiled `main.pdf` if it exists. The verifier rehashes these on
+`verify_paper_audits.sh` and flags `STALE` if the user edited the
+paper after running the audit.
+
+**Verdict mapping** (every (counts, severity) tuple must hit exactly one row):
+
+| Verdict | reason_code | Trigger |
+|---|---|---|
+| `FAIL` | `unresolved_critical` | ≥1 `still_unresolved` at `critical` severity |
+| `WARN` | `unresolved_major_or_minor` | ≥1 `still_unresolved` at `major` or `minor` severity (and no `critical`) |
+| `WARN` | `partial_critical_or_repeated_major` | ≥1 `partially_answered` at `critical`, OR ≥2 `partially_answered` at `major` |
+| `PASS` | `defense_survives_with_minor_partial_only` | 0 `still_unresolved`, AND all `partially_answered` are at `minor` severity |
+| `PASS` | `defense_survives` | 0 `still_unresolved`, AND 0 `partially_answered` |
+| `NOT_APPLICABLE` | `not_theory_or_scope_paper` | Paper has <2 `\begin{theorem\|lemma\|proposition\|corollary}` AND no scope / generality claims in abstract |
+| `NOT_APPLICABLE` | `headline_unstable` | Title or abstract changed within the last 2 commits — re-run after headline stabilizes |
+| `BLOCKED` | `paper_compile_failed` | Compiled PDF missing AND `main.tex` does not compile clean — adjudication needs source fidelity |
+| `BLOCKED` | `source_files_missing` | `main.tex` not found, or no `sec/*.tex` files |
+| `ERROR` | `codex_api_error` | `mcp__codex__codex` call failed |
+| `ERROR` | `decomposition_parse_failed` | Adjudicator thread did not return parseable per-point structure |
+| `ERROR` | `trace_save_failed` | Trace directory write failed |
+
+`PASS` requires `still_unresolved == 0`. Any `partially_answered` at
+`major` or higher → at most `WARN`.
+
+The verdict is computed from the per-point counts; do NOT let the
+defense thread output the top-level verdict directly (that would let
+it self-grade). The skill code does the verdict mapping.
 
 ### Step 5: Print summary
 
@@ -291,12 +337,13 @@ To the user:
 
   Attack: <one-sentence summary of the rejection thrust>
 
-  Defense breakdown:
-    already_fixed:     X
-    partially_fixed:   Y
-    still_unresolved:  Z   ← critical: <names>
+  Adjudication breakdown:
+    answered_by_current_text:   X
+    partially_answered:         Y
+    still_unresolved:           Z   ← critical: <names>
 
-  Verdict: <PASS / WARN / FAIL>
+  Verdict: <PASS / WARN / FAIL / NOT_APPLICABLE / BLOCKED / ERROR>
+  Reason:  <reason_code, e.g., defense_survives, unresolved_critical>
 
   Top action items:
   1. ...
@@ -310,24 +357,25 @@ To the user:
 
 - `<paper-dir>/KILL_ARGUMENT.md` — human-readable report
 - `<paper-dir>/KILL_ARGUMENT.json` — machine-readable ledger
-- `.aris/traces/kill-argument/<date>_runNN/` — per-thread codex traces (Attack memo + Defense memo)
+- `.aris/traces/kill-argument/<date>_runNN/` — per-thread codex traces (Attack memo + Adjudication memo)
 - Optional: applied fixes if user explicitly requests; default is **detect-only, do not auto-modify**.
 
 ## Key Rules
 
-- **Fresh thread per call.**  Both Attack and Defense use `mcp__codex__codex`, never `codex-reply`.  Thread 1 and Thread 2 must not share codex context.
+- **Fresh thread per call.**  Both Attack and Adjudication use `mcp__codex__codex`, never `codex-reply`.  Thread 1 and Thread 2 must not share codex context.
 - **Zero prior context.**  Neither thread receives prior round reviews, fix lists, executor summaries, or improvement-loop logs.
 - **Attack must commit.**  Single argument, ~200 words.  No "consider also" hedge.  The whole value is in forcing the reviewer to pick the most damaging line.
-- **Defense must classify, not minimize.**  `still_unresolved` is honest if the paper has no effective response.  Don't downgrade to `partially_fixed` unless evidence is real.
-- **Author-chosen positions** (e.g., deliberate title scope, deliberate omission of qualifier): mark `partially_fixed` with note that the position is intentional, AND say whether the position is sustainable under the attack.  Don't auto-grade as `already_fixed` just because it's intentional.
-- **Detect-only by default.**  Do not edit paper .tex files.  The recommendation is informational; the human decides whether and how to act.
+- **Adjudicator must classify, not minimize.**  `still_unresolved` is honest if the paper has no effective response.  Don't downgrade to `partially_answered` unless evidence is real.
+- **Author-chosen positions** (e.g., deliberate title scope, deliberate omission of qualifier): mark `partially_answered` with note that the position is intentional, AND say whether the position is sustainable under the attack.  Don't auto-grade as `answered_by_current_text` just because it's intentional.
+- **Verdict is computed by the skill, not by the adjudicator.**  The Codex thread emits per-point classifications; the skill code maps those to one of the 6 audit verdicts via the table in Step 4.  Never let the adjudicator self-grade the top-level verdict.
+- **Detect-only by direct invocation; can be invoked by `/auto-paper-improvement-loop` Step 5.5 which then merges unresolved findings into its fix list.**  When a user runs `/kill-argument paper/` directly, the output is informational and the human decides whether to act.  When the skill is invoked from inside the auto-improvement loop, the loop reads `KILL_ARGUMENT.json`, deduplicates against its existing weakness list, and feeds novel `still_unresolved` points into Step 6 fixes — `/kill-argument` itself never edits paper files.
 
 ## When NOT to Use
 
-- Empirical papers without theorems / scope claims — `/peer-review` is more useful.
-- Very early drafts where the headline isn't stable yet — fix the headline first.
+- Empirical papers without theorems / scope claims — `/peer-review` is more useful.  The skill emits `NOT_APPLICABLE` with `reason_code: not_theory_or_scope_paper` in this case.
+- Very early drafts where the headline isn't stable yet — fix the headline first.  The skill emits `NOT_APPLICABLE` with `reason_code: headline_unstable` if the title or abstract changed within the last 2 commits.
 - Papers with ongoing experiments — wait until results stabilize, then run.
-- Inside `/auto-paper-improvement-loop` Step 5.5 — that already runs this protocol on the final scheduled round.
+- (`/auto-paper-improvement-loop` Step 5.5 used to run this protocol inline; as of May 2026 it now invokes `/kill-argument` and reads `KILL_ARGUMENT.json` instead, so there is no longer a "do not invoke from inside auto-loop" exclusion.)
 
 ## Review Tracing
 

--- a/skills/kill-argument/SKILL.md
+++ b/skills/kill-argument/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: kill-argument
+description: "Two-thread adversarial review: a fresh reviewer constructs the strongest 200-word rejection memo, then a second fresh reviewer defends the paper point-by-point and surfaces still-unresolved critical issues. Use when user says \"kill argument\", \"adversarial review\", \"hostile review\", \"rebuttal preparation\", \"reviewer-2 simulation\", or before submitting a theory paper that has already passed standard review rounds."
+argument-hint: [paper-directory]
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__codex__codex
+---
+
+# Kill Argument Exercise: Adversarial Attack-Defense Review
+
+Stress-test the headline claims of a paper against the strongest possible rejection argument: **$ARGUMENTS**
+
+## Why This Exists
+
+Standard score-based reviews (`/peer-review`, `/research-review`, `/auto-paper-improvement-loop`) tend to produce **balanced** weakness lists.  Each weakness gets ~equal attention, ranked CRITICAL > MAJOR > MINOR.  Empirically, this misses one specific failure mode: the **single most damaging argument** a reviewer would write in a rejection paragraph — the one sentence that, if a senior area chair reads it, kills the paper.
+
+A balanced reviewer might list "scope-overclaim risk" as MAJOR alongside 3-5 other MAJORs, never quite committing.  An adversarial reviewer **must commit**: their entire job is to convince the area chair to reject in 200 words.
+
+This skill runs that adversarial pass deliberately, then forces a second fresh reviewer to defend point-by-point, classify each rejection as already-fixed / partially-fixed / still-unresolved, and surface what's actually load-bearing.
+
+**Empirical motivation** (NeurIPS 2026 D-LLM theory paper, April 2026): after 5 standard improvement rounds settling at score 7-8/10, kill-argument surfaced two framing weaknesses no prior review caught — "width-w is mostly conditional" and "CRF irrelevant to real D-LLMs".  Author rebuttal forced explicit scope qualifications in abstract and discussion that weren't visible from the score-based reviews alone.
+
+## How This Differs From Other Review Skills
+
+| Skill | What it asks the reviewer | Output |
+|-------|---------------------------|--------|
+| `/peer-review` | "Score this paper, list weaknesses by severity" | balanced weakness list |
+| `/research-review` | "Deep technical review of methods + claims" | structured deep critique |
+| `/proof-checker` | "Is this theorem actually proved?" | per-step proof obligation audit |
+| `/paper-claim-audit` | "Does the paper report numbers truthfully?" | per-claim evidence verification |
+| `/citation-audit` | "Are citations real and used in correct context?" | per-entry KEEP/FIX/REPLACE/REMOVE |
+| **`/kill-argument`** | **"Write the single strongest rejection paragraph; then defend it."** | **attack memo + per-point defense + unresolved surfaced** |
+
+This skill is **complementary**, not a replacement.  Run after standard reviews when you want to know what the worst-case reviewer paragraph would look like, before camera-ready or rebuttal preparation.
+
+## When To Use
+
+- After 1-2 rounds of `/auto-paper-improvement-loop` settled at a stable score, but before submission.  Surfaces what additional fixes would close the headline-attack gap.
+- During rebuttal preparation, to predict reviewer-2's strongest objection so you can prepare the response in advance.
+- For theory papers with a high-level title that may oversimplify the actual theorem (the most common reject-attack pattern).
+- For papers where a reviewer might attack scope, assumption-vs-claim mismatch, missing proof obligations, or evidence-vs-headline gaps.
+
+This skill is most valuable for **theory papers** with ≥5 theorem-class environments (so the headline depends on real proof obligations).  For empirical papers without theorems, use `/peer-review` instead.
+
+## Constants
+
+- **REVIEWER_MODEL** = `gpt-5.5` (default; specify `gpt-5.4` if you want the older default).  Reviewer reasoning effort = `xhigh`.
+- **CONTEXT_POLICY** = `fresh` (REVIEWER_BIAS_GUARD).  Each thread is a fresh `mcp__codex__codex` call.  **Never** use `mcp__codex__codex-reply`.  No prior review summary, fix list, or executor explanation enters either prompt.
+- **ATTACK_LENGTH** = approximately 200 words (do not exceed 250).  Single coherent argument, not a list.
+- **DEFENSE_DECOMPOSITION** = 3-7 atomic rejection points extracted from the attack memo.  Each gets its own classification.
+- **CLASSIFICATION** = `already_fixed` / `partially_fixed` / `still_unresolved`.
+- **OUTPUT** = `KILL_ARGUMENT.md` (human-readable) + `KILL_ARGUMENT.json` (machine-readable) in the paper directory.
+
+## Workflow
+
+### Step 1: Discover paper files
+
+Locate the paper directory and inventory the source.
+
+```bash
+PAPER_DIR="$ARGUMENTS"   # e.g., paper-overleaf/ or paper/
+cd "$PAPER_DIR"
+
+# Find the LaTeX entry point
+ENTRY=$(grep -lE '^\\documentclass' *.tex 2>/dev/null | head -1)
+echo "Entry: $ENTRY"
+
+# Find all source files codex should read
+find . -name "*.tex" -not -path "./.git/*" 2>/dev/null
+find . -name "*.bib" -not -path "./.git/*" 2>/dev/null
+find figures/ -name "*.pdf" -o -name "*.png" 2>/dev/null
+ls -la *.pdf 2>/dev/null  # compiled PDF
+```
+
+If a compiled PDF is missing, the skill should still run on .tex source alone, but the prompt should mention this so the reviewer doesn't waste cycles trying to extract from a non-existent PDF.
+
+### Step 2: Attack memo (Thread 1, fresh codex)
+
+Invoke `mcp__codex__codex` (NOT `codex-reply`) with the following prompt structure:
+
+```
+mcp__codex__codex:
+  model: gpt-5.5
+  config: {"model_reasoning_effort": "xhigh"}
+  sandbox: read-only
+  cwd: <paper directory>
+  prompt: |
+    You are simulating a hostile NeurIPS / ICLR / ICML reviewer for a paper.
+    This is a kill-argument adversarial check — your task is NOT to give a
+    balanced review but to construct the **single strongest argument for
+    rejecting this paper**.
+
+    ## Files to read
+    - LaTeX entry: <ENTRY>
+    - All section files under sections/ or wherever they live
+    - Macro files (math_commands.tex, etc.)
+    - Compiled PDF: <main.pdf> (if available)
+
+    Read the source carefully. Do not consult any prior reviews, fix lists,
+    or summaries; this must be a fresh, zero-context adversarial pass.
+
+    ## Your task
+    Construct the single best argument to reject this paper in approximately
+    200 words. Your goal is to write the worst-case rejection memo a senior
+    NeurIPS area chair would produce after reading the paper.
+
+    Focus on these axes (pick the most damaging combination, do not list all):
+    1. Theorem validity: are central theorems actually proved as stated?
+    2. Assumption-vs-claim mismatch: does the body silently retreat to a
+       narrower object than the title/abstract advertise?
+    3. Missing proof obligations: is a fundamental lemma invoked but not
+       proved (e.g., concentration, generic position, prefactor envelope)
+       that the headline depends on?
+    4. Limit-order ambiguity: are limits in K/n/d/eps composed in a way the
+       paper does not commit to?
+    5. Claim-vs-evidence gap: is the empirical/numerical evidence too narrow
+       to support the breadth of the stated theorem or take-away?
+    6. Scope overclaim: does the title or abstract sell a result substantially
+       broader than what the body proves?
+
+    ## Constraints
+    - Approximately 200 words total (do NOT exceed 250).
+    - Single argument, not a list — pick the most damaging line of attack
+      and develop it.
+    - Cite specific file:line locations or equation numbers when accusing.
+    - Tone: dispassionate but uncompromising. Do NOT hedge. Do NOT acknowledge
+      mitigations the paper might have made elsewhere. This is the rejection
+      paragraph; the defense gets the next pass.
+    - Do NOT reference prior review rounds, fix lists, or any context outside
+      the current paper files.
+
+    Output: just the rejection memo, nothing else.
+```
+
+Save the returned `threadId` for the trace; do NOT pass it to Thread 2.  Save the attack memo verbatim — both Thread 2 and the human-readable report use it.
+
+### Step 3: Defense memo (Thread 2, fresh codex with attack + paper)
+
+Invoke a second `mcp__codex__codex` call (still NOT `codex-reply` — Thread 2 is independent of Thread 1's codex history):
+
+```
+mcp__codex__codex:
+  model: gpt-5.5
+  config: {"model_reasoning_effort": "xhigh"}
+  sandbox: read-only
+  cwd: <paper directory>
+  prompt: |
+    You are defending a paper against a hostile reviewer's rejection memo.
+    This is the defense pass of a kill-argument adversarial check. Fresh,
+    zero-context defense; do not reference any prior reviews / fix lists.
+
+    ## Paper files
+    [list paths same as Step 2]
+
+    ## The hostile reviewer's rejection memo (the "attack")
+    > <attack memo verbatim from Thread 1>
+
+    ## Your task
+    The attack is one continuous argument, but it makes multiple distinct
+    rejection points that you must defend separately. Decompose the attack
+    into its atomic rejection points (3-7 of them), then for each point
+    classify it:
+
+    - already_fixed: the current paper text already mitigates this point
+      (cite specific file:line evidence)
+    - partially_fixed: paper has some response but not enough to refute
+      the attack as written
+    - still_unresolved: paper has no effective response
+
+    For each rejection point, output:
+    ### Point P_n: <short label>
+    **Attack claim**: <the specific accusation, ~30 words>
+    **Verdict**: already_fixed | partially_fixed | still_unresolved
+    **Defense evidence**: <cite file:line, ~50 words>
+    **Severity if unresolved**: critical | major | minor
+    **If unresolved, recommended fix**: <one specific actionable sentence>
+
+    After per-point analysis, output:
+
+    ## Summary
+    Total rejection points: N
+    - already_fixed: X
+    - partially_fixed: Y
+    - still_unresolved: Z
+
+    ## Net assessment
+    <one short paragraph: does the defense as a whole survive the attack,
+    or is the attack effective at the headline level? Be honest — if Y or Z
+    > 0 and they hit the headline, say so.>
+
+    ## Top action items (in priority order, max 3)
+    1. ...
+    2. ...
+    3. ...
+
+    ## Constraints
+    - Do NOT consult any prior round reviews or fix lists. Defense must be
+      made strictly from current paper files.
+    - If the defense cannot refute a point, do NOT minimize — keep severity
+      honest.
+    - If a point reflects an author-chosen position (e.g., conscious title
+      scope decision), classify as partially_fixed with a note that the
+      position is intentional, but say whether this position is sustainable
+      under the attack.
+    - Be specific. No flattery, no hedging.
+```
+
+Save the returned `threadId`.
+
+### Step 4: Write KILL_ARGUMENT.md and KILL_ARGUMENT.json
+
+Compose the human-readable report `<paper-dir>/KILL_ARGUMENT.md`:
+
+```markdown
+# Kill Argument Report — <paper title>
+
+**Date**: <YYYY-MM-DD>
+**Reviewer model**: gpt-5.5 xhigh, fresh threads (no codex-reply)
+**Attack thread**: <threadId 1>
+**Defense thread**: <threadId 2>
+
+## Net verdict
+
+<paragraph from defense memo's "Net assessment">
+
+## Attack memo (verbatim)
+
+> <attack memo from Thread 1>
+
+## Defense memo (per-point)
+
+<copy verbatim from Thread 2>
+
+## Top action items
+
+<copy from Thread 2>
+
+## Recommendation
+
+If P_4 (or whatever still_unresolved critical) is research-level, record
+it as a known open problem in the conclusion / limitations. If it is
+writing-level, queue for next /auto-paper-improvement-loop round.
+```
+
+Compose the machine-readable `<paper-dir>/KILL_ARGUMENT.json`:
+
+```json
+{
+  "skill": "kill-argument",
+  "verdict": "PASS | WARN | FAIL",
+  "summary": "<one-line summary>",
+  "attack_thread_id": "<...>",
+  "defense_thread_id": "<...>",
+  "reviewer_model": "gpt-5.5",
+  "reviewer_reasoning": "xhigh",
+  "generated_at": "<UTC ISO-8601>",
+  "details": {
+    "attack_memo": "<verbatim>",
+    "decomposed_points": [
+      {
+        "id": "P_1",
+        "label": "<short label>",
+        "attack_claim": "<...>",
+        "verdict": "already_fixed | partially_fixed | still_unresolved",
+        "defense_evidence": "<file:line citation>",
+        "severity_if_unresolved": "critical | major | minor",
+        "recommended_fix": "<...>"
+      }
+    ],
+    "counts": {
+      "already_fixed": <int>,
+      "partially_fixed": <int>,
+      "still_unresolved": <int>
+    },
+    "net_assessment": "<defense memo's net assessment>",
+    "top_action_items": ["...", "...", "..."]
+  }
+}
+```
+
+Verdict mapping:
+- `PASS`: 0 still_unresolved AND ≤1 partially_fixed at critical severity → defense fully survives.
+- `WARN`: ≥1 partially_fixed at critical, OR ≥1 still_unresolved at major.
+- `FAIL`: ≥1 still_unresolved at critical → headline attack effective; defense does not survive.
+
+### Step 5: Print summary
+
+To the user:
+
+```
+🗡  Kill Argument complete.
+
+  Attack: <one-sentence summary of the rejection thrust>
+
+  Defense breakdown:
+    already_fixed:     X
+    partially_fixed:   Y
+    still_unresolved:  Z   ← critical: <names>
+
+  Verdict: <PASS / WARN / FAIL>
+
+  Top action items:
+  1. ...
+  2. ...
+  3. ...
+
+  Full report: <paper-dir>/KILL_ARGUMENT.md
+```
+
+## Output Contract
+
+- `<paper-dir>/KILL_ARGUMENT.md` — human-readable report
+- `<paper-dir>/KILL_ARGUMENT.json` — machine-readable ledger
+- `.aris/traces/kill-argument/<date>_runNN/` — per-thread codex traces (Attack memo + Defense memo)
+- Optional: applied fixes if user explicitly requests; default is **detect-only, do not auto-modify**.
+
+## Key Rules
+
+- **Fresh thread per call.**  Both Attack and Defense use `mcp__codex__codex`, never `codex-reply`.  Thread 1 and Thread 2 must not share codex context.
+- **Zero prior context.**  Neither thread receives prior round reviews, fix lists, executor summaries, or improvement-loop logs.
+- **Attack must commit.**  Single argument, ~200 words.  No "consider also" hedge.  The whole value is in forcing the reviewer to pick the most damaging line.
+- **Defense must classify, not minimize.**  `still_unresolved` is honest if the paper has no effective response.  Don't downgrade to `partially_fixed` unless evidence is real.
+- **Author-chosen positions** (e.g., deliberate title scope, deliberate omission of qualifier): mark `partially_fixed` with note that the position is intentional, AND say whether the position is sustainable under the attack.  Don't auto-grade as `already_fixed` just because it's intentional.
+- **Detect-only by default.**  Do not edit paper .tex files.  The recommendation is informational; the human decides whether and how to act.
+
+## When NOT to Use
+
+- Empirical papers without theorems / scope claims — `/peer-review` is more useful.
+- Very early drafts where the headline isn't stable yet — fix the headline first.
+- Papers with ongoing experiments — wait until results stabilize, then run.
+- Inside `/auto-paper-improvement-loop` Step 5.5 — that already runs this protocol on the final scheduled round.
+
+## Review Tracing
+
+After each `mcp__codex__codex` reviewer call, save the trace following `shared-references/review-tracing.md`.  Use `tools/save_trace.sh` or write files directly to `.aris/traces/kill-argument/<date>_run<NN>/`.  Both threads' raw responses should be preserved.
+
+## Notes
+
+This skill was extracted as a standalone primitive from `/auto-paper-improvement-loop` Step 5.5 in May 2026, after the protocol proved valuable in surfacing headline-vs-body scope gaps that score-based reviews missed.  The attack-then-defense pattern was kept exactly because of empirical evidence that asking one model to "write the rejection memo" produces qualitatively different feedback than asking it to "review and grade" — the former forces commitment, the latter encourages hedging.

--- a/skills/paper-writing/SKILL.md
+++ b/skills/paper-writing/SKILL.md
@@ -408,6 +408,34 @@ fi
 
 **Empirical motivation:** in a real submission run, the final paper claimed a narrower experiment grid than the raw JSON actually contained, and a tolerance value was rounded down past the actual relative error. Both were caught only after manual `paper-claim-audit` invocation in the final round; the improvement loop did not detect them.
 
+### Phase 5.6: Kill-Argument Adversarial Review (theory / scope-heavy papers)
+
+After Phase 5.5 (claim audit) passes, run `/kill-argument` whenever the paper is theory-heavy or makes explicit scope/generality claims in the title or abstract. This is a final adversarial check that complements the claim/citation/proof audits: those verify *local correctness* (numbers match, cites resolve, theorems prove); kill-argument tests *headline-level* survival — whether the paper as a whole answers the worst rejection paragraph a senior area chair would write.
+
+```bash
+THEORY_ENV_COUNT=$(rg -c '\\begin\{(theorem|lemma|proposition|corollary)\}' paper/main.tex paper/sections 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
+SCOPE_HINT=$(rg -i 'general(ization)?|broad|universal|across|any [A-Za-z]+ model|holds for' paper/sections/0*abstract* 2>/dev/null | head -1)
+
+if [ "$THEORY_ENV_COUNT" -ge 5 ] || [ -n "$SCOPE_HINT" ]; then
+    /kill-argument "paper/"
+    KILL_VERDICT=$(jq -r '.verdict' paper/KILL_ARGUMENT.json)
+    KILL_REASON=$(jq -r '.reason_code' paper/KILL_ARGUMENT.json)
+fi
+```
+
+**Gating** (depends on the resolved `assurance` level from Phase 0):
+
+| Assurance level | THEORY/SCOPE detected | Behavior |
+|---|---|---|
+| `submission` | yes | **MANDATORY**. `FAIL` blocks the final report; `WARN` requires explicit user acknowledgment; `BLOCKED`/`ERROR` blocks the final report (cannot ship without an adversarial pass). |
+| `submission` | no | Skip — `KILL_ARGUMENT.json` is written with `verdict: NOT_APPLICABLE, reason_code: not_theory_or_scope_paper` so the submission verifier sees a record. |
+| `internal` / `draft` | yes | **Advisory**. Run if the user passed `— kill-argument: true`; otherwise skip. `WARN`/`FAIL` is logged but does not block. |
+| `internal` / `draft` | no | Skip. |
+
+`/kill-argument` itself never edits the paper; it writes `KILL_ARGUMENT.{md,json}`. If `still_unresolved critical` points are surfaced, queue them for the next `/auto-paper-improvement-loop` round (Step 5.5 of that skill auto-merges the findings into its fix list).
+
+**Why this is the right place:** Phase 5 (loop) optimizes for score, Phase 5.5 (claim audit) verifies numbers, Phase 5.8 (citation audit) verifies cites — none of these catches the case where every local component is correct but the paper still oversells what it actually proves. Kill-argument is the dedicated headline-scope check.
+
 ### Phase 5.8: Citation Audit (submission gate)
 
 After the final paper-claim-audit passes, run `/citation-audit` to verify every `\cite{...}` along three axes: existence, metadata correctness, and context appropriateness. This is the fourth and final layer of the evidence-and-claim assurance stack (`experiment-audit` → `result-to-claim` → `paper-claim-audit` → `citation-audit`).

--- a/skills/proof-checker/SKILL.md
+++ b/skills/proof-checker/SKILL.md
@@ -393,7 +393,7 @@ After fixes, re-run:
 
 This phase catches a specific class of bugs that Phase 3.5's "Statement-conclusion match" check does NOT catch: **drift between the canonical theorem statement and its restatements elsewhere in the paper** (summary tables, "Key Contributions" / "Summary" sections, abstract, discussion, captions). Common drift patterns observed in practice:
 
-- Main theorem says "width-1 unconditional, width-w conditional" but a later summary cites it as "unconditional DSM excess-risk oracle bound".
+- Main theorem makes a partly-conditional claim (e.g., "regime A unconditional, regime B conditional on assumption X") but a later summary cites it as the fully unconditional version.
 - Main theorem κ exponent is `O(d²K²)` but a constants table writes `O(K²)`.
 - Main theorem regime condition is squared envelope, but a remark elsewhere still shows the first-order envelope.
 - Restatement quietly drops a quantifier ("for $n \ge n_0$") that the proof relied on.

--- a/skills/skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md
@@ -317,7 +317,7 @@ paper/
 
 ## Typical Score Progression
 
-Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
+Based on end-to-end testing on a real theory-paper run:
 
 | Round | Score | Key Improvements |
 |-------|-------|-----------------|
@@ -326,4 +326,4 @@ Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
 | Round 2 | 7/10 (content) | Added synthetic validation, formal truncation proposition, stronger limitations |
 | Round 3 | 5→8.5/10 (format) | Removed hero fig, appendix, compressed conclusion, fixed overfull hbox |
 
-**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final: 8 pages main body, 0 overfull hbox, ICLR-compliant.
+**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final state at submission: clean overfull-hbox count and venue-format-compliant length.

--- a/skills/skills-codex-gemini-review/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex-gemini-review/auto-paper-improvement-loop/SKILL.md
@@ -317,7 +317,7 @@ paper/
 
 ## Typical Score Progression
 
-Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
+Based on end-to-end testing on a real theory-paper run:
 
 | Round | Score | Key Improvements |
 |-------|-------|-----------------|
@@ -326,4 +326,4 @@ Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
 | Round 2 | 7/10 (content) | Added synthetic validation, formal truncation proposition, stronger limitations |
 | Round 3 | 5→8.5/10 (format) | Removed hero fig, appendix, compressed conclusion, fixed overfull hbox |
 
-**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final: 8 pages main body, 0 overfull hbox, ICLR-compliant.
+**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final state at submission: clean overfull-hbox count and venue-format-compliant length.

--- a/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
@@ -251,29 +251,25 @@ spawn_agent:
 
 If `REVIEWER_BIAS_GUARD = false` (legacy debugging only), use `send_input` with the saved reviewer id; this is **not** the recommended path.
 
-### Step 5.5: Kill Argument Exercise (theory papers only)
+### Step 5.5: Kill Argument Exercise (theory / scope-heavy papers only)
 
-Run this only if the paper is theory-heavy (≥5 `\begin{theorem}|\begin{lemma}|\begin{proposition}|\begin{corollary}` environments in the source) and only on the final scheduled round (`current_round == MAX_ROUNDS`).
+Run this only if the paper is theory-heavy (≥5 `\begin{theorem}|\begin{lemma}|\begin{proposition}|\begin{corollary}` environments in the source) or has explicit scope/generality claims in title/abstract, and only on the final scheduled round (`current_round == MAX_ROUNDS`).
 
-This is a late-stage adversarial check. It must always use **fresh** `spawn_agent` reviewers, never `codex-reply`, and it must not reuse any prior review context.
+**Delegate to the `kill-argument` skill** (extracted in May 2026 as a standalone primitive). This step does NOT re-implement the Attack-and-Adjudication prompt template; instead, invoke the skill and read its output. The Codex-CLI form is to call the installed skill the same way you would call any other ARIS skill from the agent's tool list, then parse `KILL_ARGUMENT.json` from the paper directory.
 
-**Thread 1: Attack**
-- Use a fresh thread with only the current paper files.
-- Prompt: "Construct the single best argument to reject this paper in 200 words. Focus on theorem validity, assumption mismatch, missing proof obligations, limit-order ambiguity, and claim/evidence gaps. Do not reference prior rounds or fixes."
+**Merge rule** (auto-loop's responsibility — `kill-argument` itself is detect-only):
 
-**Thread 2: Defense**
-- Use a second fresh thread with the current paper files plus the attack memo.
-- Prompt: "Now defend the paper against the attack memo. For each rejection point, classify it as already fixed, partially fixed, or still unresolved, and cite the current files. Do not reuse prior review context."
-
-**Merge rule**
-- Dedupe attack points against the Round 2 weakness list by semantic overlap.
-- Append any novel unresolved attack point to the Step 6 fix list before implementation.
-- If the defense cannot refute a point, keep it at the original severity or raise it by one level if it exposes a main-theorem or core-assumption failure.
-- If the defense shows the issue is already fixed in the current files, only downgrade after verifying the file evidence.
-- Record both memos in `PAPER_IMPROVEMENT_LOG.md`.
+- Read `details.decomposed_points` from `KILL_ARGUMENT.json`.
+- For each point with `verdict == "still_unresolved"` or `verdict == "partially_answered"` at `severity_if_unresolved == "critical"`:
+  - Dedupe against the Round 2 weakness list by semantic overlap (~85% similarity threshold).
+  - If novel, append it to the Step 6 fix list with the recommended_fix as the action description.
+- If the adjudication shows the issue is `answered_by_current_text`, only downgrade an existing weakness item after verifying the cited file:line evidence yourself.
+- Record both `KILL_ARGUMENT.md` and the merge decision in `PAPER_IMPROVEMENT_LOG.md`.
 - If `HUMAN_CHECKPOINT = true`, include the merged findings in the checkpoint summary before asking the user to proceed.
 
-This phase feeds directly into Step 6. The attack/defense findings must be merged before the final recompile.
+This phase feeds directly into Step 6. The merged findings must land before the final recompile.
+
+If kill-argument returns `verdict: NOT_APPLICABLE`, skip Step 5.5 entirely and proceed to Step 6. If it returns `BLOCKED` or `ERROR`, log the reason in `PAPER_IMPROVEMENT_LOG.md` and proceed without merging — the loop should not stall on an adversarial check that cannot run.
 
 **Empirical motivation:** in a real submission run, after several rounds of standard improvement (score 7-8/10), the kill-argument exercise surfaced framing weaknesses that no prior review caught (e.g., a setting being mostly conditional rather than truly general, or a baseline being irrelevant to real systems). Author rebuttal forced explicit scope qualifications in abstract and discussion.
 
@@ -450,7 +446,7 @@ paper/
 
 ## Typical Score Progression
 
-Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
+Based on end-to-end testing on a real theory-paper run:
 
 | Round | Score | Key Improvements |
 |-------|-------|-----------------|
@@ -459,7 +455,7 @@ Based on end-to-end testing on a 9-page ICLR 2026 theory paper:
 | Round 2 | 7/10 (content) | Added synthetic validation, formal truncation proposition, stronger limitations |
 | Round 3 | 5→8.5/10 (format) | Removed hero fig, appendix, compressed conclusion, fixed overfull hbox |
 
-**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final: 8 pages main body, 0 overfull hbox, ICLR-compliant.
+**+4.5 points across 3 rounds** (2 content + 1 format) is typical for a well-structured but rough first draft. Final state at submission: clean overfull-hbox count and venue-format-compliant length.
 
 ## Review Tracing
 

--- a/tools/verify_paper_audits.sh
+++ b/tools/verify_paper_audits.sh
@@ -37,6 +37,7 @@ MANDATORY_AUDITS=(
     "PROOF_AUDIT.json|proof-checker"
     "PAPER_CLAIM_AUDIT.json|paper-claim-audit"
     "CITATION_AUDIT.json|citation-audit"
+    "KILL_ARGUMENT.json|kill-argument"
 )
 ALLOWED_VERDICTS=("PASS" "WARN" "FAIL" "NOT_APPLICABLE" "BLOCKED" "ERROR")
 SUBMISSION_BLOCKING=("FAIL" "BLOCKED" "ERROR")


### PR DESCRIPTION
## Summary

Two commits land together:

1. **`5e89ee9`** — Original extraction of `/kill-argument` as a standalone primitive from `auto-paper-improvement-loop` Step 5.5. Two fresh codex 5.5 + xhigh threads: Thread 1 writes a 200-word rejection memo (the "attack"); Thread 2 adjudicates point-by-point. Detect-only (writes `KILL_ARGUMENT.{md,json}`, never edits paper).

2. **`2212efb`** — Codex review fixups + writing-workflow integration + redact follow-ups (this PR's main work).

The flow: a senior reviewer's strongest rejection paragraph is a different artifact from a balanced weakness list. Score-based reviewers tend to hedge ("scope-overclaim risk: MAJOR" alongside 5 other MAJORs); an adversarial reviewer must commit to one line of attack. This skill runs that adversarial pass deliberately, then forces a second fresh adjudicator to classify each rejection point against the current paper text.

## Codex 5.5 + xhigh review caught 5 issues; all addressed

| Severity | Issue | Fix |
|---|---|---|
| HIGH | `KILL_ARGUMENT.json` schema incompatible with `verify_paper_audits.sh` (would silently fail submission gate) | Full audit-artifact schema per `shared-references/assurance-contract.md`: `audit_skill`, `reason_code`, `audited_input_hashes`, `trace_path`, `thread_id`, `reviewer_model`, `reviewer_reasoning`, `generated_at` + 6-state verdict (`PASS / WARN / FAIL / NOT_APPLICABLE / BLOCKED / ERROR`) |
| HIGH | `kill-argument` says detect-only + "do not invoke from auto-loop", but `auto-paper-improvement-loop` Step 5.5 says "merge unresolved attack points into Step 6 fixes" — direct contradiction | Refactored auto-loop Step 5.5 to **delegate to `/kill-argument`** and read `KILL_ARGUMENT.json`. Removed the contradictory "do not invoke from auto-loop" line. Same refactor in `skills-codex/auto-paper-improvement-loop` mirror. Prompt template now lives in one place (`/kill-argument`) — DRY pressure resolved. |
| MEDIUM | Verdict mapping had undefined cases (`still_unresolved minor` not mapped) and was too lenient (any number of `partially_answered major` could pass) | Total verdict table — every `(counts, severity)` tuple maps to exactly one row, with `reason_code` per row for forensic traceability |
| MEDIUM | Defense prompt framed thread 2 as "defending the paper" → rationalizes; `already_fixed` label biases toward optimism | Renamed to "independent area-chair adjudicator". Verdict labels: `already_fixed` → `answered_by_current_text`; `partially_fixed` → `partially_answered`. The skill (not the adjudicator thread) computes the top-level verdict — the adjudicator never self-grades. |
| LOW | Personal-info leak at L20 (NeurIPS 2026 + D-LLM + April 2026 + score 7-8/10 + width-w + CRF) | Redacted to generic phrasing matching the PR #201 redact pattern. Plus 5 other personal-info leaks PR #201 missed are also fixed in this commit (see below). |

## Writing-workflow integration

**`paper-writing/SKILL.md` Phase 5.6 (NEW)** — between Phase 5.5 (claim audit) and Phase 5.8 (citation audit). Detects theory/scope-heavy papers via `THEORY_ENV_COUNT >= 5` or scope-language heuristic on abstract.

| Assurance level | Theory/scope detected | Behavior |
|---|---|---|
| `submission` | yes | **MANDATORY**. `FAIL` blocks final report; `WARN` requires explicit user ack; `BLOCKED`/`ERROR` blocks |
| `submission` | no | Skipped, writes `verdict: NOT_APPLICABLE` so verifier sees the audit ran |
| `internal` / `draft` | yes | Advisory unless `— kill-argument: true` opt-in |
| `internal` / `draft` | no | Skipped |

`KILL_ARGUMENT.json` added to `verify_paper_audits.sh` `MANDATORY_AUDITS` — existing `NOT_APPLICABLE` handling subsumes the conditional applicability without special-casing.

## Personal-info redact follow-ups (PR #201 missed)

5 additional sites cleaned beyond the in-scope L20 redact:

- `auto-paper-improvement-loop/SKILL.md` L499: "9-page ICLR 2026 theory paper" venue+page+domain → "real theory-paper run"
- `skills-codex/auto-paper-improvement-loop/SKILL.md` L449: same
- `skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md` L320: same (mirror discovered during scan)
- `skills-codex-gemini-review/auto-paper-improvement-loop/SKILL.md` L320: same (mirror discovered during scan)
- `proof-checker/SKILL.md` L396: "width-1 unconditional, width-w conditional ... DSM excess-risk oracle bound" → generic "regime A unconditional, regime B conditional on assumption X"

Whole-tree scan after redact: 0 personal-info hits remaining (excluding venue templates, venue-reference tables, and `smart_update.{sh,ps1}` detection-pattern arrays which are intentional features).

## Files changed (8)

- `skills/kill-argument/SKILL.md` (new — original commit + this PR's schema/verdict/rename/redact fixes)
- `skills/auto-paper-improvement-loop/SKILL.md` (Step 5.5 delegates + redact)
- `skills/skills-codex/auto-paper-improvement-loop/SKILL.md` (mirror)
- `skills/skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md` (redact only)
- `skills/skills-codex-gemini-review/auto-paper-improvement-loop/SKILL.md` (redact only)
- `skills/paper-writing/SKILL.md` (Phase 5.6 added)
- `skills/proof-checker/SKILL.md` (redact only)
- `tools/verify_paper_audits.sh` (KILL_ARGUMENT.json added to MANDATORY_AUDITS)

## Test plan

- [x] Personal-info comprehensive scan: 0 hits across `skills/` and `tools/` after redact (excluding venue templates, venue-ref tables, detection-pattern arrays).
- [x] Schema check: `KILL_ARGUMENT.json` template in SKILL.md L246-323 has all 10 required fields per `assurance-contract.md` and uses the 6-state verdict.
- [x] Verdict mapping totality: every `(still_unresolved, partially_answered, severity)` triple has exactly one row in the mapping table.
- [x] Label rename completeness: `grep -c "already_fixed\|partially_fixed\|defense_evidence" skills/{kill-argument,auto-paper-improvement-loop,paper-writing,skills-codex/auto-paper-improvement-loop}/SKILL.md` returns 0.
- [x] Auto-loop / kill-argument no longer contradict: kill-argument's "When NOT to Use" no longer says "do not invoke from auto-loop"; auto-loop's Step 5.5 explicitly delegates and reads `KILL_ARGUMENT.json`.
- [ ] **Live runtime test** (skipped to save codex 5.5 xhigh budget — recommend the user runs `/kill-argument paper-overleaf/` once after merge to verify on the ARIS technical report; that paper has no `\begin{theorem}` and no scope language → expected verdict: `NOT_APPLICABLE` with `reason_code: not_theory_or_scope_paper`).

## Known follow-ups

1. `tests/test_kill_argument_schema.py` — runtime regression test (Codex's pytest pattern from PR #204). Not in this PR; queued.
2. The empirical-motivation paragraph still references "real submission run" without a footnote anchor — could later add a public benchmark when the paper-write protocol is run on a public repro corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)