### PR TITLE
feat(resubmit-pipeline): new W5 skill + Gap #1 (edit-whitelist) + Gap #2 (citation-audit --soft-only)

### DIFF
--- a/skills/auto-paper-improvement-loop/SKILL.md
+++ b/skills/auto-paper-improvement-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-paper-improvement-loop
 description: "Autonomously improve a generated paper via GPT-5.4 xhigh review → implement fixes → recompile, for 2 rounds. Use when user says \"改论文\", \"improve paper\", \"论文润色循环\", \"auto improve\", or wants to iteratively polish a generated paper."
-argument-hint: "[paper-directory] [— style-ref: <source>]"
+argument-hint: "[paper-directory] [— style-ref: <source>] [— edit-whitelist <path>]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 ---
 
@@ -22,6 +22,7 @@ Unlike `/auto-review-loop` (which iterates on **research** — running experimen
 - **REVIEWER_BIAS_GUARD = true** — When `true`, every review round uses a fresh `mcp__codex__codex` thread with no prior review context. Never use `mcp__codex__codex-reply` for review rounds. Set to `false` only for deliberate debugging of the legacy behavior. **Empirical evidence:** running the same paper with `codex-reply` + "since last round we did X" prompts inflated scores from real 3/10 → fake 8/10 across multiple rounds; switching to fresh threads recovered the true 3/10 assessment.
 - **REVIEW_LOG = `PAPER_IMPROVEMENT_LOG.md`** — Cumulative log of all rounds, stored in paper directory.
 - **HUMAN_CHECKPOINT = false** — When `true`, pause after each round's review and present score + weaknesses to the user. The user can approve fixes, provide custom modification instructions, skip specific fixes, or stop early. When `false` (default), runs fully autonomously.
+- **EDIT_WHITELIST = `null`** — Optional path to a YAML/JSON whitelist file constraining which paths and operations the fix-implementation step may touch. When `null` (default), all edits proceed unconstrained. When set via `— edit-whitelist <path>` (also accepts `— edit_whitelist <path>`), the loop loads the file at startup and consults it before each edit; rejected edits are logged to `PAPER_IMPROVEMENT_LOG.md` rather than silently dropped. See "Optional: Edit Whitelist" below.
 
 > 💡 Override: `/auto-paper-improvement-loop "paper/" — human checkpoint: true`
 
@@ -52,6 +53,112 @@ Sources accepted: local TeX dir / file, local PDF, arXiv id, http(s) URL. Overle
 - Use `style_profile.md` only during the **fix-implementation** phase, to nudge structural choices when applying reviewer feedback. Reviewer feedback always takes precedence; style ref is tie-breaker for *how* to apply a fix, not *whether* to apply it.
 - **Never copy prose, claims, examples, or terminology** from anything reachable through the cache when implementing fixes.
 - **Never pass `— style-ref` (or the cache contents) to the GPT-5.4 reviewer sub-agent.** The Reviewer Independence Protocol below requires reviewers see only the artifact and the user's prompt — leaking the style ref would contaminate the review with author-side context. **This is the most critical invariant in this skill.**
+
+## Optional: Edit Whitelist (`— edit-whitelist <path>`, opt-in)
+
+Lets the caller hard-constrain which files and operations the **fix-implementation** step (Step 3 / Step 6) is allowed to touch. **Default OFF — when the user does not pass `— edit-whitelist` (or the alias `— edit_whitelist`), the loop applies all reviewer-driven edits without restriction, exactly as before.**
+
+This is the parameter that upstream pipelines (e.g. `/resubmit-pipeline` Phase 2) use to enforce text-only resubmit microedits: no `.bib` mutations, no `.sty` / `.bst` mutations, no edits to prior-submission directories, no new `\cite{...}`, no new theorem environments, no new numerical claims.
+
+### Schema
+
+The whitelist file is YAML or JSON. All four sections are optional:
+
+```yaml
+allowed_paths:
+  - sec/*.tex
+  - main.tex
+  - figures/*.tex
+forbidden_paths:
+  - "**/*.bib"
+  - "**/*.sty"
+  - "**/*.bst"
+  - "../OldSubmission/**"
+forbidden_operations:
+  - new_cite              # blocks \cite{...}, \citep{...}, \citet{...}, \citeauthor{...} additions
+  - new_bibitem           # blocks \bibitem{...} additions
+  - new_theorem_env       # blocks \begin{theorem|lemma|proposition|corollary} additions
+  - numerical_claim       # blocks adding new numbers / percentages / metrics
+forbidden_deletions:      # operations that block REMOVALS, not additions
+  - delete_existing_cite  # blocks removal of \cite{...} from the body (use citation-audit --soft-only instead)
+  - delete_theorem_env    # blocks removal of an existing \begin{theorem|...} block
+requires_user_approval_for:  # operations that don't auto-reject but pause for explicit user OK
+  - rewrite_abstract      # paraphrasing the entire abstract triggers a checkpoint
+  - rewrite_intro_first_para
+  - delete_section
+max_edits_per_round: 30   # hard cap on number of accepted edits per round (rejections are not counted; if cap is hit, remaining proposed edits are deferred to the next round with a warning)
+rationale: "Resubmit mode: text-only microedits, paper structure frozen by user constraint."
+```
+
+### Resolution rules
+
+- **`allowed_paths` empty AND `forbidden_paths` empty** → whitelist is a no-op (advisory: the file is loaded and `rationale` echoed to the log, but no path filtering is applied).
+- **`allowed_paths` empty, `forbidden_paths` non-empty** → all paths NOT matched by `forbidden_paths` are mutable.
+- **`allowed_paths` non-empty, `forbidden_paths` empty** → only paths matching `allowed_paths` are mutable.
+- **Both non-empty** → an edit is allowed iff the target matches `allowed_paths` AND does NOT match `forbidden_paths`. `forbidden_paths` always wins on overlap.
+- **`forbidden_operations` missing or empty** → no operation-level guard; only path-level filtering applies.
+
+### Glob semantics
+
+Use bash `extglob` / Python `fnmatch.fnmatch` semantics. `**` matches any depth (zero or more directory segments). Patterns are matched against the path **relative to the paper directory** (e.g. `paper/sec/intro.tex` matches `sec/*.tex` when paper-directory is `paper/`).
+
+### Forbidden-operation detectors
+
+For each candidate edit's diff (the new lines being added — deletions are exempt), the loop runs these regex checks and rejects if any forbidden operation matches:
+
+| Operation | Detector (added lines only) |
+|-----------|------------------------------|
+| `new_cite` | `\\cite[a-zA-Z]*\{[^}]+\}` (catches `\cite`, `\citep`, `\citet`, `\citeauthor`, `\citeyear`, `\citealp`, etc.) |
+| `new_bibitem` | `\\bibitem\{[^}]+\}` |
+| `new_theorem_env` | `\\begin\{(theorem|lemma|proposition|corollary)\*?\}` |
+| `numerical_claim` | New token matching `\b\d+(\.\d+)?%?\b` that did NOT appear in the deleted/replaced lines (i.e. genuinely new numbers, not edits to existing ones) |
+
+### Behavior at loop start (before Round 1 fix-implementation)
+
+1. If `— edit-whitelist <path>` is present in `$ARGUMENTS`, set `EDIT_WHITELIST = <path>`.
+2. Load the file (`yaml.safe_load`; if it fails, fall back to `json.loads`). On load failure, abort the loop with a clear error — do NOT silently proceed unconstrained.
+3. Echo `rationale` (if present) into `PAPER_IMPROVEMENT_LOG.md` under a new "Edit Whitelist" preamble section so the audit trail records why edits were constrained.
+
+### Behavior during fix-implementation (Steps 3 and 6)
+
+Before applying each proposed edit:
+
+1. Resolve target file path relative to the paper directory.
+2. Path check: if `allowed_paths` is non-empty, target must match at least one pattern. Then if `forbidden_paths` is non-empty, target must NOT match any pattern. If either fails → reject as `path` violation.
+3. Operation check: build the unified diff (or just the set of newly-added lines) for the proposed edit. For each entry in `forbidden_operations`, run its detector on the added lines. If any detector matches → reject as `operation` violation.
+4. If all checks pass, apply the edit normally.
+5. If rejected, append an entry to `PAPER_IMPROVEMENT_LOG.md` under a `## Rejected by edit_whitelist (Round N)` heading with this schema:
+   ```
+   - file: <relative path>
+     reason: path | operation
+     pattern: <the offending forbidden_path glob, OR the offending forbidden_operation name + the matched substring>
+     reviewer_concern: <the original Round-N weakness that motivated this edit>
+   ```
+6. Continue with the remaining edits in the round. Do NOT abort the whole round on a single rejection.
+
+### End-of-round surfacing
+
+At the end of each round (after the recompile, before moving to the next round), if any edits were rejected during that round's fix step:
+
+- Print a one-line summary to the round's checkpoint output: `Edit whitelist rejected N edits this round (M path, K operation). See PAPER_IMPROVEMENT_LOG.md "Rejected by edit_whitelist (Round N)".`
+- If `HUMAN_CHECKPOINT = true`, include the rejection list in the checkpoint shown to the user before they approve next-round fixes.
+
+### Example invocations
+
+```bash
+# Resubmit-pipeline Phase 2 caller (text-only mode):
+/auto-paper-improvement-loop "paper/" — edit-whitelist .resubmit/edit_whitelist.yaml
+
+# Aliased form is accepted:
+/auto-paper-improvement-loop "paper/" — edit_whitelist .resubmit/edit_whitelist.yaml
+
+# Combined with other flags:
+/auto-paper-improvement-loop "paper/" — human checkpoint: true — edit-whitelist constraints.yaml
+```
+
+### Rationale
+
+Without a whitelist, the loop's reviewer-driven fix step is free to add citations, introduce new theorem environments, or tweak numerical claims — all of which are reasonable for first-submission polish but **forbidden** in resubmit / camera-ready / rebuttal-only modes where the paper structure is frozen by external constraint. Routing those constraints through a first-class parameter (rather than relying on the LLM to "remember" not to do them) makes the constraint enforceable, auditable via `PAPER_IMPROVEMENT_LOG.md`, and visible to the user at each round's checkpoint.
 
 ## Inputs
 
@@ -178,6 +285,8 @@ Parse the review and implement fixes by severity:
 1. CRITICAL fixes (assumption mismatches, internal contradictions)
 2. MAJOR fixes (overclaims, missing content, notation issues)
 3. MINOR fixes (if time permits)
+
+**Edit-whitelist gate (if set):** If `EDIT_WHITELIST` is set, before applying each proposed edit, check the target path against `allowed_paths` / `forbidden_paths` and the new-lines diff against `forbidden_operations` per the "Optional: Edit Whitelist" section. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 1)` with file, reason (`path` or `operation`), the offending pattern, and the original reviewer concern. The loop continues with remaining edits — a rejection never aborts the round. Surface a rejection summary at the end of the round.
 
 **Common fix patterns:**
 
@@ -334,6 +443,8 @@ Same process as Step 3. Typical Round 2 fixes:
 - Further soften any remaining overclaims
 - Formalize informal arguments (e.g., truncation → formal proposition)
 - Strengthen limitations section
+
+**Edit-whitelist gate (if set):** Same as Step 3 — if `EDIT_WHITELIST` is set, run the path + forbidden-operation checks before applying each proposed edit. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 2)` and the loop continues. Surface a rejection summary at the end of the round.
 
 ### Step 7: Recompile Round 2
 
@@ -493,6 +604,7 @@ paper/
 - **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
 - **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
 - **Global consistency** — when renaming notation or softening claims, check ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions)
+- **Edit-whitelist rejections are LOGGED, not silently dropped** — when `EDIT_WHITELIST` is set and an edit is rejected for a path or forbidden-operation violation, the rejection MUST be appended to `PAPER_IMPROVEMENT_LOG.md` with file, reason, offending pattern, and the original reviewer concern. The loop reports a rejection summary at the end of every round (and in the checkpoint, if `HUMAN_CHECKPOINT = true`). Never silently swallow a whitelist rejection — the audit trail is the whole point of the parameter.
 
 ## Typical Score Progression
 

--- a/skills/citation-audit/SKILL.md
+++ b/skills/citation-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: citation-audit
 description: "Zero-context verification that every bibliographic entry in the paper is real, correctly attributed, and used in a context the cited paper actually supports. Uses a fresh cross-model reviewer with web/DBLP/arXiv lookup to catch hallucinated authors, wrong years, fabricated venues, version mismatches, and wrong-context citations (cite present but the cited paper does not establish the claim). Use when user says \"审查引用\", \"check citations\", \"citation audit\", \"verify references\", \"引用核对\", or before submission to ensure bibliography integrity."
-argument-hint: "[paper-directory-or-bib-file] [--uncited]"
+argument-hint: "[paper-directory-or-bib-file] [--uncited] [— soft-only]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent, mcp__codex__codex, WebSearch, WebFetch
 ---
 
@@ -43,6 +43,7 @@ The dangerous citation problems are **not** wildly fake citations — those are 
 - **WEB_SEARCH = required** — The reviewer must perform real web/DBLP/arXiv lookups, not pattern-match from memory.
 - **OUTPUT = `CITATION_AUDIT.md`** — Human-readable per-entry verdict report.
 - **STATE = `CITATION_AUDIT.json`** — Machine-readable verdict ledger consumable by downstream tools.
+- **SOFT_ONLY = `false`** — When true (set via `— soft-only` / `— soft_only` flag), the audit runs all three layers normally but **forbids any `.bib` file mutation**. Findings that would otherwise mutate the bib (FIX / REPLACE / REMOVE) are translated into per-occurrence sentence-rewrite proposals against the citing `*.tex` files. Used by `/resubmit-pipeline` Phase 1 to honor the user's hard "freeze the bib" constraint.
 
 ## Workflow
 
@@ -275,6 +276,7 @@ If the bib file cannot be read well enough to audit even the cited entries, fall
 - **Always emit, never block** — this skill always writes `CITATION_AUDIT.json` with a verdict; the decision to block finalization lives in `paper-writing` Phase 6 + `tools/verify_paper_audits.sh`, driven by the `assurance` level. See "Submission Artifact Emission" below.
 - **Run once per submission** — the audit is wall-clock expensive (web lookups for each entry); not for every save
 - **Uncited detection is opt-in only** — never auto-enable; never block on uncited entries; existing callers must observe identical output if they do not pass `--uncited`
+- **Under `--soft-only`, citation-audit emits text-rewrite proposals only; bib files are never mutated regardless of finding severity.** The audit semantics (existence + metadata + context) and the per-entry KEEP/FIX/REPLACE/REMOVE ledger are preserved verbatim; only the action layer is translated to per-occurrence sentence rewrites in the citing `*.tex` files. Refuse any downstream-proposed bib edit while `--soft-only` is set.
 
 ## Comparison with Other Audit Skills
 
@@ -305,6 +307,88 @@ After each `mcp__codex__codex` reviewer call, save the trace following `shared-r
 - `.aris/traces/citation-audit/<date>_runNN/` (per-entry review traces)
 - Optional: applied fixes to `references.bib` + `sec/*.tex` (with `--apply` flag)
 - Optional: `details.uncited_entries` field in JSON + `## Uncited Entries (opt-in)` MD section (with `--uncited` flag; field absent and section omitted when flag is unset)
+
+## Optional: Soft-Only Mode (— soft-only)
+
+**Default**: disabled. The audit emits the standard `KEEP / FIX / REPLACE / REMOVE` per-entry verdicts and a downstream caller (or the `--apply` path of Step 6) is free to mutate the bib.
+
+**Opt-in**: pass `— soft-only` (also accepts `— soft_only`) on invocation. This mode is designed for callers — notably `/resubmit-pipeline` Phase 1 — that operate under a **hard "freeze the bib" constraint**: if a citation is wrong-context, soften the surrounding sentence; do **not** change, add, or remove the cite itself.
+
+### What soft-only changes
+
+The audit semantics are **unchanged**: existence + metadata + context-appropriateness checks all run, the reviewer is still invoked once per cited entry, and the per-entry KEEP/FIX/REPLACE/REMOVE verdicts are still computed and emitted exactly as in default mode. Only the **action layer** changes — soft-only translates each base verdict into a text-rewrite proposal instead of a bib mutation.
+
+### Verdict translation table
+
+| Base verdict | Soft-only translation | Notes |
+|---|---|---|
+| `KEEP` | `keep_unchanged` | No action. Cite + sentence are both fine. |
+| `FIX` (metadata wrong) | `keep_metadata_drift_acknowledged` | Bib stays as-is. Flag for human review at submission time. Append note: "metadata drift detected but not fixed under --soft-only". |
+| `REPLACE` (wrong-context cite) | `soften_citing_sentence` | Per-occurrence sentence-rewrite proposal. For each `\cite{X}` in the body, locate the surrounding sentence and propose a softened version that does not claim what `X` actually establishes. |
+| `REMOVE` (cite refers to nonexistent paper — i.e., hallucinated citation) | `drop_cite_in_body_only` | The bib entry is left untouched (per the `--soft-only` invariant), but **the inline `\cite{X}` references in the body MUST be removed and the surrounding sentence rewritten** so it no longer relies on a nonexistent paper. Two sub-strategies the rewriter may use: (a) drop the inline `\cite{X}` entirely and rephrase the sentence to remove the load-bearing claim, OR (b) re-attribute to a different in-bib source that genuinely supports the claim. **Never** leave a `\cite{X}` to a hallucinated paper in the body — that is a worse failure mode than removing the cite, because reviewers will check the reference and find nothing. The bib entry itself stays (it's harmless once not cited; the verifier's uncited-detection at submission time will surface it for cleanup outside this audit). |
+
+### Augmented JSON schema (under `--soft-only`)
+
+When the flag is set, the standard top-level fields (`audit_skill`, `verdict`, `reason_code`, `summary`, etc.) and the existing `details.per_entry` ledger are emitted exactly as in default mode. In addition:
+
+- A top-level `soft_only_mode: true` boolean is added.
+- `details` gains a `soft_only_actions` array — one entry per audited bib key, in the same order as `details.per_entry`.
+
+```json
+{
+  "audit_skill": "citation-audit",
+  "verdict": "...",
+  "soft_only_mode": true,
+  "details": {
+    "soft_only_actions": [
+      {
+        "citekey": "smith2023example",
+        "base_verdict": "REPLACE",
+        "soft_action": "soften_citing_sentence",
+        "occurrences": [
+          {
+            "file": "sec/3.method.tex",
+            "line": 142,
+            "current_sentence": "Smith et al. [2023] proves a generic result that...",
+            "proposed_rewrite": "Smith et al. [2023] discusses a related setting; while not directly applicable, the framing motivates...",
+            "rationale": "Original sentence claims smith2023 'proves' a result, but smith2023 actually only conjectures it. Softened to 'discusses ... motivates' to remove the unsupported claim."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`soft_action` is one of `keep_unchanged | keep_metadata_drift_acknowledged | soften_citing_sentence | drop_cite_in_body_only`. For `keep_unchanged` and `keep_metadata_drift_acknowledged`, `occurrences` MAY be omitted or emitted as `[]`. For `soften_citing_sentence` and `drop_cite_in_body_only`, `occurrences` MUST list one object per `\cite{X}` site in the body that triggered the verdict.
+
+For `drop_cite_in_body_only`, the `proposed_rewrite` field shows the sentence with the inline `\cite{X}` removed (or replaced by a `\cite{Y}` to an alternate in-bib source). The `bib_entry_action` field is fixed to `"leave_as_is_per_soft_only"` — the bib record itself is never modified by the audit.
+
+### Augmented human-readable report
+
+`CITATION_AUDIT.md` gains a new section `## Soft-Only Rewrites (— soft-only mode)` listing each occurrence with the proposed sentence rewrite for human approval. Example:
+
+```markdown
+## Soft-Only Rewrites (— soft-only mode)
+
+The bib file is frozen. The following sentence rewrites are proposed in lieu of bib edits.
+
+### `smith2023example` — base verdict REPLACE → `soften_citing_sentence`
+
+- **File**: `sec/3.method.tex:142`
+- **Current**: "Smith et al. [2023] proves a generic result that..."
+- **Proposed**: "Smith et al. [2023] discusses a related setting; while not directly applicable, the framing motivates..."
+- **Rationale**: Original sentence claims smith2023 "proves" a result, but smith2023 actually only conjectures it. Softened to "discusses ... motivates" to remove the unsupported claim.
+```
+
+The existing per-entry verdict table in the Summary block is **kept** but FIX/REPLACE/REMOVE rows are annotated with a `🔒 bib frozen by --soft-only` badge so downstream readers see immediately why the bib was not mutated.
+
+### Hard guarantees under `--soft-only`
+
+- **No `.bib` file mutations under any circumstance.** Step 6 ("Apply fixes (interactive)") is bypassed for the bib file; only `*.tex` rewrite proposals are produced (and still require human approval before any text edit).
+- If a downstream caller — including `paper-writing` Phase 6 or any wrapper — proposes a bib edit while `--soft-only` is set, **refuse it**: emit a one-line refusal in the trace and continue to the next finding.
+- The top-level `verdict` decision table is **unchanged**: a wrong-context cite still produces `FAIL` with `reason_code: wrong_context`. Soft-only does not silence the finding; it only constrains the action layer.
+- `--soft-only` composes with `--uncited`: both flags can be set together. Uncited entries remain detect-only and are not subject to soft-only translation (there is no citing sentence to soften).
 
 ## Submission Artifact Emission
 

--- a/skills/resubmit-pipeline/SKILL.md
+++ b/skills/resubmit-pipeline/SKILL.md
@@ -1,0 +1,427 @@
+---
+name: resubmit-pipeline
+description: "Workflow 5: orchestrate a text-only resubmit of a polished paper to a different venue under hard constraints (no new experiments, no bib edits, no framework changes, never overwrite prior submissions). Phase 0 physical isolation, Phase 0.5 health + anonymity check, Phase 1 audit (proof / claim / citation), Phase 2 microedits via auto-loop with edit-whitelist + citation-audit --soft-only, Phase 3 kill-argument adversarial gate, Phase 4 final compile + Overleaf push via /overleaf-sync. Use when user says \"resubmit pipeline\", \"重投流程\", \"port paper to <new venue>\", \"resubmit to <venue>\", \"tighten paper for resubmission\", or has a rejected/withdrawn paper to move to a different top venue under tight time budget."
+argument-hint: "[paper-base-dir] [— target-venue: <name>] [— review-corpus: <path>]"
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
+---
+
+# Resubmit Pipeline: Text-Only Microedit Mode
+
+Compose a polished paper into a new venue under text-only constraints: **$ARGUMENTS**
+
+## Why This Exists
+
+Most ARIS writing workflows assume the input is either a narrative report (Workflow 3) or an in-progress paper that may still need experiments / bib changes / structural edits. Resubmit is a fundamentally different scope:
+
+- The paper is **already polished** — proofs are done, experiments are done, bibliography is curated.
+- The user wants to absorb prior reviewer concerns from a previous venue and re-submit, **without** introducing new experiments, new citations, or framework changes (LLM hallucination paranoia + tight resubmit timing + closed compute budget).
+- The base submission directory is **read-only** — the new submission must compose into a sibling directory, never mutate prior state.
+- Page limit may shrink between source and target venue (e.g., workshop camera-ready → 9-page main).
+
+Existing skills cover adjacent territory but none of this exact composition: `/rebuttal` builds the OpenReview-style response document, not in-paper microedits; `/auto-paper-improvement-loop` is the per-round engine but presupposes someone has already chosen the base manuscript, migrated venue format, set the edit whitelist, queued the reviewer feedback, and decided what NOT to change. `/resubmit-pipeline` fills that orchestration gap.
+
+## When to Use
+
+- A theory or system paper was rejected at venue A and you want to resubmit to venue B with tight time budget (≤ 1-2 weeks).
+- You have **3 inputs ready**: the polished paper directory at venue A's format, the target venue B's format/template/style files, and the prior reviewer reports.
+- You explicitly do **not** want to re-derive theorems, run new experiments, or change the bibliography.
+
+## When NOT to Use
+
+- The paper still needs experiments — use `/experiment-bridge` → `/auto-review-loop` first.
+- The paper still needs structural rewrites or new sections — use `/paper-writing` (Workflow 3).
+- You want to write the rebuttal response itself — use `/rebuttal` (Workflow 4).
+- The reviewer feedback demands new theorems or new framework — escalate to user before starting; this skill emits `BLOCKED` with `reason_code: out_of_scope_microedit` if it detects this case.
+
+## Constants
+
+- **REVIEWER_MODEL** = inherits from `/auto-paper-improvement-loop`'s default (`gpt-5.4` via Codex MCP) unless the user passes `— reviewer-model: gpt-5.5`. Codex reasoning effort is fixed at `xhigh` for all reviewer calls per the existing skill convention.
+- **ROUNDS** = 2 (default; matches `/auto-paper-improvement-loop`'s diminishing-returns line). A 3rd round only fires if Phase 2 reports non-convergence AND the user explicitly approves at the round-2 checkpoint.
+- **EFFORT** = `max` (default for resubmit; resubmit is high-stakes). The user can override with `— effort: balanced` if time is extremely tight.
+- **EDIT_WHITELIST_PATH** = `<paper-base-dir>/../<NewVenue>/.aris/edit_whitelist.yaml` (auto-generated in Phase 0; user can override with a custom path).
+- **NEVER_OVERWRITE** = true (always; this is a hard contract — prior submission directories are immutable).
+- **ASSURANCE_LEVEL** = `submission` (default; resubmit always targets a real submission).
+
+## Inputs
+
+Three mandatory inputs:
+
+1. **`paper-base-dir`** — the polished paper at venue A's format. Must contain `main.tex` (or equivalent entry), `sec/` or `sections/`, `references.bib` (or equivalent), and a compiled `main.pdf` (used for visual review).
+2. **`— target-venue: <name>`** — one of: `iclr`, `icml`, `neurips`, `aaai`, `ijcai`, `colm`, `tmlr`, `uai`, or `other`. The skill expects venue style files at `<paper-base-dir>/templates/<venue>.{sty,tex,bst}` or in a recognized template directory. If `other`, the user passes `— target-style-dir: <path>`.
+3. **`— review-corpus: <path>`** — directory containing prior venue's reviewer reports as `.txt` or `.md` files (one per reviewer, ideally). If `--review-corpus` is omitted, the skill emits `BLOCKED` with `reason_code: missing_review_corpus` because the whole point of resubmit is absorbing those concerns.
+
+Optional:
+
+- **`— reviewer-model: gpt-5.5`** — override the default reviewer (`gpt-5.4`).
+- **`— rounds: <int>`** — override default 2.
+- **`— assurance: draft`** — relax MANDATORY gates (default `submission`).
+- **`— effort: balanced`** — relax `max` if time is critical.
+- **`— skip-anonymity-scan`** — skip Phase 0.5 anonymity check (only valid for non-double-blind venues like TMLR; else WARN).
+- **`— overleaf-target: <project-id>`** — the Overleaf project ID for Phase 4 push (per `/overleaf-sync setup`).
+
+## Pipeline
+
+### Phase 0: Physical Isolation Setup (zero edits to existing files)
+
+Resubmit's hardest invariant: **never overwrite any prior submission directory**. The new venue's submission lives as a **sibling** of all prior venues.
+
+```bash
+# Resolve target-venue → new sibling dir name (capitalized)
+NEW_VENUE_DIR="$(dirname "$PAPER_BASE_DIR")/$(echo "$TARGET_VENUE" | sed 's/.*/\u&/')"
+
+# Atomic dir create — `mkdir` (not `mkdir -p`) fails fast if the dir exists,
+# avoiding the TOCTOU race window of `[ -e ] && exit; mkdir -p`. The mkdir
+# itself must succeed exactly once; if a concurrent run gets there first,
+# this errors out per resubmit-pipeline's never-overwrite invariant.
+mkdir "$NEW_VENUE_DIR" 2>/dev/null || {
+    echo "ERROR: $NEW_VENUE_DIR already exists; resubmit-pipeline never overwrites prior submissions. Pick a different target-venue or rename the existing dir." >&2
+    exit 1
+}
+mkdir -p "$NEW_VENUE_DIR/.aris"
+```
+
+**Composition rules** (all `cp`, never `\input{../...}`, never symlink):
+
+1. **`main.tex`** — write fresh for the target venue's `.sty`. Use `templates/<venue>.tex` as the starting skeleton; only the `\title{}`, `\author{}`, abstract include, and section input lines are copied from the base venue's `main.tex`. The new `main.tex` lives entirely inside `$NEW_VENUE_DIR/`.
+2. **`sec/` (or `sections/`)** — physical `cp -r $PAPER_BASE_DIR/sec/ $NEW_VENUE_DIR/sec/`. **Do not symlink, do not `\input{../sec/...}` from the new main.** Symlinks break Overleaf zip export; cross-directory `\input` would mutate the shared pool and pollute prior submissions.
+3. **`math_commands.tex`** (and any other macro file the sections depend on) — physical `cp` into `$NEW_VENUE_DIR/`.
+4. **`Figure/` (or `figures/`)** — copy the directory in (`cp -r`). **Path trap**: existing sections likely write `\includegraphics{Figure/foo.pdf}`. If you set `\graphicspath{{../Figure/}}` from a child directory, it resolves `../Figure/Figure/foo.pdf` — wrong. Either copy `Figure/` in directly (preferred), or use `\graphicspath{{../}}`.
+5. **Bibliography** — write `\bibliographystyle{<venue-bst>}` + `\bibliography{../references}` directly in the new `main.tex`. **Never** `\input` an existing `ref.tex` or `references.tex` that already contains its own `\bibliography{}` command (path resolution silently breaks).
+6. **`.aris/`** — create `$NEW_VENUE_DIR/.aris/` and write `assurance.txt` containing `submission` (matches the verifier's expected location).
+
+**Output of Phase 0**: a new sibling dir with all source files, no edits to text content yet, ready for compile.
+
+### Phase 0.5: Health Check + Anonymity Scan (still zero text edits)
+
+Before any audit or edit, the paper must compile cleanly on the new venue's style and pass anonymity scan if the target venue is double-blind.
+
+**Compile + page count**:
+
+```bash
+cd "$NEW_VENUE_DIR"
+latexmk -C
+latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tee compile.log
+```
+
+If compile fails: emit `RESUBMIT_REPORT.json` with `verdict: BLOCKED, reason_code: phase_0_5_compile_failed`, surface the error to the user, and stop. Common causes: missing macro from `math_commands.tex`, venue style undefined command, `\graphicspath` issue.
+
+Page count vs venue limit (measure first; do not assume):
+
+```bash
+PAGES=$(pdfinfo main.pdf | awk '/^Pages:/ {print $2}')
+LIMIT=$(grep -oE "page_limit: [0-9]+" "$NEW_VENUE_DIR/templates/$TARGET_VENUE.tex" | awk '{print $2}')
+echo "Pages: $PAGES, Limit: $LIMIT, Delta: $((PAGES - LIMIT))"
+```
+
+If `PAGES > LIMIT`, queue Phase 2 to honor a page-shrink heuristic (see "Page-Shrink Heuristic" below).
+
+**Anonymity scan** (skip only if `— skip-anonymity-scan` is passed AND target venue is non-double-blind):
+
+The scan covers **5 layers** (the proposal's 1-layer scan was incomplete):
+
+1. **Surface identifiers**: author surnames, affiliations, institution names, lab codenames, prior funding tag IDs (`grep -E "$(echo $AUTHOR_SURNAMES | tr ' ' '|')|$(echo $AFFILIATIONS | tr ' ' '|')"`).
+2. **Self-citation phrasing**: any sentence using "we showed in [...]" or "in our prior work [...]" that names the paper's own authors. Must rewrite to "X et al. [year] shows..." third-person form. Grep regex: `\b(we|our|my|I)\s+(showed|proved|demonstrated|prior work|earlier paper|previous paper)\b`.
+3. **Acknowledgments + funding**: scan `acknowledgments.tex` (or `\acknowledgments{}` block) for institution-specific thanks, grant IDs, named collaborators. Comment out for double-blind submission.
+4. **Cross-rebuttal references**: scan footnotes and body for "this paper builds on rebuttal at venue X" or "addressing reviewer N's concern from venue X" — these must be removed entirely (they violate anonymity AND signal prior rejection).
+5. **Internal codenames / project links**: grep for repo URLs (`github.com/<user>/<project>`), Slack channel names, internal wiki links, and dataset codenames that may identify the lab.
+
+If **any of the 5 layers** triggers a hit, emit `RESUBMIT_REPORT.json` with `verdict: BLOCKED, reason_code: anonymity_scan_failed` and present a per-hit list to the user. They must approve a fix or accept the risk before Phase 1 runs. Layers 4-5 are equally blocking as layers 1-3 — cross-rebuttal references and internal codenames signal both prior-venue identity AND lab identity, both of which violate double-blind in different ways.
+
+**Residual coloring / margin-note scan**:
+
+Search for `\revise{...}`, `\fix{...}`, `\new{...}`, `\todo{...}`, `\todonotes{...}`, `\textcolor{red}{...}` leftovers from camera-ready cycles. List them; user decides whether to keep (some venues accept revision-marker boxes) or strip.
+
+**Output of Phase 0.5**: `BASELINE.md` with initial page count, anonymity-scan summary, residual-color list, overfull-hbox count.
+
+### Phase 1: Audit (zero edits)
+
+Three audits in parallel, all detect-only. The new dir's source files are read; nothing is written except audit artifacts.
+
+| Skill | Purpose | Artifact |
+|---|---|---|
+| `/proof-checker $NEW_VENUE_DIR/main.tex --restatement-check` | Gap-find on theorems prior reviewers attacked; cross-location consistency between main statement and restatements | `PROOF_AUDIT.json` + `.md` |
+| `/paper-claim-audit $NEW_VENUE_DIR/` | Numerical fidelity (every number in body matches what proofs / result files establish) | `PAPER_CLAIM_AUDIT.json` + `.md` |
+| `/citation-audit $NEW_VENUE_DIR/ — soft-only` | Wrong-context citations + misattributions, mapped to "soften citing sentence" actions (NOT bib edits) | `CITATION_AUDIT.json` + `.md` |
+
+**Critical**: the third audit MUST run with `— soft-only`. Without that flag, citation-audit emits `KEEP/FIX/REPLACE/REMOVE` verdicts that presuppose bib mutations — incompatible with resubmit's "no bib edits" constraint. With `--soft-only`, the same findings are translated to per-occurrence sentence-rewrite proposals consumable by Phase 2.
+
+**Atomize prior reviewer concerns** in parallel:
+
+```
+For each file under $REVIEW_CORPUS:
+    Read the reviewer report.
+    Atomize into discrete concerns: severity (critical / major / minor),
+      type (assumption / novelty / scope / rigor / experiment-coverage / framing),
+      addressability (text-fixable / partial / unaddressable-under-constraints).
+    Append to KNOWN_WEAKNESSES.md with stable IDs (W1, W2, ...).
+```
+
+`KNOWN_WEAKNESSES.md` schema:
+
+```yaml
+- id: W1
+  severity: major
+  type: scope
+  source: reviewer_2_venue_a
+  concern: "Theorem 3 states a generic result but the proof only handles a specific regime."
+  addressability: text-fixable
+  recommended_fix: "Narrow Theorem 3's title to 'restricted regime'; add scope qualifier in abstract."
+- id: W2
+  severity: critical
+  type: experiment-coverage
+  source: reviewer_3_venue_a
+  concern: "No comparison against [prior method X]."
+  addressability: unaddressable-under-constraints
+  recommended_fix: "Acknowledge in Limitations that this comparison is left for future work."
+```
+
+**Output of Phase 1**: 4 artifacts (3 audits + KNOWN_WEAKNESSES.md). All are inputs to Phase 2.
+
+### Phase 2: Targeted Text Microedits via Auto-Improvement Loop
+
+The load-bearing phase. `/auto-paper-improvement-loop` is invoked with **two safety mechanisms**:
+
+1. **`— edit-whitelist <path>`** — a YAML file enumerating allowed paths and forbidden operations. Auto-generated in Phase 0 at `$NEW_VENUE_DIR/.aris/edit_whitelist.yaml`:
+
+   ```yaml
+   allowed_paths:
+     - "sec/*.tex"
+     - "main.tex"
+     - "appendix.tex"
+   forbidden_paths:
+     - "**/*.bib"
+     - "**/*.sty"
+     - "**/*.bst"
+     - "../*Submission/**"           # all prior submission dirs
+     - "../*Camera/**"
+     - "templates/**"
+   forbidden_operations:
+     - new_cite                       # blocks \cite{...}, \citep{...}, \citet{...}, \citeauthor{...}
+     - new_bibitem                    # blocks \bibitem{...} additions
+     - new_theorem_env                # blocks \begin{theorem|lemma|proposition|corollary} additions
+     - numerical_claim                # blocks adding numbers / percentages / metrics not present in original
+   rationale: "Resubmit mode: text-only microedits, paper structure frozen by user constraint."
+   ```
+
+2. **Per-round diff gate via auto-loop's HUMAN_CHECKPOINT** — `/auto-paper-improvement-loop` does not accept `--rounds`, `--reviewer-model`, or `--resume-after-round-checkpoint` flags (those are not in its CLI). It uses the `MAX_ROUNDS = 2` constant and `REVIEWER_MODEL = gpt-5.4` defaults, with an existing `HUMAN_CHECKPOINT` mechanism for round gating. Resubmit-pipeline therefore invokes the loop **once** with `HUMAN_CHECKPOINT = true` so each round pauses for the orchestrator to inspect the diff:
+
+   ```bash
+   # Snapshot the new venue dir BEFORE auto-loop runs (for diff baseline,
+   # works whether or not paper-base-dir is a git repo)
+   SNAPSHOT_DIR="$NEW_VENUE_DIR/.aris/snapshots/round-0"
+   mkdir -p "$SNAPSHOT_DIR"
+   rsync -a --exclude='.aris' --exclude='*.pdf' --exclude='*.aux' \
+         "$NEW_VENUE_DIR/" "$SNAPSHOT_DIR/"
+
+   # Single auto-loop invocation; rounds + checkpoints are loop-internal.
+   # The whitelist file is the only resubmit-specific param.
+   /auto-paper-improvement-loop "$NEW_VENUE_DIR/" \
+       --edit-whitelist "$NEW_VENUE_DIR/.aris/edit_whitelist.yaml" \
+       — assurance: submission \
+       — effort: "$EFFORT" \
+       — human checkpoint: true
+   ```
+
+   Inside the loop, at each round-end checkpoint, the resubmit orchestrator inspects:
+
+   ```bash
+   for ROUND in 1 2; do  # auto-loop's MAX_ROUNDS = 2
+     # auto-loop pauses at HUMAN_CHECKPOINT after each round
+     # diff this round vs prior snapshot (works without git)
+     diff -ruN "$NEW_VENUE_DIR/.aris/snapshots/round-$((ROUND-1))" "$NEW_VENUE_DIR" \
+         > "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt"
+
+     # Whitelist compliance check on the diff
+     check_whitelist_compliance "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt" \
+                                  "$NEW_VENUE_DIR/.aris/edit_whitelist.yaml"
+
+     # Selective regression audits (only fire if relevant files touched)
+     if grep -qE 'theorem|lemma|proposition|corollary' "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt"; then
+         /proof-checker "$NEW_VENUE_DIR/main.tex" --restatement-check
+     fi
+     if grep -qE '[0-9]+(\.[0-9]+)?\s*(%|±|x|×)' "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt"; then
+         /paper-claim-audit "$NEW_VENUE_DIR/"
+     fi
+
+     # Snapshot this round for next-round diff
+     rsync -a --exclude='.aris' --exclude='*.pdf' --exclude='*.aux' \
+           "$NEW_VENUE_DIR/" "$NEW_VENUE_DIR/.aris/snapshots/round-$ROUND/"
+
+     # Convergence check — see "Convergence Criteria" section below
+     # If converged, signal HUMAN_CHECKPOINT to terminate early
+   done
+   ```
+
+   **Why the snapshot-rsync approach instead of `git diff HEAD~1..HEAD`**: the paper-base-dir is not guaranteed to be a git repo, and even when it is, intermediate states inside one auto-loop round don't produce per-round commits. rsync snapshots are repo-agnostic.
+
+3. **Mapping of edits to concerns** — every proposed edit must be mapped to either (a) an entry in `KNOWN_WEAKNESSES.md` with an ID, OR (b) a Phase 1 audit finding. Un-mapped edits are rejected by the loop's reviewer prompt. This is enforced via the loop's reviewer prompt template (the resubmit-pipeline's invocation passes a custom prompt addendum saying "every fix must cite a W<n> ID or audit finding ID").
+
+**Inputs into the loop's reviewer prompt** (concatenated):
+
+- The 3 Phase 1 audit reports (`PROOF_AUDIT.md`, `PAPER_CLAIM_AUDIT.md`, `CITATION_AUDIT.md`)
+- `KNOWN_WEAKNESSES.md`
+- A custom addendum: "you are reviewing a resubmit; the user constraint is text-only microedits; every proposed fix MUST cite either a W<n> ID from KNOWN_WEAKNESSES or an audit finding ID; un-mapped fixes are rejected; the edit whitelist is binding."
+
+**Output of Phase 2**: `PAPER_IMPROVEMENT_LOG.md` with per-round diffs, `rejected_by_edit_whitelist` list, and convergence status.
+
+### Phase 3: Adversarial Gate
+
+`/kill-argument $NEW_VENUE_DIR/`
+
+**No `--difficulty` parameter exists** in `/kill-argument` — earlier proposal drafts referenced a non-existent flag. The skill always uses Codex 5.5 + xhigh and runs the standard 2-thread Attack-Adjudication protocol; the `assurance` level (set to `submission` for resubmit) determines whether `FAIL` blocks the final report.
+
+The kill-argument output is **residual-risk reporting**, not auto-rewrite directives. A hostile reviewer may demand framework changes the user banned; the adjudication step exists to **triage** which findings are text-fixable vs need user escalation.
+
+```
+Read $NEW_VENUE_DIR/KILL_ARGUMENT.json
+For each decomposed_point with verdict in {still_unresolved, partially_answered}:
+    If severity_if_unresolved == critical:
+        If recommended_fix is text-only AND maps to allowed paths:
+            Append to "extra round queue"
+        Else:
+            Append to "user escalation queue" with note "outside text-only constraint"
+```
+
+If extra round queue is non-empty AND user-budget allows: one extra Phase 2 round. Else: stop and surface the user-escalation queue with a written escalation note ("here is what cannot be fixed under your constraints; please decide before submission").
+
+### Phase 4: Final Compile + Diff Report + Overleaf Push
+
+**Final compile**:
+
+```bash
+/paper-compile $NEW_VENUE_DIR/main.tex --venue $TARGET_VENUE
+```
+
+`/paper-compile` checks page limit, font, bib resolve, figure overflow, and emits `COMPILE_REPORT.json`. If page limit exceeded → trigger page-shrink heuristic (see below).
+
+**Final paper-claim-audit zero-context pass**:
+
+```bash
+/paper-claim-audit $NEW_VENUE_DIR/
+```
+
+Verifies no Phase 2 microedit accidentally introduced a numerical claim that's not backed by results.
+
+**Diff report**:
+
+```bash
+diff -u $PAPER_BASE_DIR/main.tex $NEW_VENUE_DIR/main.tex > $NEW_VENUE_DIR/.aris/DIFF_REPORT.md
+for f in $PAPER_BASE_DIR/sec/*.tex; do
+    base=$(basename $f)
+    diff -u "$f" "$NEW_VENUE_DIR/sec/$base" >> $NEW_VENUE_DIR/.aris/DIFF_REPORT.md
+done
+```
+
+This goes to the user for skim-review before any export.
+
+**Overleaf push** (if `— overleaf-target: <project-id>` was passed):
+
+Defer entirely to `/overleaf-sync setup` and `/overleaf-sync push`. Do **not** invent a parallel push mechanism — `/overleaf-sync setup` already handles token-stays-in-keychain (token never enters the agent), and `/overleaf-sync push` has a confirmation gate before writing to shared Overleaf state.
+
+```bash
+/overleaf-sync setup $OVERLEAF_TARGET   # one-time, user confirms in their terminal
+/overleaf-sync push                      # confirmation-gated push from $NEW_VENUE_DIR
+```
+
+If `overleaf-target` is not provided, skip Overleaf push and tell the user to either `/overleaf-sync setup <id>` manually or zip-export the directory.
+
+## Page-Shrink Heuristic
+
+When Phase 0.5 or Phase 4 detects page overflow, apply this **ordered** heuristic. Stop as soon as the page limit is met. Each step is fully constrained by the edit whitelist (no theorem changes, no bib changes, no framework changes):
+
+1. **Compress conclusion** (typically 1-2 paragraphs of "future work" can be cut to 2-3 sentences each). Save: 0.3-0.7 pages.
+2. **Tighten abstract / intro hedging** (cut "in this paper, we" → "we"; cut "it is well known that" → straight to point). Save: 0.2-0.4 pages.
+3. **Move marginal figures to appendix** (figures whose information is not load-bearing for the main argument). Save: 0.5-1 page per figure.
+4. **Move proof sketches / extended remarks to appendix** (keep theorem statements + 1-line proof intuition in main; full proof goes to appendix). Save: 0.5-2 pages.
+5. **Compress related-work prose** (cite-by-citation comparisons → comparison table). Save: 0.3-0.5 pages.
+
+**Forbidden** under this heuristic: removing experiments, removing theorems from main, removing citations (bib frozen). If after step 5 the paper still overflows, emit `RESUBmit_REPORT.json` with `verdict: BLOCKED, reason_code: page_shrink_failed_under_constraints` and surface to user — they must decide whether to relax a constraint or pick a different target venue.
+
+## Convergence Criteria (Phase 2 stop condition)
+
+Phase 2's per-round loop terminates when **all three** hold:
+
+1. **No new CRITICAL or MAJOR text-fixable findings** in the round's reviewer output (compared to the running running-deduped weakness list).
+2. **Page budget passes** — `/paper-compile` reports page count ≤ venue limit.
+3. **All audits non-blocking** — `/proof-checker`, `/paper-claim-audit`, `/citation-audit --soft-only` all return `verdict ∈ {PASS, NOT_APPLICABLE}` (not `WARN/FAIL/BLOCKED/ERROR`).
+
+If after `ROUNDS` (default 2) any of (1)/(2)/(3) is still failing, emit a checkpoint to the user asking whether to continue with an extra round (not auto-extend). The user explicitly approving an extra round overrides the default-2 cap.
+
+This pattern is borrowed from `/rebuttal` Phase 7's "terminate when no new substantive issues" — the same shape works for resubmit.
+
+## Master `RESUBMIT_REPORT.md` Ledger
+
+Every resubmit run writes one master report at `$NEW_VENUE_DIR/RESUBMIT_REPORT.{md,json}` collecting:
+
+- Source dir, target venue, target style files used, run start / end timestamps
+- Pointers to all artifacts: `BASELINE.md`, `PROOF_AUDIT.json`, `PAPER_CLAIM_AUDIT.json`, `CITATION_AUDIT.json`, `KNOWN_WEAKNESSES.md`, `PAPER_IMPROVEMENT_LOG.md`, `KILL_ARGUMENT.json`, `COMPILE_REPORT.json`, `DIFF_REPORT.md`
+- SHA256 hashes of every input file consumed (for `verify_paper_audits.sh` compatibility)
+- All thread IDs (Phase 1 audits + Phase 2 reviewer rounds + Phase 3 kill-argument's two threads)
+- `audit_skill: resubmit-pipeline`, `verdict ∈ {PASS, WARN, FAIL, NOT_APPLICABLE, BLOCKED, ERROR}`, `reason_code: <one of the listed codes>`
+- Decision log: every user checkpoint approval / rejection / escalation, with timestamp
+- "Skipped constraints": if any user override (e.g., `— skip-anonymity-scan`, `— rounds 3`) was passed, recorded with rationale
+
+The schema follows `shared-references/assurance-contract.md` (the same schema all mandatory audits use). This makes resubmit-pipeline runs forensically reproducible.
+
+## Failure Modes
+
+The skill emits one of 7 verdicts (the 6 from the assurance contract + a `USER_DECISION` runtime state for in-flight checkpoint pauses):
+
+| Verdict | reason_code | Trigger | Recovery |
+|---|---|---|---|
+| `PASS` | `clean_resubmit` | All gates passed; final PDF compiled at venue limit | Submit |
+| `WARN` | `partially_addressed_concerns` | All MUST-FIX gates passed but some `KNOWN_WEAKNESSES` remain unaddressable | User reviews unaddressed list; submits with awareness |
+| `FAIL` | `kill_argument_unresolved_critical` | Phase 3 surfaces a `still_unresolved` critical finding that cannot be fixed under text-only constraints | User decides: relax constraints, escalate to framework change, or pick different venue |
+| `NOT_APPLICABLE` | `not_a_resubmit` | The skill detects no prior reviews in `--review-corpus` or the directory looks like a fresh draft | User uses `/paper-writing` instead |
+| `USER_DECISION` | `awaiting_phase_<N>_checkpoint` | Skill paused at a Phase 0.5 anonymity-fix checkpoint, Phase 2 round-end diff gate, Phase 3 escalation queue, or Phase 4 page-shrink approval | User responds to the checkpoint prompt; skill resumes with the user's decision recorded in the master ledger |
+| `BLOCKED` | `phase_0_setup_blocked` | New venue dir already exists, or template files not found | User resolves the conflict; rerun |
+| `BLOCKED` | `phase_0_5_compile_failed` | Initial compile fails on new venue's style | User fixes compile error before audits run |
+| `BLOCKED` | `anonymity_scan_failed` | Phase 0.5 hits surface-identifier or self-citation patterns the user must approve | User approves fixes or passes `— skip-anonymity-scan` (only for non-double-blind) |
+| `BLOCKED` | `missing_review_corpus` | `--review-corpus` not provided AND not detected | User provides the prior reviews |
+| `BLOCKED` | `page_shrink_failed_under_constraints` | Page-shrink heuristic exhausted, paper still overflows | User relaxes a constraint or picks a different venue |
+| `BLOCKED` | `out_of_scope_microedit` | `KNOWN_WEAKNESSES` analysis shows ≥1 critical concern requires new experiments / new theorems / framework change | User decides whether to escalate (drop resubmit-pipeline; use full Workflow 1.5 + 3) |
+| `ERROR` | `audit_failure` / `loop_failure` | Any sub-skill emits `ERROR` | Examine sub-skill's report; fix + retry |
+
+`BLOCKED` is recoverable; `ERROR` indicates an unexpected sub-skill failure; only `FAIL` and unrecoverable `BLOCKED` block submission.
+
+## Key Rules
+
+- **Never overwrite prior submission directories.** This is the single hardest invariant. The skill aborts at Phase 0 if the target dir already exists.
+- **Bib is frozen.** All citation-audit findings flow through `--soft-only` and emerge as text-rewrite proposals, not bib edits.
+- **Edit whitelist is binding.** Every Phase 2 round respects the whitelist; rejections logged to `PAPER_IMPROVEMENT_LOG.md`; the user sees a per-round summary at the round checkpoint.
+- **Per-round diff gate is mandatory.** Multi-round drift is the highest-risk failure mode for resubmit (a small softening at round 1 + another small softening at round 2 can compound into a meaningful framing change). The orchestrator MUST inspect each round's diff before next round.
+- **Convergence criteria are fixed.** Default is 2 rounds; a 3rd round requires explicit user approval at the round-2 checkpoint. The loop does not auto-extend.
+- **Anonymity scan is 5-layer.** Surface identifiers, self-citation phrasing, acknowledgments, cross-rebuttal references, internal codenames — not just `grep author surnames`.
+- **Phase 3 (kill-argument) is residual-risk reporting, not auto-rewrite.** Adjudicator's `still_unresolved` critical points may need user escalation, not blind extra-round triggering.
+- **Overleaf push defers to `/overleaf-sync`.** Don't invent a parallel mechanism.
+- **Master `RESUBMIT_REPORT.md` ledger is mandatory** at `assurance: submission`.
+
+## Output Contract
+
+- `<NEW_VENUE_DIR>/main.tex` + `sec/` + `main.pdf` — the new submission, compiled
+- `<NEW_VENUE_DIR>/RESUBMIT_REPORT.md` + `RESUBMIT_REPORT.json` — master ledger (mandatory)
+- `<NEW_VENUE_DIR>/BASELINE.md` — Phase 0.5 health snapshot
+- `<NEW_VENUE_DIR>/KNOWN_WEAKNESSES.md` — atomized prior reviewer concerns with stable IDs
+- `<NEW_VENUE_DIR>/PROOF_AUDIT.json` + `.md` — Phase 1 proof audit
+- `<NEW_VENUE_DIR>/PAPER_CLAIM_AUDIT.json` + `.md` — Phase 1 claim audit
+- `<NEW_VENUE_DIR>/CITATION_AUDIT.json` + `.md` — Phase 1 citation audit (--soft-only mode)
+- `<NEW_VENUE_DIR>/PAPER_IMPROVEMENT_LOG.md` — per-round Phase 2 trace
+- `<NEW_VENUE_DIR>/KILL_ARGUMENT.json` + `.md` — Phase 3 adversarial gate
+- `<NEW_VENUE_DIR>/COMPILE_REPORT.json` — Phase 4 compile + page-limit check
+- `<NEW_VENUE_DIR>/DIFF_REPORT.md` — full diff vs base venue body
+- `<NEW_VENUE_DIR>/.aris/edit_whitelist.yaml` — Phase 0-generated whitelist
+- `<NEW_VENUE_DIR>/.aris/round-N-diff.txt` — per-round diff for the gate
+- `<NEW_VENUE_DIR>/.aris/traces/<phase>/<date>_runNN/` — Codex traces per phase
+
+The new venue dir is **the** deliverable; the prior venue dir is untouched.
+
+## Review Tracing
+
+Every Codex MCP reviewer call across all phases saves traces per `shared-references/review-tracing.md` to `<NEW_VENUE_DIR>/.aris/traces/<phase-name>/<date>_run<NN>/`. Both threads of `/kill-argument` are preserved separately. The master `RESUBMIT_REPORT.json` `trace_path` field points to the top-level traces directory.
+
+## Notes
+
+- This skill orchestrates several existing skills (proof-checker, paper-claim-audit, citation-audit, auto-paper-improvement-loop, kill-argument, paper-compile, overleaf-sync) plus uses two recently-added parameters (`/auto-paper-improvement-loop --edit-whitelist`, `/citation-audit --soft-only`). Make sure those parameters resolve to the current SKILL.md versions before relying on the resubmit pipeline.
+- The 5-layer anonymity scan is intentionally more thorough than `/paper-compile`'s generic self-citation warning, because resubmit-mode often inherits camera-ready text from a non-double-blind venue going to a double-blind venue.
+- Page-shrink heuristic is ordered (compress conclusion → tighten hedging → move marginal figures → move proof sketches → compress related-work prose). The order is calibrated to "least risky to most risky" — compressing conclusion is mostly editorial; moving proof sketches changes the reading flow. Stop as early as page limit is met.
+- `RESUBMIT_REPORT.json` schema follows `shared-references/assurance-contract.md` exactly. This makes resubmit runs forensically reproducible. **Note**: `tools/verify_paper_audits.sh` does not currently include `RESUBMIT_REPORT.json` in its `MANDATORY_AUDITS` list (the verifier checks proof / paper-claim / citation / kill-argument). The 4 mandatory audit files consumed by resubmit (which DO live in `<NEW_VENUE_DIR>/`) are recognized by the verifier as usual; `RESUBMIT_REPORT.json` is the orchestrator's own ledger and is not yet a verifier mandatory artifact. Adding it to the verifier is a separate follow-up if the user wants resubmit to be a submission gate via the verifier.

--- a/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-paper-improvement-loop
 description: "Autonomously improve a generated paper via GPT-5.4 xhigh review → implement fixes → recompile, for 2 rounds. Use when user says \"改论文\", \"improve paper\", \"论文润色循环\", \"auto improve\", or wants to iteratively polish a generated paper."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory] [— edit-whitelist <path>]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
 ---
 
@@ -22,8 +22,115 @@ Unlike `/auto-review-loop` (which iterates on **research** — running experimen
 - **REVIEWER_BIAS_GUARD = true** — When `true`, every review round uses a fresh `spawn_agent` reviewer with no prior review context. Do not use stale self-reported context for review rounds. Set to `false` only for deliberate debugging of the legacy behavior. **Empirical evidence:** running the same paper with `codex-reply` + "since last round we did X" prompts inflated scores from real 3/10 → fake 8/10 across multiple rounds; switching to fresh threads recovered the true 3/10 assessment.
 - **REVIEW_LOG = `PAPER_IMPROVEMENT_LOG.md`** — Cumulative log of all rounds, stored in paper directory.
 - **HUMAN_CHECKPOINT = false** — When `true`, pause after each round's review and present score + weaknesses to the user. The user can approve fixes, provide custom modification instructions, skip specific fixes, or stop early. When `false` (default), runs fully autonomously.
+- **EDIT_WHITELIST = `null`** — Optional path to a YAML/JSON whitelist file constraining which paths and operations the fix-implementation step may touch. When `null` (default), all edits proceed unconstrained. When set via `— edit-whitelist <path>` (also accepts `— edit_whitelist <path>`), the loop loads the file at startup and consults it before each edit; rejected edits are logged to `PAPER_IMPROVEMENT_LOG.md` rather than silently dropped. See "Optional: Edit Whitelist" below.
 
 > 💡 Override: `/auto-paper-improvement-loop "paper/" — human checkpoint: true`
+
+## Optional: Edit Whitelist (`— edit-whitelist <path>`, opt-in)
+
+Lets the caller hard-constrain which files and operations the **fix-implementation** step (Step 3 / Step 6) is allowed to touch. **Default OFF — when the user does not pass `— edit-whitelist` (or the alias `— edit_whitelist`), the loop applies all reviewer-driven edits without restriction, exactly as before.**
+
+This is the parameter that upstream pipelines (e.g. `/resubmit-pipeline` Phase 2) use to enforce text-only resubmit microedits: no `.bib` mutations, no `.sty` / `.bst` mutations, no edits to prior-submission directories, no new `\cite{...}`, no new theorem environments, no new numerical claims.
+
+### Schema
+
+The whitelist file is YAML or JSON. All four sections are optional:
+
+```yaml
+allowed_paths:
+  - sec/*.tex
+  - main.tex
+  - figures/*.tex
+forbidden_paths:
+  - "**/*.bib"
+  - "**/*.sty"
+  - "**/*.bst"
+  - "../OldSubmission/**"
+forbidden_operations:
+  - new_cite              # blocks \cite{...}, \citep{...}, \citet{...}, \citeauthor{...} additions
+  - new_bibitem           # blocks \bibitem{...} additions
+  - new_theorem_env       # blocks \begin{theorem|lemma|proposition|corollary} additions
+  - numerical_claim       # blocks adding new numbers / percentages / metrics
+forbidden_deletions:      # operations that block REMOVALS, not additions
+  - delete_existing_cite  # blocks removal of \cite{...} from the body (use citation-audit --soft-only instead)
+  - delete_theorem_env    # blocks removal of an existing \begin{theorem|...} block
+requires_user_approval_for:  # operations that don't auto-reject but pause for explicit user OK
+  - rewrite_abstract
+  - rewrite_intro_first_para
+  - delete_section
+max_edits_per_round: 30   # hard cap on accepted edits per round (rejections not counted)
+rationale: "Resubmit mode: text-only microedits, paper structure frozen by user constraint."
+```
+
+### Resolution rules
+
+- **`allowed_paths` empty AND `forbidden_paths` empty** → whitelist is a no-op (advisory: the file is loaded and `rationale` echoed to the log, but no path filtering is applied).
+- **`allowed_paths` empty, `forbidden_paths` non-empty** → all paths NOT matched by `forbidden_paths` are mutable.
+- **`allowed_paths` non-empty, `forbidden_paths` empty** → only paths matching `allowed_paths` are mutable.
+- **Both non-empty** → an edit is allowed iff the target matches `allowed_paths` AND does NOT match `forbidden_paths`. `forbidden_paths` always wins on overlap.
+- **`forbidden_operations` missing or empty** → no operation-level guard; only path-level filtering applies.
+
+### Glob semantics
+
+Use bash `extglob` / Python `fnmatch.fnmatch` semantics. `**` matches any depth (zero or more directory segments). Patterns are matched against the path **relative to the paper directory** (e.g. `paper/sec/intro.tex` matches `sec/*.tex` when paper-directory is `paper/`).
+
+### Forbidden-operation detectors
+
+For each candidate edit's diff (the new lines being added — deletions are exempt), the loop runs these regex checks and rejects if any forbidden operation matches:
+
+| Operation | Detector (added lines only) |
+|-----------|------------------------------|
+| `new_cite` | `\\cite[a-zA-Z]*\{[^}]+\}` (catches `\cite`, `\citep`, `\citet`, `\citeauthor`, `\citeyear`, `\citealp`, etc.) |
+| `new_bibitem` | `\\bibitem\{[^}]+\}` |
+| `new_theorem_env` | `\\begin\{(theorem|lemma|proposition|corollary)\*?\}` |
+| `numerical_claim` | New token matching `\b\d+(\.\d+)?%?\b` that did NOT appear in the deleted/replaced lines (i.e. genuinely new numbers, not edits to existing ones) |
+
+### Behavior at loop start (before Round 1 fix-implementation)
+
+1. If `— edit-whitelist <path>` is present in `$ARGUMENTS`, set `EDIT_WHITELIST = <path>`.
+2. Load the file (`yaml.safe_load`; if it fails, fall back to `json.loads`). On load failure, abort the loop with a clear error — do NOT silently proceed unconstrained.
+3. Echo `rationale` (if present) into `PAPER_IMPROVEMENT_LOG.md` under a new "Edit Whitelist" preamble section so the audit trail records why edits were constrained.
+
+### Behavior during fix-implementation (Steps 3 and 6)
+
+Before applying each proposed edit:
+
+1. Resolve target file path relative to the paper directory.
+2. Path check: if `allowed_paths` is non-empty, target must match at least one pattern. Then if `forbidden_paths` is non-empty, target must NOT match any pattern. If either fails → reject as `path` violation.
+3. Operation check: build the unified diff (or just the set of newly-added lines) for the proposed edit. For each entry in `forbidden_operations`, run its detector on the added lines. If any detector matches → reject as `operation` violation.
+4. If all checks pass, apply the edit normally.
+5. If rejected, append an entry to `PAPER_IMPROVEMENT_LOG.md` under a `## Rejected by edit_whitelist (Round N)` heading with this schema:
+   ```
+   - file: <relative path>
+     reason: path | operation
+     pattern: <the offending forbidden_path glob, OR the offending forbidden_operation name + the matched substring>
+     reviewer_concern: <the original Round-N weakness that motivated this edit>
+   ```
+6. Continue with the remaining edits in the round. Do NOT abort the whole round on a single rejection.
+
+### End-of-round surfacing
+
+At the end of each round (after the recompile, before moving to the next round), if any edits were rejected during that round's fix step:
+
+- Print a one-line summary to the round's checkpoint output: `Edit whitelist rejected N edits this round (M path, K operation). See PAPER_IMPROVEMENT_LOG.md "Rejected by edit_whitelist (Round N)".`
+- If `HUMAN_CHECKPOINT = true`, include the rejection list in the checkpoint shown to the user before they approve next-round fixes.
+
+### Example invocations
+
+```bash
+# Resubmit-pipeline Phase 2 caller (text-only mode):
+/auto-paper-improvement-loop "paper/" — edit-whitelist .resubmit/edit_whitelist.yaml
+
+# Aliased form is accepted:
+/auto-paper-improvement-loop "paper/" — edit_whitelist .resubmit/edit_whitelist.yaml
+
+# Combined with other flags:
+/auto-paper-improvement-loop "paper/" — human checkpoint: true — edit-whitelist constraints.yaml
+```
+
+### Rationale
+
+Without a whitelist, the loop's reviewer-driven fix step is free to add citations, introduce new theorem environments, or tweak numerical claims — all of which are reasonable for first-submission polish but **forbidden** in resubmit / camera-ready / rebuttal-only modes where the paper structure is frozen by external constraint. Routing those constraints through a first-class parameter (rather than relying on the LLM to "remember" not to do them) makes the constraint enforceable, auditable via `PAPER_IMPROVEMENT_LOG.md`, and visible to the user at each round's checkpoint.
 
 ## Inputs
 
@@ -150,6 +257,8 @@ Parse the review and implement fixes by severity:
 1. CRITICAL fixes (assumption mismatches, internal contradictions)
 2. MAJOR fixes (overclaims, missing content, notation issues)
 3. MINOR fixes (if time permits)
+
+**Edit-whitelist gate (if set):** If `EDIT_WHITELIST` is set, before applying each proposed edit, check the target path against `allowed_paths` / `forbidden_paths` and the new-lines diff against `forbidden_operations` per the "Optional: Edit Whitelist" section. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 1)` with file, reason (`path` or `operation`), the offending pattern, and the original reviewer concern. The loop continues with remaining edits — a rejection never aborts the round. Surface a rejection summary at the end of the round.
 
 **Common fix patterns:**
 
@@ -284,6 +393,8 @@ Same process as Step 3. Typical Round 2 fixes:
 - Further soften any remaining overclaims
 - Formalize informal arguments (e.g., truncation → formal proposition)
 - Strengthen limitations section
+
+**Edit-whitelist gate (if set):** Same as Step 3 — if `EDIT_WHITELIST` is set, run the path + forbidden-operation checks before applying each proposed edit. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 2)` and the loop continues. Surface a rejection summary at the end of the round.
 
 ### Step 7: Recompile Round 2
 
@@ -443,6 +554,7 @@ paper/
 - **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
 - **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
 - **Global consistency** — when renaming notation or softening claims, check ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions)
+- **Edit-whitelist rejections are LOGGED, not silently dropped** — when `EDIT_WHITELIST` is set and an edit is rejected for a path or forbidden-operation violation, the rejection MUST be appended to `PAPER_IMPROVEMENT_LOG.md` with file, reason, offending pattern, and the original reviewer concern. The loop reports a rejection summary at the end of every round (and in the checkpoint, if `HUMAN_CHECKPOINT = true`). Never silently swallow a whitelist rejection — the audit trail is the whole point of the parameter.
 
 ## Typical Score Progression
 

--- a/skills/skills-codex/citation-audit/SKILL.md
+++ b/skills/skills-codex/citation-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: citation-audit
 description: "Zero-context verification that every bibliographic entry in the paper is real, correctly attributed, and used in a context the cited paper actually supports. Uses a fresh cross-model reviewer with web/DBLP/arXiv lookup to catch hallucinated authors, wrong years, fabricated venues, version mismatches, and wrong-context citations (cite present but the cited paper does not establish the claim). Use when user says \"审查引用\", \"check citations\", \"citation audit\", \"verify references\", \"引用核对\", or before submission to ensure bibliography integrity."
-argument-hint: "[paper-directory-or-bib-file] [--uncited]"
+argument-hint: "[paper-directory-or-bib-file] [--uncited] [— soft-only]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent, WebSearch, WebFetch
 ---
 
@@ -43,6 +43,7 @@ The dangerous citation problems are **not** wildly fake citations — those are 
 - **WEB_SEARCH = required** — The reviewer must perform real web/DBLP/arXiv lookups, not pattern-match from memory.
 - **OUTPUT = `CITATION_AUDIT.md`** — Human-readable per-entry verdict report.
 - **STATE = `CITATION_AUDIT.json`** — Machine-readable verdict ledger consumable by downstream tools.
+- **SOFT_ONLY = `false`** — When true (set via `— soft-only` / `— soft_only` flag), the audit runs all three layers normally but **forbids any `.bib` file mutation**. Findings that would otherwise mutate the bib (FIX / REPLACE / REMOVE) are translated into per-occurrence sentence-rewrite proposals against the citing `*.tex` files. Used by `/resubmit-pipeline` Phase 1 to honor the user's hard "freeze the bib" constraint.
 
 ## Workflow
 
@@ -274,6 +275,7 @@ If the bib file cannot be read well enough to audit even the cited entries, fall
 - **Always emit, never block** — this skill always writes `CITATION_AUDIT.json` with a verdict; the decision to block finalization lives in `paper-writing` Phase 6 + `tools/verify_paper_audits.sh`, driven by the `assurance` level. See "Submission Artifact Emission" below.
 - **Run once per submission** — the audit is wall-clock expensive (web lookups for each entry); not for every save
 - **Uncited detection is opt-in only** — never auto-enable; never block on uncited entries; existing callers must observe identical output if they do not pass `--uncited`
+- **Under `--soft-only`, citation-audit emits text-rewrite proposals only; bib files are never mutated regardless of finding severity.** The audit semantics (existence + metadata + context) and the per-entry KEEP/FIX/REPLACE/REMOVE ledger are preserved verbatim; only the action layer is translated to per-occurrence sentence rewrites in the citing `*.tex` files. Refuse any downstream-proposed bib edit while `--soft-only` is set.
 
 ## Comparison with Other Audit Skills
 
@@ -304,6 +306,88 @@ After each reviewer agent call, save the trace following `shared-references/revi
 - `.aris/traces/citation-audit/<date>_runNN/` (per-entry review traces)
 - Optional: applied fixes to `references.bib` + `sec/*.tex` (with `--apply` flag)
 - Optional: `details.uncited_entries` field in JSON + `## Uncited Entries (opt-in)` MD section (with `--uncited` flag; field absent and section omitted when flag is unset)
+
+## Optional: Soft-Only Mode (— soft-only)
+
+**Default**: disabled. The audit emits the standard `KEEP / FIX / REPLACE / REMOVE` per-entry verdicts and a downstream caller (or the `--apply` path of Step 6) is free to mutate the bib.
+
+**Opt-in**: pass `— soft-only` (also accepts `— soft_only`) on invocation. This mode is designed for callers — notably `/resubmit-pipeline` Phase 1 — that operate under a **hard "freeze the bib" constraint**: if a citation is wrong-context, soften the surrounding sentence; do **not** change, add, or remove the cite itself.
+
+### What soft-only changes
+
+The audit semantics are **unchanged**: existence + metadata + context-appropriateness checks all run, the reviewer is still invoked once per cited entry, and the per-entry KEEP/FIX/REPLACE/REMOVE verdicts are still computed and emitted exactly as in default mode. Only the **action layer** changes — soft-only translates each base verdict into a text-rewrite proposal instead of a bib mutation.
+
+### Verdict translation table
+
+| Base verdict | Soft-only translation | Notes |
+|---|---|---|
+| `KEEP` | `keep_unchanged` | No action. Cite + sentence are both fine. |
+| `FIX` (metadata wrong) | `keep_metadata_drift_acknowledged` | Bib stays as-is. Flag for human review at submission time. Append note: "metadata drift detected but not fixed under --soft-only". |
+| `REPLACE` (wrong-context cite) | `soften_citing_sentence` | Per-occurrence sentence-rewrite proposal. For each `\cite{X}` in the body, locate the surrounding sentence and propose a softened version that does not claim what `X` actually establishes. |
+| `REMOVE` (cite refers to nonexistent paper — i.e., hallucinated citation) | `drop_cite_in_body_only` | The bib entry is left untouched (per the `--soft-only` invariant), but **the inline `\cite{X}` references in the body MUST be removed and the surrounding sentence rewritten** so it no longer relies on a nonexistent paper. Two sub-strategies: (a) drop the inline `\cite{X}` entirely and rephrase the sentence; (b) re-attribute to a different in-bib source that genuinely supports the claim. **Never** leave a `\cite{X}` to a hallucinated paper in the body. The bib entry itself stays (uncited entries are harmless and surfaced separately by uncited-detection). |
+
+### Augmented JSON schema (under `--soft-only`)
+
+When the flag is set, the standard top-level fields (`audit_skill`, `verdict`, `reason_code`, `summary`, etc.) and the existing `details.per_entry` ledger are emitted exactly as in default mode. In addition:
+
+- A top-level `soft_only_mode: true` boolean is added.
+- `details` gains a `soft_only_actions` array — one entry per audited bib key, in the same order as `details.per_entry`.
+
+```json
+{
+  "audit_skill": "citation-audit",
+  "verdict": "...",
+  "soft_only_mode": true,
+  "details": {
+    "soft_only_actions": [
+      {
+        "citekey": "smith2023example",
+        "base_verdict": "REPLACE",
+        "soft_action": "soften_citing_sentence",
+        "occurrences": [
+          {
+            "file": "sec/3.method.tex",
+            "line": 142,
+            "current_sentence": "Smith et al. [2023] proves a generic result that...",
+            "proposed_rewrite": "Smith et al. [2023] discusses a related setting; while not directly applicable, the framing motivates...",
+            "rationale": "Original sentence claims smith2023 'proves' a result, but smith2023 actually only conjectures it. Softened to 'discusses ... motivates' to remove the unsupported claim."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`soft_action` is one of `keep_unchanged | keep_metadata_drift_acknowledged | soften_citing_sentence | drop_cite_in_body_only`. For `keep_unchanged` and `keep_metadata_drift_acknowledged`, `occurrences` MAY be omitted or emitted as `[]`. For `soften_citing_sentence` and `drop_cite_in_body_only`, `occurrences` MUST list one object per `\cite{X}` site in the body that triggered the verdict.
+
+For `drop_cite_in_body_only`, the `proposed_rewrite` field shows the sentence with the inline `\cite{X}` removed (or replaced by a `\cite{Y}` to an alternate in-bib source). The `bib_entry_action` field is fixed to `"leave_as_is_per_soft_only"` — the bib record itself is never modified by the audit.
+
+### Augmented human-readable report
+
+`CITATION_AUDIT.md` gains a new section `## Soft-Only Rewrites (— soft-only mode)` listing each occurrence with the proposed sentence rewrite for human approval. Example:
+
+```markdown
+## Soft-Only Rewrites (— soft-only mode)
+
+The bib file is frozen. The following sentence rewrites are proposed in lieu of bib edits.
+
+### `smith2023example` — base verdict REPLACE → `soften_citing_sentence`
+
+- **File**: `sec/3.method.tex:142`
+- **Current**: "Smith et al. [2023] proves a generic result that..."
+- **Proposed**: "Smith et al. [2023] discusses a related setting; while not directly applicable, the framing motivates..."
+- **Rationale**: Original sentence claims smith2023 "proves" a result, but smith2023 actually only conjectures it. Softened to "discusses ... motivates" to remove the unsupported claim.
+```
+
+The existing per-entry verdict table in the Summary block is **kept** but FIX/REPLACE/REMOVE rows are annotated with a `🔒 bib frozen by --soft-only` badge so downstream readers see immediately why the bib was not mutated.
+
+### Hard guarantees under `--soft-only`
+
+- **No `.bib` file mutations under any circumstance.** Step 6 ("Apply fixes (interactive)") is bypassed for the bib file; only `*.tex` rewrite proposals are produced (and still require human approval before any text edit).
+- If a downstream caller — including `paper-writing` Phase 6 or any wrapper — proposes a bib edit while `--soft-only` is set, **refuse it**: emit a one-line refusal in the trace and continue to the next finding.
+- The top-level `verdict` decision table is **unchanged**: a wrong-context cite still produces `FAIL` with `reason_code: wrong_context`. Soft-only does not silence the finding; it only constrains the action layer.
+- `--soft-only` composes with `--uncited`: both flags can be set together. Uncited entries remain detect-only and are not subject to soft-only translation (there is no citing sentence to soften).
 
 ## Submission Artifact Emission
 

--- a/skills/skills-codex/resubmit-pipeline/SKILL.md
+++ b/skills/skills-codex/resubmit-pipeline/SKILL.md
@@ -1,0 +1,427 @@
+---
+name: resubmit-pipeline
+description: "Workflow 5: orchestrate a text-only resubmit of a polished paper to a different venue under hard constraints (no new experiments, no bib edits, no framework changes, never overwrite prior submissions). Phase 0 physical isolation, Phase 0.5 health + anonymity check, Phase 1 audit (proof / claim / citation), Phase 2 microedits via auto-loop with edit-whitelist + citation-audit --soft-only, Phase 3 kill-argument adversarial gate, Phase 4 final compile + Overleaf push via /overleaf-sync. Use when user says \"resubmit pipeline\", \"重投流程\", \"port paper to <new venue>\", \"resubmit to <venue>\", \"tighten paper for resubmission\", or has a rejected/withdrawn paper to move to a different top venue under tight time budget."
+argument-hint: "[paper-base-dir] [— target-venue: <name>] [— review-corpus: <path>]"
+allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, spawn_agent
+---
+
+# Resubmit Pipeline: Text-Only Microedit Mode
+
+Compose a polished paper into a new venue under text-only constraints: **$ARGUMENTS**
+
+## Why This Exists
+
+Most ARIS writing workflows assume the input is either a narrative report (Workflow 3) or an in-progress paper that may still need experiments / bib changes / structural edits. Resubmit is a fundamentally different scope:
+
+- The paper is **already polished** — proofs are done, experiments are done, bibliography is curated.
+- The user wants to absorb prior reviewer concerns from a previous venue and re-submit, **without** introducing new experiments, new citations, or framework changes (LLM hallucination paranoia + tight resubmit timing + closed compute budget).
+- The base submission directory is **read-only** — the new submission must compose into a sibling directory, never mutate prior state.
+- Page limit may shrink between source and target venue (e.g., workshop camera-ready → 9-page main).
+
+Existing skills cover adjacent territory but none of this exact composition: `/rebuttal` builds the OpenReview-style response document, not in-paper microedits; `/auto-paper-improvement-loop` is the per-round engine but presupposes someone has already chosen the base manuscript, migrated venue format, set the edit whitelist, queued the reviewer feedback, and decided what NOT to change. `/resubmit-pipeline` fills that orchestration gap.
+
+## When to Use
+
+- A theory or system paper was rejected at venue A and you want to resubmit to venue B with tight time budget (≤ 1-2 weeks).
+- You have **3 inputs ready**: the polished paper directory at venue A's format, the target venue B's format/template/style files, and the prior reviewer reports.
+- You explicitly do **not** want to re-derive theorems, run new experiments, or change the bibliography.
+
+## When NOT to Use
+
+- The paper still needs experiments — use `/experiment-bridge` → `/auto-review-loop` first.
+- The paper still needs structural rewrites or new sections — use `/paper-writing` (Workflow 3).
+- You want to write the rebuttal response itself — use `/rebuttal` (Workflow 4).
+- The reviewer feedback demands new theorems or new framework — escalate to user before starting; this skill emits `BLOCKED` with `reason_code: out_of_scope_microedit` if it detects this case.
+
+## Constants
+
+- **REVIEWER_MODEL** = inherits from `/auto-paper-improvement-loop`'s default (`gpt-5.4` via Codex MCP) unless the user passes `— reviewer-model: gpt-5.5`. Codex reasoning effort is fixed at `xhigh` for all reviewer calls per the existing skill convention.
+- **ROUNDS** = 2 (default; matches `/auto-paper-improvement-loop`'s diminishing-returns line). A 3rd round only fires if Phase 2 reports non-convergence AND the user explicitly approves at the round-2 checkpoint.
+- **EFFORT** = `max` (default for resubmit; resubmit is high-stakes). The user can override with `— effort: balanced` if time is extremely tight.
+- **EDIT_WHITELIST_PATH** = `<paper-base-dir>/../<NewVenue>/.aris/edit_whitelist.yaml` (auto-generated in Phase 0; user can override with a custom path).
+- **NEVER_OVERWRITE** = true (always; this is a hard contract — prior submission directories are immutable).
+- **ASSURANCE_LEVEL** = `submission` (default; resubmit always targets a real submission).
+
+## Inputs
+
+Three mandatory inputs:
+
+1. **`paper-base-dir`** — the polished paper at venue A's format. Must contain `main.tex` (or equivalent entry), `sec/` or `sections/`, `references.bib` (or equivalent), and a compiled `main.pdf` (used for visual review).
+2. **`— target-venue: <name>`** — one of: `iclr`, `icml`, `neurips`, `aaai`, `ijcai`, `colm`, `tmlr`, `uai`, or `other`. The skill expects venue style files at `<paper-base-dir>/templates/<venue>.{sty,tex,bst}` or in a recognized template directory. If `other`, the user passes `— target-style-dir: <path>`.
+3. **`— review-corpus: <path>`** — directory containing prior venue's reviewer reports as `.txt` or `.md` files (one per reviewer, ideally). If `--review-corpus` is omitted, the skill emits `BLOCKED` with `reason_code: missing_review_corpus` because the whole point of resubmit is absorbing those concerns.
+
+Optional:
+
+- **`— reviewer-model: gpt-5.5`** — override the default reviewer (`gpt-5.4`).
+- **`— rounds: <int>`** — override default 2.
+- **`— assurance: draft`** — relax MANDATORY gates (default `submission`).
+- **`— effort: balanced`** — relax `max` if time is critical.
+- **`— skip-anonymity-scan`** — skip Phase 0.5 anonymity check (only valid for non-double-blind venues like TMLR; else WARN).
+- **`— overleaf-target: <project-id>`** — the Overleaf project ID for Phase 4 push (per `/overleaf-sync setup`).
+
+## Pipeline
+
+### Phase 0: Physical Isolation Setup (zero edits to existing files)
+
+Resubmit's hardest invariant: **never overwrite any prior submission directory**. The new venue's submission lives as a **sibling** of all prior venues.
+
+```bash
+# Resolve target-venue → new sibling dir name (capitalized)
+NEW_VENUE_DIR="$(dirname "$PAPER_BASE_DIR")/$(echo "$TARGET_VENUE" | sed 's/.*/\u&/')"
+
+# Atomic dir create — `mkdir` (not `mkdir -p`) fails fast if the dir exists,
+# avoiding the TOCTOU race window of `[ -e ] && exit; mkdir -p`. The mkdir
+# itself must succeed exactly once; if a concurrent run gets there first,
+# this errors out per resubmit-pipeline's never-overwrite invariant.
+mkdir "$NEW_VENUE_DIR" 2>/dev/null || {
+    echo "ERROR: $NEW_VENUE_DIR already exists; resubmit-pipeline never overwrites prior submissions. Pick a different target-venue or rename the existing dir." >&2
+    exit 1
+}
+mkdir -p "$NEW_VENUE_DIR/.aris"
+```
+
+**Composition rules** (all `cp`, never `\input{../...}`, never symlink):
+
+1. **`main.tex`** — write fresh for the target venue's `.sty`. Use `templates/<venue>.tex` as the starting skeleton; only the `\title{}`, `\author{}`, abstract include, and section input lines are copied from the base venue's `main.tex`. The new `main.tex` lives entirely inside `$NEW_VENUE_DIR/`.
+2. **`sec/` (or `sections/`)** — physical `cp -r $PAPER_BASE_DIR/sec/ $NEW_VENUE_DIR/sec/`. **Do not symlink, do not `\input{../sec/...}` from the new main.** Symlinks break Overleaf zip export; cross-directory `\input` would mutate the shared pool and pollute prior submissions.
+3. **`math_commands.tex`** (and any other macro file the sections depend on) — physical `cp` into `$NEW_VENUE_DIR/`.
+4. **`Figure/` (or `figures/`)** — copy the directory in (`cp -r`). **Path trap**: existing sections likely write `\includegraphics{Figure/foo.pdf}`. If you set `\graphicspath{{../Figure/}}` from a child directory, it resolves `../Figure/Figure/foo.pdf` — wrong. Either copy `Figure/` in directly (preferred), or use `\graphicspath{{../}}`.
+5. **Bibliography** — write `\bibliographystyle{<venue-bst>}` + `\bibliography{../references}` directly in the new `main.tex`. **Never** `\input` an existing `ref.tex` or `references.tex` that already contains its own `\bibliography{}` command (path resolution silently breaks).
+6. **`.aris/`** — create `$NEW_VENUE_DIR/.aris/` and write `assurance.txt` containing `submission` (matches the verifier's expected location).
+
+**Output of Phase 0**: a new sibling dir with all source files, no edits to text content yet, ready for compile.
+
+### Phase 0.5: Health Check + Anonymity Scan (still zero text edits)
+
+Before any audit or edit, the paper must compile cleanly on the new venue's style and pass anonymity scan if the target venue is double-blind.
+
+**Compile + page count**:
+
+```bash
+cd "$NEW_VENUE_DIR"
+latexmk -C
+latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tee compile.log
+```
+
+If compile fails: emit `RESUBMIT_REPORT.json` with `verdict: BLOCKED, reason_code: phase_0_5_compile_failed`, surface the error to the user, and stop. Common causes: missing macro from `math_commands.tex`, venue style undefined command, `\graphicspath` issue.
+
+Page count vs venue limit (measure first; do not assume):
+
+```bash
+PAGES=$(pdfinfo main.pdf | awk '/^Pages:/ {print $2}')
+LIMIT=$(grep -oE "page_limit: [0-9]+" "$NEW_VENUE_DIR/templates/$TARGET_VENUE.tex" | awk '{print $2}')
+echo "Pages: $PAGES, Limit: $LIMIT, Delta: $((PAGES - LIMIT))"
+```
+
+If `PAGES > LIMIT`, queue Phase 2 to honor a page-shrink heuristic (see "Page-Shrink Heuristic" below).
+
+**Anonymity scan** (skip only if `— skip-anonymity-scan` is passed AND target venue is non-double-blind):
+
+The scan covers **5 layers** (the proposal's 1-layer scan was incomplete):
+
+1. **Surface identifiers**: author surnames, affiliations, institution names, lab codenames, prior funding tag IDs (`grep -E "$(echo $AUTHOR_SURNAMES | tr ' ' '|')|$(echo $AFFILIATIONS | tr ' ' '|')"`).
+2. **Self-citation phrasing**: any sentence using "we showed in [...]" or "in our prior work [...]" that names the paper's own authors. Must rewrite to "X et al. [year] shows..." third-person form. Grep regex: `\b(we|our|my|I)\s+(showed|proved|demonstrated|prior work|earlier paper|previous paper)\b`.
+3. **Acknowledgments + funding**: scan `acknowledgments.tex` (or `\acknowledgments{}` block) for institution-specific thanks, grant IDs, named collaborators. Comment out for double-blind submission.
+4. **Cross-rebuttal references**: scan footnotes and body for "this paper builds on rebuttal at venue X" or "addressing reviewer N's concern from venue X" — these must be removed entirely (they violate anonymity AND signal prior rejection).
+5. **Internal codenames / project links**: grep for repo URLs (`github.com/<user>/<project>`), Slack channel names, internal wiki links, and dataset codenames that may identify the lab.
+
+If **any of the 5 layers** triggers a hit, emit `RESUBMIT_REPORT.json` with `verdict: BLOCKED, reason_code: anonymity_scan_failed` and present a per-hit list to the user. They must approve a fix or accept the risk before Phase 1 runs. Layers 4-5 are equally blocking as layers 1-3 — cross-rebuttal references and internal codenames signal both prior-venue identity AND lab identity, both of which violate double-blind in different ways.
+
+**Residual coloring / margin-note scan**:
+
+Search for `\revise{...}`, `\fix{...}`, `\new{...}`, `\todo{...}`, `\todonotes{...}`, `\textcolor{red}{...}` leftovers from camera-ready cycles. List them; user decides whether to keep (some venues accept revision-marker boxes) or strip.
+
+**Output of Phase 0.5**: `BASELINE.md` with initial page count, anonymity-scan summary, residual-color list, overfull-hbox count.
+
+### Phase 1: Audit (zero edits)
+
+Three audits in parallel, all detect-only. The new dir's source files are read; nothing is written except audit artifacts.
+
+| Skill | Purpose | Artifact |
+|---|---|---|
+| `/proof-checker $NEW_VENUE_DIR/main.tex --restatement-check` | Gap-find on theorems prior reviewers attacked; cross-location consistency between main statement and restatements | `PROOF_AUDIT.json` + `.md` |
+| `/paper-claim-audit $NEW_VENUE_DIR/` | Numerical fidelity (every number in body matches what proofs / result files establish) | `PAPER_CLAIM_AUDIT.json` + `.md` |
+| `/citation-audit $NEW_VENUE_DIR/ — soft-only` | Wrong-context citations + misattributions, mapped to "soften citing sentence" actions (NOT bib edits) | `CITATION_AUDIT.json` + `.md` |
+
+**Critical**: the third audit MUST run with `— soft-only`. Without that flag, citation-audit emits `KEEP/FIX/REPLACE/REMOVE` verdicts that presuppose bib mutations — incompatible with resubmit's "no bib edits" constraint. With `--soft-only`, the same findings are translated to per-occurrence sentence-rewrite proposals consumable by Phase 2.
+
+**Atomize prior reviewer concerns** in parallel:
+
+```
+For each file under $REVIEW_CORPUS:
+    Read the reviewer report.
+    Atomize into discrete concerns: severity (critical / major / minor),
+      type (assumption / novelty / scope / rigor / experiment-coverage / framing),
+      addressability (text-fixable / partial / unaddressable-under-constraints).
+    Append to KNOWN_WEAKNESSES.md with stable IDs (W1, W2, ...).
+```
+
+`KNOWN_WEAKNESSES.md` schema:
+
+```yaml
+- id: W1
+  severity: major
+  type: scope
+  source: reviewer_2_venue_a
+  concern: "Theorem 3 states a generic result but the proof only handles a specific regime."
+  addressability: text-fixable
+  recommended_fix: "Narrow Theorem 3's title to 'restricted regime'; add scope qualifier in abstract."
+- id: W2
+  severity: critical
+  type: experiment-coverage
+  source: reviewer_3_venue_a
+  concern: "No comparison against [prior method X]."
+  addressability: unaddressable-under-constraints
+  recommended_fix: "Acknowledge in Limitations that this comparison is left for future work."
+```
+
+**Output of Phase 1**: 4 artifacts (3 audits + KNOWN_WEAKNESSES.md). All are inputs to Phase 2.
+
+### Phase 2: Targeted Text Microedits via Auto-Improvement Loop
+
+The load-bearing phase. `/auto-paper-improvement-loop` is invoked with **two safety mechanisms**:
+
+1. **`— edit-whitelist <path>`** — a YAML file enumerating allowed paths and forbidden operations. Auto-generated in Phase 0 at `$NEW_VENUE_DIR/.aris/edit_whitelist.yaml`:
+
+   ```yaml
+   allowed_paths:
+     - "sec/*.tex"
+     - "main.tex"
+     - "appendix.tex"
+   forbidden_paths:
+     - "**/*.bib"
+     - "**/*.sty"
+     - "**/*.bst"
+     - "../*Submission/**"           # all prior submission dirs
+     - "../*Camera/**"
+     - "templates/**"
+   forbidden_operations:
+     - new_cite                       # blocks \cite{...}, \citep{...}, \citet{...}, \citeauthor{...}
+     - new_bibitem                    # blocks \bibitem{...} additions
+     - new_theorem_env                # blocks \begin{theorem|lemma|proposition|corollary} additions
+     - numerical_claim                # blocks adding numbers / percentages / metrics not present in original
+   rationale: "Resubmit mode: text-only microedits, paper structure frozen by user constraint."
+   ```
+
+2. **Per-round diff gate via auto-loop's HUMAN_CHECKPOINT** — `/auto-paper-improvement-loop` does not accept `--rounds`, `--reviewer-model`, or `--resume-after-round-checkpoint` flags (those are not in its CLI). It uses the `MAX_ROUNDS = 2` constant and `REVIEWER_MODEL = gpt-5.4` defaults, with an existing `HUMAN_CHECKPOINT` mechanism for round gating. Resubmit-pipeline therefore invokes the loop **once** with `HUMAN_CHECKPOINT = true` so each round pauses for the orchestrator to inspect the diff:
+
+   ```bash
+   # Snapshot the new venue dir BEFORE auto-loop runs (for diff baseline,
+   # works whether or not paper-base-dir is a git repo)
+   SNAPSHOT_DIR="$NEW_VENUE_DIR/.aris/snapshots/round-0"
+   mkdir -p "$SNAPSHOT_DIR"
+   rsync -a --exclude='.aris' --exclude='*.pdf' --exclude='*.aux' \
+         "$NEW_VENUE_DIR/" "$SNAPSHOT_DIR/"
+
+   # Single auto-loop invocation; rounds + checkpoints are loop-internal.
+   # The whitelist file is the only resubmit-specific param.
+   /auto-paper-improvement-loop "$NEW_VENUE_DIR/" \
+       --edit-whitelist "$NEW_VENUE_DIR/.aris/edit_whitelist.yaml" \
+       — assurance: submission \
+       — effort: "$EFFORT" \
+       — human checkpoint: true
+   ```
+
+   Inside the loop, at each round-end checkpoint, the resubmit orchestrator inspects:
+
+   ```bash
+   for ROUND in 1 2; do  # auto-loop's MAX_ROUNDS = 2
+     # auto-loop pauses at HUMAN_CHECKPOINT after each round
+     # diff this round vs prior snapshot (works without git)
+     diff -ruN "$NEW_VENUE_DIR/.aris/snapshots/round-$((ROUND-1))" "$NEW_VENUE_DIR" \
+         > "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt"
+
+     # Whitelist compliance check on the diff
+     check_whitelist_compliance "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt" \
+                                  "$NEW_VENUE_DIR/.aris/edit_whitelist.yaml"
+
+     # Selective regression audits (only fire if relevant files touched)
+     if grep -qE 'theorem|lemma|proposition|corollary' "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt"; then
+         /proof-checker "$NEW_VENUE_DIR/main.tex" --restatement-check
+     fi
+     if grep -qE '[0-9]+(\.[0-9]+)?\s*(%|±|x|×)' "$NEW_VENUE_DIR/.aris/round-$ROUND-diff.txt"; then
+         /paper-claim-audit "$NEW_VENUE_DIR/"
+     fi
+
+     # Snapshot this round for next-round diff
+     rsync -a --exclude='.aris' --exclude='*.pdf' --exclude='*.aux' \
+           "$NEW_VENUE_DIR/" "$NEW_VENUE_DIR/.aris/snapshots/round-$ROUND/"
+
+     # Convergence check — see "Convergence Criteria" section below
+     # If converged, signal HUMAN_CHECKPOINT to terminate early
+   done
+   ```
+
+   **Why the snapshot-rsync approach instead of `git diff HEAD~1..HEAD`**: the paper-base-dir is not guaranteed to be a git repo, and even when it is, intermediate states inside one auto-loop round don't produce per-round commits. rsync snapshots are repo-agnostic.
+
+3. **Mapping of edits to concerns** — every proposed edit must be mapped to either (a) an entry in `KNOWN_WEAKNESSES.md` with an ID, OR (b) a Phase 1 audit finding. Un-mapped edits are rejected by the loop's reviewer prompt. This is enforced via the loop's reviewer prompt template (the resubmit-pipeline's invocation passes a custom prompt addendum saying "every fix must cite a W<n> ID or audit finding ID").
+
+**Inputs into the loop's reviewer prompt** (concatenated):
+
+- The 3 Phase 1 audit reports (`PROOF_AUDIT.md`, `PAPER_CLAIM_AUDIT.md`, `CITATION_AUDIT.md`)
+- `KNOWN_WEAKNESSES.md`
+- A custom addendum: "you are reviewing a resubmit; the user constraint is text-only microedits; every proposed fix MUST cite either a W<n> ID from KNOWN_WEAKNESSES or an audit finding ID; un-mapped fixes are rejected; the edit whitelist is binding."
+
+**Output of Phase 2**: `PAPER_IMPROVEMENT_LOG.md` with per-round diffs, `rejected_by_edit_whitelist` list, and convergence status.
+
+### Phase 3: Adversarial Gate
+
+`/kill-argument $NEW_VENUE_DIR/`
+
+**No `--difficulty` parameter exists** in `/kill-argument` — earlier proposal drafts referenced a non-existent flag. The skill always uses Codex 5.5 + xhigh and runs the standard 2-thread Attack-Adjudication protocol; the `assurance` level (set to `submission` for resubmit) determines whether `FAIL` blocks the final report.
+
+The kill-argument output is **residual-risk reporting**, not auto-rewrite directives. A hostile reviewer may demand framework changes the user banned; the adjudication step exists to **triage** which findings are text-fixable vs need user escalation.
+
+```
+Read $NEW_VENUE_DIR/KILL_ARGUMENT.json
+For each decomposed_point with verdict in {still_unresolved, partially_answered}:
+    If severity_if_unresolved == critical:
+        If recommended_fix is text-only AND maps to allowed paths:
+            Append to "extra round queue"
+        Else:
+            Append to "user escalation queue" with note "outside text-only constraint"
+```
+
+If extra round queue is non-empty AND user-budget allows: one extra Phase 2 round. Else: stop and surface the user-escalation queue with a written escalation note ("here is what cannot be fixed under your constraints; please decide before submission").
+
+### Phase 4: Final Compile + Diff Report + Overleaf Push
+
+**Final compile**:
+
+```bash
+/paper-compile $NEW_VENUE_DIR/main.tex --venue $TARGET_VENUE
+```
+
+`/paper-compile` checks page limit, font, bib resolve, figure overflow, and emits `COMPILE_REPORT.json`. If page limit exceeded → trigger page-shrink heuristic (see below).
+
+**Final paper-claim-audit zero-context pass**:
+
+```bash
+/paper-claim-audit $NEW_VENUE_DIR/
+```
+
+Verifies no Phase 2 microedit accidentally introduced a numerical claim that's not backed by results.
+
+**Diff report**:
+
+```bash
+diff -u $PAPER_BASE_DIR/main.tex $NEW_VENUE_DIR/main.tex > $NEW_VENUE_DIR/.aris/DIFF_REPORT.md
+for f in $PAPER_BASE_DIR/sec/*.tex; do
+    base=$(basename $f)
+    diff -u "$f" "$NEW_VENUE_DIR/sec/$base" >> $NEW_VENUE_DIR/.aris/DIFF_REPORT.md
+done
+```
+
+This goes to the user for skim-review before any export.
+
+**Overleaf push** (if `— overleaf-target: <project-id>` was passed):
+
+Defer entirely to `/overleaf-sync setup` and `/overleaf-sync push`. Do **not** invent a parallel push mechanism — `/overleaf-sync setup` already handles token-stays-in-keychain (token never enters the agent), and `/overleaf-sync push` has a confirmation gate before writing to shared Overleaf state.
+
+```bash
+/overleaf-sync setup $OVERLEAF_TARGET   # one-time, user confirms in their terminal
+/overleaf-sync push                      # confirmation-gated push from $NEW_VENUE_DIR
+```
+
+If `overleaf-target` is not provided, skip Overleaf push and tell the user to either `/overleaf-sync setup <id>` manually or zip-export the directory.
+
+## Page-Shrink Heuristic
+
+When Phase 0.5 or Phase 4 detects page overflow, apply this **ordered** heuristic. Stop as soon as the page limit is met. Each step is fully constrained by the edit whitelist (no theorem changes, no bib changes, no framework changes):
+
+1. **Compress conclusion** (typically 1-2 paragraphs of "future work" can be cut to 2-3 sentences each). Save: 0.3-0.7 pages.
+2. **Tighten abstract / intro hedging** (cut "in this paper, we" → "we"; cut "it is well known that" → straight to point). Save: 0.2-0.4 pages.
+3. **Move marginal figures to appendix** (figures whose information is not load-bearing for the main argument). Save: 0.5-1 page per figure.
+4. **Move proof sketches / extended remarks to appendix** (keep theorem statements + 1-line proof intuition in main; full proof goes to appendix). Save: 0.5-2 pages.
+5. **Compress related-work prose** (cite-by-citation comparisons → comparison table). Save: 0.3-0.5 pages.
+
+**Forbidden** under this heuristic: removing experiments, removing theorems from main, removing citations (bib frozen). If after step 5 the paper still overflows, emit `RESUBmit_REPORT.json` with `verdict: BLOCKED, reason_code: page_shrink_failed_under_constraints` and surface to user — they must decide whether to relax a constraint or pick a different target venue.
+
+## Convergence Criteria (Phase 2 stop condition)
+
+Phase 2's per-round loop terminates when **all three** hold:
+
+1. **No new CRITICAL or MAJOR text-fixable findings** in the round's reviewer output (compared to the running running-deduped weakness list).
+2. **Page budget passes** — `/paper-compile` reports page count ≤ venue limit.
+3. **All audits non-blocking** — `/proof-checker`, `/paper-claim-audit`, `/citation-audit --soft-only` all return `verdict ∈ {PASS, NOT_APPLICABLE}` (not `WARN/FAIL/BLOCKED/ERROR`).
+
+If after `ROUNDS` (default 2) any of (1)/(2)/(3) is still failing, emit a checkpoint to the user asking whether to continue with an extra round (not auto-extend). The user explicitly approving an extra round overrides the default-2 cap.
+
+This pattern is borrowed from `/rebuttal` Phase 7's "terminate when no new substantive issues" — the same shape works for resubmit.
+
+## Master `RESUBMIT_REPORT.md` Ledger
+
+Every resubmit run writes one master report at `$NEW_VENUE_DIR/RESUBMIT_REPORT.{md,json}` collecting:
+
+- Source dir, target venue, target style files used, run start / end timestamps
+- Pointers to all artifacts: `BASELINE.md`, `PROOF_AUDIT.json`, `PAPER_CLAIM_AUDIT.json`, `CITATION_AUDIT.json`, `KNOWN_WEAKNESSES.md`, `PAPER_IMPROVEMENT_LOG.md`, `KILL_ARGUMENT.json`, `COMPILE_REPORT.json`, `DIFF_REPORT.md`
+- SHA256 hashes of every input file consumed (for `verify_paper_audits.sh` compatibility)
+- All thread IDs (Phase 1 audits + Phase 2 reviewer rounds + Phase 3 kill-argument's two threads)
+- `audit_skill: resubmit-pipeline`, `verdict ∈ {PASS, WARN, FAIL, NOT_APPLICABLE, BLOCKED, ERROR}`, `reason_code: <one of the listed codes>`
+- Decision log: every user checkpoint approval / rejection / escalation, with timestamp
+- "Skipped constraints": if any user override (e.g., `— skip-anonymity-scan`, `— rounds 3`) was passed, recorded with rationale
+
+The schema follows `shared-references/assurance-contract.md` (the same schema all mandatory audits use). This makes resubmit-pipeline runs forensically reproducible.
+
+## Failure Modes
+
+The skill emits one of 7 verdicts (the 6 from the assurance contract + a `USER_DECISION` runtime state for in-flight checkpoint pauses):
+
+| Verdict | reason_code | Trigger | Recovery |
+|---|---|---|---|
+| `PASS` | `clean_resubmit` | All gates passed; final PDF compiled at venue limit | Submit |
+| `WARN` | `partially_addressed_concerns` | All MUST-FIX gates passed but some `KNOWN_WEAKNESSES` remain unaddressable | User reviews unaddressed list; submits with awareness |
+| `FAIL` | `kill_argument_unresolved_critical` | Phase 3 surfaces a `still_unresolved` critical finding that cannot be fixed under text-only constraints | User decides: relax constraints, escalate to framework change, or pick different venue |
+| `NOT_APPLICABLE` | `not_a_resubmit` | The skill detects no prior reviews in `--review-corpus` or the directory looks like a fresh draft | User uses `/paper-writing` instead |
+| `USER_DECISION` | `awaiting_phase_<N>_checkpoint` | Skill paused at a Phase 0.5 anonymity-fix checkpoint, Phase 2 round-end diff gate, Phase 3 escalation queue, or Phase 4 page-shrink approval | User responds to the checkpoint prompt; skill resumes with the user's decision recorded in the master ledger |
+| `BLOCKED` | `phase_0_setup_blocked` | New venue dir already exists, or template files not found | User resolves the conflict; rerun |
+| `BLOCKED` | `phase_0_5_compile_failed` | Initial compile fails on new venue's style | User fixes compile error before audits run |
+| `BLOCKED` | `anonymity_scan_failed` | Phase 0.5 hits surface-identifier or self-citation patterns the user must approve | User approves fixes or passes `— skip-anonymity-scan` (only for non-double-blind) |
+| `BLOCKED` | `missing_review_corpus` | `--review-corpus` not provided AND not detected | User provides the prior reviews |
+| `BLOCKED` | `page_shrink_failed_under_constraints` | Page-shrink heuristic exhausted, paper still overflows | User relaxes a constraint or picks a different venue |
+| `BLOCKED` | `out_of_scope_microedit` | `KNOWN_WEAKNESSES` analysis shows ≥1 critical concern requires new experiments / new theorems / framework change | User decides whether to escalate (drop resubmit-pipeline; use full Workflow 1.5 + 3) |
+| `ERROR` | `audit_failure` / `loop_failure` | Any sub-skill emits `ERROR` | Examine sub-skill's report; fix + retry |
+
+`BLOCKED` is recoverable; `ERROR` indicates an unexpected sub-skill failure; only `FAIL` and unrecoverable `BLOCKED` block submission.
+
+## Key Rules
+
+- **Never overwrite prior submission directories.** This is the single hardest invariant. The skill aborts at Phase 0 if the target dir already exists.
+- **Bib is frozen.** All citation-audit findings flow through `--soft-only` and emerge as text-rewrite proposals, not bib edits.
+- **Edit whitelist is binding.** Every Phase 2 round respects the whitelist; rejections logged to `PAPER_IMPROVEMENT_LOG.md`; the user sees a per-round summary at the round checkpoint.
+- **Per-round diff gate is mandatory.** Multi-round drift is the highest-risk failure mode for resubmit (a small softening at round 1 + another small softening at round 2 can compound into a meaningful framing change). The orchestrator MUST inspect each round's diff before next round.
+- **Convergence criteria are fixed.** Default is 2 rounds; a 3rd round requires explicit user approval at the round-2 checkpoint. The loop does not auto-extend.
+- **Anonymity scan is 5-layer.** Surface identifiers, self-citation phrasing, acknowledgments, cross-rebuttal references, internal codenames — not just `grep author surnames`.
+- **Phase 3 (kill-argument) is residual-risk reporting, not auto-rewrite.** Adjudicator's `still_unresolved` critical points may need user escalation, not blind extra-round triggering.
+- **Overleaf push defers to `/overleaf-sync`.** Don't invent a parallel mechanism.
+- **Master `RESUBMIT_REPORT.md` ledger is mandatory** at `assurance: submission`.
+
+## Output Contract
+
+- `<NEW_VENUE_DIR>/main.tex` + `sec/` + `main.pdf` — the new submission, compiled
+- `<NEW_VENUE_DIR>/RESUBMIT_REPORT.md` + `RESUBMIT_REPORT.json` — master ledger (mandatory)
+- `<NEW_VENUE_DIR>/BASELINE.md` — Phase 0.5 health snapshot
+- `<NEW_VENUE_DIR>/KNOWN_WEAKNESSES.md` — atomized prior reviewer concerns with stable IDs
+- `<NEW_VENUE_DIR>/PROOF_AUDIT.json` + `.md` — Phase 1 proof audit
+- `<NEW_VENUE_DIR>/PAPER_CLAIM_AUDIT.json` + `.md` — Phase 1 claim audit
+- `<NEW_VENUE_DIR>/CITATION_AUDIT.json` + `.md` — Phase 1 citation audit (--soft-only mode)
+- `<NEW_VENUE_DIR>/PAPER_IMPROVEMENT_LOG.md` — per-round Phase 2 trace
+- `<NEW_VENUE_DIR>/KILL_ARGUMENT.json` + `.md` — Phase 3 adversarial gate
+- `<NEW_VENUE_DIR>/COMPILE_REPORT.json` — Phase 4 compile + page-limit check
+- `<NEW_VENUE_DIR>/DIFF_REPORT.md` — full diff vs base venue body
+- `<NEW_VENUE_DIR>/.aris/edit_whitelist.yaml` — Phase 0-generated whitelist
+- `<NEW_VENUE_DIR>/.aris/round-N-diff.txt` — per-round diff for the gate
+- `<NEW_VENUE_DIR>/.aris/traces/<phase>/<date>_runNN/` — Codex traces per phase
+
+The new venue dir is **the** deliverable; the prior venue dir is untouched.
+
+## Review Tracing
+
+Every Codex MCP reviewer call across all phases saves traces per `shared-references/review-tracing.md` to `<NEW_VENUE_DIR>/.aris/traces/<phase-name>/<date>_run<NN>/`. Both threads of `/kill-argument` are preserved separately. The master `RESUBMIT_REPORT.json` `trace_path` field points to the top-level traces directory.
+
+## Notes
+
+- This skill orchestrates several existing skills (proof-checker, paper-claim-audit, citation-audit, auto-paper-improvement-loop, kill-argument, paper-compile, overleaf-sync) plus uses two recently-added parameters (`/auto-paper-improvement-loop --edit-whitelist`, `/citation-audit --soft-only`). Make sure those parameters resolve to the current SKILL.md versions before relying on the resubmit pipeline.
+- The 5-layer anonymity scan is intentionally more thorough than `/paper-compile`'s generic self-citation warning, because resubmit-mode often inherits camera-ready text from a non-double-blind venue going to a double-blind venue.
+- Page-shrink heuristic is ordered (compress conclusion → tighten hedging → move marginal figures → move proof sketches → compress related-work prose). The order is calibrated to "least risky to most risky" — compressing conclusion is mostly editorial; moving proof sketches changes the reading flow. Stop as early as page limit is met.
+- `RESUBMIT_REPORT.json` schema follows `shared-references/assurance-contract.md` exactly. This makes resubmit runs forensically reproducible. **Note**: `tools/verify_paper_audits.sh` does not currently include `RESUBMIT_REPORT.json` in its `MANDATORY_AUDITS` list (the verifier checks proof / paper-claim / citation / kill-argument). The 4 mandatory audit files consumed by resubmit (which DO live in `<NEW_VENUE_DIR>/`) are recognized by the verifier as usual; `RESUBMIT_REPORT.json` is the orchestrator's own ledger and is not yet a verifier mandatory artifact. Adding it to the verifier is a separate follow-up if the user wants resubmit to be a submission gate via the verifier.


### PR DESCRIPTION
## Summary

New top-level Workflow 5 skill `/resubmit-pipeline` for porting a polished paper across venues under text-only constraints. Lands together with two prerequisite SKILL upgrades: `--edit-whitelist` parameter on `/auto-paper-improvement-loop`, and `--soft-only` mode on `/citation-audit`.

## Origin

This PR promotes the v2 design from `docs/RESUBMIT_WORKFLOW_PROPOSAL.md` (commit `2e07d31` on `discuss/theory-paper-resubmit-workflow-proposal`) to a real skill. Two Codex `gpt-5.5 + xhigh` review passes on the proposal + integration:
- Pass 1 (proposal review, thread `019df89d`): identified 8 blockers + 3 missing items = 11 issues
- Pass 2 (final integration review, thread `019df8af`): caught 5 additional gaps in the v2 implementation

All 16 issues are addressed in this PR.

## Files (6 changed, 1250 insertions)

| File | Change |
|---|---|
| `skills/resubmit-pipeline/SKILL.md` | NEW (~430 lines): 5-phase orchestration |
| `skills/skills-codex/resubmit-pipeline/SKILL.md` | NEW: Codex mirror (`spawn_agent` instead of `mcp__codex__codex`) |
| `skills/auto-paper-improvement-loop/SKILL.md` | +114: `--edit-whitelist` param (Gap #1) |
| `skills/skills-codex/auto-paper-improvement-loop/SKILL.md` | +114: same in mirror |
| `skills/citation-audit/SKILL.md` | +86: `--soft-only` mode (Gap #2) |
| `skills/skills-codex/citation-audit/SKILL.md` | +86: same in mirror |

## /resubmit-pipeline phases

- **Phase 0**: atomic `mkdir` of new sibling venue dir; physical `cp -r` of `sec/`, `Figure/`, `math_commands.tex`; new `main.tex` for target venue's `.sty`; `.aris/` setup. Never overwrites prior submission directories.
- **Phase 0.5**: compile + page count + 5-layer anonymity scan (surface IDs / self-citation phrasing / acknowledgments / cross-rebuttal references / internal codenames — all 5 blocking) + residual color scan.
- **Phase 1**: parallel audits — `/proof-checker --restatement-check`, `/paper-claim-audit`, `/citation-audit --soft-only`. Atomize prior reviewer reports into `KNOWN_WEAKNESSES.md` with stable IDs.
- **Phase 2**: single `/auto-paper-improvement-loop` invocation with `--edit-whitelist` + `HUMAN_CHECKPOINT=true`; per-round diff gate via `rsync` snapshots (repo-agnostic, doesn't assume git); selective regression audits.
- **Phase 3**: `/kill-argument` (no `difficulty` knob — that parameter does not exist in the skill); residual-risk reporting, not auto-rewrite.
- **Phase 4**: `/paper-compile` + final `/paper-claim-audit` + `DIFF_REPORT.md`; Overleaf push deferred to `/overleaf-sync setup` + `push` (no parallel push mechanism).

Convergence criteria + ordered page-shrink heuristic (compress conclusion → tighten hedging → move marginal figures → move proof sketches → compress related-work) + master `RESUBMIT_REPORT.{md,json}` ledger + 7-verdict failure mode table including `USER_DECISION` runtime state.

## Edit-whitelist schema (Gap #1)

YAML/JSON file with: `allowed_paths`, `forbidden_paths`, `forbidden_operations` (added-line detectors: `new_cite` / `new_bibitem` / `new_theorem_env` / `numerical_claim`), `forbidden_deletions` (removed-line detectors: `delete_existing_cite` / `delete_theorem_env`), `requires_user_approval_for` (`rewrite_abstract` / `rewrite_intro_first_para` / `delete_section`), `max_edits_per_round`, `rationale`. Opt-in; default behavior unchanged.

## Soft-only verdict translation (Gap #2)

| Base verdict | Soft-only action |
|---|---|
| KEEP | keep_unchanged |
| FIX (metadata wrong) | keep_metadata_drift_acknowledged |
| REPLACE (wrong-context) | soften_citing_sentence |
| REMOVE (hallucinated cite) | drop_cite_in_body_only |

The hallucinated-cite case is the load-bearing edge: drop inline `\cite{X}` from body (rephrase / re-attribute to in-bib alternative), bib entry untouched.

## Test plan

- [x] All 6 modified files parse via `yaml.safe_load` (frontmatter)
- [x] Personal-info scan: 0 hits across diff
- [x] Both CC and Codex skill mirrors updated for all 3 components
- [x] All cross-skill references in `/resubmit-pipeline` resolve to real skills + parameters (no fictional flags)
- [ ] Live runtime test: skipped (would consume codex 5.5 xhigh budget; recommend user runs `/resubmit-pipeline <paper-base-dir> — target-venue: <venue> — review-corpus: <reviews-dir>` once on a real resubmit task to verify end-to-end)

## Known follow-ups

- `tools/verify_paper_audits.sh` does not yet include `RESUBMIT_REPORT.json` in `MANDATORY_AUDITS` — orchestrator's own ledger is informational. Adding it is a separate small PR if the user wants resubmit verdict to gate via the verifier.
- The `tests/test_codex_skill_mirror.py` count assertion (== 67) is pre-existing-broken on main (4 skills missing from codex mirror: gemini-search, kill-argument, openalex, paper-illustration-image2). This PR adds resubmit-pipeline to BOTH sides, which is the right thing to do, but doesn't fix the pre-existing 4-skill gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
