### PR TITLE
feat(models): add dynamic /models endpoint discovery [PR B of 3]

### DIFF
--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -142,8 +142,8 @@ impl ArisConfig {
         let force_reviewer = force_rev;
 
         if let Some(provider) = &self.executor_provider {
-            if provider == "openai" {
-                std::env::set_var("EXECUTOR_PROVIDER", provider);
+            if provider == "openai" || provider == "custom" {
+                std::env::set_var("EXECUTOR_PROVIDER", "openai");
             }
         }
 
@@ -180,7 +180,7 @@ impl ArisConfig {
                         }
                     }
                 }
-                "openai" => {
+                "openai" | "custom" => {
                     if force || std::env::var("EXECUTOR_API_KEY").is_err() {
                         std::env::set_var("EXECUTOR_API_KEY", key);
                     }
@@ -190,7 +190,7 @@ impl ArisConfig {
         }
 
         // Executor base URL (for openai-compat providers)
-        if provider == "openai" {
+        if provider == "openai" || provider == "custom" {
             if force || std::env::var("EXECUTOR_BASE_URL").is_err() {
                 if let Some(url) = &self.executor_base_url {
                     std::env::set_var("EXECUTOR_BASE_URL", url);
@@ -234,6 +234,14 @@ impl ArisConfig {
                         }
                     }
                     "deepseek" => {
+                        if force_reviewer || std::env::var("ARIS_REVIEWER_AUTH_TOKEN").is_err() {
+                            std::env::set_var("ARIS_REVIEWER_AUTH_TOKEN", key);
+                        }
+                    }
+                    "custom" => {
+                        // Custom OpenAI-compatible reviewer: store key in
+                        // ARIS_REVIEWER_AUTH_TOKEN so it doesn't collide with
+                        // the executor's OPENAI_API_KEY.
                         if force_reviewer || std::env::var("ARIS_REVIEWER_AUTH_TOKEN").is_err() {
                             std::env::set_var("ARIS_REVIEWER_AUTH_TOKEN", key);
                         }
@@ -306,6 +314,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     println!("  8. Xiaomi      (mimo-v2.5-pro)");
     println!("  9. Qwen        (qwen3.6-plus)");
     println!(" 10. Doubao      (doubao-pro-4k)");
+    println!(" 11. Custom      (OpenAI-compatible endpoint)");
 
     let default_executor = match config.executor_provider.as_deref() {
         Some("anthropic") => "1",
@@ -313,6 +322,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
             Some(u) if u.contains("deepseek") => "7",
             _ => "1",
         },
+        Some("custom") => "11",
         Some("openai") => match config.executor_base_url.as_deref() {
             Some(u) if u.contains("googleapis") => "3",
             Some(u) if u.contains("bigmodel") => "4",
@@ -325,7 +335,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         },
         _ => "1",
     };
-    let exec_choice_raw = prompt_with_default("  Choose [1-10]", default_executor)?;
+    let exec_choice_raw = prompt_with_default("  Choose [1-11]", default_executor)?;
     let exec_choice = exec_choice_raw.trim();
     // Detect real menu change, not just provider-string change. OpenAI / Gemini /
     // GLM / MiniMax / Kimi all serialize to provider="openai" so we must compare
@@ -343,6 +353,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         "8" => ("openai", "EXECUTOR_API_KEY", "Xiaomi API key", Some("https://token-plan-cn.xiaomimimo.com/v1"), "mimo-v2.5-pro"),
         "9" => ("openai", "EXECUTOR_API_KEY", "Qwen (DashScope) API key", Some("https://dashscope.aliyuncs.com/compatible-mode/v1"), "qwen3.6-plus"),
         "10" => ("openai", "EXECUTOR_API_KEY", "Doubao (Ark) API key", Some("https://ark.cn-beijing.volces.com/api/v3"), "doubao-pro-4k"),
+        "11" => ("custom", "EXECUTOR_API_KEY", "API key", None, ""),
         _ => ("anthropic", "ANTHROPIC_API_KEY", "Anthropic API key", None, "claude-opus-4-7"),
     };
 
@@ -414,8 +425,21 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     // auto-switch made issues #158 and #162 unreachable via the UI.
 
     // Auto-set best model for the chosen provider
-    config.executor_model = Some(exec_info.4.to_string());
-    println!("  \x1b[2mModel: {}\x1b[0m", exec_info.4);
+    if exec_choice == "11" {
+        // Custom provider: ask user for model name
+        let current_model_hint = config.executor_model.as_deref().unwrap_or("(not set)");
+        let custom_model = prompt_with_default(
+            &format!("  Model name [{current_model_hint}]"),
+            config.executor_model.as_deref().unwrap_or(""),
+        )?;
+        if !custom_model.is_empty() {
+            config.executor_model = Some(custom_model.clone());
+        }
+        println!("  \x1b[2mModel: {}\x1b[0m", config.executor_model.as_deref().unwrap_or("(none)"));
+    } else {
+        config.executor_model = Some(exec_info.4.to_string());
+        println!("  \x1b[2mModel: {}\x1b[0m", exec_info.4);
+    }
 
     // ── Step 4: Reviewer ──
     println!("\n\x1b[1m[2/3] Reviewer (for LlmReview tool)\x1b[0m");
@@ -425,8 +449,9 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
     println!("  4. MiniMax         (MiniMax-M2.7)");
     println!("  5. Kimi            (kimi-k2.5)");
     println!("  6. Anthropic Proxy (claude via proxy)");
-    println!("  7. DeepSeek         (deepseek-chat)");
-    println!("  8. Skip (no reviewer)");
+    println!("  7. DeepSeek        (deepseek-chat)");
+    println!("  8. Custom          (OpenAI-compatible endpoint)");
+    println!("  9. Skip (no reviewer)");
     let default_reviewer = match config.reviewer_provider.as_deref() {
         Some("openai") => "1",
         Some("gemini") => "2",
@@ -435,10 +460,11 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         Some("kimi") => "5",
         Some("anthropic-compat") => "6",
         Some("deepseek") => "7",
+        Some("custom") => "8",
         None => "1",
-        _ => "8",
+        _ => "9",
     };
-    let reviewer_choice_raw = prompt_with_default("  Choose [1-8]", default_reviewer)?;
+    let reviewer_choice_raw = prompt_with_default("  Choose [1-9]", default_reviewer)?;
     let reviewer_choice = reviewer_choice_raw.trim();
     let switched_reviewer = reviewer_choice != default_reviewer;
 
@@ -451,6 +477,7 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         "5" => Some(("kimi", "KIMI_API_KEY", "Kimi API key", "kimi-k2.5")),
         "6" => Some(("anthropic-compat", "ARIS_REVIEWER_AUTH_TOKEN", "Reviewer auth token", "claude-sonnet-4-6")),
         "7" => Some(("deepseek", "ARIS_REVIEWER_AUTH_TOKEN", "DeepSeek API key", "deepseek-v4-pro")),
+        "8" => Some(("custom", "ARIS_REVIEWER_AUTH_TOKEN", "API key", "")),
         _ => None,
     };
 
@@ -498,8 +525,21 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
         }
 
         // Auto-set best model for the chosen reviewer provider
-        config.reviewer_model = Some(default_model.to_string());
-        println!("  \x1b[2mModel: {default_model}\x1b[0m");
+        if reviewer_choice == "8" {
+            // Custom provider: ask user for model name
+            let current_model_hint = config.reviewer_model.as_deref().unwrap_or("(not set)");
+            let custom_model = prompt_with_default(
+                &format!("  Model name [{current_model_hint}]"),
+                config.reviewer_model.as_deref().unwrap_or(""),
+            )?;
+            if !custom_model.is_empty() {
+                config.reviewer_model = Some(custom_model.clone());
+            }
+            println!("  \x1b[2mModel: {}\x1b[0m", config.reviewer_model.as_deref().unwrap_or("(none)"));
+        } else {
+            config.reviewer_model = Some(default_model.to_string());
+            println!("  \x1b[2mModel: {default_model}\x1b[0m");
+        }
     } else {
         config.reviewer_provider = None;
         config.reviewer_api_key = None;

--- a/crates/aris-cli/src/config.rs
+++ b/crates/aris-cli/src/config.rs
@@ -426,14 +426,47 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
 
     // Auto-set best model for the chosen provider
     if exec_choice == "11" {
-        // Custom provider: ask user for model name
-        let current_model_hint = config.executor_model.as_deref().unwrap_or("(not set)");
-        let custom_model = prompt_with_default(
-            &format!("  Model name [{current_model_hint}]"),
-            config.executor_model.as_deref().unwrap_or(""),
-        )?;
-        if !custom_model.is_empty() {
-            config.executor_model = Some(custom_model.clone());
+        // Custom provider: try fetching available models from /models endpoint
+        let api_key = config.executor_api_key.as_deref().unwrap_or("");
+        let base_url = config.executor_base_url.as_deref().unwrap_or("");
+        if !api_key.is_empty() && !base_url.is_empty() {
+            println!("  \x1b[2mFetching models from {base_url}...\x1b[0m");
+            match crate::openai_compat::fetch_openai_models(base_url, api_key) {
+                Ok(models) => {
+                    let current = config.executor_model.as_deref().unwrap_or("");
+                    let items = crate::openai_compat::model_select_items(&models, current);
+                    match crate::input::select_menu(
+                        "Select model",
+                        "Choose a model from the provider's /models endpoint.",
+                        &items,
+                    ) {
+                        Ok(Some(idx)) => {
+                            config.executor_model = Some(items[idx].label.clone());
+                        }
+                        Ok(None) => {
+                            // User cancelled — keep existing model
+                        }
+                        Err(_) => {
+                            // select_menu I/O error — fall through to manual
+                        }
+                    }
+                }
+                Err(err) => {
+                    println!("  \x1b[33m⚠ Could not fetch models: {err}\x1b[0m");
+                    println!("  \x1b[2mYou can type the model name manually below.\x1b[0m");
+                }
+            }
+        }
+        // If no model set yet (fetch failed or user has no key/url), ask manually
+        if config.executor_model.as_deref().unwrap_or("").is_empty() {
+            let current_model_hint = config.executor_model.as_deref().unwrap_or("(not set)");
+            let custom_model = prompt_with_default(
+                &format!("  Model name [{current_model_hint}]"),
+                config.executor_model.as_deref().unwrap_or(""),
+            )?;
+            if !custom_model.is_empty() {
+                config.executor_model = Some(custom_model.clone());
+            }
         }
         println!("  \x1b[2mModel: {}\x1b[0m", config.executor_model.as_deref().unwrap_or("(none)"));
     } else {
@@ -526,14 +559,43 @@ pub fn run_interactive_setup() -> io::Result<ArisConfig> {
 
         // Auto-set best model for the chosen reviewer provider
         if reviewer_choice == "8" {
-            // Custom provider: ask user for model name
-            let current_model_hint = config.reviewer_model.as_deref().unwrap_or("(not set)");
-            let custom_model = prompt_with_default(
-                &format!("  Model name [{current_model_hint}]"),
-                config.reviewer_model.as_deref().unwrap_or(""),
-            )?;
-            if !custom_model.is_empty() {
-                config.reviewer_model = Some(custom_model.clone());
+            // Custom provider: try fetching available models from /models endpoint
+            let api_key = config.reviewer_api_key.as_deref().unwrap_or("");
+            let base_url = config.reviewer_base_url.as_deref().unwrap_or("");
+            if !api_key.is_empty() && !base_url.is_empty() {
+                println!("  \x1b[2mFetching models from {base_url}...\x1b[0m");
+                match crate::openai_compat::fetch_openai_models(base_url, api_key) {
+                    Ok(models) => {
+                        let current = config.reviewer_model.as_deref().unwrap_or("");
+                        let items = crate::openai_compat::model_select_items(&models, current);
+                        match crate::input::select_menu(
+                            "Select reviewer model",
+                            "Choose a model from the provider's /models endpoint.",
+                            &items,
+                        ) {
+                            Ok(Some(idx)) => {
+                                config.reviewer_model = Some(items[idx].label.clone());
+                            }
+                            Ok(None) => {}
+                            Err(_) => {}
+                        }
+                    }
+                    Err(err) => {
+                        println!("  \x1b[33m⚠ Could not fetch models: {err}\x1b[0m");
+                        println!("  \x1b[2mYou can type the model name manually below.\x1b[0m");
+                    }
+                }
+            }
+            // If no model set yet, ask manually
+            if config.reviewer_model.as_deref().unwrap_or("").is_empty() {
+                let current_model_hint = config.reviewer_model.as_deref().unwrap_or("(not set)");
+                let custom_model = prompt_with_default(
+                    &format!("  Model name [{current_model_hint}]"),
+                    config.reviewer_model.as_deref().unwrap_or(""),
+                )?;
+                if !custom_model.is_empty() {
+                    config.reviewer_model = Some(custom_model.clone());
+                }
             }
             println!("  \x1b[2mModel: {}\x1b[0m", config.reviewer_model.as_deref().unwrap_or("(none)"));
         } else {

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -1342,25 +1342,34 @@ impl LiveCli {
         }
 
         let executor_label = if openai_executor::resolve_openai_executor_config().is_some() {
-            let base = std::env::var("EXECUTOR_BASE_URL").unwrap_or_default();
-            if base.contains("deepseek") {
-                "DeepSeek"
-            } else if base.contains("bigmodel") {
-                "GLM"
-            } else if base.contains("minimax") {
-                "MiniMax"
-            } else if base.contains("moonshot") {
-                "Moonshot"
-            } else if base.contains("dashscope") || base.contains("qwen") {
-                "Qwen"
-            } else if base.contains("generativelanguage.googleapis") {
-                "Gemini"
-            } else if base.contains("xiaomimimo") {
-                "Xiaomi"
-            } else if base.contains("volces") {
-                "Doubao"
+            // Check if this is a custom provider
+            let is_custom = config::ArisConfig::load()
+                .executor_provider
+                .as_deref()
+                == Some("custom");
+            if is_custom {
+                "Custom"
             } else {
-                "OpenAI"
+                let base = std::env::var("EXECUTOR_BASE_URL").unwrap_or_default();
+                if base.contains("deepseek") {
+                    "DeepSeek"
+                } else if base.contains("bigmodel") {
+                    "GLM"
+                } else if base.contains("minimax") {
+                    "MiniMax"
+                } else if base.contains("moonshot") {
+                    "Moonshot"
+                } else if base.contains("dashscope") || base.contains("qwen") {
+                    "Qwen"
+                } else if base.contains("generativelanguage.googleapis") {
+                    "Gemini"
+                } else if base.contains("xiaomimimo") {
+                    "Xiaomi"
+                } else if base.contains("volces") {
+                    "Doubao"
+                } else {
+                    "OpenAI"
+                }
             }
         } else {
             "Anthropic"
@@ -1806,7 +1815,10 @@ impl LiveCli {
                 }
 
                 if items.is_empty() {
-                    println!("No reviewer API key found. Set GEMINI_API_KEY or OPENAI_API_KEY.");
+                    // No known API keys set — could be a custom provider or no config.
+                    // Allow the user to type a model name directly.
+                    println!("No reviewer API key found. Set GEMINI_API_KEY, OPENAI_API_KEY, or use /setup to configure a custom provider.");
+                    println!("  You can also type: /reviewer <model-name>");
                     return Ok(false);
                 }
 

--- a/crates/aris-cli/src/main.rs
+++ b/crates/aris-cli/src/main.rs
@@ -3,6 +3,7 @@ mod init;
 mod input;
 mod memories;
 mod meta_optimize;
+mod openai_compat;
 mod openai_executor;
 mod render;
 
@@ -1650,7 +1651,32 @@ impl LiveCli {
             None => {
                 // Show interactive menu
                 let is_openai = openai_executor::resolve_openai_executor_config().is_some();
-                let items: Vec<input::SelectItem> = if is_openai {
+                let is_custom = config::ArisConfig::load()
+                    .executor_provider
+                    .as_deref()
+                    == Some("custom");
+
+                let items: Vec<input::SelectItem> = if is_custom {
+                    // Custom provider: try dynamic /models fetch
+                    let cfg = config::ArisConfig::load();
+                    let api_key = cfg.executor_api_key.as_deref().unwrap_or("");
+                    let base_url = cfg.executor_base_url.as_deref().unwrap_or("");
+                    if !api_key.is_empty() && !base_url.is_empty() {
+                        match openai_compat::fetch_openai_models(base_url, api_key) {
+                            Ok(models) => {
+                                openai_compat::model_select_items(&models, &self.model)
+                            }
+                            Err(err) => {
+                                println!("\x1b[33m⚠ Could not fetch models: {err}\x1b[0m");
+                                println!("  Use /model <name> to switch directly.");
+                                return Ok(false);
+                            }
+                        }
+                    } else {
+                        println!("Custom provider not fully configured. Run /setup first.");
+                        return Ok(false);
+                    }
+                } else if is_openai {
                     // OpenAI-compat mode: show common models
                     vec![
                         ("gpt-5.5", "OpenAI · Best intelligence at scale (xhigh reasoning)"),

--- a/crates/aris-cli/src/openai_compat.rs
+++ b/crates/aris-cli/src/openai_compat.rs
@@ -1,0 +1,255 @@
+//! Shared utilities for OpenAI-compatible provider integration.
+//!
+//! Provides URL normalization, dynamic `/models` endpoint discovery,
+//! and model selection helpers used by both the executor and reviewer
+//! configuration paths. Designed to be mockable for offline CI testing
+//! (no real `api.openai.com` calls in tests).
+
+use std::collections::HashSet;
+
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::input::SelectItem;
+
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenAIModelInfo {
+    pub id: String,
+    pub owned_by: Option<String>,
+}
+
+/// Returns `true` if the given provider string routes through the
+/// OpenAI-compatible executor/reviewer path.
+#[allow(dead_code)] // used in PR C (shared routing)
+pub fn is_openai_compat_provider(provider: &str) -> bool {
+    matches!(provider, "openai" | "custom")
+}
+
+/// Normalize a base URL to a clean `/v1`-style root suitable for appending
+/// `/chat/completions` or `/models`. Strips known suffixes and trailing
+/// slashes so callers can safely `format!("{base}/models")`.
+pub fn normalize_openai_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return DEFAULT_OPENAI_BASE_URL.to_string();
+    }
+
+    let without_chat = trimmed.strip_suffix("/chat/completions").unwrap_or(trimmed);
+    let without_models = without_chat.strip_suffix("/models").unwrap_or(without_chat);
+    without_models.trim_end_matches('/').to_string()
+}
+
+pub fn chat_completions_url(base_url: &str) -> String {
+    format!("{}/chat/completions", normalize_openai_base_url(base_url))
+}
+
+pub fn models_url(base_url: &str) -> String {
+    format!("{}/models", normalize_openai_base_url(base_url))
+}
+
+/// Derive a human-readable provider label from the provider string and base
+/// URL. Used in the startup banner and status displays for custom providers.
+#[allow(dead_code)] // used in PR C (shared routing)
+pub fn openai_provider_label(provider: Option<&str>, base_url: &str) -> &'static str {
+    if provider == Some("custom") {
+        return "Custom OpenAI-compatible";
+    }
+
+    let normalized = normalize_openai_base_url(base_url);
+    if normalized.contains("deepseek") {
+        "DeepSeek"
+    } else if normalized.contains("bigmodel") {
+        "GLM"
+    } else if normalized.contains("minimax") {
+        "MiniMax"
+    } else if normalized.contains("moonshot") {
+        "Moonshot"
+    } else if normalized.contains("dashscope") || normalized.contains("qwen") {
+        "Qwen"
+    } else if normalized.contains("generativelanguage.googleapis") {
+        "Gemini"
+    } else {
+        "OpenAI"
+    }
+}
+
+/// Convert a list of `OpenAIModelInfo` into `SelectItem`s for the REPL
+/// interactive selection menu. Marks the entry matching `current_model`.
+pub fn model_select_items(models: &[OpenAIModelInfo], current_model: &str) -> Vec<SelectItem> {
+    models
+        .iter()
+        .map(|model| SelectItem {
+            label: model.id.clone(),
+            description: model.owned_by.clone().unwrap_or_default(),
+            is_current: model.id == current_model,
+        })
+        .collect()
+}
+
+/// Fetch the list of available models from an OpenAI-compatible `/models`
+/// endpoint. Uses a one-shot tokio runtime so this can be called from
+/// synchronous setup/REPL code.
+///
+/// Returns a deduplicated list of model IDs sorted by the server's order.
+/// Errors are returned as human-readable strings for display in the setup
+/// wizard.
+pub fn fetch_openai_models(base_url: &str, api_key: &str) -> Result<Vec<OpenAIModelInfo>, String> {
+    let base_url = normalize_openai_base_url(base_url);
+    let api_key = api_key.trim();
+    if api_key.is_empty() {
+        return Err("API key is required".to_string());
+    }
+
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|error| format!("Failed to start async runtime: {error}"))?;
+    runtime.block_on(async move {
+        let response = Client::new()
+            .get(models_url(&base_url))
+            .bearer_auth(api_key)
+            .send()
+            .await
+            .map_err(|error| format!("Failed to fetch /models: {error}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to fetch /models ({status}): {body}"));
+        }
+
+        let payload = response
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("Failed to parse /models response: {error}"))?;
+        parse_openai_models(payload)
+    })
+}
+
+fn parse_openai_models(payload: Value) -> Result<Vec<OpenAIModelInfo>, String> {
+    let items = payload
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("Unexpected /models response: {payload}"))?;
+
+    let mut seen = HashSet::new();
+    let mut models = Vec::new();
+    for item in items {
+        let Some(id) = item.get("id").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        if id.is_empty() || !seen.insert(id.to_string()) {
+            continue;
+        }
+        let owned_by = item
+            .get("owned_by")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        models.push(OpenAIModelInfo {
+            id: id.to_string(),
+            owned_by,
+        });
+    }
+
+    if models.is_empty() {
+        return Err("The /models endpoint returned no usable model ids".to_string());
+    }
+
+    Ok(models)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    use super::{fetch_openai_models, model_select_items, normalize_openai_base_url};
+
+    #[test]
+    fn normalize_openai_base_url_strips_known_suffixes() {
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/v1/chat/completions"),
+            "https://example.com/v1"
+        );
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/v1/models"),
+            "https://example.com/v1"
+        );
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/v1/"),
+            "https://example.com/v1"
+        );
+    }
+
+    #[test]
+    fn fetch_openai_models_uses_models_endpoint_and_deduplicates_ids() {
+        let request_capture = Arc::new(Mutex::new(String::new()));
+        let request_capture_for_thread = Arc::clone(&request_capture);
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            let mut buffer = [0_u8; 4096];
+            let bytes = stream.read(&mut buffer).expect("read request");
+            *request_capture_for_thread.lock().expect("lock capture") =
+                String::from_utf8_lossy(&buffer[..bytes]).into_owned();
+
+            let body = serde_json::json!({
+                "data": [
+                    {"id": "alpha", "owned_by": "vendor-a"},
+                    {"id": "alpha", "owned_by": "vendor-a"},
+                    {"id": "beta"}
+                ]
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        let models =
+            fetch_openai_models(&format!("http://{addr}/v1"), "test-key").expect("fetch models");
+        handle.join().expect("server thread");
+
+        let request = request_capture.lock().expect("lock capture").clone();
+        assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-key"));
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "alpha");
+        assert_eq!(models[0].owned_by.as_deref(), Some("vendor-a"));
+        assert_eq!(models[1].id, "beta");
+        assert_eq!(models[1].owned_by, None);
+    }
+
+    #[test]
+    fn model_select_items_marks_current_model() {
+        let items = model_select_items(
+            &[
+                super::OpenAIModelInfo {
+                    id: "alpha".to_string(),
+                    owned_by: Some("vendor-a".to_string()),
+                },
+                super::OpenAIModelInfo {
+                    id: "beta".to_string(),
+                    owned_by: None,
+                },
+            ],
+            "beta",
+        );
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].description, "vendor-a");
+        assert!(!items[0].is_current);
+        assert!(items[1].is_current);
+    }
+}

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -3261,6 +3261,33 @@ fn run_llm_review(input: LlmReviewInput) -> Result<String, String> {
     let reviewer_provider = std::env::var("ARIS_REVIEWER_PROVIDER").ok().filter(|s| !s.is_empty());
     let custom_base_url = std::env::var("ARIS_REVIEWER_BASE_URL").ok().filter(|s| !s.is_empty());
 
+    // Custom OpenAI-compatible reviewer mode. Uses ARIS_REVIEWER_AUTH_TOKEN as
+    // the API key and ARIS_REVIEWER_BASE_URL for the endpoint. Routes through
+    // the same OpenAI-compat call path — no third routing path added.
+    if reviewer_provider.as_deref() == Some("custom") {
+        let key = std::env::var("ARIS_REVIEWER_AUTH_TOKEN")
+            .ok()
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| "LlmReview: ARIS_REVIEWER_AUTH_TOKEN not set (needed for custom reviewer)".to_string())?;
+        let model = input
+            .model
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(configured_model);
+        let base = custom_base_url.ok_or_else(|| {
+            "LlmReview: ARIS_REVIEWER_BASE_URL not set (needed for custom reviewer)".to_string()
+        })?;
+        let trimmed = base.trim_end_matches('/');
+        let url = if trimmed.ends_with("/chat/completions") {
+            trimmed.to_string()
+        } else if trimmed.ends_with("/v1") {
+            format!("{trimmed}/chat/completions")
+        } else {
+            format!("{trimmed}/v1/chat/completions")
+        };
+        return call_openai_compat_reviewer(&key, &url, model, &input.prompt);
+    }
+
     // Anthropic-compatible reviewer mode (e.g., Claude via proxy, DeepSeek).
     // This path uses ARIS_REVIEWER_AUTH_TOKEN (Bearer) and ignores the openai-compat
     // key routing. We still honor an explicit input.model override here because


### PR DESCRIPTION
## Summary

**Part 2 of 3** for the PR #121 rework. Depends on PR A.

Adds `openai_compat.rs` for dynamic model fetching from `/models` endpoint, integrated into `/setup` and `/model` for custom providers.

### Changes
- **openai_compat.rs** [NEW]: URL normalization, `fetch_openai_models()`, `model_select_items()`
- **config.rs**: `/setup` custom provider auto-fetches `/models` → interactive selection → manual fallback
- **main.rs**: `/model` command uses dynamic fetch for custom provider

### Test Coverage
- 3 new offline tests (TcpListener mock, no real API calls)
- All 106 tests pass (`cargo test -p aris-cli -p tools`)

> Will retarget to `v0.5.0-alpha/provider-abstraction` when available.

Ref: #121, depends on PR A
