### PR TITLE
fix: tighten parse_claude_json legacy NDJSON diagnostics

### DIFF
--- a/mcp-servers/claude-review/server.py
+++ b/mcp-servers/claude-review/server.py
@@ -147,6 +147,7 @@ def parse_claude_json(raw_stdout: str) -> tuple[dict[str, Any] | None, str | Non
     # JSON-array line surrounded by non-JSON noise (wrapper warnings, nvm/asdf
     # banners, future CLI debug prints) still surfaces the result event
     # instead of being silently dropped.
+    saw_array_without_result = False
     for candidate in reversed(stripped.splitlines()):
         candidate = candidate.strip()
         if not candidate:
@@ -156,6 +157,8 @@ def parse_claude_json(raw_stdout: str) -> tuple[dict[str, Any] | None, str | Non
         except json.JSONDecodeError:
             continue
         if isinstance(line_payload, dict):
+            if saw_array_without_result and line_payload.get("type") != "result":
+                continue
             return line_payload, None
         if isinstance(line_payload, list):
             for item in reversed(line_payload):
@@ -163,7 +166,10 @@ def parse_claude_json(raw_stdout: str) -> tuple[dict[str, Any] | None, str | Non
                     return item, None
             # fall through: this line was an array without a result event,
             # but earlier lines might still carry one — keep scanning.
+            saw_array_without_result = True
 
+    if saw_array_without_result:
+        return None, "Claude CLI returned a JSON array without a 'result' event"
     return None, "Claude CLI did not return JSON output"
 
 
@@ -293,7 +299,12 @@ def run_claude_review(
         # Surface it explicitly; otherwise the user sees only the generic
         # "Claude review failed" and loses the actionable message.
         errors_list = payload.get("errors")
-        errors_text = "; ".join(str(e) for e in errors_list) if isinstance(errors_list, list) and errors_list else ""
+        if isinstance(errors_list, list) and errors_list:
+            errors_text = "; ".join(str(e) for e in errors_list)
+        elif isinstance(errors_list, str):
+            errors_text = errors_list
+        else:
+            errors_text = ""
         message = str(
             payload.get("result")
             or payload.get("error")

--- a/tests/test_claude_review_parse.py
+++ b/tests/test_claude_review_parse.py
@@ -140,8 +140,8 @@ class ParseClaudeJsonTests(unittest.TestCase):
         self.assertEqual(payload["result"], "recovered")
         self.assertEqual(payload["session_id"], "sess-noisy")
 
-    def test_noisy_stdout_with_array_line_no_result_falls_through(self) -> None:
-        """Noisy stdout + JSON-array line that has no result event continues scanning earlier lines."""
+    def test_noisy_stdout_with_array_line_no_result_surfaces_specific_diagnostic(self) -> None:
+        """Noisy stdout + JSON-array line with no result event: surface the specific 'array without result event' diagnostic (symmetry with the whole-stdout path)."""
         events_no_result = [_system_init_event(), _assistant_event()]
         stdout = (
             "warning: banner\n"
@@ -149,7 +149,7 @@ class ParseClaudeJsonTests(unittest.TestCase):
         )
         payload, err = MODULE.parse_claude_json(stdout)
         self.assertIsNone(payload)
-        self.assertEqual(err, "Claude CLI did not return JSON output")
+        self.assertEqual(err, "Claude CLI returned a JSON array without a 'result' event")
 
 
 def _completed_process(stdout: str, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary

Fixes #223

The legacy NDJSON parsing loop in `parse_claude_json` could surface a generic "Claude CLI did not return JSON output" error when a JSON array lacking a `result` event was encountered, instead of the specific "returned a JSON array without a result event" message. Additionally, a low-probability edge case could silently surface a non-result dict (e.g., a system init event) as the review payload.

## Root Cause

In `mcp-servers/claude-review/server.py`, the legacy NDJSON per-line loop (lines 150-167) had no mechanism to track whether it had seen an array-without-result. When scanning lines in reverse:

1. An array line without a `result` event would fall through silently — if no other line yielded a usable payload, the final fallback returned only the generic message (line 167)
2. A dict line appearing earlier in the scan would be returned unconditionally (line 159), even if we had already seen `saw_array_without_result` — potentially surfacing a non-result dict as the review output

## Fix

- Added `saw_array_without_result` flag before the loop, set to `True` when an array line lacks a result event
- In the dict branch: require `type == "result"` when `saw_array_without_result` is set, matching the symmetry the whole-stdout array path already has
- After the loop: return the specific error message when `saw_array_without_result` is set
- Also handle non-list `errors` values (plain strings) in the error extraction path

## Changes

- `mcp-servers/claude-review/server.py`: 12 lines added, 1 line modified (`+12 -1`)

## Testing

- **Legacy NDJSON with array without result, then dict without type=result**: dict is skipped, specific error returned ✅
- **Legacy NDJSON with array without result, no other usable payload**: specific "array without result event" error instead of generic fallback ✅
- **Legacy NDJSON with valid result event in array line (happy path)**: result still returned correctly ✅
- **Whole-stdout path (CLI 2.x)**: unaffected, existing behavior preserved ✅