### PR TITLE
fix(idea-discovery): add missing research-refine-pipeline to frontmatter description

### DIFF
--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-discovery
-description: "Workflow 1: Full idea discovery pipeline. Orchestrates research-lit → idea-creator → novelty-check → research-review to go from a broad research direction to validated, pilot-tested ideas. Use when user says \"找idea全流程\", \"idea discovery pipeline\", \"从零开始找方向\", or wants the complete idea exploration workflow."
+description: "Workflow 1: Full idea discovery pipeline. Orchestrates research-lit → idea-creator → novelty-check → research-review → research-refine-pipeline to go from a broad research direction to validated, pilot-tested ideas. Use when user says \"找idea全流程\", \"idea discovery pipeline\", \"从零开始找方向\", or wants the complete idea exploration workflow."
 argument-hint: [research-direction]
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "idea-discovery"
-description: "Workflow 1: Full idea discovery pipeline. Orchestrates research-lit \u2192 idea-creator \u2192 novelty-check \u2192 research-review to go from a broad research direction to validated, pilot-tested ideas. Use when user says \\\"\u627eidea\u5168\u6d41\u7a0b\\\", \\\"idea discovery pipeline\\\", \\\"\u4ece\u96f6\u5f00\u59cb\u627e\u65b9\u5411\\\", or wants the complete idea exploration workflow."
+description: "Workflow 1: Full idea discovery pipeline. Orchestrates research-lit \u2192 idea-creator \u2192 novelty-check \u2192 research-review \u2192 research-refine-pipeline to go from a broad research direction to validated, pilot-tested ideas. Use when user says \\\"\u627eidea\u5168\u6d41\u7a0b\\\", \\\"idea discovery pipeline\\\", \\\"\u4ece\u96f6\u5f00\u59cb\u627e\u65b9\u5411\\\", or wants the complete idea exploration workflow."
 ---
 
 # Workflow 1: Idea Discovery Pipeline


### PR DESCRIPTION
## Problem

The `description` field in the frontmatter of `/idea-discovery` lists the pipeline as:

```
research-lit → idea-creator → novelty-check → research-review
```

but omits the final `→ research-refine-pipeline` step.

## Evidence

All other references in the repo have it correctly:
- `skills/idea-discovery/SKILL.md` Overview section (line 17): includes `research-refine-pipeline`
- `docs/SKILLS_CATALOG.md` (line 28): includes `research-refine-pipeline`
- Pipeline diagram at bottom of SKILL.md: includes `research-refine-pipeline`

Only the frontmatter `description` field was out of sync.

## Fix

Add `→ research-refine-pipeline` to the frontmatter description. Same fix applied to the Codex CLI mirror (`skills/skills-codex/idea-discovery/SKILL.md`).