### PR TITLE
fix(deepxiv): add /alphaxiv to Role & Positioning table, unify format and row order

### DIFF
--- a/skills/deepxiv/SKILL.md
+++ b/skills/deepxiv/SKILL.md
@@ -13,11 +13,12 @@ Search topic or paper ID: $ARGUMENTS
 
 DeepXiv is the **progressive-reading** literature source:
 
-| Skill | Best for |
-|------|----------|
-| `/arxiv` | Direct preprint search and PDF download |
-| `/semantic-scholar` | Published venue metadata, citation counts, DOI links |
-| `/deepxiv` | Layered reading: search → brief → head → section, plus trending and web search |
+| Skill | Source | Best for |
+|-------|--------|----------|
+| `/arxiv` | arXiv API | Batch search, PDF download, metadata |
+| `/semantic-scholar` | S2 API | Published venue metadata, citation counts |
+| `/alphaxiv` | alphaxiv.org | Instant LLM-optimized summary of one paper, with LaTeX source fallback |
+| **`/deepxiv`** | **DeepXiv SDK** | **Progressive section-level reading** |
 
 Use DeepXiv when you want to avoid loading full papers too early.
 

--- a/skills/deepxiv/SKILL.md
+++ b/skills/deepxiv/SKILL.md
@@ -16,9 +16,9 @@ DeepXiv is the **progressive-reading** literature source:
 | Skill | Source | Best for |
 |-------|--------|----------|
 | `/arxiv` | arXiv API | Batch search, PDF download, metadata |
+| **`/deepxiv`** | **DeepXiv SDK** | **Progressive section-level reading** |
 | `/semantic-scholar` | S2 API | Published venue metadata, citation counts |
 | `/alphaxiv` | alphaxiv.org | Instant LLM-optimized summary of one paper, with LaTeX source fallback |
-| **`/deepxiv`** | **DeepXiv SDK** | **Progressive section-level reading** |
 
 Use DeepXiv when you want to avoid loading full papers too early.
 

--- a/skills/skills-codex/deepxiv/SKILL.md
+++ b/skills/skills-codex/deepxiv/SKILL.md
@@ -11,11 +11,12 @@ Search topic or paper ID: $ARGUMENTS
 
 DeepXiv is the progressive-reading literature source:
 
-| Skill | Best for |
-|------|----------|
-| `/arxiv` | Direct preprint search and PDF download |
-| `/semantic-scholar` | Published venue metadata, citation counts, DOI links |
-| `/deepxiv` | Layered reading: search → brief → head → section, plus trending and web search |
+| Skill | Source | Best for |
+|-------|--------|----------|
+| `/arxiv` | arXiv API | Batch search, PDF download, metadata |
+| `/semantic-scholar` | S2 API | Published venue metadata, citation counts |
+| `/alphaxiv` | alphaxiv.org | Instant LLM-optimized summary of one paper, with LaTeX source fallback |
+| **`/deepxiv`** | **DeepXiv SDK** | **Progressive section-level reading** |
 
 Use DeepXiv when you want to inspect papers incrementally instead of loading the full text immediately.
 

--- a/skills/skills-codex/deepxiv/SKILL.md
+++ b/skills/skills-codex/deepxiv/SKILL.md
@@ -14,9 +14,9 @@ DeepXiv is the progressive-reading literature source:
 | Skill | Source | Best for |
 |-------|--------|----------|
 | `/arxiv` | arXiv API | Batch search, PDF download, metadata |
+| **`/deepxiv`** | **DeepXiv SDK** | **Progressive section-level reading** |
 | `/semantic-scholar` | S2 API | Published venue metadata, citation counts |
 | `/alphaxiv` | alphaxiv.org | Instant LLM-optimized summary of one paper, with LaTeX source fallback |
-| **`/deepxiv`** | **DeepXiv SDK** | **Progressive section-level reading** |
 
 Use DeepXiv when you want to inspect papers incrementally instead of loading the full text immediately.
 


### PR DESCRIPTION
## What

`skills/deepxiv/SKILL.md` and its Codex mirror `skills/skills-codex/deepxiv/SKILL.md` were missing the `/alphaxiv` row in the **Role & Positioning** table, and the table format/row order differed from the canonical table in `skills/alphaxiv/SKILL.md`.

## Changes

- Add `/alphaxiv` row to both deepxiv SKILL.md files
- Unify column headers (`Skill | Source | Best for`) with alphaxiv's table
- Unify row order: `/arxiv` → `/deepxiv` (bold) → `/semantic-scholar` → `/alphaxiv`

## Why

Every skill that lists the sibling skills should cross-reference all of them. The alphaxiv skill already referenced deepxiv, so deepxiv should reciprocate. A consistent row order across all Role & Positioning tables makes the comparison easier to scan.

## Testing

Visually verified both files render the same table structure and row order as `skills/alphaxiv/SKILL.md`. No functional code changes.