### PR TITLE
fix(alphaxiv): make wiki ingest Step 6 reliable

### DIFF
--- a/skills/alphaxiv/SKILL.md
+++ b/skills/alphaxiv/SKILL.md
@@ -123,22 +123,13 @@ Temporary source artifacts live under `/tmp`. Do not rely on persistence.
 
 If the user only asks for one specific detail, answer it directly — skip the full template.
 
-#### Suggest Follow-Up Skills
+**After presenting the summary, you MUST proceed to Step 6 before ending the turn.**
 
-```text
-/arxiv "PAPER_ID" - download          - download the PDF to local library
-/deepxiv "PAPER_ID" - section: Methods  - read a specific section progressively
-/research-lit "related topic"        - multi-source literature survey
-/novelty-check "idea from paper"     - verify novelty against this paper's area
-```
+### Step 6: Research Wiki Ingest
 
-## Update Research Wiki (if active)
+**You MUST always run the bash block below — it checks for `research-wiki/` internally and exits silently when absent.** Do NOT skip this step based on your own directory check; the bash block handles that for you.
 
-**Required when `research-wiki/` exists in the project**; skip silently
-otherwise. When the wiki dir exists, resolve `$WIKI_SCRIPT` per the
-canonical chain at
-[`shared-references/wiki-helper-resolution.md`](../shared-references/wiki-helper-resolution.md)
-(Variant B — warn-and-skip), then ingest the single paper that was read:
+Substitute only `<paper_arxiv_id>` and `<thesis>`; keep `${ARIS_REPO:-...}` as-is so an already-set env var is preserved.
 
 ```bash
 if [ -d research-wiki/ ]; then
@@ -164,6 +155,15 @@ If wiki was not present at read time (or the helper was unreachable),
 the user can backfill via
 `python3 "$WIKI_SCRIPT" sync research-wiki/ --arxiv-ids <id>` after
 resolving `$WIKI_SCRIPT` as above.
+
+#### Suggest Follow-Up Skills (after Step 6 completes)
+
+```text
+/arxiv "PAPER_ID" - download          - download the PDF to local library
+/deepxiv "PAPER_ID" - section: Methods  - read a specific section progressively
+/research-lit "related topic"        - multi-source literature survey
+/novelty-check "idea from paper"     - verify novelty against this paper's area
+```
 
 ## Key Rules
 

--- a/skills/skills-codex/alphaxiv/SKILL.md
+++ b/skills/skills-codex/alphaxiv/SKILL.md
@@ -123,31 +123,25 @@ Temporary source artifacts live under `/tmp`. Do not rely on persistence.
 
 If the user only asks for one specific detail, answer it directly — skip the full template.
 
-#### Suggest Follow-Up Skills
+**After presenting the summary, you MUST proceed to Step 6 before ending the turn.**
 
-```text
-/arxiv "PAPER_ID" - download          - download the PDF to local library
-/deepxiv "PAPER_ID" - section: Methods  - read a specific section progressively
-/research-lit "related topic"        - multi-source literature survey
-/novelty-check "idea from paper"     - verify novelty against this paper's area
-```
+### Step 6: Research Wiki Ingest
 
-## Update Research Wiki (if active)
+**You MUST always run the bash block below — it checks for `research-wiki/` internally and exits silently when absent.** Do NOT skip this step based on your own directory check; the bash block handles that for you.
 
-**Required when `research-wiki/` exists in the project**; skip silently
-otherwise. After presenting the paper summary, ingest the single paper
-that was read:
+Substitute only `<paper_arxiv_id>` and `<thesis>`; keep `${ARIS_REPO:-...}` as-is so an already-set env var is preserved.
 
-```
-if [ -d research-wiki/ ]:
-    ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
-    WIKI_SCRIPT=""
-    [ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
-    [ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
-    [ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
-    [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
-        --arxiv-id "<paper_arxiv_id>" \
-        [--thesis "<one-line thesis from the Tier 1 overview>"]
+```bash
+if [ -d research-wiki/ ]; then
+  ARIS_REPO="${ARIS_REPO:-$(awk -F'	' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+  WIKI_SCRIPT=""
+  [ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+  [ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+  [ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+  [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" ingest_paper research-wiki/ \
+      --arxiv-id "<paper_arxiv_id>" \
+      [--thesis "<one-line thesis from the Tier 1 overview>"]
+fi
 ```
 
 The helper handles metadata fetch, slug, dedup, page creation, index
@@ -156,6 +150,14 @@ rebuild, and log append — **do not handwrite `papers/<slug>.md`**. See
 If wiki was not present at read time, the user can backfill via
 `python3 "$WIKI_SCRIPT" sync research-wiki/ --arxiv-ids <id>` after resolving `WIKI_SCRIPT` as above.
 
+#### Suggest Follow-Up Skills (after Step 6 completes)
+
+```text
+/arxiv "PAPER_ID" - download          - download the PDF to local library
+/deepxiv "PAPER_ID" - section: Methods  - read a specific section progressively
+/research-lit "related topic"        - multi-source literature survey
+/novelty-check "idea from paper"     - verify novelty against this paper's area
+```
 ## Key Rules
 
 - **Overview first**: `overview` is the fastest path and must always be tried before deeper tiers. Only escalate when needed.

--- a/tests/test_research_wiki_fetch_arxiv_metadata.py
+++ b/tests/test_research_wiki_fetch_arxiv_metadata.py
@@ -1,0 +1,150 @@
+import importlib.util
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+import urllib.error
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "research_wiki.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("research_wiki", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+VALID_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2510.23672v1</id>
+    <title>DBLoss Test Paper</title>
+    <summary>An abstract.</summary>
+    <published>2025-10-27T12:00:00Z</published>
+    <author><name>Alice Smith</name></author>
+    <author><name>Bob Jones</name></author>
+    <arxiv:primary_category term="cs.LG"/>
+  </entry>
+</feed>"""
+
+
+class FakeResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+def _http_error_429():
+    return urllib.error.HTTPError(
+        url="http://example/",
+        code=429,
+        msg="Too Many Requests",
+        hdrs=None,
+        fp=BytesIO(b""),
+    )
+
+
+def _patch_urlopen(monkeypatch, mod, responses):
+    """Each call to urlopen pops one item from `responses`.
+    A bytes item is returned as a FakeResponse; an Exception is raised."""
+    queue = list(responses)
+    calls = {"n": 0}
+
+    def fake_urlopen(url, timeout=None):
+        calls["n"] += 1
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return FakeResponse(item)
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    return calls
+
+
+def test_success_first_try(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(monkeypatch, mod, [VALID_XML])
+
+    meta = mod.fetch_arxiv_metadata("2510.23672")
+
+    assert calls["n"] == 1
+    assert meta["arxiv_id"] == "2510.23672"
+    assert meta["title"] == "DBLoss Test Paper"
+    assert meta["authors"] == ["Alice Smith", "Bob Jones"]
+    assert meta["primary_category"] == "cs.LG"
+
+
+def test_retries_on_http_429_then_succeeds(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(monkeypatch, mod, [_http_error_429(), VALID_XML])
+
+    meta = mod.fetch_arxiv_metadata("2510.23672")
+
+    assert calls["n"] == 2
+    assert meta["title"] == "DBLoss Test Paper"
+
+
+def test_retries_on_rate_exceeded_body_then_succeeds(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(monkeypatch, mod, [b"Rate exceeded.", VALID_XML])
+
+    meta = mod.fetch_arxiv_metadata("2510.23672")
+
+    assert calls["n"] == 2
+    assert meta["title"] == "DBLoss Test Paper"
+
+
+def test_raises_after_three_429s(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(
+        monkeypatch, mod, [_http_error_429(), _http_error_429(), _http_error_429()]
+    )
+
+    with pytest.raises(RuntimeError, match="arXiv API fetch failed"):
+        mod.fetch_arxiv_metadata("2510.23672")
+    assert calls["n"] == 3
+
+
+def test_raises_after_three_rate_exceeded_bodies(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(
+        monkeypatch, mod, [b"Rate exceeded.", b"Rate exceeded.", b"Rate exceeded."]
+    )
+
+    with pytest.raises(RuntimeError, match="rate-limited"):
+        mod.fetch_arxiv_metadata("2510.23672")
+    assert calls["n"] == 3
+
+
+def test_non_429_http_error_does_not_retry(monkeypatch):
+    mod = load_module()
+    err_500 = urllib.error.HTTPError(
+        url="http://example/", code=500, msg="Server Error",
+        hdrs=None, fp=BytesIO(b""),
+    )
+    calls = _patch_urlopen(monkeypatch, mod, [err_500])
+
+    with pytest.raises(RuntimeError, match="arXiv API fetch failed"):
+        mod.fetch_arxiv_metadata("2510.23672")
+    assert calls["n"] == 1
+
+
+def test_malformed_xml_raises(monkeypatch):
+    mod = load_module()
+    _patch_urlopen(monkeypatch, mod, [b"<not valid xml"])
+
+    with pytest.raises(RuntimeError, match="unparseable XML"):
+        mod.fetch_arxiv_metadata("2510.23672")

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -42,13 +42,14 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.request
 import urllib.error
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
-_ARXIV_API = "http://export.arxiv.org/api/query?id_list={ids}"
+_ARXIV_API = "https://export.arxiv.org/api/query?id_list={ids}"
 _ARXIV_NS = {"atom": "http://www.w3.org/2005/Atom",
              "arxiv": "http://arxiv.org/schemas/atom"}
 
@@ -308,16 +309,35 @@ def _yaml_quote(s: str) -> str:
 def fetch_arxiv_metadata(arxiv_id: str, timeout: float = 15.0) -> dict:
     """Query arXiv Atom API for one paper. Returns a metadata dict.
 
-    Raises RuntimeError on network failure or malformed response — callers
-    decide whether to abort the ingest or fall back to manual metadata.
+    Retries up to 3 times on arXiv rate limits (HTTP 429 or the plain-text
+    "Rate exceeded." body the API sometimes returns with 200 OK) and on
+    transient network errors. Raises RuntimeError when all retries are
+    exhausted — callers decide whether to abort the ingest or fall back
+    to manual metadata.
     """
     aid = _normalize_arxiv_id(arxiv_id)
     url = _ARXIV_API.format(ids=aid)
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            body = resp.read()
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
-        raise RuntimeError(f"arXiv API fetch failed for {aid}: {e}")
+    body = b""
+    for attempt in (1, 2, 3):
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as resp:
+                body = resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < 3:
+                time.sleep(5 * attempt)
+                continue
+            raise RuntimeError(f"arXiv API fetch failed for {aid}: {e}")
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            if attempt < 3:
+                time.sleep(2 * attempt)
+                continue
+            raise RuntimeError(f"arXiv API fetch failed for {aid}: {e}")
+        if body.strip() == b"Rate exceeded.":
+            if attempt < 3:
+                time.sleep(5 * attempt)
+                continue
+            raise RuntimeError(f"arXiv API rate-limited for {aid} after 3 attempts")
+        break
 
     try:
         root = ET.fromstring(body)


### PR DESCRIPTION
## Problem

\`/alphaxiv\` wiki ingest (Step 6) was unreliable — invocations either skipped the step entirely or failed with arXiv API errors.

Three root causes all surface as "ingest skipped or failed":

### 1. LLM skips Step 6 entirely (SKILL.md)

The old wording \`"Required when research-wiki/ exists; skip silently otherwise"\` let the model decide to skip the bash block, sometimes checking the wrong cwd and bailing without running it.

### 2. arXiv API rate limit aborts ingest (research_wiki.py)

\`fetch_arxiv_metadata\` had no retry. arXiv intermittently returns HTTP 429 — or a 200 OK with plain-text body \`Rate exceeded.\` — and a single failure raised \`RuntimeError\` that killed the whole ingest. \`tools/arxiv_fetch.py:147-151\` already handles 429 the same way; this PR brings \`research_wiki.py\` to parity.

### 3. http→https redirect + proxy causes TLS timeout (research_wiki.py)

\`_ARXIV_API\` used \`http://\` which arXiv redirects to \`https://\`. When urllib follows this redirect through a proxy, it needs to set up a new CONNECT tunnel for the HTTPS leg — this combination hangs in Python 3.9 with certain proxy configurations, causing \`socket.timeout\`. \`tools/verify_papers.py\` already uses \`https://\` correctly; this PR aligns \`research_wiki.py\`.

## Fix

### \`skills/alphaxiv/SKILL.md\` (and codex mirror)

- Step 5 ends with \`MUST proceed to Step 6 before ending the turn\`
- Step 6 renamed to \`Research Wiki Ingest\` with \`MUST always run the bash block — it checks for research-wiki/ internally\`
- Follow-up suggestions moved **after** Step 6 (prevents early turn exit)
- Codex: pseudo-code \`if [ -d ... ]:\` → valid bash \`if ...; then ... fi\`
- Codex: preserve \`installed-skills-codex.txt\` + \`~/.codex/\` resolution

### \`tools/research_wiki.py\`

- \`_ARXIV_API\`: \`http://\` → \`https://\` — eliminates the redirect that causes proxy+TLS timeouts
- \`fetch_arxiv_metadata\`: 3-attempt retry with linear backoff on HTTP 429, on \`Rate exceeded.\` plain-text body, and on transient \`URLError\` / \`TimeoutError\`. Non-429 HTTP errors still raise immediately. Stays on \`urllib\` (project-wide convention).

### \`tests/test_research_wiki_fetch_arxiv_metadata.py\` (new, 7 tests)

- success first try
- 429 then success
- \`Rate exceeded.\` body then success
- 3 × 429 → raises
- 3 × \`Rate exceeded.\` → raises
- non-429 HTTP error does not retry
- malformed XML raises

## Checklist

- [x] Code follows the project style
- [x] Documentation is updated (if applicable) — N/A, bug fix only
- [x] Changes are tested locally — \`conda run -n ARIS python -m pytest tests/test_research_wiki_* -q\` → 14 passed