### PR TITLE
fix(openalex): handle null fields in _parse_work

### DIFF
--- a/tools/openalex_fetch.py
+++ b/tools/openalex_fetch.py
@@ -151,13 +151,13 @@ class OpenAlexClient:
             author_name = author.get("display_name", "Unknown")
             authors.append(author_name)
 
-        # Extract venue/source
-        primary_location = work.get("primary_location", {})
-        source = primary_location.get("source", {})
+        # Extract venue/source — `or {}` because OpenAlex returns explicit null (not missing key) for some works
+        primary_location = work.get("primary_location") or {}
+        source = primary_location.get("source") or {}
         venue = source.get("display_name", "Unknown")
 
         # Extract open access info
-        oa_info = work.get("open_access", {})
+        oa_info = work.get("open_access") or {}
         oa_status = oa_info.get("oa_status", "closed")
         oa_url = oa_info.get("oa_url")
 


### PR DESCRIPTION
## Summary
- `_parse_work` crashed with `'NoneType' object has no attribute 'get'` when OpenAlex returned an explicit `null` value (vs a missing key) for `primary_location` / `source` / `open_access`
- Root cause: `dict.get(key, default)` only substitutes `default` when the key is absent; when the key is present with value `None`, the `None` falls through and trips the next `.get()` call
- Surgical 4-line patch: switch the 3 affected lookups to `dict.get(key) or {}` to handle both missing-key and explicit-null cases

## Test plan
- [x] Repro before fix: `python3 tools/openalex_fetch.py search "multilingual natural language inference Chinese" --max 5 --sort relevance` → `Error: 'NoneType' object has no attribute 'get'`
- [x] After fix: same command returns 5 papers including Hu et al. 2021 ACL-Findings (DOI 10.18653/v1/2021.findings-acl.331)
- [ ] Sanity-check: existing usage with `--type article` filter still works (article-type works typically have populated `primary_location`; this PR does not change that path)