### PR TITLE
docs: add quick setup guide (EN + CN)

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -1,0 +1,235 @@
+# ARIS Quick Setup Guide
+
+> Get ARIS fully configured from scratch. Once done, you're ready to use the complete research workflow.
+>
+> This guide targets a **macOS local + remote Linux GPU server** setup with the recommended configuration: **Claude Code as executor, Codex MCP (GPT) as reviewer**.
+>
+> English | [中文版](SETUP_GUIDE_CN.md)
+
+---
+
+## Step 1: Install Required Tools
+
+### 1.1 Claude Code
+
+Claude Code is Anthropic's CLI tool — all ARIS skills run on top of it. See the [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) for installation.
+
+```bash
+claude --version   # verify installation
+```
+
+### 1.2 Codex CLI + MCP Registration
+
+Codex CLI is OpenAI's CLI tool — ARIS uses it to call GPT as a cross-model reviewer. See the [Codex CLI docs](https://developers.openai.com/codex) for installation.
+
+After installing, register Codex CLI as a Claude Code MCP server:
+
+```bash
+codex --version   # verify installation
+claude mcp add codex -s user -- codex mcp-server
+```
+
+- `codex` (after `add`) — the registered name. ARIS skills hardcode this name, **do not change it**
+- `-s user` — applies globally to all projects
+- `codex mcp-server` — built-in subcommand that starts the MCP server mode
+
+Restart Claude Code after registration. Verify:
+
+```bash
+claude mcp list | grep codex
+# should show: codex: codex mcp-server - ✓ Connected
+```
+
+### 1.3 LaTeX Environment (Optional)
+
+Required for Workflow 3 (paper writing), providing `latexmk` and `pdfinfo`:
+
+```bash
+brew install --cask mactex    # or: brew install basictex
+brew install poppler          # provides pdfinfo
+
+# verify
+latexmk --version && pdfinfo -v
+```
+> If you only need Workflow 1 & 2 (idea discovery + auto review), LaTeX is not required.
+
+## Step 2: Create a Research Project
+
+```bash
+mkdir ~/your-paper-project
+cd ~/your-paper-project
+git init
+touch CLAUDE.md
+```
+
+- `git init` — some skills need git to locate the project root
+- `CLAUDE.md` — Claude Code's project config file; the install script will write ARIS info into it
+
+## Step 3: Install Skills
+
+Install ARIS skills into your project via symlinks (the recommended project-local install method):
+
+```bash
+# 1. Clone ARIS once to a stable location, ~/aris_repo is the local dir name (customizable)
+git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git ~/aris_repo
+
+# 2. Install in each project that uses ARIS (via symlinks):
+cd ~/your-paper-project
+bash ~/aris_repo/tools/install_aris.sh
+
+# Other useful flags:
+bash ~/aris_repo/tools/install_aris.sh --dry-run        # preview install plan, no changes
+bash ~/aris_repo/tools/install_aris.sh --uninstall      # uninstall per manifest, leaves other files intact
+```
+
+The script shows an install plan and asks for confirmation (type `y`). See [`install_aris.sh`](tools/install_aris.sh):
+
+```
+.claude/skills/<skill>        ← one symlink per skill → ~/aris_repo/skills/<skill>
+.aris/installed-skills.txt    ← install manifest (tracks every entry ARIS installed)
+.aris/tools                   ← → ~/aris_repo/tools/ (helper scripts)
+CLAUDE.md                     ← updates the ARIS config block
+```
+
+Symlinks reference ARIS repo source files directly — no copies. Updates fall into two cases:
+
+```bash
+# Case 1: upstream modified existing skill content
+# symlinks pick up changes automatically, just pull the latest
+cd ~/aris_repo && git pull
+
+# Case 2: upstream added or removed skill directories
+# pull first, then rerun the install script to sync
+cd ~/aris_repo && git pull
+cd ~/your-paper-project
+bash ~/aris_repo/tools/install_aris.sh
+```
+
+## Step 4: Configure GPU Server
+
+If your experiments run on a remote GPU server, you need two things: SSH key-based auth + server info in CLAUDE.md.
+
+### 4.1 Set Up SSH Key-Based Login
+
+Make sure you have an SSH key locally; generate one if you don't:
+
+```bash
+ls ~/.ssh/id_*.pub
+# output exists → key already present, skip the next command
+# No such file → run:
+
+ssh-keygen -t ed25519   # press Enter through all prompts
+```
+
+Copy your public key to the server:
+
+```bash
+# will ask for server password once
+ssh-copy-id username@your-server-ip
+```
+
+Verify key-based login (should not ask for password):
+
+```bash
+ssh username@your-server-ip "echo ok"
+```
+
+### 4.2 Add Server Info to CLAUDE.md
+
+Append the following to your project's `CLAUDE.md`, replacing with your actual values:
+
+```markdown
+## Remote Server
+
+- gpu: remote
+- SSH: `ssh username@your-server-ip` (key-based auth, no password)
+- GPU: 8x RTX 4090 (24GB)
+- Conda env: `YOUR_ENV` (Python 3.x + PyTorch x.x.x)
+- Activate: `eval "$(/path/to/miniconda3/bin/conda shell.bash hook)" && conda activate YOUR_ENV`
+- Code directory: `/home/user/experiments/`
+- Use `tmux` for background jobs: `tmux new -d -s exp0 'bash -c "..."'`
+```
+
+You can also use `screen`: `screen -dmS exp0 bash -c '...'` (ARIS README defaults to `screen`).
+
+Verify the remote environment (run on your local Mac, replace with your actual values):
+
+```bash
+ssh username@your-server-ip 'eval "$(/path/to/miniconda3/bin/conda shell.bash hook)" && conda activate YOUR_ENV && python --version && python -c "import torch; print(torch.__version__, torch.cuda.device_count())"'
+```
+
+Should output Python version, PyTorch version, and GPU count.
+
+## Step 5: Initialize Research Wiki
+
+Research Wiki is ARIS's core knowledge base — it automatically accumulates papers you've read, ideas you've generated, and experiments you've run. Other skills write to it automatically; you don't need to maintain it manually.
+
+Open Claude Code in your research project directory and enter:
+
+```
+/research-wiki init
+```
+
+This creates a `research-wiki/` directory. See [`research_wiki.py`](tools/research_wiki.py):
+
+```
+research-wiki/
+  index.md               ← categorical index (auto-generated)
+  log.md                 ← append-only timeline
+  gap_map.md             ← field gap map
+  query_pack.md          ← compressed summary (for /idea-creator)
+  papers/                ← auto-populated by /alphaxiv, /arxiv, etc.
+  ideas/                 ← auto-populated by /idea-creator
+  experiments/           ← auto-populated by /result-to-claim
+  claims/                ← scientific claims
+  graph/                 ← relationship graph (edges.jsonl)
+```
+
+## Step 6: Verify
+
+Restart Claude Code and test in your research project directory:
+
+**1. Test MCP connectivity** — enter in Claude Code:
+
+```
+Ask GPT via codex MCP: what is 1+1?
+```
+
+Receiving GPT's answer means cross-model communication is working.
+
+**2. Test skill recognition** — enter in Claude Code:
+
+```
+/alphaxiv http://arxiv.org/abs/1706.03762
+```
+
+A successful invocation means skills are installed. This skill will also auto-write the paper into Research Wiki — check `research-wiki/papers/`.
+
+---
+
+After completing all steps, your research project structure looks like:
+
+```
+~/your-paper-project/
+  CLAUDE.md               ← ARIS config + GPU server info
+  .claude/skills/          ← skill symlinks
+  .aris/
+    installed-skills.txt   ← install manifest
+    tools/                 ← → ARIS repo tools/
+  research-wiki/           ← knowledge base (auto-accumulated)
+  .git/                    ← git repository
+```
+
+You're now ready to use ARIS research workflows:
+
+```
+claude
+> /idea-discovery "your research direction"          # Workflow 1 — be specific! not "NLP" but "factorized gap in discrete diffusion LMs"
+> /experiment-bridge                                 # Workflow 1.5 — have a plan? implement + deploy + collect results
+> /auto-review-loop "your paper topic or scope"      # Workflow 2: review → fix → re-review overnight
+> /paper-writing "NARRATIVE_REPORT.md"               # Workflow 3: narrative → polished PDF
+> /rebuttal "paper/ + reviews" — venue: ICML          # Workflow 4: parse reviews → draft rebuttal → follow-up
+> /resubmit-pipeline "paper/" — venue: NeurIPS        # Workflow 5: port to new venue (text-only, no new experiments)
+> /paper-talk "paper/" — venue: ICLR                  # Workflow 6: paper → Beamer + PPTX talk + speaker notes + assurance audits
+> /research-pipeline "your research direction"       # Full pipeline: Workflow 1 → 1.5 → 2 → 3 end-to-end
+```

--- a/SETUP_GUIDE_CN.md
+++ b/SETUP_GUIDE_CN.md
@@ -1,0 +1,235 @@
+# ARIS 快速配置指南
+
+> 从零开始，手把手完成 ARIS 的全部配置。完成后你就可以使用 ARIS 的完整研究工作流。
+>
+> 本指南面向 **macOS 本地 + 远程 Linux GPU 服务器** 环境，使用 **Claude Code 作为执行者、Codex MCP（GPT）作为审稿人** 的推荐配置。
+>
+> [English](SETUP_GUIDE.md) | 中文版
+
+---
+
+## 第一步：安装必要工具
+
+### 1.1 Claude Code
+
+Claude Code 是 Anthropic 的 CLI 工具，ARIS 的所有 skill 都在它上面运行。安装方式见 [Claude Code 官方文档](https://docs.anthropic.com/en/docs/claude-code)。
+
+```bash
+claude --version   # 验证安装
+```
+
+### 1.2 Codex CLI + MCP 注册
+
+Codex CLI 是 OpenAI 的 CLI 工具，ARIS 通过它调用 GPT 作为跨模型审稿人。安装方式见 [Codex CLI 官方文档](https://developers.openai.com/codex)。
+
+安装完成后，将 Codex CLI 注册为 Claude Code 的 MCP server：
+
+```bash
+codex --version   # 验证安装
+claude mcp add codex -s user -- codex mcp-server
+```
+
+- `codex`（add 后面）— 注册名称。ARIS 的 skill 硬编码了这个名字，**不要改**
+- `-s user` — 全局生效，所有项目都能用
+- `codex mcp-server` — Codex CLI 内置的子命令，启动 MCP 服务模式
+
+注册后需要**重启 Claude Code** 才会生效。验证：
+
+```bash
+claude mcp list | grep codex
+# 应显示: codex: codex mcp-server - ✓ Connected
+```
+
+### 1.3 LaTeX 环境（可选）
+
+工作流 3（论文写作）需要，含 `latexmk` 和 `pdfinfo`：
+
+```bash
+brew install --cask mactex    # 或: brew install basictex
+brew install poppler          # 提供 pdfinfo
+
+# 验证
+latexmk --version && pdfinfo -v
+```
+> 如果只用工作流 1 和 2（找 idea + 自动 review），不需要安装 LaTeX 环境。
+
+## 第二步：创建研究项目
+
+```bash
+mkdir ~/your-paper-project
+cd ~/your-paper-project
+git init
+touch CLAUDE.md
+```
+
+- `git init` — 部分技能需要 git 来定位项目根目录
+- `CLAUDE.md` — Claude Code 的项目配置文件，安装脚本会向其中写入 ARIS 信息
+
+## 第三步：安装 Skills
+
+通过符号链接将 ARIS skill 安装到项目中（推荐的项目级安装方式）：
+
+```bash
+# 1. 克隆 ARIS 一次到稳定位置，~/aris_repo 是本地目录名，可自定义
+git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git ~/aris_repo
+
+# 2. 在每个使用 ARIS 的项目中安装（通过符号链接）：
+cd ~/your-paper-project
+bash ~/aris_repo/tools/install_aris.sh
+
+# 其他常用：
+bash ~/aris_repo/tools/install_aris.sh --dry-run        # 预览安装计划，不实际执行
+bash ~/aris_repo/tools/install_aris.sh --uninstall      # 按安装清单卸载，不影响其他文件
+```
+
+脚本会显示安装计划并要求确认（输入 `y`），详见 [`install_aris.sh`](tools/install_aris.sh)：
+
+```
+.claude/skills/<skill>        ← 每个 skill 一个符号链接 → ~/aris_repo/skills/<skill>
+.aris/installed-skills.txt    ← 安装清单（追踪 ARIS 装的每条）
+.aris/tools                   ← → ~/aris_repo/tools/（工具脚本）
+CLAUDE.md                     ← 更新 ARIS 配置区块
+```
+
+符号链接直接引用 ARIS 仓库源文件，不复制内容。更新时分两种情况：
+
+```bash
+# 情况一：上游修改了已有技能的内容
+# 符号链接自动生效，只需拉取最新代码
+cd ~/aris_repo && git pull
+
+# 情况二：上游新增或删除了技能目录
+# 需要先拉取最新代码，再重新运行安装脚本
+cd ~/aris_repo && git pull
+cd ~/your-paper-project
+bash ~/aris_repo/tools/install_aris.sh
+```
+
+## 第四步：配置 GPU 服务器
+
+如果你的实验需要跑在远程 GPU 服务器上，需要两步：SSH 免密登录 + 写入服务器信息。
+
+### 4.1 配置 SSH 免密登录
+
+确保本地有 SSH 密钥，没有的话先生成：
+
+```bash
+ls ~/.ssh/id_*.pub
+# 有输出 → 已有密钥，跳过下一条命令
+# No such file → 执行：
+
+ssh-keygen -t ed25519   # 一路回车即可
+```
+
+将公钥复制到服务器：
+
+```bash
+# 需要输入一次服务器密码
+ssh-copy-id username@your-server-ip
+```
+
+验证免密登录（不应再要求输入密码）：
+
+```bash
+ssh username@your-server-ip "echo ok"
+```
+
+### 4.2 写入服务器信息
+
+在项目的 `CLAUDE.md` 末尾添加以下内容，根据你的实际情况替换：
+
+```markdown
+## Remote Server
+
+- gpu: remote
+- SSH: `ssh username@your-server-ip` (key-based auth, no password)
+- GPU: 8x RTX 4090 (24GB)
+- Conda env: `YOUR_ENV` (Python 3.x + PyTorch x.x.x)
+- Activate: `eval "$(/path/to/miniconda3/bin/conda shell.bash hook)" && conda activate YOUR_ENV`
+- Code directory: `/home/user/experiments/`
+- Use `tmux` for background jobs: `tmux new -d -s exp0 'bash -c "..."'`
+```
+
+也可以使用 `screen`：`screen -dmS exp0 bash -c '...'`（ARIS README 默认使用 `screen`）。
+
+验证远程环境（在本地 Mac 上运行，替换为你的实际值）：
+
+```bash
+ssh username@your-server-ip 'eval "$(/path/to/miniconda3/bin/conda shell.bash hook)" && conda activate YOUR_ENV && python --version && python -c "import torch; print(torch.__version__, torch.cuda.device_count())"'
+```
+
+应输出 Python 版本、PyTorch 版本和 GPU 数量。
+
+## 第五步：初始化 Research Wiki
+
+Research Wiki 是 ARIS 的核心知识库，自动积累你整个研究过程中读过的论文、产生的想法、跑过的实验。其他 skill 会自动往里写入内容，你不需要手动维护。
+
+在研究项目目录下打开 Claude Code，输入：
+
+```
+/research-wiki init
+```
+
+它会创建 `research-wiki/` 目录，详见 [`research_wiki.py`](tools/research_wiki.py)：
+
+```
+research-wiki/
+  index.md               ← 分类索引（自动生成）
+  log.md                 ← 时间线日志
+  gap_map.md             ← 领域空白地图
+  query_pack.md          ← 压缩摘要（供 /idea-creator 使用）
+  papers/                ← /alphaxiv、/arxiv 等自动写入
+  ideas/                 ← /idea-creator 自动写入
+  experiments/           ← /result-to-claim 自动写入
+  claims/                ← 科学声明
+  graph/                 ← 关系图谱（edges.jsonl）
+```
+
+## 第六步：验证
+
+重启 Claude Code，在研究项目目录下测试：
+
+**1. 测试 MCP 连通性** — 在 Claude Code 中输入：
+
+```
+用 codex MCP 问一下 GPT：1+1 等于几
+```
+
+收到 GPT 的回答说明跨模型通信正常。
+
+**2. 测试技能识别** — 在 Claude Code 中输入：
+
+```
+/alphaxiv http://arxiv.org/abs/1706.03762
+```
+
+正常调用说明技能安装成功。该技能还会自动将论文写入 Research Wiki，你可以在 `research-wiki/papers/` 下查看。
+
+---
+
+全部完成后，你的研究项目结构如下：
+
+```
+~/your-paper-project/
+  CLAUDE.md               ← ARIS 配置 + GPU 服务器信息
+  .claude/skills/          ← 技能符号链接
+  .aris/
+    installed-skills.txt   ← 安装清单
+    tools/                 ← → ARIS 仓库 tools/
+  research-wiki/           ← 知识库（自动积累）
+  .git/                    ← git 仓库
+```
+
+接下来就可以开始使用 ARIS 的研究工作流了：
+
+```
+claude
+> /idea-discovery "你的研究方向"              # 工作流 1 — 方向要具体！不要 "NLP"，要 "离散扩散语言模型的 factorized gap"
+> /experiment-bridge                         # 工作流 1.5 — 有计划了？实现 + 部署 + 收结果
+> /auto-review-loop "你的论文主题或范围"         # 工作流 2：审稿 → 修复 → 再审，一夜完成
+> /paper-writing "NARRATIVE_REPORT.md"       # 工作流 3：研究叙事 → 精修 PDF
+> /rebuttal "paper/ + reviews" — venue: ICML  # 工作流 4：解析 review → 起草 rebuttal → follow-up
+> /resubmit-pipeline "paper/" — venue: NeurIPS  # 工作流 5：移植到新 venue（纯文本，不跑新实验）
+> /paper-talk "paper/" — venue: ICLR            # 工作流 6：论文 → Beamer + PPTX + 讲稿 + 评审审计
+> /research-pipeline "你的研究方向"            # 全流程：工作流 1 → 1.5 → 2 → 3 端到端
+```


### PR DESCRIPTION
## What

Adds a step-by-step quick setup guide for ARIS in both English (`SETUP_GUIDE.md`) and Chinese (`SETUP_GUIDE_CN.md`).

## Motivation

The README is a comprehensive reference, but it currently lacks a focused from-scratch setup guide. New users need to piece together instructions scattered across the Quick Start section, Section 10 (Install Skills), and the GPU server config section. This PR consolidates the essential setup flow into a single, easy-to-follow document.

## Scope

- **Target environment**: macOS local + remote Linux GPU server
- **Recommended config**: Claude Code as executor + Codex MCP (GPT) as reviewer
- **Install method**: project-local symlink install via `install_aris.sh`

## Steps covered

1. Install tools (Claude Code, Codex CLI + MCP, optional LaTeX)
2. Create a research project
3. Install skills via symlinks
4. Configure GPU server (SSH + server info in CLAUDE.md)
5. Initialize Research Wiki
6. Verify setup + workflow quick reference

## Notes

- Follows existing project conventions (`_CN` suffix, `~/aris_repo` / `~/your-paper-project` naming)
- Bilingual switching links between EN/CN versions
- Tested end-to-end on an actual research project (macOS + remote GPU server)
- Does not modify any existing files — purely additive