### PR TITLE
docs(research-lit): promote SOURCES to Constants block

### DIFF
--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -17,16 +17,15 @@ Research topic: $ARGUMENTS
   2. `literature/` in the current project directory
   3. Custom path specified by user in `CLAUDE.md` under `## Paper Library`
 - **MAX_LOCAL_PAPERS = 20** — Maximum number of local PDFs to scan (read first 3 pages each). If more are found, prioritize by filename relevance to the topic.
+- **SOURCES = `all`** — Which literature sources to search. Options: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, `gemini`, `openalex`, `all`. Full source table and selection rules: see `## Data Sources` below.
 - **ARXIV_DOWNLOAD = false** — When `true`, download top 3-5 most relevant arXiv PDFs to PAPER_LIBRARY after search. When `false` (default), only fetch metadata (title, abstract, authors) via arXiv API — no files are downloaded.
 - **ARXIV_MAX_DOWNLOAD = 5** — Maximum number of PDFs to download when `ARXIV_DOWNLOAD = true`.
 
 > 💡 Overrides:
 > - `/research-lit "topic" — paper library: ~/my_papers/` — custom local PDF path
 > - `/research-lit "topic" — sources: zotero, local` — only search Zotero + local PDFs
-> - `/research-lit "topic" — sources: zotero` — only search Zotero
 > - `/research-lit "topic" — sources: web` — only search the web (skip all local)
 > - `/research-lit "topic" — sources: web, semantic-scholar` — also search Semantic Scholar for published venue papers (IEEE, ACM, etc.)
-> - `/research-lit "topic" — sources: deepxiv` — only search via DeepXiv progressive retrieval
 > - `/research-lit "topic" — sources: all, deepxiv` — use default sources plus DeepXiv
 > - `/research-lit "topic" — arxiv download: true` — download top relevant arXiv PDFs
 > - `/research-lit "topic" — arxiv download: true, max download: 10` — download up to 10 PDFs

--- a/skills/skills-codex/research-lit/SKILL.md
+++ b/skills/skills-codex/research-lit/SKILL.md
@@ -14,6 +14,7 @@ Research topic: $ARGUMENTS
   2. `literature/` in the current project directory
   3. Custom path specified by user in `AGENTS.md` under `## Paper Library`
 - **MAX_LOCAL_PAPERS = 20** — Maximum number of local PDFs to scan (read first 3 pages each). If more are found, prioritize by filename relevance to the topic.
+- **SOURCES = `all`** — Which literature sources to search. Options: `zotero`, `obsidian`, `local`, `web`, `semantic-scholar`, `deepxiv`, `exa`, `all`. Full source table and selection rules: see `## Data Sources` below.
 - **ARXIV_DOWNLOAD = false** — When `true`, download top 3-5 most relevant arXiv PDFs to PAPER_LIBRARY after search. When `false` (default), only fetch metadata (title, abstract, authors) via arXiv API — no files are downloaded.
 - **ARXIV_MAX_DOWNLOAD = 5** — Maximum number of PDFs to download when `ARXIV_DOWNLOAD = true`.
 - **REVIEWER_BACKEND = `codex`** — Default reviewer route for optional literature synthesis cross-checks. Use `--reviewer: oracle-pro` only when explicitly requested; if Oracle is unavailable, warn and continue with Codex xhigh or local synthesis.
@@ -21,10 +22,8 @@ Research topic: $ARGUMENTS
 > 💡 Overrides:
 > - `/research-lit "topic" — paper library: ~/my_papers/` — custom local PDF path
 > - `/research-lit "topic" — sources: zotero, local` — only search Zotero + local PDFs
-> - `/research-lit "topic" — sources: zotero` — only search Zotero
 > - `/research-lit "topic" — sources: web` — only search the web (skip all local)
 > - `/research-lit "topic" — sources: web, semantic-scholar` — also search Semantic Scholar for published venue papers
-> - `/research-lit "topic" — sources: deepxiv` — only search via DeepXiv progressive retrieval
 > - `/research-lit "topic" — sources: all, deepxiv` — use default sources plus DeepXiv
 > - `/research-lit "topic" — arxiv download: true` — download top relevant arXiv PDFs
 > - `/research-lit "topic" — arxiv download: true, max download: 10` — download up to 10 PDFs


### PR DESCRIPTION
## Summary

The `## Constants` block in `skills/research-lit/SKILL.md` lists 4 entries (`PAPER_LIBRARY`, `MAX_LOCAL_PAPERS`, `ARXIV_DOWNLOAD`, `ARXIV_MAX_DOWNLOAD`) but omits `SOURCES` — the most-used parameter in the skill. The `> 💡 Overrides:` block immediately below was dominated by `— sources:` examples (6 of 9 lines) with no anchoring constant. `README.md` lines 1888-1896 (_"Show source-selection and arXiv download constants for /research-lit"_) already documents SOURCES as a public constant alongside `ARXIV_DOWNLOAD`/`ARXIV_MAX_DOWNLOAD`, so SKILL.md was simply out of sync with README.

- Adds `SOURCES = all` between `MAX_LOCAL_PAPERS` and `ARXIV_DOWNLOAD` (matching README's source-selection + arXiv-download grouping). The entry declares default + options + points to `## Data Sources` for the full source table — does not duplicate the runtime parsing spec.
- Trims the Overrides block from 9 → 7 lines by removing two single-source examples (`sources: zotero`, `sources: deepxiv`) that are redundant with surviving combination examples. Heading + `command — description` format unchanged.
- Same change applied to `skills/skills-codex/research-lit/SKILL.md` (mirror's option list is narrower — no `gemini`/`openalex` — matching its existing `## Data Sources` section).

**No runtime behavior change.** `## Data Sources` (including the parse-`\$ARGUMENTS` instructions and the 15-line Examples block) is untouched. Net diff: `+2 / -4`.

## Test plan

- [x] `bash tools/lint_skills_helpers.sh` → pass (no new violations)
- [x] `python tools/check_skills_inventory.py` → `ARIS skill inventory is consistent.`
- [x] `pytest tests/test_codex_skill_mirror.py tests/test_install_aris_tools_symlink.py tests/test_install_aris_ps1.py` → pass
- [x] Verified the 7 unrelated test failures in `test_codex_install_update.py` / `test_copilot_install.py` pre-exist on main (independent of this change)