### PR TITLE
fix(research-wiki): arxiv User-Agent + batch id_list fetch to cut 429s

### DIFF
--- a/tests/test_research_wiki_fetch_arxiv_metadata.py
+++ b/tests/test_research_wiki_fetch_arxiv_metadata.py
@@ -226,6 +226,8 @@ def test_batch_fetch_one_request_many_entries(monkeypatch):
     assert len(seen["requests"]) == 1
     # id_list carried both ids, comma-joined
     assert "2510.23672,2402.14992" in seen["requests"][0].full_url
+    # max_results set to the id count so >10 ids are not silently truncated
+    assert "max_results=2" in seen["requests"][0].full_url
     # keyed by normalized id, version stripped
     assert set(out) == {"2510.23672", "2402.14992"}
     assert out["2510.23672"]["title"] == "First Paper"

--- a/tests/test_research_wiki_fetch_arxiv_metadata.py
+++ b/tests/test_research_wiki_fetch_arxiv_metadata.py
@@ -148,3 +148,93 @@ def test_malformed_xml_raises(monkeypatch):
 
     with pytest.raises(RuntimeError, match="unparseable XML"):
         mod.fetch_arxiv_metadata("2510.23672")
+
+
+# ---- User-Agent (arXiv lenient pool) -------------------------------------
+
+BATCH_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2510.23672v1</id>
+    <title>First Paper</title>
+    <summary>Abstract one.</summary>
+    <published>2025-10-27T12:00:00Z</published>
+    <author><name>Alice Smith</name></author>
+    <arxiv:primary_category term="cs.LG"/>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2402.14992v2</id>
+    <title>Second Paper</title>
+    <summary>Abstract two.</summary>
+    <published>2024-02-22T12:00:00Z</published>
+    <author><name>Bob Jones</name></author>
+    <arxiv:primary_category term="cs.CL"/>
+  </entry>
+</feed>"""
+
+
+def _capture_urlopen(monkeypatch, mod, responses):
+    """Like _patch_urlopen but records each Request object passed to urlopen."""
+    queue = list(responses)
+    seen = {"requests": []}
+
+    def fake_urlopen(req, timeout=None):
+        seen["requests"].append(req)
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return FakeResponse(item)
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    return seen
+
+
+def test_sends_descriptive_user_agent(monkeypatch):
+    mod = load_module()
+    monkeypatch.delenv("ARIS_VERIFY_EMAIL", raising=False)
+    seen = _capture_urlopen(monkeypatch, mod, [VALID_XML])
+
+    mod.fetch_arxiv_metadata("2510.23672")
+
+    req = seen["requests"][0]
+    ua = req.get_header("User-agent")  # urllib normalizes header key casing
+    assert ua and ua.startswith("ARIS-research-wiki/")
+    assert "Python-urllib" not in (ua or "")
+
+
+def test_user_agent_includes_contact_when_env_set(monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("ARIS_VERIFY_EMAIL", "dev@example.org")
+    seen = _capture_urlopen(monkeypatch, mod, [VALID_XML])
+
+    mod.fetch_arxiv_metadata("2510.23672")
+
+    ua = seen["requests"][0].get_header("User-agent")
+    assert "mailto:dev@example.org" in ua
+
+
+# ---- Batch id_list fetch -------------------------------------------------
+
+def test_batch_fetch_one_request_many_entries(monkeypatch):
+    mod = load_module()
+    seen = _capture_urlopen(monkeypatch, mod, [BATCH_XML])
+
+    out = mod.fetch_arxiv_metadata_batch(["2510.23672", "2402.14992"])
+
+    # single network call for both ids
+    assert len(seen["requests"]) == 1
+    # id_list carried both ids, comma-joined
+    assert "2510.23672,2402.14992" in seen["requests"][0].full_url
+    # keyed by normalized id, version stripped
+    assert set(out) == {"2510.23672", "2402.14992"}
+    assert out["2510.23672"]["title"] == "First Paper"
+    assert out["2402.14992"]["authors"] == ["Bob Jones"]
+
+
+def test_batch_fetch_empty_input_no_request(monkeypatch):
+    mod = load_module()
+    seen = _capture_urlopen(monkeypatch, mod, [])
+
+    assert mod.fetch_arxiv_metadata_batch([]) == {}
+    assert len(seen["requests"]) == 0

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -54,6 +54,22 @@ _ARXIV_NS = {"atom": "http://www.w3.org/2005/Atom",
              "arxiv": "http://arxiv.org/schemas/atom"}
 
 
+def _arxiv_user_agent() -> str:
+    """Descriptive User-Agent for arXiv API calls.
+
+    arXiv rate-limits the default ``Python-urllib/x.y`` agent far more
+    aggressively than a named client; sending a descriptive UA (with an
+    optional contact address) lands requests in arXiv's more lenient pool.
+    The contact is read from ``ARIS_VERIFY_EMAIL`` — the same env var the
+    /research-lit skill already uses for the CrossRef polite pool — so no
+    address is hard-coded. Falls back to a contactless UA when unset.
+    """
+    contact = os.environ.get("ARIS_VERIFY_EMAIL", "").strip()
+    base = ("ARIS-research-wiki/1.0 "
+            "(+https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)")
+    return f"{base} (mailto:{contact})" if contact else base
+
+
 def slugify(title: str, author_last: str = "", year: int = 0) -> str:
     """Generate a canonical slug: author_last + year + keyword."""
     # Extract first meaningful word from title
@@ -306,55 +322,46 @@ def _yaml_quote(s: str) -> str:
     return f'"{s}"'
 
 
-def fetch_arxiv_metadata(arxiv_id: str, timeout: float = 15.0) -> dict:
-    """Query arXiv Atom API for one paper. Returns a metadata dict.
+def _arxiv_api_get(url: str, what: str, timeout: float = 15.0) -> bytes:
+    """GET an arXiv API URL with a descriptive User-Agent + retry/backoff.
 
-    Retries up to 3 times on arXiv rate limits (HTTP 429 or the plain-text
-    "Rate exceeded." body the API sometimes returns with 200 OK) and on
-    transient network errors. Raises RuntimeError when all retries are
-    exhausted — callers decide whether to abort the ingest or fall back
-    to manual metadata.
+    Centralizes the rate-limit handling shared by the single and batch
+    fetchers: sends ``_arxiv_user_agent()`` (lands in arXiv's lenient pool),
+    retries up to 3 times on HTTP 429, transient network errors, and the
+    plain-text "Rate exceeded." body the API sometimes returns with 200 OK.
+    ``what`` is a label for error messages (e.g. the id or id-list).
     """
-    aid = _normalize_arxiv_id(arxiv_id)
-    url = _ARXIV_API.format(ids=aid)
-    body = b""
+    req = urllib.request.Request(url, headers={"User-Agent": _arxiv_user_agent()})
     for attempt in (1, 2, 3):
         try:
-            with urllib.request.urlopen(url, timeout=timeout) as resp:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
                 body = resp.read()
         except urllib.error.HTTPError as e:
             if e.code == 429 and attempt < 3:
                 time.sleep(5 * attempt)
                 continue
-            raise RuntimeError(f"arXiv API fetch failed for {aid}: {e}")
+            raise RuntimeError(f"arXiv API fetch failed for {what}: {e}")
         except (urllib.error.URLError, TimeoutError, OSError) as e:
             if attempt < 3:
                 time.sleep(2 * attempt)
                 continue
-            raise RuntimeError(f"arXiv API fetch failed for {aid}: {e}")
+            raise RuntimeError(f"arXiv API fetch failed for {what}: {e}")
         if body.strip() == b"Rate exceeded.":
             if attempt < 3:
                 time.sleep(5 * attempt)
                 continue
-            raise RuntimeError(f"arXiv API rate-limited for {aid} after 3 attempts")
-        break
+            raise RuntimeError(f"arXiv API rate-limited for {what} after 3 attempts")
+        return body
+    return b""  # unreachable; loop either returns or raises
 
-    try:
-        root = ET.fromstring(body)
-    except ET.ParseError as e:
-        raise RuntimeError(f"arXiv API returned unparseable XML for {aid}: {e}")
 
-    entry = root.find("atom:entry", _ARXIV_NS)
-    if entry is None:
-        raise RuntimeError(f"arXiv API returned no entry for {aid}")
-
+def _parse_arxiv_entry(entry) -> dict:
+    """Parse one Atom <entry> element into the metadata dict shape."""
     def _txt(el, default=""):
         return el.text.strip() if el is not None and el.text else default
 
-    title = _txt(entry.find("atom:title", _ARXIV_NS))
-    title = re.sub(r"\s+", " ", title)
-    summary = _txt(entry.find("atom:summary", _ARXIV_NS))
-    summary = re.sub(r"\s+", " ", summary)
+    title = re.sub(r"\s+", " ", _txt(entry.find("atom:title", _ARXIV_NS)))
+    summary = re.sub(r"\s+", " ", _txt(entry.find("atom:summary", _ARXIV_NS)))
     published = _txt(entry.find("atom:published", _ARXIV_NS))
     year = int(published[:4]) if published[:4].isdigit() else 0
 
@@ -367,9 +374,14 @@ def fetch_arxiv_metadata(arxiv_id: str, timeout: float = 15.0) -> dict:
     primary = entry.find("arxiv:primary_category", _ARXIV_NS)
     primary_cat = primary.get("term") if primary is not None else ""
 
-    # Check for published journal reference
     journal_ref = _txt(entry.find("arxiv:journal_ref", _ARXIV_NS))
     venue = journal_ref if journal_ref else "arXiv"
+
+    # The <id> element holds e.g. http://arxiv.org/abs/2510.23672v1 — recover
+    # the bare, version-stripped id so batch results can be keyed back to the
+    # ids the caller asked for.
+    raw_id = _txt(entry.find("atom:id", _ARXIV_NS))
+    aid = _normalize_arxiv_id(raw_id.rsplit("/abs/", 1)[-1]) if raw_id else ""
 
     return {
         "arxiv_id": aid,
@@ -380,6 +392,60 @@ def fetch_arxiv_metadata(arxiv_id: str, timeout: float = 15.0) -> dict:
         "abstract": summary,
         "primary_category": primary_cat,
     }
+
+
+def fetch_arxiv_metadata(arxiv_id: str, timeout: float = 15.0) -> dict:
+    """Query arXiv Atom API for one paper. Returns a metadata dict.
+
+    Sends a descriptive User-Agent and retries up to 3 times on arXiv rate
+    limits (HTTP 429 or the plain-text "Rate exceeded." body) and transient
+    network errors. Raises RuntimeError when all retries are exhausted —
+    callers decide whether to abort the ingest or fall back to manual metadata.
+    """
+    aid = _normalize_arxiv_id(arxiv_id)
+    body = _arxiv_api_get(_ARXIV_API.format(ids=aid), aid, timeout=timeout)
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as e:
+        raise RuntimeError(f"arXiv API returned unparseable XML for {aid}: {e}")
+
+    entry = root.find("atom:entry", _ARXIV_NS)
+    if entry is None:
+        raise RuntimeError(f"arXiv API returned no entry for {aid}")
+
+    meta = _parse_arxiv_entry(entry)
+    # The single-id query is authoritative for the id even if <id> parsing
+    # came up empty (e.g. malformed feed); keep the caller's normalized id.
+    meta["arxiv_id"] = aid
+    return meta
+
+
+def fetch_arxiv_metadata_batch(arxiv_ids: list[str], timeout: float = 30.0) -> dict:
+    """Fetch metadata for many papers in ONE arXiv request via id_list.
+
+    arXiv's ``id_list`` parameter accepts a comma-separated list and returns
+    all entries in a single Atom feed, so N papers cost 1 request instead of
+    N — the structural fix for the burst-429 problem when ingesting a batch.
+    Returns ``{normalized_id: meta}``; ids the API did not return are simply
+    absent from the dict (caller decides how to handle misses).
+    """
+    norm = [_normalize_arxiv_id(a.strip()) for a in arxiv_ids if a and a.strip()]
+    if not norm:
+        return {}
+    body = _arxiv_api_get(
+        _ARXIV_API.format(ids=",".join(norm)), f"id_list[{len(norm)}]", timeout=timeout
+    )
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as e:
+        raise RuntimeError(f"arXiv API returned unparseable XML for batch: {e}")
+
+    out: dict = {}
+    for entry in root.findall("atom:entry", _ARXIV_NS):
+        meta = _parse_arxiv_entry(entry)
+        if meta.get("arxiv_id"):
+            out[meta["arxiv_id"]] = meta
+    return out
 
 
 def _last_name(full_name: str) -> str:
@@ -499,7 +565,8 @@ def ingest_paper(wiki_root: str, *, arxiv_id: str = "", title: str = "",
                  authors: list[str] | None = None, year: int = 0,
                  venue: str = "", doi: str = "", thesis: str = "",
                  tags: list[str] | None = None,
-                 update_on_exist: bool = False) -> Path:
+                 update_on_exist: bool = False,
+                 prefetched_meta: dict | None = None) -> Path:
     """Canonical paper-ingest entrypoint.
 
     Preferred: pass --arxiv-id and let the helper fetch metadata. If the
@@ -534,14 +601,20 @@ def ingest_paper(wiki_root: str, *, arxiv_id: str = "", title: str = "",
                                   f"{existing.name} (arxiv:{aid})")
             print(f"Paper already ingested: {existing.name} (arxiv:{aid}) — skipping.")
             return existing
-        try:
-            meta = fetch_arxiv_metadata(aid)
-        except RuntimeError as e:
-            if title:  # caller provided manual fallback
-                print(f"Warning: {e} — falling back to manual metadata.", file=sys.stderr)
-                meta = {"arxiv_id": aid}
-            else:
-                raise
+        if prefetched_meta is not None:
+            # Batch path (sync): metadata already fetched in one id_list call;
+            # skip the per-id network round-trip entirely.
+            meta = dict(prefetched_meta)
+            meta.setdefault("arxiv_id", aid)
+        else:
+            try:
+                meta = fetch_arxiv_metadata(aid)
+            except RuntimeError as e:
+                if title:  # caller provided manual fallback
+                    print(f"Warning: {e} — falling back to manual metadata.", file=sys.stderr)
+                    meta = {"arxiv_id": aid}
+                else:
+                    raise
         # Manual overrides on top of fetched metadata
         if title:
             meta["title"] = title
@@ -602,14 +675,30 @@ def ingest_paper(wiki_root: str, *, arxiv_id: str = "", title: str = "",
 
 
 def sync_papers(wiki_root: str, arxiv_ids: list[str], update_on_exist: bool = False) -> None:
-    """Batch backfill: ingest each arxiv id; dedup is handled per-id."""
+    """Batch backfill: ingest many arxiv ids with a SINGLE metadata request.
+
+    All ids are fetched in one ``id_list`` call (see fetch_arxiv_metadata_batch),
+    then each page is written from the pre-fetched metadata — N papers cost 1
+    arXiv request instead of N, avoiding the burst-429 problem. Ids the batch
+    did not return fall back to a per-id fetch (handles the occasional miss).
+    Dedup is still handled per-id inside ingest_paper.
+    """
+    ids = [a.strip() for a in arxiv_ids if a and a.strip()]
+    if not ids:
+        return
+    try:
+        batch = fetch_arxiv_metadata_batch(ids)
+    except RuntimeError as e:
+        print(f"Warning: batch fetch failed ({e}); falling back to per-id.", file=sys.stderr)
+        batch = {}
+
     errors = []
-    for aid in arxiv_ids:
-        aid = aid.strip()
-        if not aid:
-            continue
+    for aid in ids:
+        norm = _normalize_arxiv_id(aid)
+        meta = batch.get(norm)
         try:
-            ingest_paper(wiki_root, arxiv_id=aid, update_on_exist=update_on_exist)
+            ingest_paper(wiki_root, arxiv_id=aid, update_on_exist=update_on_exist,
+                         prefetched_meta=meta)
         except RuntimeError as e:
             print(f"ERROR: {aid}: {e}", file=sys.stderr)
             errors.append((aid, str(e)))

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -432,9 +432,11 @@ def fetch_arxiv_metadata_batch(arxiv_ids: list[str], timeout: float = 30.0) -> d
     norm = [_normalize_arxiv_id(a.strip()) for a in arxiv_ids if a and a.strip()]
     if not norm:
         return {}
-    body = _arxiv_api_get(
-        _ARXIV_API.format(ids=",".join(norm)), f"id_list[{len(norm)}]", timeout=timeout
-    )
+    # arXiv defaults max_results to 10, so an id_list of >10 silently returns
+    # only the first 10 entries — set max_results to the full count so all
+    # requested papers come back in the single request.
+    url = _ARXIV_API.format(ids=",".join(norm)) + f"&max_results={len(norm)}"
+    body = _arxiv_api_get(url, f"id_list[{len(norm)}]", timeout=timeout)
     try:
         root = ET.fromstring(body)
     except ET.ParseError as e:


### PR DESCRIPTION
## Problem
`tools/research_wiki.py`'s `fetch_arxiv_metadata` calls the arXiv API with the
default `Python-urllib/x.y` User-Agent, which arXiv rate-limits aggressively,
and `sync_papers` issues one request per id. Batch ingests (e.g. ~20 papers
from a `/research-lit` run) reliably trip HTTP 429 and stall. #251/#252 already
showed that a UA fix resolves the analogous bot-block for `/alphaxiv`; this is
the same class of fix for the arXiv metadata path.

## Changes
- `_arxiv_user_agent()`: descriptive UA, contact read from the existing
  `ARIS_VERIFY_EMAIL` env var (no hard-coded address) → lands in arXiv's more
  lenient pool instead of the throttled default.
- `_arxiv_api_get()` + `_parse_arxiv_entry()`: shared UA + retry/backoff HTTP
  helper and Atom-entry parser (refactor of `fetch_arxiv_metadata`, behavior
  preserved — builds on the existing https + 429-backoff already in main).
- `fetch_arxiv_metadata_batch()`: one `id_list` request for N papers, with
  `max_results=N` so lists longer than 10 are not silently truncated.
- `sync_papers`: batch-fetch once, then write each page from prefetched
  metadata (N papers = 1 arXiv request instead of N); per-id fallback for misses.
- `ingest_paper`: optional `prefetched_meta` to skip the per-id round-trip.

## Test plan
- [x] `tests/test_research_wiki_fetch_arxiv_metadata.py` — 11 pass (7 existing
  + 4 new: UA header sent, UA contact when env set, batch multi-entry, empty input).
- [x] Existing arxiv-fetch tests unchanged (refactor preserves behavior).
- [x] Real-scenario: ingested 23 papers via the batched path; a 20-id batch
  returns 20/20 in a single request. (The real test caught the `max_results`
  default-10 truncation, fixed in the second commit.)

No behavior change when `ARIS_VERIFY_EMAIL` is unset (UA still sent, just
contactless). Pure-stdlib, no new deps.