### PR TITLE
fix(arxiv-fetch): descriptive UA + 3-attempt 429 retry to cut search-path failures

### DIFF
--- a/tests/test_arxiv_fetch.py
+++ b/tests/test_arxiv_fetch.py
@@ -1,0 +1,242 @@
+"""Tests for tools/arxiv_fetch.py UA + 429 retry behavior.
+
+Mirrors the test structure in test_research_wiki_fetch_arxiv_metadata.py
+(introduced by PR #266) to keep the two helpers' rate-limit handling
+verified against equivalent scenarios.
+"""
+
+import importlib.util
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+import urllib.error
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "arxiv_fetch.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("arxiv_fetch", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+VALID_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2509.14933v1</id>
+    <title>Test Paper</title>
+    <summary>An abstract.</summary>
+    <published>2025-09-18T12:00:00Z</published>
+    <updated>2025-09-18T12:00:00Z</updated>
+    <author><name>Alice Smith</name></author>
+    <author><name>Bob Jones</name></author>
+    <category term="cs.LG"/>
+  </entry>
+</feed>"""
+
+
+class FakeResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+def _http_error_429():
+    return urllib.error.HTTPError(
+        url="http://example/",
+        code=429,
+        msg="Too Many Requests",
+        hdrs=None,
+        fp=BytesIO(b""),
+    )
+
+
+def _patch_urlopen(monkeypatch, mod, responses):
+    """Each call to urlopen pops one item from `responses`."""
+    queue = list(responses)
+    calls = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        calls["n"] += 1
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return FakeResponse(item)
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    return calls
+
+
+def _capture_urlopen(monkeypatch, mod, responses):
+    """Like _patch_urlopen but records each Request object passed in."""
+    queue = list(responses)
+    seen = {"requests": []}
+
+    def fake_urlopen(req, timeout=None):
+        seen["requests"].append(req)
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return FakeResponse(item)
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    return seen
+
+
+# ---- search() retry behavior ---------------------------------------------
+
+def test_search_success_first_try(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(monkeypatch, mod, [VALID_XML])
+
+    results = mod.search("2509.14933", max_results=1)
+
+    assert calls["n"] == 1
+    assert len(results) == 1
+    assert results[0]["title"] == "Test Paper"
+    assert results[0]["authors"] == ["Alice Smith", "Bob Jones"]
+
+
+def test_search_retries_on_http_429_then_succeeds(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(monkeypatch, mod, [_http_error_429(), VALID_XML])
+
+    results = mod.search("2509.14933", max_results=1)
+
+    assert calls["n"] == 2
+    assert results[0]["title"] == "Test Paper"
+
+
+def test_search_retries_on_urlerror_then_succeeds(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(
+        monkeypatch, mod, [urllib.error.URLError("conn refused"), VALID_XML]
+    )
+
+    results = mod.search("2509.14933", max_results=1)
+
+    assert calls["n"] == 2
+    assert results[0]["title"] == "Test Paper"
+
+
+def test_search_retries_on_rate_exceeded_body_then_succeeds(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(monkeypatch, mod, [b"Rate exceeded.", VALID_XML])
+
+    results = mod.search("2509.14933", max_results=1)
+
+    assert calls["n"] == 2
+    assert results[0]["title"] == "Test Paper"
+
+
+def test_search_raises_after_three_429s(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(
+        monkeypatch, mod, [_http_error_429(), _http_error_429(), _http_error_429()]
+    )
+
+    with pytest.raises(RuntimeError, match="arXiv API fetch failed"):
+        mod.search("2509.14933", max_results=1)
+    assert calls["n"] == 3
+
+
+def test_search_raises_after_three_rate_exceeded_bodies(monkeypatch):
+    mod = load_module()
+    calls = _patch_urlopen(
+        monkeypatch, mod, [b"Rate exceeded.", b"Rate exceeded.", b"Rate exceeded."]
+    )
+
+    with pytest.raises(RuntimeError, match="rate-limited"):
+        mod.search("2509.14933", max_results=1)
+    assert calls["n"] == 3
+
+
+def test_search_non_429_http_error_does_not_retry(monkeypatch):
+    mod = load_module()
+    err_500 = urllib.error.HTTPError(
+        url="http://example/", code=500, msg="Server Error",
+        hdrs=None, fp=BytesIO(b""),
+    )
+    calls = _patch_urlopen(monkeypatch, mod, [err_500])
+
+    with pytest.raises(RuntimeError, match="arXiv API fetch failed"):
+        mod.search("2509.14933", max_results=1)
+    assert calls["n"] == 1
+
+
+# ---- User-Agent (arXiv lenient pool) -------------------------------------
+
+def test_search_sends_descriptive_user_agent(monkeypatch):
+    mod = load_module()
+    monkeypatch.delenv("ARIS_VERIFY_EMAIL", raising=False)
+    seen = _capture_urlopen(monkeypatch, mod, [VALID_XML])
+
+    mod.search("2509.14933", max_results=1)
+
+    ua = seen["requests"][0].get_header("User-agent")
+    assert ua and ua.startswith("arxiv-skill/")
+    assert "Python-urllib" not in (ua or "")
+
+
+def test_user_agent_includes_contact_when_env_set(monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("ARIS_VERIFY_EMAIL", "dev@example.org")
+    seen = _capture_urlopen(monkeypatch, mod, [VALID_XML])
+
+    mod.search("2509.14933", max_results=1)
+
+    ua = seen["requests"][0].get_header("User-agent")
+    assert "mailto:dev@example.org" in ua
+
+
+def test_user_agent_no_contact_when_env_unset(monkeypatch):
+    mod = load_module()
+    monkeypatch.delenv("ARIS_VERIFY_EMAIL", raising=False)
+    seen = _capture_urlopen(monkeypatch, mod, [VALID_XML])
+
+    mod.search("2509.14933", max_results=1)
+
+    ua = seen["requests"][0].get_header("User-agent")
+    assert "mailto:" not in (ua or "")
+
+
+# ---- download() retry behavior -------------------------------------------
+
+_FAKE_PDF = b"%PDF-1.4\n" + b"x" * 20_000  # > _MIN_PDF_BYTES
+
+
+def test_download_retries_on_429_then_succeeds(monkeypatch, tmp_path):
+    mod = load_module()
+    calls = _patch_urlopen(monkeypatch, mod, [_http_error_429(), _FAKE_PDF])
+
+    result = mod.download("2509.14933", output_dir=str(tmp_path))
+
+    assert calls["n"] == 2
+    assert result["skipped"] is False
+    assert Path(result["path"]).exists()
+
+
+def test_download_raises_after_three_429s(monkeypatch, tmp_path):
+    mod = load_module()
+    calls = _patch_urlopen(
+        monkeypatch, mod, [_http_error_429(), _http_error_429(), _http_error_429()]
+    )
+
+    with pytest.raises(urllib.error.HTTPError):
+        mod.download("2509.14933", output_dir=str(tmp_path))
+    assert calls["n"] == 3

--- a/tools/arxiv_fetch.py
+++ b/tools/arxiv_fetch.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import time
@@ -30,11 +31,25 @@ from pathlib import Path
 
 _ATOM_NS = "http://www.w3.org/2005/Atom"
 _API_BASE = "http://export.arxiv.org/api/query"
-_USER_AGENT = (
-    "arxiv-skill/1.0 "
-    "(github.com/wanshuiyin/Auto-claude-code-research-in-sleep)"
-)
 _MIN_PDF_BYTES = 10_240
+
+
+def _arxiv_user_agent() -> str:
+    """Descriptive User-Agent for arXiv API calls.
+
+    arXiv rate-limits the default ``Python-urllib/x.y`` agent far more
+    aggressively than a named client; sending a descriptive UA (with an
+    optional contact address) lands requests in arXiv's more lenient pool.
+    The contact is read from ``ARIS_VERIFY_EMAIL`` — the same env var
+    ``tools/research_wiki.py`` and ``tools/verify_papers.py`` already use —
+    so no address is hard-coded. Falls back to a contactless UA when unset.
+    """
+    contact = os.environ.get("ARIS_VERIFY_EMAIL", "").strip()
+    base = ("arxiv-skill/1.0 "
+            "(+https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)")
+    return f"{base} (mailto:{contact})" if contact else base
+
+
 _NEW_STYLE_ID_RE = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$")
 _OLD_STYLE_ID_RE = re.compile(r"^[A-Za-z.-]+/\d{7}(v\d+)?$")
 
@@ -76,10 +91,36 @@ def _api_url(query: str, max_results: int, start: int) -> str:
 
 
 def _fetch_atom(url: str) -> ET.Element:
-    """Fetch an arXiv Atom feed and return the parsed XML root."""
-    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return ET.fromstring(resp.read())
+    """Fetch an arXiv Atom feed and return the parsed XML root.
+
+    Sends a descriptive User-Agent (landing requests in arXiv's lenient pool)
+    and retries up to 3 times on HTTP 429, transient network errors, and the
+    plain-text ``Rate exceeded.`` body the API sometimes returns with 200 OK.
+    Raises RuntimeError when all retries are exhausted.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": _arxiv_user_agent()})
+    for attempt in (1, 2, 3):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < 3:
+                time.sleep(5 * attempt)
+                continue
+            raise RuntimeError(f"arXiv API fetch failed: {e}")
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            if attempt < 3:
+                time.sleep(2 * attempt)
+                continue
+            raise RuntimeError(f"arXiv API fetch failed: {e}")
+        if body.strip() == b"Rate exceeded.":
+            if attempt < 3:
+                time.sleep(5 * attempt)
+                continue
+            raise RuntimeError("arXiv API rate-limited after 3 attempts")
+        return ET.fromstring(body)
+    # unreachable; loop either returns or raises
+    raise RuntimeError("arXiv API fetch failed: exhausted retries")
 
 
 def _parse_entry(entry: ET.Element) -> dict:
@@ -137,20 +178,26 @@ def download(arxiv_id: str, output_dir: str = "papers") -> dict:
         }
 
     pdf_url = f"https://arxiv.org/pdf/{clean_id}.pdf"
-    req = urllib.request.Request(pdf_url, headers={"User-Agent": _USER_AGENT})
+    req = urllib.request.Request(pdf_url, headers={"User-Agent": _arxiv_user_agent()})
 
-    for attempt in (1, 2):
+    data = b""
+    for attempt in (1, 2, 3):
         try:
             with urllib.request.urlopen(req, timeout=60) as resp:
                 data = resp.read()
             break
         except urllib.error.HTTPError as exc:
-            if exc.code == 429 and attempt == 1:
-                time.sleep(5)
+            if exc.code == 429 and attempt < 3:
+                time.sleep(5 * attempt)
                 continue
             raise
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            if attempt < 3:
+                time.sleep(2 * attempt)
+                continue
+            raise RuntimeError(f"Failed to download {pdf_url}: {exc}")
     else:
-        raise RuntimeError(f"Failed to download {pdf_url} after retries")
+        raise RuntimeError(f"Failed to download {pdf_url} after 3 attempts")
 
     if len(data) < _MIN_PDF_BYTES:
         raise ValueError(


### PR DESCRIPTION
## Problem

`/research-lit` repeatedly triggers arXiv HTTP 429 / TimeoutError in Step 1 (search) and Step 1.5 (verify), causing the skill to degrade or fail. The root cause is in `tools/arxiv_fetch.py`:

- `_fetch_atom()` (search path) has **zero retry** — a single 429 or timeout kills the entire search
- `_USER_AGENT` is a static string without mailto contact — no access to arXiv's lenient/polite pool
- `download()` has only 1 retry on 429 — weaker than the 3-attempt standard set by PR #256

PR #256 and PR #266 already fixed the same issues in `research_wiki.py`, but `arxiv_fetch.py` was never updated.

## Fix (two layers)

### Layer 1 — Descriptive User-Agent

Replaces the static `_USER_AGENT` constant with `_arxiv_user_agent()` helper (same pattern as PR #266's `_arxiv_user_agent` in research_wiki.py):

- Reads `ARIS_VERIFY_EMAIL` env var for optional `mailto:` contact
- No hard-coded addresses; falls back to contactless UA when unset
- Same env var already used by `verify_papers.py` (CrossRef polite pool) and `research_wiki.py`

### Layer 2 — 3-attempt retry with linear backoff

`_fetch_atom()` (search path):
- HTTP 429: `sleep(5 * attempt)`, retry up to 3 times
- URLError / TimeoutError / OSError: `sleep(2 * attempt)`, retry up to 3 times
- "Rate exceeded." plain-text body: same as 429 handling
- All 3 attempts exhausted → `raise RuntimeError`

`download()` path:
- Upgraded from 1 retry to 3, matching search path behavior
- Added URLError/TimeoutError/OSError retry (previously only 429)

## Tests

12 new tests in `tests/test_arxiv_fetch.py`:

| # | Test | Status |
|---|------|--------|
| 1 | search success first try | ✅ |
| 2 | search retries on HTTP 429 then succeeds | ✅ |
| 3 | search retries on URLError then succeeds | ✅ |
| 4 | search retries on "Rate exceeded." body then succeeds | ✅ |
| 5 | search raises after three 429s | ✅ |
| 6 | search raises after three "Rate exceeded." bodies | ✅ |
| 7 | search non-429 HTTP error does not retry | ✅ |
| 8 | search sends descriptive UA | ✅ |
| 9 | UA includes mailto when ARIS_VERIFY_EMAIL set | ✅ |
| 10 | UA has no mailto when ARIS_VERIFY_EMAIL unset | ✅ |
| 11 | download retries on 429 then succeeds | ✅ |
| 12 | download raises after three 429s | ✅ |

All 23 tests pass (12 new + 11 existing research_wiki tests).

## Related PRs

- **PR #256** (by me) — 3-attempt 429 retry in `research_wiki.py`
- **PR #266** — Descriptive UA + batch id_list in `research_wiki.py`

This PR is the sister fix for `arxiv_fetch.py`, completing the rate-limit mitigation across both arXiv callers.

## Verification

```bash
ARIS_VERIFY_EMAIL=your@email.com conda run -n ARIS python tools/arxiv_fetch.py search "2509.14933" --max 1
```

Previously this would 429 on repeated calls; now retries succeed within 3 attempts.