### PR TITLE
fix(verify-papers): add User-Agent header to arXiv API calls to cut 429s

### DIFF
--- a/tools/verify_papers.py
+++ b/tools/verify_papers.py
@@ -110,6 +110,12 @@ DEFAULT_FUZZY_THRESHOLD = 0.6
 DEFAULT_CACHE_TTL_DAYS = 30
 DEFAULT_HALLUCINATION_WARN_THRESHOLD = 0.2
 
+def _arxiv_user_agent() -> str:
+    contact = os.environ.get("ARIS_VERIFY_EMAIL", "").strip()
+    base = "verify-papers/1.0 (+https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)"
+    return f"{base} (mailto:{contact})" if contact else base
+
+
 ARXIV_VERSION_RE = re.compile(r"v\d+$")
 TITLE_NORMALIZE_RE = re.compile(r"[^\w\s]", re.UNICODE)
 WHITESPACE_RE = re.compile(r"\s+")
@@ -256,7 +262,7 @@ def _verify_arxiv_batch_with_retry(batch: list[str]) -> dict[str, str]:
     base_ids = [normalize_arxiv_id(x)[0] for x in batch]
     url = f"{ARXIV_API}?id_list={','.join(base_ids)}&max_results={len(base_ids)}"
     for attempt in range(3):
-        status, body = http_get(url, timeout=30)
+        status, body = http_get(url, headers={"User-Agent": _arxiv_user_agent()}, timeout=30)
         if status == 200 and body is not None:
             found = set()
             for bid in base_ids:


### PR DESCRIPTION
## Problem

`verify_papers.py`'s `_verify_arxiv_batch_with_retry` calls `http_get()`
without a User-Agent header. arXiv rate-limits the default Python-urllib agent
aggressively, returning HTTP 429. With 15 candidate papers and 30s timeout ×
3 retries × recursive batch splitting, a single `/research-lit` Step 1.5
verification stalled for several minutes.

PR #268 fixed the same issue in `arxiv_fetch.py`; this file was missed.

## Changes

- `_arxiv_user_agent()`: reads `ARIS_VERIFY_EMAIL` for optional `mailto:`
  contact, same pattern as `arxiv_fetch.py` and `research_wiki.py`.
- Pass `{"User-Agent": _arxiv_user_agent()}` to `http_get` in
  `_verify_arxiv_batch_with_retry`.

## Test plan

- [x] `verify_papers.py --arxiv-ids 2509.14933,2402.19072,...` — all 8 papers
  verified as PASS in seconds (previously 429/timeout)
- [x] `tests/test_research_wiki_fetch_arxiv_metadata.py` — 11 passed
- [x] `bash tools/lint_skills_helpers.sh` — clean
- [x] `python tools/check_skills_inventory.py` — consistent