### PR TITLE
fix(arxiv-fetch): accept get/fetch as search aliases to defuse hallucinated subcommands

### DIFF
--- a/tools/arxiv_fetch.py
+++ b/tools/arxiv_fetch.py
@@ -173,24 +173,33 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    def _add_search_args(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "query",
+            help="Search query or arXiv ID (bare ID or id:ARXIV_ID).",
+        )
+        p.add_argument(
+            "--max",
+            type=int,
+            default=10,
+            metavar="N",
+            help="Maximum number of results (default: 10).",
+        )
+        p.add_argument(
+            "--start",
+            type=int,
+            default=0,
+            help="Start offset for pagination (default: 0).",
+        )
+
     search_parser = subparsers.add_parser("search", help="Search arXiv papers")
-    search_parser.add_argument(
-        "query",
-        help="Search query or arXiv ID (bare ID or id:ARXIV_ID).",
-    )
-    search_parser.add_argument(
-        "--max",
-        type=int,
-        default=10,
-        metavar="N",
-        help="Maximum number of results (default: 10).",
-    )
-    search_parser.add_argument(
-        "--start",
-        type=int,
-        default=0,
-        help="Start offset for pagination (default: 0).",
-    )
+    _add_search_args(search_parser)
+
+    # Defensive aliases — models frequently hallucinate `get` / `fetch`
+    # instead of `search`.  Accept them silently so the invocation succeeds
+    # regardless of model quality.
+    for alias in ("get", "fetch"):
+        _add_search_args(subparsers.add_parser(alias, help="Alias for search"))
 
     download_parser = subparsers.add_parser("download", help="Download a paper PDF by arXiv ID")
     download_parser.add_argument(
@@ -216,7 +225,7 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
 
-    if args.command == "search":
+    if args.command in ("search", "get", "fetch"):
         results = search(args.query, max_results=args.max, start=args.start)
         print(json.dumps(results, ensure_ascii=False, indent=2))
         return 0


### PR DESCRIPTION
## Problem

Models frequently call `arxiv_fetch.py` with subcommands `get` or `fetch`
instead of `search` — pattern-matching "fetch this paper" to an invented
command. argparse returns a hard error, aborting the enclosing skill invocation.

This has been observed repeatedly with DeepSeek and GLM models running
`/research-lit`, but the tool interface should tolerate it regardless of
which model invokes it.

## Changes

Register `get` and `fetch` as transparent aliases for `search` in
`_build_parser()`. The `main()` dispatch handles all three identically.
`download` is unchanged. Invalid subcommands still error with the
standard argparse message.

## Test plan

- [x] `arxiv_fetch.py fetch 2509.14933 --max 1` — correct JSON, same as search
- [x] `arxiv_fetch.py get 2509.14933 --max 1` — same
- [x] `arxiv_fetch.py search 2509.14933 --max 1` — unchanged
- [x] `arxiv_fetch.py download 2509.14933 --dir /tmp` — unchanged
- [x] `arxiv_fetch.py invalid` — still errors with clear message
- [x] `tests/test_research_wiki_fetch_arxiv_metadata.py` — 11 passed
- [x] `bash tools/lint_skills_helpers.sh` — clean
- [x] `python tools/check_skills_inventory.py` — consistent