### PR TITLE
fix(smart_update): --apply silently writes nothing when a skill needs merge

### DIFF
--- a/tools/smart_update.sh
+++ b/tools/smart_update.sh
@@ -321,7 +321,13 @@ for s in "${MERGE_SKILLS[@]:-}"; do
         # Show what personal patterns were found
         local_file="$LOCAL_DIR/$s/SKILL.md"
         for pattern in "${PERSONAL_PATTERNS[@]}"; do
-            match=$(grep -n "$pattern" "$local_file" 2>/dev/null | head -1)
+            # `|| true`: under `set -euo pipefail` this assignment would otherwise
+            # abort the whole script — grep exits 1 on no-match, and even on a match
+            # `head -1` closes the pipe early so grep dies with SIGPIPE (141). Either
+            # way pipefail propagates the failure and `set -e` kills the run *before*
+            # the Summary and the apply block, so `--apply` silently writes nothing
+            # whenever a skill is flagged "needs merge".
+            match=$(grep -n "$pattern" "$local_file" 2>/dev/null | head -1 || true)
             if [[ -n "$match" ]]; then
                 echo -e "     ${YELLOW}→ contains: ${match}${NC}"
                 break


### PR DESCRIPTION
## Problem

`tools/smart_update.sh --apply` **exits 1 and copies nothing — with no error message — whenever at least one skill is classified "needs merge."**

The script runs under `set -euo pipefail`. The needs-merge display loop builds its `→ contains:` hint with an unguarded command substitution:

```sh
match=$(grep -n "$pattern" "$local_file" 2>/dev/null | head -1)
```

This fails for **two** reasons, both fatal under `set -e`:

- **No match** — `grep` exits `1`, and `pipefail` propagates it.
- **A match** — `head -1` closes the pipe after the first line, so `grep` dies with `SIGPIPE` (exit `141`), which `pipefail` also propagates.

Because the first `PERSONAL_PATTERNS` entry (`'ssh '`) misses almost every `SKILL.md`, the **first** iteration aborts the whole script — *before* the Summary block and *before* the `if $APPLY` apply block. So `--apply` silently writes nothing.

The dry-run appeared to work only because it is usually run in a state with `0` needs-merge skills, where the loop body never executes.

## Fix

Append `|| true` to swallow the expected non-zero exit, exactly matching the already-guarded `grep -c … || true` calls in the classifier above (lines 266/268). The hint is best-effort display only, so dropping the status is safe.

```diff
-            match=$(grep -n "$pattern" "$local_file" 2>/dev/null | head -1)
+            match=$(grep -n "$pattern" "$local_file" 2>/dev/null | head -1 || true)
```

(plus an explanatory comment).

## Verification

Controlled upstream/local pair — one safe-update skill (`skillA`) + one needs-merge skill (`skillB`, local has an extra `/Users/…` line), run via `--upstream/--local --apply`:

| | exit | `skillA` (safe) | `skillB` (needs-merge) | `Done!` printed |
|---|---|---|---|---|
| **before** | `1` | stale (not updated) | untouched | ✗ |
| **after**  | `0` | updated | untouched (correct) | ✓ |

`bash -n tools/smart_update.sh` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
