### PR TITLE
fix(skills): quote Codex argument hints

### DIFF
--- a/skills/research-pipeline/SKILL.md
+++ b/skills/research-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-pipeline
 description: "Full research pipeline: Workflow 1 (idea discovery) → Workflow 1.5 (experiment bridge) → Workflow 2 (auto review loop) → Workflow 3 (paper writing, optional). Goes from a broad research direction all the way to a polished PDF. Use when user says \"全流程\", \"full pipeline\", \"从找idea到投稿\", \"end-to-end research\", or wants the complete autonomous research lifecycle."
-argument-hint: [research-direction] [— resume <run_id>]
+argument-hint: "[research-direction] [— resume <run_id>]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/wiki-enrich/SKILL.md
+++ b/skills/wiki-enrich/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: wiki-enrich
 description: "Fill in the per-paper TODO sections (Problem/Method/Key Results/Limitations/Reusable Ingredients/...) of research-wiki/papers/<slug>.md pages that /research-lit, /arxiv, /alphaxiv, /deepxiv, /semantic-scholar, /exa-search ingest as bare scaffolds. Implements the Karpathy LLM-wiki principle that the LLM (not the human) writes and maintains wiki bodies. Use when user says 'enrich wiki', 'fill paper TODOs', 'wiki body 補完', '把 paper 摘要寫進 wiki', 'research-wiki 自動填', or after a batch ingest that left papers/ as TODO scaffolds."
-argument-hint: [target: slug|missing|all] [--source alphaxiv|deepxiv|arxiv|auto] [--force] [--max N]
+argument-hint: "[target: slug|missing|all] [--source alphaxiv|deepxiv|arxiv|auto] [--force] [--max N]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, WebFetch
 ---
 


### PR DESCRIPTION
## Summary

Fix two invalid skill frontmatter entries that prevent Codex from loading the skills.

Codex reports these warnings when importing/loading local skills:

```text
Skipped loading 2 skill(s) due to invalid SKILL.md files.

.../skills/research-pipeline/SKILL.md: invalid YAML: did not find expected key
.../skills/wiki-enrich/SKILL.md: invalid YAML: did not find expected key
```

The issue is that `argument-hint` values were written as unquoted bracketed text. YAML parses `[ ... ]` as a flow sequence, and `wiki-enrich` also contains `target:` inside the value, which makes the frontmatter invalid.

This PR quotes both `argument-hint` values so they are parsed as plain strings.

## Changes

- Quote `argument-hint` in `/research-pipeline`
- Quote `argument-hint` in `/wiki-enrich`

## Validation

- Parsed both modified `SKILL.md` frontmatter blocks with Python YAML successfully
- Ran `git diff --check`
- Confirmed Codex no longer reports these invalid skill warnings locally after the same fix is applied to `~/.codex/skills`
