### PR TITLE
 output-hygiene: shared output-composition contract + wire idea-discovery's 3 sub-skills (closes #277)

### DIFF
--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -405,9 +405,22 @@ if research-wiki/ exists:
 ## Output Protocols
 
 > Follow these shared protocols for all output files:
+> - **[Output Composition Protocol](../shared-references/output-composition.md)** — see composed-mode note below
 > - **[Output Versioning Protocol](../shared-references/output-versioning.md)** — write timestamped file first, then copy to fixed name
-> - **[Output Manifest Protocol](../shared-references/output-manifest.md)** — log every output to MANIFEST.md
+> - **[Output Manifest Protocol](../shared-references/output-manifest.md)** — maintain `MANIFEST.md` only above the 15-artifact threshold (not "log every output")
 > - **[Output Language Protocol](../shared-references/output-language.md)** — respect the project's language setting
+
+> **Composed mode** — if invoked with `— composed: <canonical-report-path>` (e.g.
+> `/idea-discovery` passes `— composed: idea-stage/IDEA_REPORT.md`), that report is the
+> single canonical deliverable: fold the literature survey, novelty notes, and any
+> external-review conclusions into it as sections/appendices instead of emitting
+> `LIT_LANDSCAPE.md` / `RESEARCH_REVIEW.md` / `MANIFEST.md` alongside. Pilot scratch is
+> disposable (keep the script + one results file; delete launcher logs and redundant
+> `*_summary.json`); review traces stay in `.aris/traces/…` and the report cites the
+> path. **Default (no `— composed:` directive): standalone — write `IDEA_REPORT.md` and
+> any other documented files as normal.** Never infer composed mode from a report file
+> merely existing. Full rules:
+> [`shared-references/output-composition.md`](../shared-references/output-composition.md).
 
 ## Key Rules
 

--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -117,11 +117,13 @@ Invoke `/research-lit` to map the research landscape. Idea discovery is exactly 
 ```
 # If $ARGUMENTS already contains "— sources:", pass through unchanged
 # (the user is in control of source selection):
-/research-lit "$ARGUMENTS"
+/research-lit "$ARGUMENTS" — composed: idea-stage/IDEA_REPORT.md
 
 # Otherwise (the common case), include gemini explicitly for broader discovery:
-/research-lit "$ARGUMENTS" — sources: all, gemini
+/research-lit "$ARGUMENTS" — sources: all, gemini — composed: idea-stage/IDEA_REPORT.md
 ```
+
+`— composed: idea-stage/IDEA_REPORT.md` puts `/research-lit` in composed mode (see *Output hygiene* above): it returns the landscape for folding into the report instead of writing a standalone landscape file. The report doesn't exist yet at Phase 1 — the directive names the *forthcoming* canonical doc, and `/idea-creator` creates it in Phase 2.
 
 If `gemini-cli` is not installed, `/research-lit` skips the Gemini source gracefully with a warning — no break to the pipeline. Users who want to force-disable Gemini in idea-discovery can pass `/idea-discovery "topic" — sources: all` explicitly (which becomes the literal source list, no auto-injection).
 
@@ -150,8 +152,10 @@ Does this match your understanding? Should I adjust the scope before generating 
 Invoke `/idea-creator` with the landscape context (and `idea-stage/REF_PAPER_SUMMARY.md` if available):
 
 ```
-/idea-creator "$ARGUMENTS"
+/idea-creator "$ARGUMENTS" — composed: idea-stage/IDEA_REPORT.md
 ```
+
+`/idea-creator` owns `idea-stage/IDEA_REPORT.md` as the canonical deliverable; the `— composed:` directive tells it to fold the survey/novelty findings in rather than emitting `LIT_LANDSCAPE.md` / `RESEARCH_REVIEW.md` / `MANIFEST.md` alongside.
 
 **What this does:**
 - If `idea-stage/REF_PAPER_SUMMARY.md` exists, include it as context — ideas should build on, improve, or extend the reference paper
@@ -201,8 +205,10 @@ For each top idea (positive pilot signal), run a thorough novelty check:
 For the surviving top idea(s), get brutal feedback:
 
 ```
-/research-review "[top idea with hypothesis + pilot results]"
+/research-review "[top idea with hypothesis + pilot results]" — composed: idea-stage/IDEA_REPORT.md
 ```
+
+In composed mode `/research-review` folds its conclusions into `idea-stage/IDEA_REPORT.md` and cites the `.aris/traces/…` path instead of writing a standalone review `.md` in the project root.
 
 **What this does:**
 - GPT-5.4 xhigh acts as a senior reviewer (NeurIPS/ICML level)
@@ -311,9 +317,39 @@ This file is intentionally small (~30 lines) so downstream skills and session re
 ## Output Protocols
 
 > Follow these shared protocols for all output files:
+> - **[Output Composition Protocol](../shared-references/output-composition.md)** — ONE canonical deliverable per pipeline; fold sub-skill findings in, don't scatter overlapping `.md` files
 > - **[Output Versioning Protocol](../shared-references/output-versioning.md)** — write timestamped file first, then copy to fixed name
-> - **[Output Manifest Protocol](../shared-references/output-manifest.md)** — log every output to MANIFEST.md
+> - **[Output Manifest Protocol](../shared-references/output-manifest.md)** — maintain `MANIFEST.md` only above the 15-artifact threshold (not "log every output")
 > - **[Output Language Protocol](../shared-references/output-language.md)** — respect the project's language setting
+
+### Output hygiene — ONE canonical doc, no duplicate MDs (REQUIRED)
+
+This pipeline runs its sub-skills in **composed mode** (see
+[`output-composition.md`](../shared-references/output-composition.md)): it owns a single
+canonical deliverable and folds every sub-skill's findings into it rather than letting
+each emit its own overlapping file. Concretely, for this workflow:
+
+1. **`idea-stage/IDEA_REPORT.md` is the single canonical deliverable.** Sub-skills'
+   intermediate findings (literature landscape, novelty notes, external review) are
+   folded into it as sections/appendices — they do NOT become standalone files just
+   because a sub-skill could emit one. If a sub-skill writes a scratch file, inline its
+   unique content into the report and delete the scratch when the phase closes.
+2. **Pass `— composed: idea-stage/IDEA_REPORT.md` to every sub-skill** (`/research-lit`,
+   `/idea-creator`, `/research-review`) so they fold instead of scatter. This is the
+   explicit signal; without it a sub-skill stays standalone by design.
+3. **Refined-method outputs stay in `refine-logs/`** (`FINAL_PROPOSAL.md` /
+   `EXPERIMENT_PLAN.md` / `EXPERIMENT_TRACKER.md`). Do NOT also restate them as separate
+   files under `idea-stage/`; the report **links** to them, it does not copy them.
+4. **No `MANIFEST.md`** for a handful of files — only above the 15-artifact threshold in
+   [`output-manifest.md`](../shared-references/output-manifest.md).
+5. **Pilot scratch is disposable:** keep the pilot script (reusable) + one results file
+   (`pilot_results.jsonl` or a small summary). Delete launcher logs, smoke files, and
+   redundant `*_summary.json` once the numbers are in the report.
+6. **Cross-model review traces belong in `.aris/traces/…`** (the audit trail); do not
+   ALSO keep a human-facing copy under `idea-stage/` — cite the trace path from the report.
+7. **Before finishing,** the `idea-stage/` top level should be roughly: `IDEA_REPORT.md`
+   (+ `.html`), the pilot script + results, and the `refine-logs/` dir. Nothing else
+   unless it carries content not in the report.
 
 ## Render HTML view (auto, when `RENDER_HTML = true`)
 
@@ -337,7 +373,7 @@ Skip this step if `RENDER_HTML = false`.
 - **Checkpoint between phases.** Briefly summarize what was found before moving on.
 - **Kill ideas early.** It's better to kill 10 bad ideas in Phase 3 than to implement one and fail.
 - **Empirical signal > theoretical appeal.** An idea with a positive pilot outranks a "sounds great" idea without evidence.
-- **Document everything.** Dead ends are just as valuable as successes for future reference.
+- **Document everything — inside the one report, not in scattered files.** Dead ends and eliminated ideas are valuable, so record them as sections of `idea-stage/IDEA_REPORT.md` (see *Output hygiene* above). Do not spawn a separate `.md` per phase.
 - **Be honest with the reviewer.** Include negative results and failed pilots in the review prompt.
 - **Feishu notifications are optional.** If `~/.claude/feishu.json` exists, send `checkpoint` at each phase transition and `pipeline_done` at final report. If absent/off, skip silently.
 

--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -645,6 +645,17 @@ If Zotero BibTeX was exported, include a `references.bib` snippet for direct use
 - Update related work notes in project memory
 - If Obsidian is available, optionally create a literature review note in the vault
 
+> **Composed mode** — if invoked with `— composed: <canonical-report-path>` (an
+> orchestrator like `/idea-discovery` passes this), do **not** write a standalone
+> landscape `.md`. Return the structured table + narrative summary for the orchestrator
+> to fold into its canonical report as a "Literature Landscape" section; the report
+> links any saved PDFs/`references.bib`, it does not get a duplicate landscape file.
+> Step 6 (research-wiki ingest) still runs — the wiki is a separate persistent store,
+> not a duplicate of the report. **Default (no `— composed:` directive): behave exactly
+> as above — standalone, write files as documented.** Never infer composed mode from a
+> report file merely existing on disk. Full rules:
+> [`shared-references/output-composition.md`](../shared-references/output-composition.md).
+
 ### Step 6: Update Research Wiki
 
 **Required when `research-wiki/` exists.** Skip entirely (no action, no

--- a/skills/research-review/SKILL.md
+++ b/skills/research-review/SKILL.md
@@ -114,6 +114,16 @@ Save the full interaction and conclusions to a review document in the project ro
 
 Update project memory/notes with key review conclusions.
 
+> **Composed mode** — if invoked with `— composed: <canonical-report-path>` (an
+> orchestrator like `/idea-discovery` passes this), do **not** write a standalone review
+> `.md` in the project root. The raw conversation is already persisted to `.aris/traces/…`
+> (see *Review Tracing* below — that audit copy is kept in every mode); fold the review
+> *conclusions* (consensus, claims matrix, prioritized TODOs) into the orchestrator's
+> canonical report and cite the trace path there. **Default (no `— composed:` directive):
+> behave exactly as above — write the standalone review document.** Never infer composed
+> mode from a report file merely existing. Full rules:
+> [`shared-references/output-composition.md`](../shared-references/output-composition.md).
+
 ## Key Rules
 
 - ALWAYS use `config: {"model_reasoning_effort": "xhigh"}` for reviews

--- a/skills/shared-references/output-composition.md
+++ b/skills/shared-references/output-composition.md
@@ -1,0 +1,93 @@
+# Output Composition Protocol
+
+When a skill runs **inside an orchestrating pipeline** (e.g. `/idea-discovery`,
+`/research-pipeline`, `/grant-proposal`, `/kill-argument`), its intermediate
+findings should fold into the pipeline's single canonical deliverable instead of
+each sub-skill scattering its own overlapping `.md` files. When the same skill
+runs **on its own**, it writes its files exactly as documented — unchanged.
+
+This protocol defines the two states, the explicit signal that switches between
+them, and the **enforced default**: with no signal, behave standalone.
+
+> Past idea-discovery runs scattered `LIT_LANDSCAPE.md` + `RESEARCH_REVIEW.md` +
+> `MANIFEST.md` + multiple pilot logs whose content was *also* summarized inside
+> `IDEA_REPORT.md` — pure duplication. This contract is the fix, lifted out of the
+> individual skills so the ~20 skills that compose these don't each carry (and
+> drift) their own copy.
+
+## The two states
+
+- **Standalone (DEFAULT).** The skill writes its own output files exactly as its
+  SKILL.md documents. This is the behavior whenever no composed-mode signal is
+  present — see the fail-safe rule below.
+- **Composed.** The skill is running under an orchestrator that owns one canonical
+  deliverable. The skill's unique findings are folded into that deliverable (as a
+  section, appendix, or linked sub-file the orchestrator manages); the skill does
+  **not** emit standalone overlapping files.
+
+## Composed-mode signal (explicit, fail-safe)
+
+A skill is in composed mode **if and only if** an explicit signal is present:
+
+1. **Orchestrator directive (canonical signal).** The invoking skill passed
+   `— composed: <canonical-report-path>` in the arguments, e.g.
+   `— composed: idea-stage/IDEA_REPORT.md`. The value names the canonical doc to
+   fold into (it may not exist yet — the orchestrator creates/owns it). Orchestrators
+   MUST pass this directive to every sub-skill they want folded.
+2. **Escape hatch.** `— standalone` (or `— composed: false`) forces standalone even
+   if an orchestrator would otherwise pass the directive. Standalone always wins a
+   conflict.
+
+### Fail-safe rule (the one regression we cannot ship)
+
+**When no `— composed:` directive is present, the skill MUST behave standalone and
+write its files as normal.** This is enforced by the contract, not left to per-skill
+discretion.
+
+In particular: **the mere existence of a canonical report file (e.g. a leftover
+`idea-stage/IDEA_REPORT.md` from a previous run) does NOT trigger composed mode.**
+Inferring "composed" from a file on disk would silently swallow a standalone user's
+output the moment they happen to have an old report around — exactly the regression
+to avoid. Composed mode is a decision the orchestrator makes and signals explicitly;
+a sub-skill never guesses it.
+
+## What "fold in" means
+
+When in composed mode, a sub-skill:
+
+1. Returns / hands its unique content to the orchestrator for inlining into the
+   canonical deliverable, rather than writing `LIT_LANDSCAPE.md`,
+   `RESEARCH_REVIEW.md`, or similar standalone summaries.
+2. If it must use a scratch file mid-phase, deletes that scratch once its content is
+   inlined and the phase closes.
+3. Keeps **audit-trail** outputs where they belong — cross-model review traces always
+   go to `.aris/traces/…` per [`review-tracing.md`](review-tracing.md); the canonical
+   report cites the trace path instead of carrying a duplicate human-facing copy.
+4. Keeps **reusable** artifacts (a pilot script, a small results file) but discards
+   disposable scratch (launcher logs, smoke files, redundant `*_summary.json`) once
+   the numbers are in the canonical report.
+
+## Orchestrator responsibilities
+
+An orchestrator that wants folding:
+
+1. Owns exactly one canonical deliverable and passes its path via `— composed: <path>`
+   to each sub-skill.
+2. Inlines each sub-skill's returned findings into the canonical deliverable (or into
+   a small set of stage-scoped files it explicitly manages — e.g. `refine-logs/` —
+   which the report *links to*, not copies).
+3. Does not create a `MANIFEST.md` for a handful of files — see the threshold in
+   [`output-manifest.md`](output-manifest.md). A manifest is itself a duplicate index
+   that has to be kept in sync.
+4. On finish, the deliverable's directory top level should be roughly: the canonical
+   report (+ its `.html`), any reusable script + results, and explicitly-managed
+   stage sub-dirs. Nothing else unless it carries content not in the report.
+
+## Relationship to the other output protocols
+
+- [`output-versioning.md`](output-versioning.md) — *how* to write a file you do write
+  (timestamp + fixed-name copy). Composition decides *whether* a sub-skill writes a
+  standalone file at all.
+- [`output-manifest.md`](output-manifest.md) — only maintain a manifest above the
+  artifact threshold; below it the manifest is itself duplication.
+- [`output-language.md`](output-language.md) — orthogonal; applies in both states.

--- a/skills/shared-references/output-manifest.md
+++ b/skills/shared-references/output-manifest.md
@@ -1,6 +1,15 @@
 # Output Manifest Protocol
 
-After writing any output file, append an entry to `MANIFEST.md` in the project root.
+Maintain a `MANIFEST.md` in the project root **only when a run produces more than
+15 artifacts**. Below that threshold, do not create one: a manifest for a handful
+of files is itself a duplicate index that has to be kept in sync with the files it
+lists — the very duplication this protocol family exists to prevent (see
+[`output-composition.md`](output-composition.md)). When the threshold is met, append
+one entry per output file as below.
+
+> Threshold rationale: the original "log *every* output to MANIFEST" rule is what
+> drove the `MANIFEST.md` clutter in small idea-discovery runs. A manifest earns its
+> keep only when there are enough artifacts that an index genuinely helps.
 
 ## Format
 


### PR DESCRIPTION
Closes #277.
  
  Implements the design from #277 following @wanshuiyin's review guidance: a
  single shared contract (not per-skill rules), fail-safe to standalone, and a
  reconciled manifest protocol — wiring idea-discovery + its three sub-skills as
  the first scope.
  
  ## What changed
  
  **1. New shared contract — `shared-references/output-composition.md`** (review point #1)
  Lifts the "ONE canonical doc, no duplicate MDs" rule out of the individual
  skills so the ~20 composers don't each carry and drift their own copy. Defines:
  - **Two states**: standalone (default) vs composed.
  - **Explicit signal**: the orchestrator passes `— composed: <canonical-report-path>`;
    `— standalone` is the escape hatch.
  - **Enforced fail-safe** (review point #2 — the one regression we can't ship):
    no directive ⇒ standalone, and **the mere existence of a report file on disk
    never triggers folding**. Composed mode is an explicit orchestrator decision,
    never a sub-skill guess.
    
  **2. Reconciled `shared-references/output-manifest.md`** (review point #3)
  Softened "log *every* output to MANIFEST" → "only above 15 artifacts," since
  that rule is what drove the MANIFEST duplication in small runs.

  **3. Wired the orchestrator + 3 sub-skills**
  - `idea-discovery`: new "Output hygiene — ONE canonical doc" section citing the
    contract; passes `— composed: idea-stage/IDEA_REPORT.md` to `/research-lit`,
    `/idea-creator`, `/research-review`; softened the "Document everything" Key
    Rule; updated the Output Protocols block.
  - `research-lit` / `idea-creator` / `research-review`: composed-mode notes that
    fold findings into the canonical report when the directive is present, and
    **explicitly default to standalone otherwise**.

  ## Scope & follow-up
  
  Per the review's suggestion to keep this reviewable and low-risk, this PR is the
  contract + idea-discovery's three sub-skills only. A follow-up will expand the
  contract to the other composers (every literature source, research-pipeline,
  grant-proposal, kill-argument…) and mirror these edits into the `skills-codex*`
  overlays.
  
  Note: research-lit's existing "orchestrator maintains in-context list" awareness
  (≈L148/L196/L428) is the **D2 source-tracking** state — a different concept from
  output composition. Left untouched; the composition signal is a clean new
  directive rather than an overload of that mechanism.

  ## Verification
  - All `output-composition.md` links resolve; `— composed:` directives wired into
    all three phase invocations; no stale "log every output to MANIFEST" text
    remains in the edited skills.
  - Skill **count is unchanged** (this adds a shared-reference, not a skill), so
    the inventory/mirror checks are unaffected by this change.