### PR TITLE
fix(gemini-review): make debug-log fchmod Windows-compatible

### DIFF
--- a/mcp-servers/gemini-review/server.py
+++ b/mcp-servers/gemini-review/server.py
@@ -134,7 +134,7 @@ def append_private_text(path: Path, text: str) -> None:
         os.write(fd, text.encode("utf-8"))
         try:
             os.fchmod(fd, 0o600)
-        except OSError:
+        except (OSError, AttributeError):
             pass
     finally:
         os.close(fd)


### PR DESCRIPTION
## Problem
On Windows the `gemini-review` MCP server crashes at startup. `main()` calls `debug_log(...)` → `append_private_text()` → `os.fchmod(fd, 0o600)`. `os.fchmod` does not exist on Windows, so it raises **AttributeError**, which the surrounding `except OSError:` does not catch. The exception propagates and the server exits before the MCP handshake, so Claude Code reports `gemini-review: ✗ Failed to connect`.

## Root cause
`os.fchmod` is POSIX-only. The existing `try/except OSError` clearly intends to swallow the chmod-hardening failure, but on Windows the failure type is `AttributeError`, not `OSError`.

## Fix
Catch `AttributeError` alongside `OSError` so the fd-permission hardening is skipped where `os.fchmod` is absent. One line; no behavior change on POSIX.

```diff
-        except OSError:
+        except (OSError, AttributeError):
             pass
```

## Testing
- Windows 11 + Python 3.11: before — crashes with `AttributeError: module 'os' has no attribute 'fchmod'`; after — server starts and connects as an MCP reviewer.
- POSIX unaffected (`os.fchmod` present → identical behavior).