### PR TITLE
fix(skills): prefer bundle-file prompts for large Codex MCP payloads

### DIFF
--- a/skills/grant-proposal/SKILL.md
+++ b/skills/grant-proposal/SKILL.md
@@ -456,7 +456,7 @@ Which should I generate? (e.g., "1 and 3", "all", "skip")
 Invoke `/research-review` on the complete draft for grant-type-specific evaluation:
 
 ```
-/research-review "Complete [GRANT_TYPE] [GRANT_SUBTYPE] proposal draft. Evaluate as a [GRANT_TYPE] review panelist using official criteria. [PASTE FULL PROPOSAL TEXT]"
+/research-review "Read the grant review bundle at grant-proposal/codex_panel_review_bundle_round_1.md and evaluate it as a [GRANT_TYPE] [GRANT_SUBTYPE] review panelist using the official criteria."
 ```
 
 **What this does:**
@@ -472,11 +472,23 @@ If `/research-review` is invoked (preferred), it handles the Codex call internal
 
 #### Round 1 (full draft review):
 
+Write `grant-proposal/codex_panel_review_bundle_round_1.md` containing the
+criteria below plus the absolute path to `grant-proposal/GRANT_PROPOSAL.md`,
+then keep the Codex MCP prompt short:
+
 ```
 mcp__codex__codex-reply:
   threadId: [from Phase 2]
   config: {"model_reasoning_effort": "xhigh"}
   prompt: |
+    Read the grant review bundle at <absolute path to
+    grant-proposal/codex_panel_review_bundle_round_1.md> and follow all
+    instructions in it.
+```
+
+Bundle contents:
+
+```
     Review this complete [GRANT_TYPE] [GRANT_SUBTYPE] proposal draft.
 
     Act as a [GRANT_TYPE] review panelist. Evaluate using the official criteria:
@@ -494,18 +506,32 @@ mcp__codex__codex-reply:
     - Single most impactful change to improve funding chances?
     - Any fatal flaws?
 
-    [PASTE FULL PROPOSAL TEXT]
+    Proposal draft path (read this file yourself): <absolute path to
+    grant-proposal/GRANT_PROPOSAL.md>
 ```
 
 #### Round 2+ (after revisions):
 
 If MAX_REVIEW_ROUNDS > 1 and revisions were applied:
 
+Write `grant-proposal/codex_panel_review_bundle_round_N.md` containing the
+change log, any raw diff / changed-file paths worth inspecting, and the
+absolute path to the current `grant-proposal/GRANT_PROPOSAL.md`, then reuse the
+same short MCP prompt pattern:
+
 ```
 mcp__codex__codex-reply:
   threadId: [saved from Round 1]
   config: {"model_reasoning_effort": "xhigh"}
   prompt: |
+    Read the grant review bundle at <absolute path to
+    grant-proposal/codex_panel_review_bundle_round_N.md> and follow all
+    instructions in it.
+```
+
+Bundle contents:
+
+```
     [Round N review of revised [GRANT_TYPE] [GRANT_SUBTYPE] proposal]
 
     Since your last review, I have applied the following changes:
@@ -516,7 +542,8 @@ mcp__codex__codex-reply:
     Please re-evaluate. Same format: section scores, overall assessment, remaining weaknesses.
     Focus on whether the CRITICAL and MAJOR issues from Round 1 have been adequately addressed.
 
-    [PASTE REVISED PROPOSAL TEXT]
+    Revised proposal path (read this file yourself): <absolute path to
+    grant-proposal/GRANT_PROPOSAL.md>
 ```
 
 ### Phase 5: Revision & Output

--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -43,8 +43,11 @@ When calling the reviewer for idea evaluation, branch on REVIEWER_BACKEND:
     prompt: [follow-up prompt]
     config: {"model_reasoning_effort": "xhigh"}
 
-Prompt fidelity: the manual prompt must be exactly the same text that Codex would receive.
-Review tracing applies equally to both backends.
+Content fidelity: the manual reviewer should see the same substantive bundle
+content Codex would read. If the manual UI supports file upload / attachment,
+reuse the same bundle file; otherwise paste the bundle contents inline because
+remote web UIs cannot read your local filesystem paths. Review tracing applies
+equally to both backends.
 
 ## Workflow
 
@@ -164,19 +167,25 @@ the candidate set that enters Phase 3.
 
 Use the selected reviewer backend (see Reviewer Calling Convention) for divergent thinking.
 
-*For `codex` backend:*
+For the `codex` backend, **do not inline the full landscape + gaps prompt**
+once it stops being tiny. Write the full brainstorming request to
+`idea-stage/codex_brainstorm_bundle.md`, then keep the MCP prompt short:
 
 ```
 mcp__codex__codex:
   model: REVIEWER_MODEL
   config: {"model_reasoning_effort": "xhigh"}
   prompt: |
-    You are a senior ML researcher brainstorming research ideas.
+    Read the idea-generation bundle at <absolute path to
+    idea-stage/codex_brainstorm_bundle.md> and follow all instructions in it.
 ```
 
-*For `manual` backend:* use `mcp__manual_review__review` with the exact same prompt text and `config: {"model_reasoning_effort": "xhigh"}`. Save the returned `threadId` for Phase 4 follow-up.
+*For `manual` backend:* use `mcp__manual_review__review` with the same bundle
+contents. If the manual-review UI supports attachments, attach
+`idea-stage/codex_brainstorm_bundle.md`; otherwise paste the bundle contents
+inline. Save the returned `threadId` for Phase 4 follow-up.
 
-The brainstorming prompt:
+Bundle contents:
 
 ```
     You are a senior ML researcher brainstorming research ideas.
@@ -184,10 +193,10 @@ The brainstorming prompt:
     Research direction: [user's direction]
 
     Here is the current landscape:
-    [paste landscape map from Phase 1]
+    [write the Phase-1 landscape map into this bundle file]
 
     Key gaps identified:
-    [paste gaps from Phase 1]
+    [write the Phase-1 gap summary into this bundle file]
 
     Generate 8-12 concrete research ideas. For each idea:
     1. One-sentence summary
@@ -256,11 +265,18 @@ per-idea novelty search:
 1. **Cross-model triage (devil's advocate) — ranks ALL candidates first.**
    Use the selected reviewer backend (see Reviewer Calling Convention). For
    `codex`, use `mcp__codex__codex-reply` (same thread). For `manual`, use
-   `mcp__manual_review__review_reply` with the saved threadId. Pass every
-   candidate with its `prior_work` / `so_what` / `effort_note` annotations:
+   `mcp__manual_review__review_reply` with the saved threadId. For the
+   `codex` backend, write the full annotated candidate set to
+   `idea-stage/codex_triage_bundle.md` and send only a path-based follow-up:
+   ```
+   Read the idea-triage bundle at <absolute path to
+   idea-stage/codex_triage_bundle.md> and follow all instructions in it.
+   ```
+   For the `manual` backend, attach that same bundle if possible; otherwise
+   paste its contents inline. Bundle contents:
    ```
    Here is the full annotated candidate set (deduped, budget-feasible):
-   [paste all candidates with their prior_work / so_what / effort_note notes]
+   [write all candidates with their prior_work / so_what / effort_note notes]
 
    For each, play devil's advocate:
    - What's the strongest objection a reviewer would raise?

--- a/skills/novelty-check/SKILL.md
+++ b/skills/novelty-check/SKILL.md
@@ -41,11 +41,20 @@ For EACH core claim, search using ALL available sources:
 3. **Read abstracts**: For each potentially overlapping paper, WebFetch its abstract and related work section
 
 ### Phase C: Cross-Model Verification
-Call REVIEWER_MODEL via Codex MCP (`mcp__codex__codex`) with xhigh reasoning:
+Call REVIEWER_MODEL via Codex MCP (`mcp__codex__codex`) with xhigh reasoning.
+When the method description plus the Phase-B paper list is more than a short
+note, avoid pasting it inline into the MCP prompt. Write a dossier file such as
+`NOVELTY_DOSSIER.md` (or a project-local equivalent) containing the method
+description, core claims, candidate papers, and the exact questions below, then
+send only the file path:
 ```
-config: {"model_reasoning_effort": "xhigh"}
+mcp__codex__codex:
+  config: {"model_reasoning_effort": "xhigh"}
+  prompt: |
+    Read the novelty dossier at <absolute path to NOVELTY_DOSSIER.md> and
+    follow all instructions in it.
 ```
-Prompt should include:
+Dossier contents should include:
 - The proposed method description
 - All papers found in Phase B
 - Ask: "Is this method novel? What is the closest prior work? What is the delta?"

--- a/skills/research-refine/SKILL.md
+++ b/skills/research-refine/SKILL.md
@@ -315,13 +315,27 @@ Use this structure:
 
 ### Phase 2: External Method Review (Round 1)
 
-Send the full proposal to GPT-5.5 for an **elegance-first, frontier-aware, method-first** review. The reviewer should spend most of the critique budget on the method itself, not on expanding the experiment menu.
+Send the proposal to GPT-5.5 for an **elegance-first, frontier-aware,
+method-first** review. The reviewer should spend most of the critique budget
+on the method itself, not on expanding the experiment menu. For Codex MCP, do
+not inline the whole rubric + proposal once the prompt becomes large. Instead,
+write `refine-logs/codex_round_1_review_bundle.md` containing the instructions
+below plus the absolute path to `refine-logs/round-0-initial-proposal.md`, then
+keep the MCP prompt short:
 
 ```
 mcp__codex__codex:
   model: REVIEWER_MODEL
   config: {"model_reasoning_effort": "xhigh"}
   prompt: |
+    Read the review bundle at <absolute path to
+    refine-logs/codex_round_1_review_bundle.md> and follow all instructions in
+    it.
+```
+
+Bundle contents:
+
+```
     You are a senior ML reviewer for a top venue (NeurIPS/ICML/ICLR).
     This is an early-stage, method-first research proposal.
 
@@ -342,9 +356,8 @@ mcp__codex__codex:
     Read the Problem Anchor first. If your suggested fix would change the problem being solved,
     call that out explicitly as drift instead of treating it as a normal revision request.
 
-    === PROPOSAL ===
-    [Paste the FULL proposal from Phase 1]
-    === END PROPOSAL ===
+    Proposal path (read this file yourself): <absolute path to
+    refine-logs/round-0-initial-proposal.md>
 
     Score these 7 dimensions from 1-10:
 
@@ -494,7 +507,11 @@ Save to `refine-logs/round-N-refinement.md`:
 
 ### Phase 4: Re-evaluation (Round 2+)
 
-Send the revised proposal back to GPT-5.5 in the **same thread**:
+Send the revised proposal back to GPT-5.5 in the **same thread**. Again, keep
+the MCP payload short: write `refine-logs/codex_round_N_review_bundle.md`
+containing the re-evaluation instructions below, the key changes, and the
+absolute path to `refine-logs/round-N-refinement.md`, then ask Codex to read
+that bundle file.
 
 ```
 mcp__codex__codex-reply:
@@ -502,6 +519,14 @@ mcp__codex__codex-reply:
   model: REVIEWER_MODEL
   config: {"model_reasoning_effort": "xhigh"}
   prompt: |
+    Read the re-evaluation bundle at <absolute path to
+    refine-logs/codex_round_N_review_bundle.md> and follow all instructions in
+    it.
+```
+
+Bundle contents:
+
+```
     [Round N re-evaluation]
 
     I revised the proposal based on your feedback.
@@ -513,9 +538,8 @@ mcp__codex__codex-reply:
     2. [Method change 2]
     3. [Simplification / modernization / pushback if any]
 
-    === REVISED PROPOSAL ===
-    [Paste the FULL revised proposal]
-    === END REVISED PROPOSAL ===
+    Revised proposal path (read this file yourself): <absolute path to
+    refine-logs/round-N-refinement.md>
 
     Please:
     - Re-score the same 7 dimensions and overall

--- a/skills/research-review/SKILL.md
+++ b/skills/research-review/SKILL.md
@@ -40,8 +40,11 @@ When calling the reviewer, branch on REVIEWER_BACKEND:
     prompt: [follow-up prompt]
     config: {"model_reasoning_effort": "xhigh"}
 
-Prompt fidelity: the manual prompt must be exactly the same text that Codex would receive.
-Review tracing applies equally to both backends.
+Content fidelity: the manual reviewer should see the same substantive review
+brief Codex would read. If the manual UI supports file upload / attachment,
+reuse the same brief file; otherwise paste the brief contents inline because
+remote web UIs cannot read your local filesystem paths. Review tracing applies
+equally to both backends.
 
 ## Context: $ARGUMENTS
 
@@ -62,7 +65,9 @@ Before calling the external reviewer, compile a comprehensive briefing:
 3. Identify: core claims, methodology, key results, known weaknesses
 
 ### Step 2: Initial Review (Round 1)
-Send a detailed prompt with xhigh reasoning, using the selected backend.
+Send a detailed prompt with xhigh reasoning, using the selected backend. For
+the `codex` backend, keep the MCP payload short: write the full briefing to
+`RESEARCH_REVIEW_REQUEST.md`, then point Codex at that file.
 
 *For codex backend:*
 
@@ -70,7 +75,9 @@ Send a detailed prompt with xhigh reasoning, using the selected backend.
 mcp__codex__codex:
   config: {"model_reasoning_effort": "xhigh"}
   prompt: |
-    [Full research context + specific questions]
+    Read the review brief at <absolute path to RESEARCH_REVIEW_REQUEST.md>.
+    Executor notes are not evidence beyond the files they cite, so verify the
+    referenced artifacts before judging.
     Please act as a senior ML reviewer (NeurIPS/ICML level). Identify:
     1. Logical gaps or unjustified claims
     2. Missing experiments that would strengthen the story
@@ -79,12 +86,34 @@ mcp__codex__codex:
     Please be brutally honest.
 ```
 
-*For manual backend:* use `mcp__manual_review__review` with the same prompt and `config: {"model_reasoning_effort": "xhigh"}`. Save the returned `threadId`.
+The review brief should contain the full research context, the specific
+questions, and the primary artifact / raw-result paths the reviewer should
+inspect.
+
+*For manual backend:* use `mcp__manual_review__review` with the same brief
+contents. If the manual-review UI supports attachments, attach
+`RESEARCH_REVIEW_REQUEST.md`; otherwise paste the brief inline. Save the
+returned `threadId`.
 
 ### Step 3: Iterative Dialogue (Rounds 2-N)
 For `codex` backend: use `mcp__codex__codex-reply` with the returned `threadId`.
 For `manual` backend: use `mcp__manual_review__review_reply` with the same `threadId`.
-Use the appropriate tool to continue the conversation:
+Use the appropriate tool to continue the conversation. For Codex follow-up
+rounds, write an updated brief such as `RESEARCH_REVIEW_ROUND_2.md` and send
+only the path:
+
+```text
+mcp__codex__codex-reply:
+  threadId: [saved reviewer threadId from Step 2]
+  config: {"model_reasoning_effort": "xhigh"}
+  prompt: |
+    Read the updated review brief at <absolute path to
+    RESEARCH_REVIEW_ROUND_2.md>.
+    Focus on unresolved weaknesses and whether the revision actually fixed them.
+```
+
+For manual follow-up rounds, attach that same updated brief if possible;
+otherwise paste it inline.
 
 For each round:
 1. **Respond** to criticisms with evidence/counterarguments
@@ -127,7 +156,9 @@ Update project memory/notes with key review conclusions.
 ## Key Rules
 
 - ALWAYS use `config: {"model_reasoning_effort": "xhigh"}` for reviews
-- Send comprehensive context in Round 1 — the external model cannot read your files
+- Put comprehensive context in the review brief. Codex can read local files
+  when you pass an absolute path; manual reviewers usually cannot, so attach or
+  paste the same brief there.
 - Be honest about weaknesses — hiding them leads to worse feedback
 - Push back on criticisms you disagree with, but accept valid ones
 - Focus on ACTIONABLE feedback — "what experiment would fix this?"

--- a/tests/test_mainline_large_payload_prompts.py
+++ b/tests/test_mainline_large_payload_prompts.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAIN_SKILLS = REPO_ROOT / "skills"
+
+
+def read_skill(name: str) -> str:
+    return (MAIN_SKILLS / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_mainline_large_payload_skills_prefer_path_only_codex_prompts() -> None:
+    checks = {
+        "idea-creator": [
+            "idea-stage/codex_brainstorm_bundle.md",
+            "Read the idea-generation bundle at <absolute path",
+            "idea-stage/codex_triage_bundle.md",
+        ],
+        "research-review": [
+            "RESEARCH_REVIEW_REQUEST.md",
+            "Read the review brief at <absolute path",
+            "RESEARCH_REVIEW_ROUND_2.md",
+            "Read the updated review brief at <absolute path",
+        ],
+        "research-refine": [
+            "refine-logs/codex_round_1_review_bundle.md",
+            "Read the review bundle at <absolute path",
+            "refine-logs/codex_round_N_review_bundle.md",
+            "Read the re-evaluation bundle at <absolute path",
+        ],
+        "grant-proposal": [
+            "grant-proposal/codex_panel_review_bundle_round_1.md",
+            "Read the grant review bundle at <absolute path",
+            "grant-proposal/codex_panel_review_bundle_round_N.md",
+        ],
+        "novelty-check": [
+            "NOVELTY_DOSSIER.md",
+            "Read the novelty dossier at <absolute path",
+        ],
+    }
+
+    for skill, needles in checks.items():
+        text = read_skill(skill)
+        for needle in needles:
+            assert needle in text, f"{skill}: missing path-only prompt guidance: {needle}"
+
+
+def test_mainline_large_payload_skills_remove_inline_paste_placeholders() -> None:
+    forbidden = {
+        "idea-creator": [
+            "[paste landscape map from Phase 1]",
+            "[paste gaps from Phase 1]",
+            "[paste all candidates with their prior_work / so_what / effort_note notes]",
+        ],
+        "research-review": [
+            "[Full research context + specific questions]",
+        ],
+        "research-refine": [
+            "[Paste the FULL proposal from Phase 1]",
+            "[Paste the FULL revised proposal]",
+        ],
+        "grant-proposal": [
+            "[PASTE FULL PROPOSAL TEXT]",
+        ],
+    }
+
+    for skill, needles in forbidden.items():
+        text = read_skill(skill)
+        for needle in needles:
+            assert needle not in text, f"{skill}: still contains inline large-payload placeholder: {needle}"


### PR DESCRIPTION
Fixes #286.

This PR routes large Codex MCP prompt payloads through on-disk bundle files instead of inline stdio payloads in high-frequency mainline skills.

This is a skill-layer mitigation/workaround for #286, not a transport-layer fix to Codex MCP itself.

What changed:
- `idea-creator`: use `idea-stage/codex_brainstorm_bundle.md` and `idea-stage/codex_triage_bundle.md`
- `research-review`: use `RESEARCH_REVIEW_REQUEST.md` / follow-up review brief files
- `research-refine`: use `refine-logs/codex_round_*_review_bundle.md`
- `grant-proposal`: use `grant-proposal/codex_panel_review_bundle_round_*.md`
- `novelty-check`: document `NOVELTY_DOSSIER.md` workflow
- add regression tests to prevent large inline MCP placeholders from returning

Why:
- long inline Codex MCP stdio payloads can hang on Windows / Claude Code setups
- path-based prompting already matches the repo’s reviewer-independence direction
- this keeps the change focused at the skill layer without changing runtime behavior

Validation:
- `pytest tests/test_mainline_large_payload_prompts.py tests/test_codex_skill_mirror.py -q`
- 18 passed