### PR TITLE
feat: upgrade paper-figure with domain-aware plotting

### DIFF
--- a/skills/paper-figure/SKILL.md
+++ b/skills/paper-figure/SKILL.md
@@ -199,7 +199,7 @@ Save all snippets to `figures/latex_includes.tex` for easy copy-paste into the p
 
 ### Step 7: Figure Quality Review with REVIEWER_MODEL
 
-Send figure descriptions and captions to GPT-5.5 for review:
+Send figure descriptions and captions to GPT-5.4 for review:
 
 ```
 mcp__codex__codex:


### PR DESCRIPTION
Adds 7 chart types (bar/heatmap/scatter/line/box/forest/violin), 4 journal themes (Nature/Lancet/conservative/publication), and contract-first approach.

Key changes:
- Default color palette: colorblind (not tab10)
- Domain conventions loaded from KB before plotting
- Statistical annotation support (error bars, significance, CI)
- Contract-first: define what the figure proves before drawing
- Architecture diagrams delegated to /figure-spec

Signed-off-by: hxm2023