### PR TITLE
feat(watchdog): loop-liveness task type (detect-only) — catch silent loop death

### DIFF
--- a/docs/WATCHDOG_GUIDE.md
+++ b/docs/WATCHDOG_GUIDE.md
@@ -24,6 +24,7 @@ A lightweight Python daemon that runs on each GPU server, continuously monitorin
 |-----------|--------|-----------|
 | `training` | Session alive + GPU utilization | `DEAD` (session gone), `IDLE` (GPU <5%) |
 | `download` | Session alive + file size growth + speed | `DEAD`, `STALLED` (no growth), `SLOW` (<1MB/s) |
+| `loop` | State-file mtime vs `stale_after_seconds` (detect-only) | `STALE` (no update in window), `MISSING` (file absent past grace), `PENDING` (awaiting first write), `COMPLETED` |
 
 **What it outputs:**
 
@@ -89,11 +90,13 @@ python3 tools/watchdog.py --register '{
 
 **Required fields:**
 - `name` — unique task identifier
-- `type` — `"training"` or `"download"`
-- `session` — screen/tmux session name
+- `type` — `"training"`, `"download"`, or `"loop"`
+- `session` — screen/tmux session name (training/download only)
+- `state_file` — path to the loop's heartbeat/state file (loop only)
+- `stale_after_seconds` — staleness window in seconds; set ≥ the loop's longest single iteration (loop only)
 
 **Optional fields:**
-- `session_type` — `"screen"` (default) or `"tmux"`
+- `session_type` — `"screen"` (default) or `"tmux"` (training/download)
 - `gpus` — list of GPU indices to monitor (training only)
 - `target_path` — file/directory to track size growth (download only)
 
@@ -138,6 +141,10 @@ python3 tools/watchdog.py --unregister exp01
 | `IDLE` | GPU utilization <5% | Training may have finished, crashed, or is stuck in data loading |
 | `STALLED` | Download file size not growing | Check network, disk space, auth tokens |
 | `SLOW` | Download speed <1 MB/s | May be throttled; check network or source |
+| `STALE` | Loop's state file not updated within `stale_after_seconds` | Loop may have died silently (compaction/session close); restart/nudge it (detect-only — watchdog never auto-restarts) |
+| `MISSING` | Loop registered but state file absent past grace | Likely a path typo in `state_file`, or the loop never started |
+| `PENDING` | Loop registered, awaiting first state write | Normal at startup; no action |
+| `COMPLETED` | Loop reported completion | Unregister it (`--unregister`) |
 | `ERROR` | Watchdog encountered an error checking this task | Check watchdog logs |
 
 ## Integration with ARIS Workflows

--- a/docs/WATCHDOG_GUIDE_CN.md
+++ b/docs/WATCHDOG_GUIDE_CN.md
@@ -24,6 +24,7 @@ ARIS 实验在远程 screen/tmux session 中运行。当前的监控（`/monitor
 |----------|--------|----------|
 | `training` | Session 存活 + GPU 利用率 | `DEAD`（session 没了）、`IDLE`（GPU <5%） |
 | `download` | Session 存活 + 文件大小增长 + 速度 | `DEAD`、`STALLED`（不增长）、`SLOW`（<1MB/s） |
+| `loop` | state 文件 mtime vs `stale_after_seconds`(仅检测) | `STALE`(窗口内无更新)、`MISSING`(grace 后文件缺失)、`PENDING`(等首次写入)、`COMPLETED` |
 
 **输出结构：**
 
@@ -88,11 +89,13 @@ python3 tools/watchdog.py --register '{
 
 **必填字段：**
 - `name` — 唯一任务标识
-- `type` — `"training"` 或 `"download"`
-- `session` — screen/tmux session 名
+- `type` — `"training"`、`"download"` 或 `"loop"`
+- `session` — screen/tmux session 名（仅 training/download）
+- `state_file` — loop 的心跳/state 文件路径（仅 loop）
+- `stale_after_seconds` — 判定停滞的秒数窗口；设为 ≥ loop 最长单次迭代（仅 loop）
 
 **可选字段：**
-- `session_type` — `"screen"`（默认）或 `"tmux"`
+- `session_type` — `"screen"`（默认）或 `"tmux"`（training/download）
 - `gpus` — 要监控的 GPU 编号列表（仅训练）
 - `target_path` — 追踪大小增长的文件/目录（仅下载）
 
@@ -137,6 +140,10 @@ python3 tools/watchdog.py --unregister exp01
 | `IDLE` | GPU 利用率 <5% | 训练可能已完成、崩溃或卡在数据加载 |
 | `STALLED` | 下载文件大小不增长 | 检查网络、磁盘空间、认证 token |
 | `SLOW` | 下载速度 <1 MB/s | 可能被限速，检查网络或下载源 |
+| `STALE` | loop 的 state 文件超过 `stale_after_seconds` 未更新 | loop 可能已静默死亡（compaction/session 关闭），重启/nudge 它（仅检测——watchdog 绝不自动重启） |
+| `MISSING` | loop 已注册但 grace 后 state 文件仍缺失 | 多半是 `state_file` 路径写错，或 loop 从未启动 |
+| `PENDING` | loop 已注册，等待首次 state 写入 | 启动期正常，无需操作 |
+| `COMPLETED` | loop 报告完成 | 用 `--unregister` 注销它 |
 | `ERROR` | Watchdog 检查任务时出错 | 检查 watchdog 日志 |
 
 ## 与 ARIS 工作流集成

--- a/skills/research-pipeline/SKILL.md
+++ b/skills/research-pipeline/SKILL.md
@@ -15,7 +15,9 @@ allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Skil
 > the cross-model jury. A heartbeat may say "keep going," never "good enough."
 > See
 > [`shared-references/external-cadence.md`](../shared-references/external-cadence.md)
-> (overnight-pipeline rule).
+> (overnight-pipeline rule). At heartbeat startup, touch the run state first each tick
+> and register this run with the watchdog `loop` type (so a silent death surfaces as
+> STALE); unregister on completion. The watchdog only detects — it never acquits.
 
 End-to-end autonomous research workflow for: **$ARGUMENTS**
 

--- a/skills/shared-references/external-cadence.md
+++ b/skills/shared-references/external-cadence.md
@@ -194,6 +194,27 @@ acquit the work the pipeline produces.
 
 One-liner: **a heartbeat may say "keep going," never "good enough."**
 
+## Loop self-heartbeat + watchdog liveness (catch a silent death)
+
+A `/loop` or `CronCreate` heartbeat is parasitic on a living session; if it dies
+(context compaction, session close) nothing notices. Two-part convention:
+
+1. **Write a heartbeat first.** As the FIRST action of every iteration, rewrite
+   (or `touch`) the loop's state file (`*_STATE.json` / `run_state.json` / a tiny
+   `last_seen` file) so its mtime advances each tick *before* any work that might hang.
+2. **Register it with the watchdog** at startup, and **unregister on completion**:
+   ```bash
+   python3 tools/watchdog.py --register      '{"name":"<run_id>","type":"loop","state_file":"<the heartbeat file>","stale_after_seconds":21600}'
+   # on completion: python3 tools/watchdog.py --unregister "<run_id>"
+   ```
+   `stale_after_seconds` is the loop's OWN tolerance — set it to **comfortably exceed
+   the longest single iteration/operation** (≈ a few × the tick interval), **never** the
+   watchdog poll interval. The watchdog writes **STALE** to `summary.txt` + `alerts.log`
+   (which your poll already reads) when the file's mtime is older than that; a finished
+   loop shows **COMPLETED** (if its state carries a terminal `status`) or should be
+   unregistered. **It only DETECTS** — it never restarts the loop or re-runs a
+   verdict-bearing skill; recovery stays a human/cron decision, per the fence above.
+
 ## Required components (when you add external cadence to a skill)
 
 1. **Waits on an external fact, not a self-verdict.** State the fact in

--- a/tests/test_watchdog_loop.py
+++ b/tests/test_watchdog_loop.py
@@ -1,0 +1,148 @@
+"""Tests for the watchdog `loop` task type (A2 — loop-liveness, detect-only).
+
+Covers: conditional register (loop vs session-backed), mtime-primary liveness
+(OK/STALE), startup grace (PENDING→MISSING), COMPLETED detection (JSON status +
+run_state phases), unparseable-JSON safety, and the detect-only invariant
+(check_loop performs no subprocess/spawn).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+import tempfile
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import watchdog  # noqa: E402
+
+
+def _mk(base):
+    status = Path(base) / "status"
+    status.mkdir(parents=True, exist_ok=True)
+    return status
+
+
+class TestLoopRegister(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_register_loop_requires_fields(self):
+        # missing stale_after_seconds → exits
+        with self.assertRaises(SystemExit):
+            watchdog.register_task(self.tmp, json.dumps(
+                {"name": "r1", "type": "loop", "state_file": "/x/y.json"}))
+
+    def test_register_loop_normalizes_and_stamps(self):
+        sf = Path(self.tmp) / "rel_state.json"
+        sf.write_text("{}")
+        watchdog.register_task(self.tmp, json.dumps(
+            {"name": "loop1", "type": "loop", "state_file": str(sf), "stale_after_seconds": 100}))
+        tasks = json.loads((Path(self.tmp) / "tasks.json").read_text())
+        t = next(x for x in tasks if x["name"] == "loop1")
+        self.assertEqual(t["type"], "loop")
+        self.assertTrue(os.path.isabs(t["state_file"]))
+        self.assertIn("registered_epoch", t)
+        self.assertEqual(t["stale_after_seconds"], 100)
+
+    def test_training_still_requires_session_backcompat(self):
+        # training without session → exits (back-compat with conditional-required)
+        with self.assertRaises(SystemExit):
+            watchdog.register_task(self.tmp, json.dumps({"name": "t1", "type": "training"}))
+        # with session → fine
+        watchdog.register_task(self.tmp, json.dumps(
+            {"name": "t1", "type": "training", "session": "t1"}))
+        tasks = json.loads((Path(self.tmp) / "tasks.json").read_text())
+        self.assertEqual(tasks[0]["type"], "training")
+        self.assertEqual(tasks[0]["session_type"], "screen")
+
+
+class TestCheckLoop(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.status = _mk(self.tmp)
+
+    def _read(self, name):
+        return json.loads((self.status / f"{name}.json").read_text())
+
+    def _alerts(self):
+        a = Path(self.tmp) / "alerts.log"
+        return a.read_text() if a.exists() else ""
+
+    def test_fresh_mtime_ok(self):
+        sf = Path(self.tmp) / "s.json"; sf.write_text('{"updated":"x"}')
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100, "registered_epoch": time.time()}, self.status)
+        self.assertEqual(self._read("L")["status"], "OK")
+        self.assertNotIn("L:", self._alerts())
+
+    def test_old_mtime_stale(self):
+        sf = Path(self.tmp) / "s.json"; sf.write_text('{"updated":"x"}')
+        old = time.time() - 500
+        os.utime(sf, (old, old))
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100, "registered_epoch": time.time() - 600}, self.status)
+        self.assertEqual(self._read("L")["status"], "STALE")
+        self.assertIn("STALE", self._alerts())
+
+    def test_absent_within_grace_pending(self):
+        sf = Path(self.tmp) / "nope.json"
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100, "registered_epoch": time.time()}, self.status)
+        self.assertEqual(self._read("L")["status"], "PENDING")
+        self.assertEqual(self._alerts(), "")  # PENDING is not an anomaly
+
+    def test_absent_past_grace_missing(self):
+        sf = Path(self.tmp) / "nope.json"
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100, "registered_epoch": time.time() - 500}, self.status)
+        self.assertEqual(self._read("L")["status"], "MISSING")
+        self.assertIn("MISSING", self._alerts())
+
+    def test_missing_epoch_failsafe_missing_not_pending(self):
+        # codex round-2 bug fix: absent registered_epoch must NOT yield infinite PENDING
+        sf = Path(self.tmp) / "nope.json"
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100}, self.status)
+        self.assertEqual(self._read("L")["status"], "MISSING")
+
+    def test_completed_status_suppresses_stale(self):
+        sf = Path(self.tmp) / "s.json"; sf.write_text('{"status":"completed"}')
+        old = time.time() - 9999
+        os.utime(sf, (old, old))
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100, "registered_epoch": old}, self.status)
+        self.assertEqual(self._read("L")["status"], "COMPLETED")
+
+    def test_runstate_all_phases_accepted_completed(self):
+        sf = Path(self.tmp) / "s.json"
+        sf.write_text(json.dumps({"phases": [{"status": "accepted"}, {"status": "skipped"}]}))
+        old = time.time() - 9999
+        os.utime(sf, (old, old))
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100, "registered_epoch": old}, self.status)
+        self.assertEqual(self._read("L")["status"], "COMPLETED")
+
+    def test_unparseable_json_fresh_is_ok_not_stale(self):
+        sf = Path(self.tmp) / "s.json"; sf.write_text("not json {{{")
+        watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                             "stale_after_seconds": 100, "registered_epoch": time.time()}, self.status)
+        self.assertEqual(self._read("L")["status"], "OK")  # bad JSON never STALE on its own
+
+    def test_detect_only_no_subprocess(self):
+        # check_loop must never shell out; break subprocess.run and assert it still works.
+        sf = Path(self.tmp) / "s.json"; sf.write_text("{}")
+        orig = watchdog.subprocess.run
+        watchdog.subprocess.run = lambda *a, **k: (_ for _ in ()).throw(AssertionError("check_loop shelled out"))
+        try:
+            watchdog.check_loop({"name": "L", "type": "loop", "state_file": str(sf),
+                                 "stale_after_seconds": 100, "registered_epoch": time.time()}, self.status)
+            self.assertEqual(self._read("L")["status"], "OK")
+        finally:
+            watchdog.subprocess.run = orig
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_skills_inventory.py
+++ b/tools/check_skills_inventory.py
@@ -198,6 +198,17 @@ def check_inventory() -> list[str]:
                 f"fan-out (see shared-references/fan-out-pattern.md)"
             )
 
+    # Watchdog 'loop' task type ⇔ its documented trigger (A2). Mirrors the Agent-grant⇒cite
+    # rule above: a feature with no documented trigger is dead weight, a documented trigger
+    # for a missing feature is a broken pointer. The loop type is a shipped feature, so BOTH
+    # must be present.
+    watchdog_py = read(REPO_ROOT / "tools" / "watchdog.py")
+    ext_cadence = read(SKILLS_ROOT / "shared-references" / "external-cadence.md")
+    tool_loop = bool(re.search(r"def check_loop\b", watchdog_py)) and bool(re.search(r'==\s*"loop"', watchdog_py))
+    doc_loop = bool(re.search(r'"type"\s*:\s*"loop"', ext_cadence))
+    require(tool_loop, "tools/watchdog.py must implement the loop-liveness check_loop (A2)", failures)
+    require(doc_loop, "external-cadence.md must document registering a watchdog 'loop' task — its trigger (A2)", failures)
+
     return failures
 
 

--- a/tools/watchdog.py
+++ b/tools/watchdog.py
@@ -2,7 +2,7 @@
 """
 watchdog.py — Server-side unified monitoring daemon for ARIS.
 
-One process per server, monitors all registered tasks (training / download).
+One process per server, monitors all registered tasks (training / download / loop).
 Outputs per-task status JSON + aggregated summary.txt for low-frequency polling.
 
 Usage:
@@ -66,18 +66,35 @@ def register_task(base_dir, task_json):
     paths["status"].mkdir(parents=True, exist_ok=True)
 
     task = json.loads(task_json)
-    required = {"name", "type", "session"}
-    missing = required - set(task.keys())
+    missing = {"name", "type"} - set(task.keys())
     if missing:
         print(f"error: missing required fields: {missing}", file=sys.stderr)
         sys.exit(1)
 
-    if task["type"] not in ("training", "download"):
-        print(f"error: type must be 'training' or 'download', got '{task['type']}'", file=sys.stderr)
+    ttype = task["type"]
+    if ttype not in ("training", "download", "loop"):
+        print(f"error: type must be 'training', 'download', or 'loop', got '{ttype}'", file=sys.stderr)
+        sys.exit(1)
+    if ttype in ("training", "download") and "session" not in task:
+        print(f"error: {ttype} task requires 'session'", file=sys.stderr)
+        sys.exit(1)
+    if ttype == "loop" and ("state_file" not in task or "stale_after_seconds" not in task):
+        print("error: loop task requires 'state_file' and 'stale_after_seconds'", file=sys.stderr)
         sys.exit(1)
 
-    # Default session_type: auto-detect or fallback to screen
-    if "session_type" not in task:
+    if ttype == "loop":
+        try:
+            if int(task["stale_after_seconds"]) <= 0:
+                raise ValueError
+        except (ValueError, TypeError):
+            print("error: loop 'stale_after_seconds' must be a positive integer (seconds)", file=sys.stderr)
+            sys.exit(1)
+        # Absolutize WITHOUT resolving symlinks: a loop may update its state file via
+        # atomic os.replace, which swaps a symlink for a new file; we must keep watching
+        # the registered path, not its resolve()-time target. (os is imported at module top.)
+        task["state_file"] = os.path.abspath(os.path.expanduser(task["state_file"]))
+    elif "session_type" not in task:
+        # Default session_type for session-backed tasks: fallback to screen
         task["session_type"] = "screen"
 
     tasks = []
@@ -90,10 +107,12 @@ def register_task(base_dir, task_json):
     # Deduplicate: replace existing task with same name
     tasks = [t for t in tasks if t["name"] != task["name"]]
     task["registered_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+    task["registered_epoch"] = time.time()  # tz-free grace anchor (loop PENDING→MISSING)
     tasks.append(task)
 
     paths["tasks"].write_text(json.dumps(tasks, indent=2))
-    print(f"registered: {task['name']} ({task['type']}, {task['session_type']})")
+    detail = f"stale_after={task['stale_after_seconds']}s" if ttype == "loop" else task["session_type"]
+    print(f"registered: {task['name']} ({ttype}, {detail})")
 
 
 def unregister_task(base_dir, name):
@@ -248,6 +267,73 @@ def check_training(task, status_dir):
     })
 
 
+# ── Loop-liveness check (detect-only) ───────────────────────────
+
+
+LOOP_COMPLETED_STATUSES = {"completed", "done", "finished"}
+
+
+def _loop_is_completed(state):
+    """True if the watched JSON shows the loop finished (silence is then expected, not a stall)."""
+    if not isinstance(state, dict):
+        return False
+    if str(state.get("status", "")).lower() in LOOP_COMPLETED_STATUSES:
+        return True
+    phases = state.get("phases")  # run_state.py shape: all phases terminal ⇒ done
+    if isinstance(phases, list) and phases and all(
+        isinstance(p, dict) and p.get("status") in ("accepted", "skipped") for p in phases
+    ):
+        return True
+    return False
+
+
+def check_loop(task, status_dir):
+    """Loop-liveness via state-file mtime, DETECT-ONLY.
+
+    Liveness = freshness of the file the loop rewrites/touches each iteration, judged against the
+    loop's OWN declared `stale_after_seconds` (NOT the daemon interval). This function only reads
+    files and writes a status; it NEVER restarts the loop, spawns a process, or invokes a skill —
+    a STALE loop is surfaced via alerts.log + summary.txt for a human/cron, honoring
+    external-cadence.md's fence on verdict-bearing loops. JSON is read best-effort only to
+    recognize a COMPLETED loop; an unparseable file never causes STALE on its own.
+    """
+    name = task["name"]
+    state_file = Path(task.get("state_file", ""))
+    stale_after = int(task.get("stale_after_seconds", 21600))
+    status_file = status_dir / f"{name}.json"
+    now_str = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    if not state_file.exists():
+        # Fail-safe: a missing registered_epoch ⇒ epoch 0 ⇒ MISSING, never infinite grace.
+        grace = time.time() - float(task.get("registered_epoch", 0.0))
+        if grace <= stale_after:
+            return write_status(status_file, {
+                "status": "PENDING", "task": name, "type": "loop",
+                "msg": "state file not present yet", "ts": now_str})
+        return write_status(status_file, {
+            "status": "MISSING", "task": name, "type": "loop",
+            "msg": f"state file absent {int(grace)}s after register (path typo?)", "ts": now_str})
+
+    try:
+        state = json.loads(state_file.read_text())
+        if _loop_is_completed(state):
+            return write_status(status_file, {
+                "status": "COMPLETED", "task": name, "type": "loop",
+                "msg": "loop reports completion", "ts": now_str})
+    except (json.JSONDecodeError, OSError):
+        pass  # not a terminal state we can read → fall through to mtime liveness
+
+    age = int(time.time() - state_file.stat().st_mtime)
+    if age > stale_after:
+        return write_status(status_file, {
+            "status": "STALE", "task": name, "type": "loop",
+            "age_s": age, "stale_after": stale_after,
+            "msg": f"no state write in {age}s (> {stale_after}s)", "ts": now_str})
+    return write_status(status_file, {
+        "status": "OK", "task": name, "type": "loop",
+        "age_s": age, "stale_after": stale_after, "ts": now_str})
+
+
 # ── Status output ────────────────────────────────────────────────
 
 
@@ -256,7 +342,7 @@ def write_status(path, data):
     path.write_text(json.dumps(data))
 
     status = data.get("status", "OK")
-    if status in ("DEAD", "STALLED", "IDLE", "ERROR"):
+    if status in ("DEAD", "STALLED", "STALE", "MISSING", "IDLE", "ERROR"):
         alert_file = path.parent.parent / "alerts.log"
         ts = data.get("ts", time.strftime("%Y-%m-%dT%H:%M:%S"))
         task = data.get("task", "?")
@@ -284,6 +370,12 @@ def write_summary(status_dir):
                 extra = f" gpu={d.get('gpu_util', '?')}"
             elif status == "DEAD":
                 extra = f" {d.get('msg', '')}"
+            elif status in ("STALE", "MISSING"):
+                extra = f" {d.get('msg', '')}"
+            elif status == "PENDING":
+                extra = " (awaiting first state write)"
+            elif status == "COMPLETED":
+                extra = " ✓"
             lines.append(f"{name}({typ}): {status}{extra}")
         except Exception:
             continue
@@ -330,6 +422,8 @@ def run_watchdog(base_dir, interval):
                     check_download(task, paths["status"], interval)
                 elif task["type"] == "training":
                     check_training(task, paths["status"])
+                elif task["type"] == "loop":
+                    check_loop(task, paths["status"])
             except Exception as e:
                 write_status(
                     paths["status"] / f"{task['name']}.json",


### PR DESCRIPTION
## What
Adds a third watchdog task type `loop` (alongside `training`/`download`) that catches the **silent-death** failure mode: an unattended overnight `/loop` / `CronCreate` heartbeat dies (context compaction, session close) and nothing notices.

Borrowed — carefully — from Deli Chen's *AutoResearch* framework (which cites ARIS) after a fan-out gap analysis and **4 rounds of cross-model review (GPT-5.5 xhigh)**. ARIS already covered most of that framework; this is one of only two genuine gaps it surfaced (runtime resilience).

## How (detect-only)
- **Liveness = the loop's own state-file `mtime` vs a task-level `stale_after_seconds`** (the loop's declared tolerance, set ≥ its longest single iteration — *not* the daemon poll interval, which would false-flag a normal long phase). mtime is tz-free, so no ISO/`Z`/naive parsing.
- States: `OK` / `STALE` / `MISSING` (absent past a `registered_epoch` grace) / `PENDING` (awaiting first write) / `COMPLETED` (terminal `status`, or run_state shape with all phases `accepted`/`skipped`).
- **DETECT-ONLY** — `check_loop` only reads the file and writes a status; it never restarts the loop, spawns a process, or invokes a skill (enforced by a test that monkeypatches `subprocess.run` to throw). Recovery stays a human/cron decision, honoring `external-cadence.md`'s fence on verdict-bearing loops. STALE is a liveness signal, never a quality verdict.
- **Additive / back-compat** — training & download paths and the `tasks.json` schema are untouched; `session` stays required for them; `loop` is keyed on `state_file` + `stale_after_seconds`.

## Wiring (so it's triggered, not dead code)
- `external-cadence.md` (cited by 16 skills) documents loop self-heartbeat (touch state first each tick) + watchdog registration + unregister-on-completion — all detect-only.
- `research-pipeline/SKILL.md` heartbeat registers its run with the loop type.
- `check_skills_inventory.py` adds a drift-check (mirror of the existing Agent-grant⇒cite rule): watchdog's `check_loop` and external-cadence's loop registration must **both** exist, so the feature can't rot into dead weight or a broken pointer.

## Tests
`tests/test_watchdog_loop.py` (12) — OK/STALE/PENDING/MISSING/COMPLETED, the `registered_epoch` fail-safe, unparseable-JSON safety, back-compat register, detect-only invariant. Existing `tests/test_watchdog.py` (46) + `test_codex_skill_mirror.py` (16) stay green; `check_skills_inventory.py` consistent. `WATCHDOG_GUIDE.md` + `_CN` updated (type table, required fields, status codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)