### PR TITLE
feat(stall-pivot): iteration_log.py — overnight stall detection → forced structural pivot

### DIFF
--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -180,7 +180,14 @@ Which ideas should I validate further? Or should I regenerate with different con
 ```
 
 - **User picks ideas** (or no response + AUTO_PROCEED=true) → proceed to Phase 3 with top-ranked ideas.
-- **User unhappy with all ideas** → collect feedback ("what's missing?", "what direction do you prefer?"), update the prompt with user's constraints, and re-run Phase 2 (idea generation). Repeat until the user selects at least 1 idea.
+- **User unhappy with all ideas** → collect feedback ("what's missing?", "what direction do you prefer?"), update the prompt with user's constraints, and re-run Phase 2 (idea generation). Before
+  regenerating, read the already-tried directions (research-wiki Failed Ideas + any
+  `.aris/runs/<run_id>.iterations.jsonl`) and forbid a candidate too close to one already
+  tried — enforced direction diversity; when an overnight heartbeat drives the run,
+  record each chosen direction via `iteration_log.py note ... --direction "<frame>"`
+  so later ticks can reject near-duplicates (see
+  [`shared-references/external-cadence.md`](../shared-references/external-cadence.md) →
+  Stall detection & forced structural pivot). Repeat until the user selects at least 1 idea.
 - **User wants to adjust scope** → go back to Phase 1 with refined direction.
 
 ### Phase 3: Deep Novelty Verification

--- a/skills/research-pipeline/SKILL.md
+++ b/skills/research-pipeline/SKILL.md
@@ -15,9 +15,16 @@ allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Skil
 > the cross-model jury. A heartbeat may say "keep going," never "good enough."
 > See
 > [`shared-references/external-cadence.md`](../shared-references/external-cadence.md)
-> (overnight-pipeline rule). At heartbeat startup, touch the run state first each tick
-> and register this run with the watchdog `loop` type (so a silent death surfaces as
-> STALE); unregister on completion. The watchdog only detects — it never acquits.
+> (overnight-pipeline rule + stall detection & forced structural pivot). At heartbeat
+> startup, touch the run state first each tick and register this run with the watchdog
+> `loop` type (so a silent death surfaces as STALE); unregister on completion. The
+> watchdog only detects — it never acquits. Each tick also record the new-finding count
+> via the `iteration_log.py` helper (resolve through the canonical
+> `.aris/tools → tools → $ARIS_REPO/tools` chain, integration-contract §2; warn-and-skip
+> if unresolved): `python3 "$ITER_LOG" note <root> <run_id> <phase> <n>`. On the returned
+> `pivot=structural` (stale ≥ 2) the nudge must change a STRUCTURAL constraint and pick an
+> untried direction; on `pivot=human` (stale ≥ 4) flag for attention. Counting only —
+> never a quality verdict.
 
 End-to-end autonomous research workflow for: **$ARGUMENTS**
 
@@ -90,6 +97,40 @@ output JSON) — not just the reviewer label.
 
 A stage left `done` (gate failed/ambiguous, or the run crashed before the gate)
 is re-validated on the next resume — the acceptance obligation is never skipped.
+
+## Overnight heartbeat: stall detection → forced structural pivot
+
+Only when an unattended heartbeat is driving this run (overnight `/loop` /
+`CronCreate`). Skip otherwise. Doctrine + rationale:
+[`shared-references/external-cadence.md`](../shared-references/external-cadence.md)
+→ "Stall detection & forced structural pivot". This is a Type-A signal — it counts
+findings and changes *direction*, never *judges quality*.
+
+Resolve the helper via the canonical chain (integration-contract §2), warn-and-skip
+if unresolved (never block the run):
+```bash
+ITER_LOG=".aris/tools/iteration_log.py"
+[ -f "$ITER_LOG" ] || ITER_LOG="tools/iteration_log.py"
+[ -f "$ITER_LOG" ] || ITER_LOG="${ARIS_REPO:-}/tools/iteration_log.py"
+[ -f "$ITER_LOG" ] || { echo "WARN: iteration_log.py not resolved; skipping stall detection" >&2; ITER_LOG=""; }
+```
+Then, **each heartbeat tick**, record how many concrete new findings the current
+stage produced and read the returned `pivot`:
+```bash
+[ -n "$ITER_LOG" ] && python3 "$ITER_LOG" note "$ROOT" "$RUN_ID" "$STAGE" "$N_NEW_FINDINGS"
+# → {"stale_count": N, "pivot": "none|structural|human"}
+```
+Act on `pivot`:
+- `none` — keep going.
+- `structural` (stale ≥ 2) — the next nudge must change a **structural constraint**
+  (frame / objective / data / representation), not a tactical parameter, and pick a
+  direction different from every one already tried. Record the chosen frame so future
+  ticks can avoid it: `python3 "$ITER_LOG" note "$ROOT" "$RUN_ID" "$STAGE" 0 --direction "<the new frame>"`.
+- `human` (stale ≥ 4) — stop nudging blindly; flag for human attention (escalate, do
+  not silently abandon).
+
+The heartbeat may say "keep going / change direction," never "good enough" — every
+quality verdict still terminates in the cross-model jury (`acceptance-gate.md`).
 
 ## Pipeline
 

--- a/skills/shared-references/external-cadence.md
+++ b/skills/shared-references/external-cadence.md
@@ -215,6 +215,35 @@ A `/loop` or `CronCreate` heartbeat is parasitic on a living session; if it dies
    unregistered. **It only DETECTS** — it never restarts the loop or re-runs a
    verdict-bearing skill; recovery stays a human/cron decision, per the fence above.
 
+## Stall detection & forced structural pivot
+
+An overnight loop can spin: each iteration tries a near-variant of the last and gets
+diminishing returns. Detect it mechanically and force a *structural* change — not harder
+tuning of the same frame.
+
+- **Count, don't vibe.** Each iteration, record the number of NEW findings (concrete
+  added entries — new evidence, a falsified hypothesis, a candidate direction — *not* a
+  subjective "valuable result"). Resolve the helper via the canonical chain
+  (integration-contract §2): `.aris/tools/iteration_log.py` → `tools/iteration_log.py` →
+  `$ARIS_REPO/tools/iteration_log.py` (warn-and-skip if unresolved), then
+  `python3 "$ITER_LOG" note <root> <run_id> <phase> <new_findings> [--direction "..."]`.
+  Consecutive zero-finding iterations accumulate a `stale_count` in
+  `.aris/runs/<run_id>.iterations.jsonl` — a sidecar that does **not** touch run_state's
+  done/accepted state.
+- **Forced pivot ladder** (the heartbeat reads the returned `pivot`):
+  - `stale_count >= 2` → **pivot structure, not tactics**: change a structural constraint
+    (frame / objective / data / representation), not a tactical parameter, and pick a
+    direction that differs from every one already tried.
+  - `stale_count >= 4` → **escalate to a human** (flag for attention; stop nudging blindly).
+- **Direction diversity.** Before a re-generation, read the tried directions (research-wiki
+  Failed Ideas + the iteration ledger) and reject a candidate too close to one already tried.
+
+This is a Type-A signal — it counts findings and changes *direction*, it never *judges
+quality* ("keep going / change direction," never "good enough"; quality stays with the
+cross-model jury, acceptance-gate.md). Why structure over tactics: when a task stalls
+repeatedly inside one frame, the decisive gain comes from correcting the frame itself, not
+from tuning parameters harder within it.
+
 ## Required components (when you add external cadence to a skill)
 
 1. **Waits on an external fact, not a self-verdict.** State the fact in

--- a/skills/shared-references/integration-contract.md
+++ b/skills/shared-references/integration-contract.md
@@ -324,6 +324,7 @@ here first.
 | `capture_filter.py` (in `/research-wiki` capture, `/meta-optimize` Step 3) | B (side-effect) | Anti-self-poisoning screen on durable captures; if unresolved the capture proceeds (the screen is advisory, and a passing screen is never an ACCEPT — the cross-model jury still judges) |
 | `provenance.py` (in `/meta-apply`; `assert_cross_family`/`stamp`) | A (gate) | The landing acquittal: if unresolved, `/meta-apply` cannot verify author≠reviewer family and MUST refuse to land (fail-closed). `stamp()` itself raises on same-family, so an unresolved or same-family case blocks the corpus mutation |
 | `run_state.py` (in `/research-pipeline`) | B (side-effect) | Resumability is a convenience; the pipeline still runs end-to-end without it (warn-and-skip, never block). Predicate = `RESUMABLE` / `— resume <run_id>` set |
+| `iteration_log.py` (in `/research-pipeline`, `/idea-discovery`) | B (side-effect) | Stall→pivot ledger is a convenience for overnight loops; the pipeline runs without it (warn-and-skip, never block). Predicate = an overnight heartbeat is driving the loop. Mainline-only for now (Codex-mirror sync pending external-cadence mirror). |
 
 When a SKILL invokes a helper not listed above, add the row here as
 part of the same commit and link the chosen policy. Inconsistency in

--- a/tests/test_iteration_log.py
+++ b/tests/test_iteration_log.py
@@ -1,0 +1,85 @@
+"""Tests for iteration_log.py — stall detection → forced structural pivot (B)."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import iteration_log as il  # noqa: E402
+
+
+class TestIterationLog(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.run = "demo-run"
+
+    def _path(self):
+        return Path(self.root) / ".aris" / "runs" / f"{self.run}.iterations.jsonl"
+
+    def test_findings_reset_stale(self):
+        r = il.note(self.root, self.run, "lit", 3)
+        self.assertEqual(r["stale_count"], 0)
+        self.assertEqual(r["pivot"], "none")
+
+    def test_stall_ladder(self):
+        self.assertEqual(il.note(self.root, self.run, "p", 0)["pivot"], "none")        # stale 1
+        r2 = il.note(self.root, self.run, "p", 0)                                       # stale 2
+        self.assertEqual((r2["stale_count"], r2["pivot"]), (2, "structural"))
+        r3 = il.note(self.root, self.run, "p", 0)                                       # stale 3
+        self.assertEqual(r3["pivot"], "structural")
+        r4 = il.note(self.root, self.run, "p", 0)                                       # stale 4
+        self.assertEqual((r4["stale_count"], r4["pivot"]), (4, "human"))
+
+    def test_findings_break_the_stall(self):
+        il.note(self.root, self.run, "p", 0)
+        il.note(self.root, self.run, "p", 0)        # stale 2 → structural
+        r = il.note(self.root, self.run, "p", 5)    # progress resets
+        self.assertEqual((r["stale_count"], r["pivot"]), (0, "none"))
+
+    def test_sidecar_path_and_append_only(self):
+        il.note(self.root, self.run, "p", 1)
+        il.note(self.root, self.run, "p", 0)
+        p = self._path()
+        self.assertTrue(p.is_file())
+        lines = [l for l in p.read_text().splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2)  # append-only: one line per note
+        self.assertEqual(json.loads(lines[0])["new_findings"], 1)
+
+    def test_does_not_touch_run_state(self):
+        # B must not write run_state.py's <run_id>.json — only the .iterations.jsonl sidecar
+        il.note(self.root, self.run, "p", 0)
+        self.assertFalse((Path(self.root) / ".aris" / "runs" / f"{self.run}.json").exists())
+
+    def test_tolerates_garbled_line(self):
+        p = self._path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('{"stale_count": 1}\nGARBAGE NOT JSON\n')
+        r = il.note(self.root, self.run, "p", 0)   # last good stale was 1 → now 2
+        self.assertEqual(r["stale_count"], 2)
+
+    def test_show(self):
+        il.note(self.root, self.run, "p", 2)
+        self.assertIn('"new_findings": 2', il.show(self.root, self.run))
+        self.assertEqual(il.show(self.root, "no-such-run"), "")
+
+    def test_invalid_run_id_rejected(self):
+        # path-escape / separators must be rejected like run_state.py
+        for bad in ("../escape", "a/b", "..", ".", "a b", "a;rm -rf x", "", "x/../y"):
+            with self.assertRaises(ValueError):
+                il.note(self.root, bad, "p", 0)
+
+    def test_direction_field_recorded(self):
+        il.note(self.root, self.run, "p", 0, direction="reframe as graph problem")
+        line = [l for l in self._path().read_text().splitlines() if l.strip()][-1]
+        self.assertEqual(json.loads(line)["direction"], "reframe as graph problem")
+        # omitted direction → field absent (not null)
+        il.note(self.root, self.run, "p", 1)
+        last = json.loads([l for l in self._path().read_text().splitlines() if l.strip()][-1])
+        self.assertNotIn("direction", last)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_skills_inventory.py
+++ b/tools/check_skills_inventory.py
@@ -209,6 +209,23 @@ def check_inventory() -> list[str]:
     require(tool_loop, "tools/watchdog.py must implement the loop-liveness check_loop (A2)", failures)
     require(doc_loop, "external-cadence.md must document registering a watchdog 'loop' task — its trigger (A2)", failures)
 
+    # iteration_log.py (stall→pivot, B) must exist AND be both documented (the ladder with
+    # both thresholds) and actually wired into a heartbeat consumer — else it is dead code.
+    # Same dead-code guard as the Agent-grant⇒cite rule above.
+    extc = read(SKILLS_ROOT / "shared-references" / "external-cadence.md")
+    rp = read(SKILLS_ROOT / "research-pipeline" / "SKILL.md")
+    tool_stall = (REPO_ROOT / "tools" / "iteration_log.py").is_file()
+    doc_ladder = bool(re.search(r"forced structural pivot", extc, re.IGNORECASE)) and \
+        bool(re.search(r"stale_count`?\s*>=\s*2", extc)) and bool(re.search(r"stale_count`?\s*>=\s*4", extc))
+    # Prove the wiring is real (not a prose mention): resolver chain + note invocation +
+    # both pivot branches handled in research-pipeline.
+    wired = ('iteration_log.py' in rp and 'ITER_LOG' in rp
+             and re.search(r'"\$ITER_LOG"\s+note', rp) is not None
+             and 'pivot' in rp and 'structural' in rp and 'human' in rp)
+    require(tool_stall, "tools/iteration_log.py (stall→pivot, B) must exist", failures)
+    require(doc_ladder, "external-cadence.md must document the stall ladder with both thresholds (>=2 structural, >=4 human) (B)", failures)
+    require(wired, "research-pipeline/SKILL.md must actually wire iteration_log.py (resolver + `$ITER_LOG note` + pivot handling) — not just mention it (B)", failures)
+
     return failures
 
 

--- a/tools/iteration_log.py
+++ b/tools/iteration_log.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""iteration_log.py — overnight-loop stall detection → forced structural pivot.
+
+Append-only per-iteration ledger for an unattended research loop. Each tick the
+orchestrator records how many NEW findings the iteration produced — where a "finding"
+is a concrete added entry (new evidence, a falsified hypothesis, a candidate direction),
+NOT a subjective "valuable result". Consecutive zero-finding iterations accumulate a
+stale_count, which drives a forced pivot:
+
+  stale_count >= 2  → pivot = "structural"  (change a STRUCTURAL constraint, not tactical params)
+  stale_count >= 4  → pivot = "human"        (flag for human attention)
+
+This is a **Type-A signal**: it COUNTS entries and changes *direction*; it does NOT judge
+quality — quality/correctness stays with the cross-model jury (shared-references/
+acceptance-gate.md). It only ever says "keep going / change direction," never "good enough".
+
+The ledger is a sidecar at `.aris/runs/<run_id>.iterations.jsonl`; it deliberately does
+NOT import or touch run_state.py's done/accepted state machine (only shares the `.aris/runs/`
+dir, with a distinct `.iterations.jsonl` suffix). An optional `direction` per record lets
+the loop's re-generation step reject candidates too close to a tried direction. See
+shared-references/external-cadence.md → "Stall detection & forced structural pivot".
+
+Usage:
+    python3 iteration_log.py note <root> <run_id> <phase> <new_findings> [--direction "..."]
+    python3 iteration_log.py show <root> <run_id>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX
+    fcntl = None  # type: ignore
+
+PIVOT_STRUCTURAL_AT = 2   # consecutive zero-finding iterations → force a structural pivot
+ESCALATE_HUMAN_AT = 4     # still stalled → flag for human attention
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _log_path(root: str, run_id: str) -> Path:
+    # Same run_id discipline as run_state.py: no path escape.
+    safe = "".join(c for c in run_id if c.isalnum() or c in "-_.")
+    if not safe or safe != run_id or run_id in (".", ".."):
+        raise ValueError(f"invalid run_id {run_id!r} (use [A-Za-z0-9-_.])")
+    return Path(root) / ".aris" / "runs" / f"{run_id}.iterations.jsonl"
+
+
+@contextmanager
+def _lock(path: Path) -> Iterator[None]:
+    """Best-effort advisory lock (single-orchestrator contract; guards a stray resumer)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if fcntl is None:
+        yield
+        return
+    fh = open(path.with_suffix(".jsonl.lock"), "w")
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+        finally:
+            fh.close()
+
+
+def _last_stale(path: Path) -> int:
+    """Read the most recent stale_count from the append-only ledger (0 if none)."""
+    if not path.is_file():
+        return 0
+    last = 0
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                last = int(json.loads(line).get("stale_count", last))
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue  # tolerate a partial/garbled line, keep the last good count
+    except OSError:
+        return 0
+    return last
+
+
+def pivot_for(stale_count: int) -> str:
+    if stale_count >= ESCALATE_HUMAN_AT:
+        return "human"
+    if stale_count >= PIVOT_STRUCTURAL_AT:
+        return "structural"
+    return "none"
+
+
+def note(root: str, run_id: str, phase: str, new_findings: int,
+         direction: Optional[str] = None) -> dict:
+    """Record one iteration; return {stale_count, pivot}. Append-only; never blocks work."""
+    new_findings = int(new_findings)
+    if new_findings < 0:
+        raise ValueError(f"new_findings must be >= 0, got {new_findings}")
+    path = _log_path(root, run_id)
+    with _lock(path):
+        stale_count = 0 if new_findings > 0 else _last_stale(path) + 1
+        pivot = pivot_for(stale_count)
+        rec = {"ts": _now(), "phase": phase, "new_findings": new_findings,
+               "stale_count": stale_count, "pivot": pivot}
+        if direction is not None:
+            rec["direction"] = direction
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    return {"stale_count": stale_count, "pivot": pivot}
+
+
+def show(root: str, run_id: str) -> str:
+    path = _log_path(root, run_id)
+    return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="overnight-loop stall detection → forced structural pivot")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    n = sub.add_parser("note")
+    n.add_argument("root"); n.add_argument("run_id"); n.add_argument("phase")
+    n.add_argument("new_findings", type=int); n.add_argument("--direction", default=None)
+    s = sub.add_parser("show"); s.add_argument("root"); s.add_argument("run_id")
+    a = ap.parse_args()
+    if a.cmd == "note":
+        print(json.dumps(note(a.root, a.run_id, a.phase, a.new_findings, a.direction)))
+    elif a.cmd == "show":
+        sys.stdout.write(show(a.root, a.run_id))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_skills_helpers.sh
+++ b/tools/lint_skills_helpers.sh
@@ -17,7 +17,7 @@
 set -u
 
 # Patterns that indicate hardcoded helper invocation (no resolver).
-INVOCATION_PY='python3 tools/(verify_papers|extract_paper_style|paper_illustration_image2|figure_renderer|arxiv_fetch|semantic_scholar_fetch|deepxiv_fetch|exa_search|openalex_fetch|research_wiki)\.py'
+INVOCATION_PY='python3 tools/(verify_papers|extract_paper_style|paper_illustration_image2|figure_renderer|arxiv_fetch|semantic_scholar_fetch|deepxiv_fetch|exa_search|openalex_fetch|research_wiki|iteration_log)\.py'
 INVOCATION_SH='bash tools/(verify_paper_audits|save_trace|verify_wiki_coverage|overleaf_audit)\.sh'
 
 # Files exempted from the lint:


### PR DESCRIPTION
## What
Adds **stall detection → forced structural pivot** for unattended overnight loops — the second genuine gap a fan-out + **3-round cross-model review (GPT-5.5 xhigh)** surfaced from Deli Chen's *AutoResearch* framework. ARIS had round/time caps but no domain-level *"this iteration produced 0 new findings → change the **frame**, not the knobs"* mechanism.

## How (Type-A signal, sidecar, never a quality gate)
`tools/iteration_log.py` — an append-only ledger at `.aris/runs/<run_id>.iterations.jsonl`. `note(root, run_id, phase, new_findings, direction?)` increments a `stale_count` when `new_findings == 0` (resets otherwise) and returns a `pivot`:
- `stale_count >= 2` → `structural` (change a structural constraint — frame/objective/data/representation — and pick an untried direction)
- `stale_count >= 4` → `human` (escalate; stop nudging blindly)

It **counts concrete entries and changes direction; it never judges quality** — that stays with the cross-model jury (`acceptance-gate.md`). Reports only "keep going / change direction," never "good enough."

- **Sidecar by design** — does NOT import or touch `run_state.py`'s done/accepted state machine (distinct `.iterations.jsonl` suffix). Mirrors run_state's run_id validation (no path escape) + best-effort flock. Rejects negative `new_findings`. Optional `direction` per record powers near-duplicate rejection.

## Wiring (genuinely triggered, not dead code)
- `external-cadence.md` (cited by 17 skills) documents the doctrine: count-don't-vibe, the pivot ladder, direction diversity, "pivot structure not tactics."
- `research-pipeline/SKILL.md` adds a concrete **Overnight heartbeat** block: the canonical helper resolver chain + the real `python3 "$ITER_LOG" note ...` call + per-pivot actions (structural writes the chosen `--direction`; human escalates).
- `idea-discovery` re-ideation reads tried directions and forbids near-duplicates.
- `check_skills_inventory.py` drift-check requires the tool + the documented ladder (both thresholds) + the **real wiring** (resolver + `$ITER_LOG note` + pivot branches) — proving the trigger exists, not just a prose mention.
- `integration-contract.md` registers the helper (Policy B, warn-and-skip); `lint_skills_helpers.sh` scans it.

## Scope
**Mainline-only**, matching `external-cadence.md` itself (17 mainline consumers / **0** in the Codex mirror — the whole cadence doctrine is pre-existing mainline-only). Mirroring external-cadence to `skills-codex` is a separate pre-existing parity task, noted in the integration-contract row. *(Cross-model review explicitly concurred with this scope.)*

## Tests
`tests/test_iteration_log.py` (9) — ladder, reset, sidecar isolation from run_state, run_id rejection (path escape), direction field, garbled-line tolerance. `test_codex_skill_mirror.py` + `check_skills_inventory.py` green.

> Note: independent of #300 (watchdog loop-liveness); both branch off main and lightly touch `external-cadence.md` + `check_skills_inventory.py`, so a small rebase may be needed depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)