### PR TITLE
docs(shared-references): absorb 4 Deli-borrow doctrines (PASS epistemics · autonomous discipline · shard safety)

### DIFF
--- a/skills/shared-references/acceptance-gate.md
+++ b/skills/shared-references/acceptance-gate.md
@@ -294,6 +294,20 @@ regardless of how many rounds it runs or how confident it sounds.
   clock instead of on the reviewer's turn — noise at best, a corrupted
   acquittal at worst. Keep external cadence outside the acceptance gate.
 
+## Epistemic status of a PASS
+
+A cross-model PASS is a **heterogeneous second opinion**, not external ground truth. Its
+value is specific and bounded: a reviewer from a different model family breaks *correlated*
+blind spots — the executor's own failure modes it cannot see in itself — so a PASS means
+"a differently-built model, reading the artifact cold, did not find the flaw the author
+would miss." It does **not** mean the work is correct, novel, publishable, or that a venue
+will accept it. Same-family review (Claude judging Claude) does not even clear that bar,
+which is why the jury must be cross-family.
+
+Treat a PASS as the strongest *automatable* heterogeneous quality check this framework has, then keep the human in the loop for
+what no in-framework verdict can supply: updated literature, venue taste, and ground truth.
+A green gate lowers risk; it does not transfer accountability.
+
 ## See Also
 
 - `reviewer-independence.md` — the single-shot form: executor never

--- a/skills/shared-references/external-cadence.md
+++ b/skills/shared-references/external-cadence.md
@@ -269,6 +269,20 @@ from tuning parameters harder within it.
    a blocking poll or a manual re-invocation; the cross-model jury at
    the end is identical either way (`fan-out-pattern.md`).
 
+## Autonomous-mode discipline (when the human checkpoint is off)
+
+When a skill runs with its human-checkpoint toggle OFF (e.g. `AUTO_PROCEED=true`) or under
+an external heartbeat, it must not stall by ending on a question. Resolve a routine
+ambiguity yourself, act, and log the decision and its reasoning (a `level=decision` log
+line) so the choice is auditable — "ready means execute": finishing preparation and then
+asking "should I proceed?" is the stall this rule forbids.
+
+This does **not** override an *explicit* human gate. A checkpoint the skill declares as
+load-bearing — a missing venue/target, a patent/submission step, anything marked as
+requiring sign-off — still stops and waits. If you are unsure whether a gate is explicit, treat it as explicit and stop. Autonomy removes *needless* pauses, not
+deliberate ones; and it never lets the loop self-acquit a quality verdict (that stays with
+the cross-model jury, see [`acceptance-gate.md`](acceptance-gate.md)).
+
 ## Cross-references
 
 - `acceptance-gate.md` — who is allowed to ACCEPT. Cadence drives;

--- a/skills/shared-references/fan-out-pattern.md
+++ b/skills/shared-references/fan-out-pattern.md
@@ -230,13 +230,11 @@ pass. After fan-out the merged set should be **mechanically deduped only**
 (cluster near-identical ideas; never drop one for being "weak"). The
 **jury** is the already-existing Phase-4 cross-model devil's-advocate
 pass: GPT-5.5 via Codex MCP surfaces the strongest reviewer objection per
-idea and ranks for a top venue. `/idea-creator` does **not** currently
-declare the `Agent` tool — it was stripped in the WB2 least-privilege
-sweep because its body does not yet fan out. The WB3 fan-out refactor
-re-grants `Agent` in the *same* change that wires these lens shards and
-fixes the Phase-3 gap below (per the re-grant rule in **Allowed-tools
-hygiene**). On a Tier-1 runtime the lenses then run as Workflow shards;
-on Tier 3 they fall back to sequential enumeration with no grant needed.
+idea and ranks for a top venue. `/idea-creator` declares the `Agent` tool — re-granted (per the re-grant
+rule in **Allowed-tools hygiene**) when the lens fan-out was wired, after
+the WB2 sweep had stripped the earlier vestigial grant. On a Tier-1 runtime
+the lenses run as Workflow shards; on Tier 3 they fall back to sequential
+enumeration with no grant needed.
 
 > ⚠️ **Known gap — idea-creator is an *aspirational* example here, not yet a clean one.**
 > Today `/idea-creator` Phase 3 (`skills/idea-creator/SKILL.md:159,175`)
@@ -268,6 +266,23 @@ so there is no same-family-self-judgment risk to begin with. When the
 "jury" is a deterministic check rather than a model verdict, the
 cross-model-family rule is automatically satisfied (a process is not a
 model family). Fan out freely.
+
+## Shard safety invariants
+
+Two invariants keep a fan-out from manufacturing or laundering errors:
+
+- **Shards are read-only on shared artifacts.** A shard may read the repo/workspace and
+  return its findings; it must NOT write shared state, mutate files the executor or other
+  shards also touch, or rank/drop another shard's output. The *only* write is the
+  post-merge executor write, after dedup. This forecloses silent world-model divergence
+  (parallel agents mutating a shared workspace and integrating into conflicts only
+  discovered at composition time).
+- **Don't inherit the upstream premise unchecked.** When a phase's jury reviews work built
+  on a load-bearing upstream artifact (a prior phase's claim, a cited number, an earlier
+  agent's conclusion), give the jury the *path to that upstream artifact* and ask it to
+  check the dependency, not just the local step. Otherwise one plausible-but-wrong upstream
+  assertion is treated as ground truth and amplified down the chain — a cascading
+  hallucination that compounds instead of self-correcting.
 
 ## Cross-references
 
@@ -332,12 +347,13 @@ This matters because the other two tiers need no per-skill grant:
   Correctly, `kill-argument` does **not** grant `Agent`.
 
 So `Agent` is needed *only* for the Tier-2 form, *only* in skills that
-genuinely fan out. As of the WB2 least-privilege sweep, **no mainline skill
-spawns Claude subagents in its body**, so no mainline skill grants `Agent`.
-(48 vestigial grants — pure copied boilerplate, never invoked — were
-removed.) Note that "reviewer **sub-agent**" in several skills refers to the
-cross-model *codex/GPT reviewer*, not the Agent tool, and never implied a
-real grant need.
+genuinely fan out. The WB2 least-privilege sweep removed 48 vestigial grants
+(pure copied boilerplate, never invoked); since then **only skills that
+genuinely fan out at Tier-2 re-grant `Agent`, and each must cite this doc in
+its body** (enforced by `check_skills_inventory.py`). As of writing those are
+`idea-creator`, `proof-checker`, and `research-lit`. Note that "reviewer
+**sub-agent**" in several skills refers to the cross-model *codex/GPT
+reviewer*, not the Agent tool, and never implied a real grant need.
 
 **Re-granting rule.** A skill that adds genuine fan-out re-introduces
 `Agent` to its `allowed-tools` **in the same change that adds the fan-out


### PR DESCRIPTION
## What
Four doc-only doctrines borrowed from Deli Chen's *AutoResearch* framework (fan-out gap analysis + **3-round cross-model review, GPT-5.5 xhigh**), each landed in a shared-reference **skills already cite** — so it's live on merge, not dead weight.

| Doctrine | Home (citations) | Gist |
|---|---|---|
| **Epistemic status of a PASS** | `acceptance-gate.md` (6) | A cross-model PASS is a heterogeneous second opinion that breaks correlated blind spots — **not** external ground truth / a venue guarantee. Lowers risk, doesn't transfer accountability. |
| **Autonomous-mode discipline** | `external-cadence.md` (17) | Checkpoint off / under a heartbeat → don't stall on a question; resolve routine ambiguity + log `level=decision` ("ready means execute"). **Never** overrides an explicit human gate (venue/patent/submission — if unsure, treat as explicit and stop); never self-acquits quality. |
| **Shard safety invariants** (×2) | `fan-out-pattern.md` (4) | (1) shards are read-only on shared artifacts — only the post-merge executor writes (no silent world-model divergence); (2) don't inherit the upstream premise unchecked — give the jury the upstream artifact's path (no cascading hallucination). |

## Also fixed
Two **pre-existing stale claims** in `fan-out-pattern.md` this change surfaced: it said "no mainline skill grants `Agent`" and that `/idea-creator` hadn't re-granted it — but `idea-creator` / `proof-checker` / `research-lit` *do* grant `Agent` (re-granted with their fan-out, per the doc's own re-grant rule + the `check_skills_inventory.py` drift-check). Now consistent with reality + the drift-check.

## Scope
Mainline-only, matching these three docs (none is mirrored into `skills-codex/shared-references/` — a pre-existing mainline-only convention; cross-model review concurred this is out of scope for this PR).

## Verification
`check_skills_inventory.py` + `test_codex_skill_mirror.py` green. Doc-only (+45 lines, 3 files).

> Note: independent of #300 / #301; #301 also adds a section to `external-cadence.md`, so a trivial rebase may be needed depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)