### PR TITLE
feat: wire the research-wiki claim layer — born at /proof-checker (PROVE/JUDGE ledger)

### DIFF
--- a/skills/proof-checker/SKILL.md
+++ b/skills/proof-checker/SKILL.md
@@ -553,6 +553,69 @@ Write `PROOF_CHECK_STATE.json`:
 }
 ```
 
+### Phase 5.5: Research Wiki Claim Ledger (additive; only if a wiki is active)
+
+If — and only if — a `research-wiki/` exists, persist each top-level
+theorem/headline as a **claim node** so the wiki's PROVE/JUDGE ledger records what
+was proven and with what honesty. This is the **birth point** for wiki claim nodes
+(`claims/<slug>.md`). It is a **detect-only record, never a verdict**: it never
+changes the audit's `verdict`/`reason_code`, never blocks, and is skipped entirely
+when `verdict == NOT_APPLICABLE` (no theorems) or no wiki is found.
+
+> The claim's `status` is the **PROOF axis only** (`verified` / `sound-modulo-imports`
+> / `refuted` / `unproven` / `drafted` / `retracted`). Empirical experiment support is
+> a **separate axis** carried by `supports` / `invalidates` *edges* from
+> `/result-to-claim` — those words are NEVER written into this `status` field (the
+> `research_wiki.py` validator rejects them).
+
+Resolve the helper via the **canonical resolver** (integration-contract §2). Check
+`NOT_APPLICABLE` first (in cwd, where the audit ran), then run from the project root
+(the wiki sits at root; a paper audit may run from a `paper/` subdir). Every guard
+warn-and-skips — the audit is already complete and is never affected:
+
+```bash
+grep -q '"verdict"[[:space:]]*:[[:space:]]*"NOT_APPLICABLE"' PROOF_AUDIT.json 2>/dev/null \
+  && { echo "verdict NOT_APPLICABLE (no theorems); skipping claim ledger" >&2; exit 0; }
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || exit 0
+[ -d research-wiki ] || { echo "no research-wiki/ at project root; skipping claim ledger (audit complete)" >&2; exit 0; }
+if [ -z "${ARIS_REPO:-}" ] && [ -f .aris/installed-skills.txt ]; then
+    ARIS_REPO=$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills.txt 2>/dev/null) || true
+fi
+WIKI_SCRIPT=".aris/tools/research_wiki.py"
+[ -f "$WIKI_SCRIPT" ] || WIKI_SCRIPT="tools/research_wiki.py"
+[ -f "$WIKI_SCRIPT" ] || { [ -n "${ARIS_REPO:-}" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"; }
+[ -f "$WIKI_SCRIPT" ] || { echo "WARN: research_wiki.py not resolved; skipping claim ledger (audit unaffected)" >&2; exit 0; }
+```
+
+For each top-level theorem/headline in `PROOF_SKELETON.md` (the main theorem + the
+key lemmas the headline depends on — NOT every micro-claim), map the audit outcome
+to an **honest** claim status:
+
+| Audit outcome (`PROOF_AUDIT.json` verdict + Phase 1.5 counterexamples) | `--status` |
+|---|---|
+| `verdict=PASS` / `all_proofs_complete`, no flagged imports | `verified` |
+| proof closes but rests on a flagged `[unverified-axiom]` / imported result | `sound-modulo-imports` |
+| counterexample found (Phase 1.5) **or** reviewer judged the statement false | `refuted` |
+| open gap (unresolved FATAL/CRITICAL / UNJUSTIFIED, no counterexample) | `unproven` |
+
+Never invent a status: a plain proof gap is `unproven` — never `refuted` (which
+asserts falsity) and never `verified`/`drafted`. Then record (idempotent):
+
+```bash
+python3 "$WIKI_SCRIPT" add_claim research-wiki/ \
+  --slug "<stable-theorem-id, e.g. thm-main-ub>" --name "<theorem headline>" \
+  --status "<mapped status>" --provenance "<trace_path from PROOF_AUDIT.json>" \
+  --statement "<canonical theorem statement>" \
+  --scope "<what it does NOT say; any flagged imports>" \
+  --evidence "<PROOF_AUDIT.json verdict + counterexample / obligation pointers>" \
+  --update-on-exist \
+  || echo "WARN: add_claim failed for <slug> (audit unaffected; fix wiki/status and re-run)" >&2
+```
+
+`--update-on-exist` lets a re-audit refresh a claim's status (an `unproven` claim
+becomes `verified` once the gap closes). `--provenance` is the honesty receipt (the
+`trace_path`); never omit it.
+
 ## Deep-Fix Mode (opt-in)
 
 **Default**: disabled. The Phase 1 reviewer emits issues with `minimal_fix` (a 1-2 sentence pointer); existing callers see no change.

--- a/skills/research-wiki/SKILL.md
+++ b/skills/research-wiki/SKILL.md
@@ -24,7 +24,7 @@ Inspired by [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6
 | **Paper** | `papers/` | `paper:<slug>` | A published or preprint research paper |
 | **Idea** | `ideas/` | `idea:<id>` | A research idea (proposed, tested, or failed) |
 | **Experiment** | `experiments/` | `exp:<id>` | A concrete experiment run with results |
-| **Claim** | `claims/` | `claim:<id>` | A testable scientific claim with evidence status |
+| **Claim** | `claims/` | `claim:<id>` | A theorem/headline with an honest PROOF status — born via `/proof-checker` (see Hook 4) |
 
 ### Typed Relationships (`graph/edges.jsonl`)
 
@@ -281,7 +281,7 @@ Update a specific entity:
 ```
 /research-wiki update paper:chen2025 — relevance: core
 /research-wiki update idea:001 — outcome: negative
-/research-wiki update claim:C1 — status: invalidated
+/research-wiki update claim:C1 — status: refuted
 ```
 
 After any update: rebuild `query_pack.md`, update `log.md`.
@@ -291,7 +291,7 @@ After any update: rebuild `query_pack.md`, update `log.md`.
 Health check the wiki:
 
 1. **Orphan pages** — entities with zero edges
-2. **Stale claims** — claims with `status: reported` older than 14 days
+2. **Stale claims** — claims still `status: drafted` or `status: unproven` older than 14 days
 3. **Contradictions** — claims with both `supports` and `invalidates` edges
 4. **Missing connections** — papers sharing 2+ tags but no explicit relationship
 5. **Dead ideas** — `stage: proposed` ideas that were never tested
@@ -308,7 +308,7 @@ Quick overview:
 Papers: 28 (12 core, 10 related, 6 peripheral)
 Ideas: 7 (2 active, 3 failed, 1 partial, 1 succeeded)
 Experiments: 12
-Claims: 15 (5 supported, 3 invalidated, 7 reported)
+Claims: 15 (8 verified, 4 unproven, 2 refuted, 1 sound-modulo-imports)
 Edges: 64
 Gaps: 8 (3 unresolved)
 Last updated: 2026-04-07T10:12:00Z
@@ -374,19 +374,20 @@ log "idea-creator wrote N ideas to wiki"
 ### Hook 3: After `/result-to-claim` verdict
 
 ```
-# Create experiment page
+# Create experiment page (the experiment verdict lives HERE)
 exp_id = upsert_experiment(experiment_data)
 
-# Update each claim's status
+# Record empirical support as EDGES ONLY — never overwrite the claim's `status`.
+# A claim's `status` is the PROOF axis (verified / sound-modulo-imports / refuted /
+# unproven / drafted / retracted), owned by /proof-checker (the claim birth point).
+# Experiment support is a SEPARATE axis, carried entirely by supports/invalidates
+# edges; writing "supported"/"invalidated" into status is rejected by the validator.
 for claim_id in resolved_claims:
     if verdict == "yes":
-        set_claim_status(claim_id, "supported")
         add_edge(exp_id, claim_id, "supports")
     elif verdict == "partial":
-        set_claim_status(claim_id, "partial")
-        add_edge(exp_id, claim_id, "supports")  # partial
+        add_edge(exp_id, claim_id, "supports")   # partial — qualify in --evidence
     else:
-        set_claim_status(claim_id, "invalidated")
         add_edge(exp_id, claim_id, "invalidates")
 
 # Update idea outcome
@@ -399,6 +400,25 @@ if verdict in ("no", "partial"):
 rebuild query_pack
 log "result-to-claim: exp_id updated, verdict=..."
 ```
+
+### Hook 4: Claim birth — from `/proof-checker` (the ONLY birth point)
+
+Wiki **claim nodes are born here.** `/proof-checker` Phase 5.5 calls `add_claim`
+for each top-level theorem/headline after writing `PROOF_AUDIT.json`, stamping an
+honest PROOF-axis `status` and a `provenance` pointer to the audit trace. No other
+skill creates a claim node: `/result-to-claim` (Hook 3) only adds empirical
+`supports`/`invalidates` *edges* to an already-born claim and never edits its `status`.
+
+```bash
+# (run by /proof-checker; shown here for the wiki's record)
+python3 "$WIKI_SCRIPT" add_claim research-wiki/ --slug thm-main-ub \
+  --name "Main upper bound" --status verified \
+  --provenance ".aris/traces/proof-checker/<run>/" --statement "..." --update-on-exist
+```
+
+Claim `status` ∈ {`drafted`, `unproven`, `sound-modulo-imports`, `verified`,
+`refuted`, `retracted`} — the **proof axis only**. Empirical support is a separate
+axis, carried entirely by edges (Hook 3), never written into `status`.
 
 ## Re-ideation Trigger
 

--- a/skills/result-to-claim/SKILL.md
+++ b/skills/result-to-claim/SKILL.md
@@ -222,9 +222,11 @@ See `shared-references/experiment-integrity.md` for the full integrity protocol.
 If `research-wiki/` exists, resolve `$WIKI_SCRIPT` per the canonical
 chain documented in
 [`shared-references/wiki-helper-resolution.md`](../shared-references/wiki-helper-resolution.md)
-(Variant B — warn-and-skip for caller skills). The verdict / claim
-status / idea-outcome page edits below run on raw markdown and don't
-need the helper, but edges, query-pack rebuild, and the log line do.
+(Variant B — warn-and-skip for caller skills). The verdict / idea-outcome
+page edits below run on raw markdown and don't need the helper, but edges,
+query-pack rebuild, and the log line do. **This skill never edits a claim's
+`status` field and never creates a claim node** — claims are born (and their
+proof `status` set) by `/proof-checker`; here we only attach experiment edges.
 
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || exit 1
@@ -247,16 +249,20 @@ if research-wiki/ exists:
       - date, hardware, duration, metrics
       - verdict, confidence, reasoning summary
 
-    # 2. Update claim status (page edits run unconditionally; edges only if $WIKI_SCRIPT resolved)
-    for each claim resolved by this verdict:
+    # 2. Record empirical support as EDGES ONLY — never edit the claim page's `status`
+    #    field. A claim's `status` is the PROOF axis (verified / refuted / unproven /
+    #    sound-modulo-imports / drafted / retracted), owned by /proof-checker (the claim
+    #    birth point). Experiment support is a SEPARATE axis carried by these edges;
+    #    "supported"/"invalidated" are NOT valid claim statuses (the validator rejects them).
+    #    The edge attaches to a claim that should ALREADY be born by /proof-checker.
+    #    add_edge does NOT verify the target exists — a missing claim yields a SILENT
+    #    dangling edge — so ensure /proof-checker ran first; never hand-create the claim here.
+    for each claim resolved by this verdict (edges only if $WIKI_SCRIPT resolved):
         if verdict == "yes":
-            Update claim page: status → supported
             [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "<metric>"
         elif verdict == "partial":
-            Update claim page: status → partial
-            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "partial"
+            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "partial: <metric>"
         else:
-            Update claim page: status → invalidated
             [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type invalidates --evidence "<why>"
 
     # 3. Update idea outcome (raw markdown, helper-free)

--- a/skills/wiki-enrich/SKILL.md
+++ b/skills/wiki-enrich/SKILL.md
@@ -160,7 +160,7 @@ Write each TODO section's body following these rules:
 | Limitations / Failure Modes | 1-3 bullets | Honest | What the paper explicitly admits OR what's structurally absent (e.g. "no multi-node evaluation", "assumes uniform request length") |
 | Reusable Ingredients | 1-3 bullets | Concrete | Techniques / datasets / insights from this paper that could be ported elsewhere. **Highest value for `/idea-creator` — write carefully.** |
 | Open Questions | 1-2 bullets | Question form | What the paper does NOT answer but raises |
-| Claims | 1 line | Static | If no `claim:` edges in `graph/edges.jsonl` reference this paper, write the literal italic line: `_No claims tracked yet — populate via /result-to-claim._`. Else list claim node IDs. |
+| Claims | 1 line | Static | If no `claim:` edges in `graph/edges.jsonl` reference this paper, write the literal italic line: `_No claims tracked yet — populate via /proof-checker._`. Else list claim node IDs. |
 | Relevance to This Project | 1-2 sentences | Project-contextual | Use `RESEARCH_BRIEF.md` / `CLAUDE.md` / `gap_map.md` to phrase the connection. If no project context, write the literal italic line: `_Project context not yet set — populate RESEARCH_BRIEF.md or gap_map.md to enable this section._` and report. |
 
 **Rules** (Karpathy fidelity):

--- a/tests/test_research_wiki_claims.py
+++ b/tests/test_research_wiki_claims.py
@@ -1,0 +1,93 @@
+"""Tests for the research-wiki claim layer — add_claim (the PROVE/JUDGE ledger).
+
+Covers: page creation with the PROOF-axis status, slug honored verbatim, the
+status validator (empirical "supported"/"invalidated" must be REJECTED — they are
+a separate axis carried by edges, not the claim's status field), the new `unproven`
+proof-gap status, dedup vs --update-on-exist, edge wiring, and the uninitialized-wiki
+guard. These lock the Option-A design: claim `status` = proof axis only.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import research_wiki as rw  # noqa: E402
+
+
+class TestClaimLayer(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        rw.init_wiki(self.root)
+
+    def _page(self, slug):
+        return Path(self.root) / "claims" / f"{slug}.md"
+
+    def _edges(self):
+        p = Path(self.root) / "graph" / "edges.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()] if p.exists() else []
+
+    def test_creates_page_with_proof_status_and_provenance(self):
+        rw.add_claim(self.root, "thm-main-ub", "Main upper bound",
+                     status="verified", provenance=".aris/traces/proof-checker/r1",
+                     statement="X <= Y")
+        fm = self._page("thm-main-ub").read_text()
+        self.assertIn("node_type: claim", fm)
+        self.assertIn("node_id: claim:thm-main-ub", fm)
+        self.assertIn("status: verified", fm)
+        self.assertIn(".aris/traces/proof-checker/r1", fm)
+
+    def test_slug_honored_verbatim(self):
+        rw.add_claim(self.root, "b1-sieve-lb", "Sieve lower bound", status="unproven")
+        self.assertTrue(self._page("b1-sieve-lb").is_file())
+
+    def test_empirical_status_rejected(self):
+        # The crux of the design: experiment outcomes are NOT claim statuses.
+        for bad in ("supported", "partial", "invalidated", "yes", "no"):
+            with self.assertRaises(RuntimeError):
+                rw.add_claim(self.root, f"c-{bad}", f"C {bad}", status=bad)
+
+    def test_unproven_is_valid(self):
+        rw.add_claim(self.root, "thm-gap", "Has an open gap", status="unproven")
+        self.assertIn("status: unproven", self._page("thm-gap").read_text())
+
+    def test_all_proof_statuses_accepted(self):
+        for i, st in enumerate(sorted(rw._CLAIM_STATUSES)):
+            rw.add_claim(self.root, f"s{i}", f"Claim {st}", status=st)
+            self.assertIn(f"status: {st}", self._page(f"s{i}").read_text())
+
+    def test_dedup_skips_without_update_flag(self):
+        rw.add_claim(self.root, "thm-x", "X", status="drafted")
+        rw.add_claim(self.root, "thm-x", "X", status="verified")  # should skip
+        self.assertIn("status: drafted", self._page("thm-x").read_text())
+
+    def test_update_on_exist_refreshes_status(self):
+        rw.add_claim(self.root, "thm-x", "X", status="unproven")
+        rw.add_claim(self.root, "thm-x", "X", status="verified", update_on_exist=True)
+        self.assertIn("status: verified", self._page("thm-x").read_text())
+
+    def test_edges_wired(self):
+        rw.add_claim(self.root, "thm-y", "Y", status="verified",
+                     uses=["paper:foo2024"], depends_on=["thm-x"], refutes=["thm-z"])
+        kinds = {(e["from"], e["type"], e["to"]) for e in self._edges()}
+        self.assertIn(("claim:thm-y", "uses", "paper:foo2024"), kinds)
+        self.assertIn(("claim:thm-y", "depends_on", "claim:thm-x"), kinds)
+        self.assertIn(("claim:thm-y", "refutes", "claim:thm-z"), kinds)
+
+    def test_uninitialized_wiki_raises(self):
+        bare = tempfile.mkdtemp()  # no init → no claims/ dir
+        with self.assertRaises(RuntimeError):
+            rw.add_claim(bare, "thm-x", "X", status="drafted")
+
+    def test_appears_in_index(self):
+        rw.add_claim(self.root, "thm-idx", "Indexed claim", status="verified")
+        idx = (Path(self.root) / "index.md")
+        self.assertTrue(idx.is_file())
+        self.assertIn("thm-idx", idx.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_skills_inventory.py
+++ b/tools/check_skills_inventory.py
@@ -226,6 +226,19 @@ def check_inventory() -> list[str]:
     require(doc_ladder, "external-cadence.md must document the stall ladder with both thresholds (>=2 structural, >=4 human) (B)", failures)
     require(wired, "research-pipeline/SKILL.md must actually wire iteration_log.py (resolver + `$ITER_LOG note` + pivot handling) — not just mention it (B)", failures)
 
+    # research_wiki.py add_claim (claim layer) ⇔ its documented birth trigger in
+    # /proof-checker. add_claim is a writer; without a skill that calls it, the claim
+    # layer is dead code (the exact orphan-writer trap). Same dead-code guard as above:
+    # the writer and its single birth point must BOTH be present.
+    rwiki = read(REPO_ROOT / "tools" / "research_wiki.py")
+    pchk = read(SKILLS_ROOT / "proof-checker" / "SKILL.md")
+    tool_claim = bool(re.search(r"def add_claim\b", rwiki)) and bool(re.search(r'add_parser\("add_claim"', rwiki))
+    # Prove the trigger is real (anchored to the actual command line, not a prose
+    # mention or comment): proof-checker must literally invoke the resolved helper.
+    born = re.search(r'python3\s+"\$WIKI_SCRIPT"\s+add_claim\b', pchk) is not None
+    require(tool_claim, "tools/research_wiki.py must implement the add_claim claim-layer writer + its CLI", failures)
+    require(born, "proof-checker/SKILL.md must invoke `add_claim` as the claim birth point — not just mention it (else add_claim is an orphan writer)", failures)
+
     return failures
 
 

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -27,6 +27,13 @@ Usage:
     # Batch backfill:
     python3 research_wiki.py sync <wiki_root> --arxiv-ids id1,id2,id3
     python3 research_wiki.py sync <wiki_root> --from-file ids.txt
+
+    # Claim layer (PROVE/JUDGE output ledger):
+    python3 research_wiki.py add_claim <wiki_root> --slug b1-main-ub \
+        --name "..." --status sound-modulo-imports --provenance <run path> \
+        --statement "..." --scope "..." --evidence "..." \
+        --addresses G2,G10 --extends paper:slug --uses paper:slug \
+        --depends-on claim:other --refutes claim:bad
 """
 
 # `from __future__ import annotations` defers annotation evaluation so that
@@ -132,6 +139,11 @@ def add_edge(wiki_root: str, from_id: str, to_id: str, edge_type: str, evidence:
     VALID_TYPES = {
         "extends", "contradicts", "addresses_gap", "inspired_by",
         "tested_by", "supports", "invalidates", "supersedes",
+        # Claim-layer edge types (additive, used by add_claim):
+        #   claim --depends_on--> claim   (proof-obligation dependency)
+        #   claim --refutes--> claim      (a claim that falsifies another)
+        #   claim --uses--> paper         (imports a result/ingredient)
+        "depends_on", "refutes", "uses",
     }
     if edge_type not in VALID_TYPES:
         print(f"Warning: unknown edge type '{edge_type}'. Valid: {VALID_TYPES}", file=sys.stderr)
@@ -406,8 +418,13 @@ def get_stats(wiki_root: str):
     print(f"Ideas:       {ideas} ({count_by_field('ideas', 'outcome', 'negative')} failed, "
           f"{count_by_field('ideas', 'outcome', 'positive')} succeeded)")
     print(f"Experiments: {experiments}")
-    print(f"Claims:      {claims} ({count_by_field('claims', 'status', 'supported')} supported, "
-          f"{count_by_field('claims', 'status', 'invalidated')} invalidated)")
+    _claim_parts = []
+    for _st in sorted(_CLAIM_STATUSES):
+        _n = count_by_field('claims', 'status', _st)
+        if _n:
+            _claim_parts.append(f"{_n} {_st}")
+    print(f"Claims:      {claims}"
+          + (f" ({', '.join(_claim_parts)})" if _claim_parts else ""))
     print(f"Edges:       {edge_count}")
     print(f"Wiki root:   {root}")
 
@@ -796,6 +813,233 @@ def ingest_paper(wiki_root: str, *, arxiv_id: str = "", title: str = "",
     return page_path
 
 
+_CLAIM_STATUSES = {
+    "drafted",                 # written, not yet adversarially reviewed
+    "unproven",                # audited; proof has an open gap (not closed, not falsified)
+    "sound-modulo-imports",    # proof closes modulo flagged [unverified-axiom] imports
+    "verified",                # passed cross-model acquittal, imports discharged
+    "refuted",                 # a counterexample / jury falsified it
+    "retracted",               # withdrawn (e.g. superseded by a corrected claim)
+}
+
+
+def _claim_slugify(name: str, slug: str = "") -> str:
+    """Slug for a claim page.
+
+    A claim usually already carries a stable human ID (e.g. ``b1-main-ub``);
+    if the caller passes ``--slug`` we honor it verbatim (lower-cased, sanitized)
+    so cross-references in proofs stay stable. Otherwise we fall back to the
+    paper slugifier's keyword extraction on the claim name.
+    """
+    if slug:
+        s = re.sub(r"[^a-z0-9._-]+", "-", slug.strip().lower()).strip("-")
+        if s:
+            return s
+    # No explicit slug: reuse the title keyword extractor (no author/year).
+    return slugify(name).lstrip("_").lstrip("0").strip("_") or "claim"
+
+
+def _render_claim_page(slug: str, name: str, description: str, status: str,
+                       provenance: str, statement: str, scope: str,
+                       evidence: str, tags: list[str]) -> str:
+    """Render a claims/<slug>.md page following the research-wiki schema.
+
+    Mirrors ``_render_paper_page``: ``---`` frontmatter block then body
+    sections. ``node_type: claim`` distinguishes the node kind; ``status``
+    is one of ``_CLAIM_STATUSES``; ``provenance`` points at the PROVE/JUDGE
+    run directory that produced the claim (the honesty receipt).
+    """
+    lines = ["---"]
+    lines.append("type: claim")
+    lines.append(f"node_id: claim:{slug}")
+    lines.append(f"name: {_yaml_quote(name)}")
+    lines.append(f"description: {_yaml_quote(description)}")
+    lines.append("node_type: claim")
+    lines.append(f"status: {status}")
+    lines.append(f"provenance: {_yaml_quote(provenance)}")
+    lines.append("tags: [" + ", ".join(_yaml_quote(t) for t in tags) + "]")
+    lines.append(f"date: {datetime.now(timezone.utc).strftime('%Y-%m-%d')}")
+    lines.append(f"added: {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {name}")
+    lines.append("")
+    lines.append(f"**status:** `{status}`")
+    lines.append("")
+    lines.append("## Statement")
+    lines.append(statement.strip() if statement.strip() else "_TODO: formal statement._")
+    lines.append("")
+    lines.append("## Honest scope")
+    lines.append(scope.strip() if scope.strip()
+                 else "_TODO: what this claim does NOT say; banned wordings; flagged imports._")
+    lines.append("")
+    lines.append("## Evidence chain")
+    lines.append(evidence.strip() if evidence.strip()
+                 else "_TODO: proof obligations, jury verdicts, provenance pointers._")
+    lines.append("")
+    lines.append("## Connections")
+    lines.append("_Edges are recorded in `graph/edges.jsonl`; summarize here for human readers._")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def add_claim(wiki_root: str, slug: str, name: str, *, description: str = "",
+              status: str = "drafted", provenance: str = "",
+              statement: str = "", scope: str = "", evidence: str = "",
+              tags: list[str] | None = None,
+              addresses: list[str] | None = None,
+              extends: list[str] | None = None,
+              uses: list[str] | None = None,
+              depends_on: list[str] | None = None,
+              refutes: list[str] | None = None,
+              update_on_exist: bool = False) -> Path:
+    """Create (or update) a claims/<slug>.md node and wire its edges.
+
+    The claim layer is the PROVE/JUDGE output ledger: every theorem/headline
+    becomes a node with an HONEST ``status`` (one of ``_CLAIM_STATUSES``) and a
+    ``provenance`` pointer to the run directory. Mirrors ``ingest_paper``:
+      - writes claims/<slug>.md from the schema above
+      - dedups by slug (``update_on_exist=False`` skips an existing page)
+      - records typed edges into graph/edges.jsonl via ``add_edge``:
+          claim --addresses_gap--> gap     (--addresses G2,G10)
+          claim --extends--> paper          (--extends paper:slug)
+          claim --uses--> paper             (--uses paper:slug)
+          claim --depends_on--> claim       (--depends-on claim:slug)
+          claim --refutes--> claim          (--refutes claim:slug)
+      - rebuilds index.md + query_pack.md, appends to log.md
+    Bare gap ids (``G2``) and bare claim/paper slugs are auto-prefixed to the
+    ``gap:`` / ``claim:`` / ``paper:`` node_id namespace used by the graph.
+    """
+    root = Path(wiki_root)
+    if not (root / "claims").exists():
+        raise RuntimeError(f"{root} is not an initialized wiki (claims/ missing). "
+                           f"Run `init` first.")
+
+    if status not in _CLAIM_STATUSES:
+        raise RuntimeError(f"unknown claim status '{status}'. "
+                           f"Valid: {sorted(_CLAIM_STATUSES)}")
+
+    tags = tags or []
+    slug = _claim_slugify(name, slug)
+    node_id = f"claim:{slug}"
+
+    page_path = root / "claims" / f"{slug}.md"
+    if page_path.exists() and not update_on_exist:
+        append_log(str(root), f"add_claim: skipped existing claim "
+                              f"{page_path.name} (slug dedup)")
+        print(f"Claim already exists: {page_path.name} (slug dedup) — skipping.")
+        return page_path
+    was_update = page_path.exists()
+
+    # Quarantine claim body fields before persist (model-authored text that is
+    # re-read into agent context via index/query_pack): same Layer-1 injection
+    # hygiene as edge evidence above. Placeholder persists; raw text goes to
+    # graph/quarantine.log for human review — nothing silently dropped.
+    if quarantine is not None:
+        _q_hits = []
+
+        def _q(val, field):
+            if not val:
+                return val
+            safe, findings = quarantine(val, scope="strict",
+                                        label=f"claim {slug}.{field}")
+            if findings:
+                _q_hits.append((field, findings, val))
+            return safe
+
+        description = _q(description, "description")
+        statement = _q(statement, "statement")
+        scope = _q(scope, "scope")
+        evidence = _q(evidence, "evidence")
+        if _q_hits:
+            qlog = root / "graph" / "quarantine.log"
+            qlog.parent.mkdir(parents=True, exist_ok=True)
+            with open(qlog, "a", encoding="utf-8") as f:
+                for field, findings, raw in _q_hits:
+                    f.write(json.dumps({
+                        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "claim": node_id, "field": field,
+                        "findings": findings, "raw_text": raw,
+                    }, ensure_ascii=False) + "\n")
+            print(f"⚠️  claim field(s) quarantined "
+                  f"({', '.join(f for f, _, _ in _q_hits)}); placeholder persisted, "
+                  f"raw text preserved in graph/quarantine.log for review.",
+                  file=sys.stderr)
+
+    rendered = _render_claim_page(slug, name, description, status, provenance,
+                                  statement, scope, evidence, tags)
+    page_path.write_text(rendered)
+
+    # Wire edges. Reuse add_edge so dedup, evidence quarantine, and the JSONL
+    # format are all identical to paper/idea edges.
+    def _norm(target: str, default_prefix: str) -> str:
+        t = target.strip()
+        if not t:
+            return ""
+        if ":" in t:  # already a namespaced node_id (gap:G2 / paper:slug / claim:x)
+            return t
+        # Bare gap ids look like G2, G10; everything else takes default prefix.
+        if default_prefix == "gap:" or re.fullmatch(r"[Gg]\d+", t):
+            return f"gap:{t.upper()}" if re.fullmatch(r"[Gg]\d+", t) else f"{default_prefix}{t}"
+        return f"{default_prefix}{t}"
+
+    def _warn_if_dangling(nid: str) -> None:
+        # Warn-only: dangling edges are recorded (a [[name]]-style forward
+        # reference is legitimate), but the operator should know.
+        if not nid:
+            return
+        kind, _, rest = nid.partition(":")
+        exists = True
+        if kind == "paper":
+            exists = (root / "papers" / f"{rest}.md").exists()
+        elif kind == "claim":
+            exists = rest == slug or (root / "claims" / f"{rest}.md").exists()
+        elif kind == "gap":
+            gm = root / "gap_map.md"
+            exists = gm.exists() and re.search(
+                rf"\b{re.escape(rest)}\b", gm.read_text(encoding="utf-8"))
+        if not exists:
+            print(f"⚠️  add_claim: edge target {nid} not found in this wiki "
+                  f"(dangling edge recorded — create the node or fix the id).",
+                  file=sys.stderr)
+
+    for tgt in (addresses or []):
+        _tid = _norm(tgt, "gap:")
+        _warn_if_dangling(_tid)
+        add_edge(str(root), node_id, _tid, "addresses_gap",
+                 evidence=f"claim {slug} addresses gap")
+    for tgt in (extends or []):
+        _tid = _norm(tgt, "paper:")
+        _warn_if_dangling(_tid)
+        add_edge(str(root), node_id, _tid, "extends",
+                 evidence=f"claim {slug} extends paper")
+    for tgt in (uses or []):
+        _tid = _norm(tgt, "paper:")
+        _warn_if_dangling(_tid)
+        add_edge(str(root), node_id, _tid, "uses",
+                 evidence=f"claim {slug} uses paper")
+    for tgt in (depends_on or []):
+        _tid = _norm(tgt, "claim:")
+        _warn_if_dangling(_tid)
+        add_edge(str(root), node_id, _tid, "depends_on",
+                 evidence=f"claim {slug} depends on claim")
+    for tgt in (refutes or []):
+        _tid = _norm(tgt, "claim:")
+        _warn_if_dangling(_tid)
+        add_edge(str(root), node_id, _tid, "refutes",
+                 evidence=f"claim {slug} refutes claim")
+
+    # Rebuild derived artifacts (same as ingest_paper)
+    rebuild_index(str(root))
+    rebuild_query_pack(str(root))
+
+    action = "updated" if was_update else "added"
+    append_log(str(root), f"add_claim: {action} {node_id} [status={status}]"
+                          + (f" prov={provenance}" if provenance else ""))
+    print(f"Claim {action}: {page_path} [status={status}]")
+    return page_path
+
+
 def sync_papers(wiki_root: str, arxiv_ids: list[str], update_on_exist: bool = False) -> None:
     """Batch backfill: ingest many arxiv ids with a SINGLE metadata request.
 
@@ -844,9 +1088,14 @@ def rebuild_index(wiki_root: str) -> None:
         for f in sorted(d.glob("*.md")):
             meta = _load_paper_frontmatter(f)
             node_id = meta.get("node_id", f.stem)
-            title = meta.get("title", f.stem)
+            # Claims use `name:` (papers use `title:`); fall back across both
+            # so each node type renders its human label without special-casing.
+            title = meta.get("title") or meta.get("name") or f.stem
             year = meta.get("year", "")
-            entries.append(f"- `{node_id}` — {title}" + (f" ({year})" if year else ""))
+            # Surface the claim's honesty status inline (papers have no status).
+            status = meta.get("status", "")
+            suffix = f" ({year})" if year else (f" [{status}]" if status else "")
+            entries.append(f"- `{node_id}` — {title}{suffix}")
         if entries:
             lines.append(f"## {header} ({len(entries)})")
             lines.extend(entries)
@@ -928,6 +1177,39 @@ def main():
     p_ing.add_argument("--update-on-exist", action="store_true",
                        help="Overwrite an existing page instead of skipping (default: skip)")
 
+    # add_claim — create a claim node (PROVE/JUDGE output ledger)
+    p_claim = subparsers.add_parser("add_claim",
+                                    help="Create (or update) a claims/<slug>.md node")
+    p_claim.add_argument("wiki_root")
+    p_claim.add_argument("--slug", default="",
+                         help="Stable claim id, e.g. b1-main-ub (honored verbatim)")
+    p_claim.add_argument("--name", required=True,
+                         help="Human-readable claim name/headline")
+    p_claim.add_argument("--description", default="",
+                         help="One-line description for the index/frontmatter")
+    p_claim.add_argument("--status", default="drafted",
+                         help="One of: " + ", ".join(sorted(_CLAIM_STATUSES)))
+    p_claim.add_argument("--provenance", default="",
+                         help="Run directory that produced this claim (honesty receipt)")
+    p_claim.add_argument("--statement", default="", help="Formal statement (body)")
+    p_claim.add_argument("--scope", default="",
+                         help="Honest scope: what the claim does NOT say / banned wordings")
+    p_claim.add_argument("--evidence", default="",
+                         help="Evidence chain: obligations, verdicts, provenance pointers")
+    p_claim.add_argument("--tags", default="", help="Comma-separated tag list")
+    p_claim.add_argument("--addresses", default="",
+                         help="Comma-separated gap ids this claim addresses, e.g. G2,G10")
+    p_claim.add_argument("--extends", default="",
+                         help="Comma-separated paper node_ids/slugs this claim extends")
+    p_claim.add_argument("--uses", default="",
+                         help="Comma-separated paper node_ids/slugs this claim uses")
+    p_claim.add_argument("--depends-on", dest="depends_on", default="",
+                         help="Comma-separated claim node_ids/slugs this claim depends on")
+    p_claim.add_argument("--refutes", default="",
+                         help="Comma-separated claim node_ids/slugs this claim refutes")
+    p_claim.add_argument("--update-on-exist", action="store_true",
+                         help="Overwrite an existing claim instead of skipping (default: skip)")
+
     # sync — batch backfill
     p_sync = subparsers.add_parser("sync",
                                     help="Batch ingest from a list of arXiv IDs")
@@ -962,6 +1244,18 @@ def main():
                      authors=authors, year=args.year, venue=args.venue,
                      doi=args.doi, thesis=args.thesis, tags=tags,
                      update_on_exist=args.update_on_exist)
+    elif args.command == "add_claim":
+        def _split(s: str) -> list[str]:
+            return [x.strip() for x in s.split(",") if x.strip()]
+        add_claim(args.wiki_root, args.slug, args.name,
+                  description=args.description, status=args.status,
+                  provenance=args.provenance, statement=args.statement,
+                  scope=args.scope, evidence=args.evidence,
+                  tags=_split(args.tags),
+                  addresses=_split(args.addresses), extends=_split(args.extends),
+                  uses=_split(args.uses), depends_on=_split(args.depends_on),
+                  refutes=_split(args.refutes),
+                  update_on_exist=args.update_on_exist)
     elif args.command == "sync":
         ids: list[str] = []
         if args.arxiv_ids:


### PR DESCRIPTION
## What & why

The research wiki has four node layers (papers / ideas / experiments / **claims**), but the **claims layer had no birth point** — a fully-implemented `add_claim` writer existed (uncommitted, drafted 2026-06-15) yet **no skill called it** (an orphan writer = dead code). This PR gives claims a single, correct birth point and fixes a latent status-vocabulary conflict found along the way.

Design was settled by a cross-model jury (**codex gpt-5.5 xhigh**), which chose **Option A — theory/proof ledger** (the writer's status enum + "PROVE/JUDGE ledger" framing + the real on-disk theory wikis all point there).

## Changes

- **`tools/research_wiki.py`** — lands the `add_claim` writer (claims/<slug>.md + provenance + injection-hygiene quarantine + typed edges); adds `unproven` to `_CLAIM_STATUSES` so an audited-but-open proof gap is representable honestly.
- **`skills/proof-checker/SKILL.md`** — **Phase 5.5** (the birth point): after `PROOF_AUDIT.json`, mint each top-level theorem as a claim via `add_claim`. Canonical resolver (`git root` + manifest `ARIS_REPO` backfill + 3-layer chain); **`NOT_APPLICABLE` / no-wiki / unresolved-helper all skip, and `add_claim` failure is non-fatal — the audit is never affected**. Honest status map (PASS→verified, flagged imports→sound-modulo-imports, counterexample/false→refuted, gap→unproven).
- **Claim `status` is the PROOF axis only.** Empirical experiment support is a *separate axis* carried by `supports`/`invalidates` **edges** — `result-to-claim` Step 5 + `research-wiki` Hook 3 no longer write `supported`/`invalidated` into a claim's `status` (the validator rejects them). Stale status examples corrected; `wiki-enrich` pointer fixed.
- **`research-wiki` Hook 4** documents `/proof-checker` as the sole claim birth point.
- **`check_skills_inventory.py`** drift-check: `add_claim` writer ⇔ its proof-checker birth trigger (anchored to the real command line) — can't regress to an orphan writer.
- **`tests/test_research_wiki_claims.py`** — 10 tests (empirical-status rejection, `unproven`, dedup, `--update-on-exist`, edges, birth, index).

## Verification

- 38 targeted tests green; `check_skills_inventory.py` consistent; codex-mirror set-test green; helper-lint clean (only a pre-existing false-positive).
- **Codex MCP (gpt-5.5 xhigh): 4 rounds** — design GO → impl NEEDS-CHANGES → NEEDS-CHANGES → **GO**.
- Zero behavior change for `/proof-checker` users without a research-wiki.

## Scope note

Mainline-only. The 4 edited SKILLs have `skills-codex/` mirrors that are already ~150–420 lines diverged (pre-existing, different reviewer convention) — content-sync to the codex mirror is a separate pre-existing follow-up, not introduced here (codex concurred it's out of scope for this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)