### PR TITLE
feat: record ideas via deterministic upsert_idea — fixes re-generated ideas not landing in the wiki

### DIFF
--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -390,35 +390,33 @@ Write a structured report to `idea-stage/IDEA_REPORT.md`:
 This is critical for spiral learning — without it, `ideas/` stays empty and re-ideation has no memory.
 
 `$WIKI_SCRIPT` was resolved in Phase 0 above. If Phase 0 did not run
-(no `research-wiki/`), this phase is skipped. If Phase 0 ran but the
-resolution chain failed to find the helper (`$WIKI_SCRIPT` is empty),
-the page-write step still runs (idea pages are plain markdown the
-agent writes directly), but the edge / query-pack / log steps that
-require the helper are skipped with a single warning.
+(no `research-wiki/`), skip this phase. The idea page is written by a
+**deterministic helper (`upsert_idea`)** — NOT freehand markdown — so **every
+generation, including a re-run with updated constraints, records reliably**
+(one CLI call per idea, not a prose step the model can skip). `upsert_idea`
+writes the page, wires the `inspired_by` / `addresses_gap` edges, and rebuilds
+index + query_pack in a single call. **Default skip-on-exist**: a re-ideation
+run records NEW ideas without clobbering an existing idea whose `outcome`
+`/result-to-claim` may already have enriched. If `$WIKI_SCRIPT` is empty
+(helper unreachable) the ideas are **NOT** recorded and a single WARN prints
+(fix: `bash tools/install_aris.sh` or `export ARIS_REPO`).
 
 ```
-if research-wiki/ exists:
+if research-wiki/ exists AND [ -n "$WIKI_SCRIPT" ]:
     for each idea in recommended_ideas + eliminated_ideas:
-        1. Create page: research-wiki/ideas/<idea_id>.md
-           - node_id: idea:<id>
-           - stage: proposed (or: piloted, archived)
-           - outcome: unknown (or: negative, mixed, positive)
-           - based_on: [paper:<slug>, ...]
-           - target_gaps: [gap:<id>, ...]
-           - Include: hypothesis, proposed method, expected outcome
-           - If pilot was run: actual outcome, failure notes, reusable components
-
-        2. Add edges (only if $WIKI_SCRIPT resolved):
-           [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "idea:<id>" --to "paper:<slug>" --type inspired_by --evidence "..."
-           [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "idea:<id>" --to "gap:<id>" --type addresses_gap --evidence "..."
-
-    Rebuild query pack (only if $WIKI_SCRIPT resolved):
-        [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" rebuild_query_pack research-wiki/
-    Log (only if $WIKI_SCRIPT resolved):
-        [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" log research-wiki/ "idea-creator wrote N ideas (M recommended, K eliminated)"
-
-    if [ -z "$WIKI_SCRIPT" ]:
-        echo "WARN: idea pages were written but edges / query_pack / log were skipped because research_wiki.py is unreachable (see Phase 0 warning above)." >&2
+        # recommended → --stage proposed; eliminated-at-ideation → --stage archived.
+        # --outcome stays "pending" (the experiment verdict, negative/mixed/positive,
+        # is set LATER by /result-to-claim — never guessed here).
+        python3 "$WIKI_SCRIPT" upsert_idea research-wiki/ \
+          --slug "<stable-idea-id>" --title "<idea title>" \
+          --stage "<proposed|archived>" --outcome pending \
+          --thesis "<core hypothesis / direction>" \
+          --risks "<novelty / feasibility risks; why killed if eliminated>" \
+          --based-on "<paper:slug,paper:slug2>" --target-gaps "<G2,G10>" \
+          || echo "WARN: upsert_idea failed for <id> (continuing; audit/report unaffected)" >&2
+    python3 "$WIKI_SCRIPT" log research-wiki/ "idea-creator wrote N ideas (M recommended, K eliminated)"
+elif research-wiki/ exists AND [ -z "$WIKI_SCRIPT" ]:
+    echo "WARN: ideas NOT recorded — research_wiki.py unreachable (see Phase 0). Fix: bash tools/install_aris.sh or export ARIS_REPO." >&2
 ```
 
 ## Output Protocols

--- a/skills/research-wiki/SKILL.md
+++ b/skills/research-wiki/SKILL.md
@@ -359,15 +359,19 @@ if research-wiki/query_pack.md exists (and < 7 days old):
     still run fresh literature search for last 3-6 months
 ```
 
-**After ideation (THIS IS CRITICAL — without it, ideas/ stays empty):**
+**After ideation (CRITICAL — without it, `ideas/` stays empty; runs on EVERY
+generation, including a re-run with updated constraints):** the page write is a
+**deterministic helper command**, not a freehand step the model can skip:
 ```
 for idea in all_generated_ideas (recommended + killed):
-    /research-wiki upsert_idea(idea)
-    for paper_id in idea.based_on:
-        add_edge(idea.node_id, paper_id, "inspired_by")
-    for gap_id in idea.target_gaps:
-        add_edge(idea.node_id, gap_id, "addresses_gap")
-rebuild query_pack
+    python3 "$WIKI_SCRIPT" upsert_idea research-wiki/ \
+      --slug <stable-id> --title <title> --stage <proposed|archived> --outcome pending \
+      --thesis <...> --risks <...> --based-on <paper:slug,...> --target-gaps <G2,...>
+    # one call: writes ideas/<slug>.md, wires inspired_by/addresses_gap edges,
+    # rebuilds index + query_pack, logs. Default skip-on-exist (won't clobber an
+    # existing idea enriched by /result-to-claim). `outcome` ∈ {unknown, pending,
+    # negative, mixed, positive} — the experiment verdict is set later by
+    # /result-to-claim, never guessed at ideation.
 log "idea-creator wrote N ideas to wiki"
 ```
 

--- a/tests/test_research_wiki_ideas.py
+++ b/tests/test_research_wiki_ideas.py
@@ -1,0 +1,113 @@
+"""Tests for the research-wiki idea layer — upsert_idea (idea-creator Phase 7 write-back).
+
+Locks the fix for "re-generated ideas not recorded": idea recording is now a
+deterministic helper (not a freehand step). Covers page creation with the `outcome`
+field (the one the re-ideation banlist + stats read), slug honored verbatim, outcome
+validation, dedup vs --update-on-exist (so a re-gen records NEW ideas without clobbering
+an enriched one), edge wiring, and that a `negative` idea lands in the query_pack banlist.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import research_wiki as rw  # noqa: E402
+
+
+class TestIdeaLayer(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        rw.init_wiki(self.root)
+
+    def _page(self, slug):
+        return Path(self.root) / "ideas" / f"{slug}.md"
+
+    def _edges(self):
+        p = Path(self.root) / "graph" / "edges.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()] if p.exists() else []
+
+    def test_creates_page_with_outcome_field(self):
+        rw.upsert_idea(self.root, "distill-executor", "Distill executor into Qwen",
+                       outcome="pending", thesis="train via OPD", stage="proposed")
+        fm = self._page("distill-executor").read_text()
+        self.assertIn("type: idea", fm)
+        self.assertIn("node_id: idea:distill-executor", fm)
+        self.assertIn("outcome: pending", fm)   # `outcome`, NOT `status` — banlist/stats read this
+        self.assertIn("stage: proposed", fm)
+
+    def test_slug_honored_verbatim(self):
+        rw.upsert_idea(self.root, "my-idea-7", "Some idea")
+        self.assertTrue(self._page("my-idea-7").is_file())
+
+    def test_invalid_outcome_rejected(self):
+        # claim/empirical words and typos must be rejected (outcome drives the banlist)
+        for bad in ("verified", "supported", "done", "good"):
+            with self.assertRaises(RuntimeError):
+                rw.upsert_idea(self.root, f"i-{bad}", f"I {bad}", outcome=bad)
+
+    def test_all_outcomes_accepted(self):
+        for i, oc in enumerate(sorted(rw._IDEA_OUTCOMES)):
+            rw.upsert_idea(self.root, f"o{i}", f"Idea {oc}", outcome=oc)
+            self.assertIn(f"outcome: {oc}", self._page(f"o{i}").read_text())
+
+    def test_dedup_skips_without_update_flag(self):
+        rw.upsert_idea(self.root, "x", "X", outcome="pending")
+        rw.upsert_idea(self.root, "x", "X", outcome="positive")  # should skip
+        self.assertIn("outcome: pending", self._page("x").read_text())
+
+    def test_update_on_exist_refreshes(self):
+        rw.upsert_idea(self.root, "x", "X", outcome="pending")
+        rw.upsert_idea(self.root, "x", "X", outcome="positive", update_on_exist=True)
+        self.assertIn("outcome: positive", self._page("x").read_text())
+
+    def test_edges_wired(self):
+        rw.upsert_idea(self.root, "y", "Y", based_on=["chen2026foo"], target_gaps=["G2"])
+        kinds = {(e["from"], e["type"], e["to"]) for e in self._edges()}
+        self.assertIn(("idea:y", "inspired_by", "paper:chen2026foo"), kinds)
+        self.assertIn(("idea:y", "addresses_gap", "gap:G2"), kinds)
+
+    def test_uninitialized_wiki_raises(self):
+        bare = tempfile.mkdtemp()  # no init → no ideas/ dir
+        with self.assertRaises(RuntimeError):
+            rw.upsert_idea(bare, "x", "X")
+
+    def test_negative_idea_enters_banlist(self):
+        # the user-facing point: a recorded failed idea feeds the re-ideation banlist
+        rw.upsert_idea(self.root, "flop", "A flop idea", outcome="negative",
+                       risks="failed because the assumption breaks")
+        qp = (Path(self.root) / "query_pack.md").read_text()
+        self.assertIn("Failed Ideas", qp)
+        self.assertIn("A flop idea", qp)
+
+    def test_appears_in_index(self):
+        rw.upsert_idea(self.root, "idx-idea", "Indexed idea")
+        self.assertIn("idx-idea", (Path(self.root) / "index.md").read_text())
+
+    def test_body_outcome_text_not_banlisted(self):
+        # A PENDING idea whose body discusses an "outcome: negative" failure mode
+        # must NOT be banlisted (the reader parses frontmatter, not full text).
+        rw.upsert_idea(self.root, "live-idea", "A live idea", outcome="pending",
+                       risks="a risk is that outcome: negative could happen if X")
+        qp = (Path(self.root) / "query_pack.md").read_text()
+        self.assertNotIn("A live idea", qp.split("## Failed Ideas")[-1] if "## Failed Ideas" in qp else "")
+        rw.get_stats(self.root)  # must not raise; pending idea not counted as negative
+
+    def test_invalid_stage_rejected(self):
+        with self.assertRaises(RuntimeError):
+            rw.upsert_idea(self.root, "bad-stage", "X", stage="proposed\noutcome: negative")
+
+    def test_frontmatter_injection_neutralized(self):
+        # A based_on id carrying a newline + a fake outcome line must not flip the
+        # parsed frontmatter outcome (quoting neutralizes the newline).
+        rw.upsert_idea(self.root, "inj", "Injection probe", outcome="pending",
+                       based_on=["paper:foo\noutcome: negative"])
+        meta = rw._load_paper_frontmatter(self._page("inj"))
+        self.assertEqual(meta.get("outcome"), "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_skills_inventory.py
+++ b/tools/check_skills_inventory.py
@@ -239,6 +239,15 @@ def check_inventory() -> list[str]:
     require(tool_claim, "tools/research_wiki.py must implement the add_claim claim-layer writer + its CLI", failures)
     require(born, "proof-checker/SKILL.md must invoke `add_claim` as the claim birth point — not just mention it (else add_claim is an orphan writer)", failures)
 
+    # research_wiki.py upsert_idea (idea layer) ⇔ its documented write-back in
+    # /idea-creator Phase 7. Same orphan-writer guard: the deterministic idea writer
+    # and the skill that calls it must BOTH be present, anchored to the real command.
+    icreator = read(SKILLS_ROOT / "idea-creator" / "SKILL.md")
+    tool_idea = bool(re.search(r"def upsert_idea\b", rwiki)) and bool(re.search(r'add_parser\("upsert_idea"', rwiki))
+    idea_written = re.search(r'python3\s+"\$WIKI_SCRIPT"\s+upsert_idea\b', icreator) is not None
+    require(tool_idea, "tools/research_wiki.py must implement the upsert_idea idea-layer writer + its CLI", failures)
+    require(idea_written, "idea-creator/SKILL.md must invoke `upsert_idea` to record ideas (Phase 7) — not just mention it (else ideas are written freehand and skipped on re-gen)", failures)
+
     return failures
 
 

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -285,15 +285,16 @@ def rebuild_query_pack(wiki_root: str, max_chars: int = 8000):
     if ideas_dir.exists():
         failed = []
         for f in sorted(ideas_dir.glob("*.md")):
-            content = f.read_text()
-            if "outcome: negative" in content or "outcome: mixed" in content:
-                # Extract frontmatter title and failure notes
+            meta = _load_paper_frontmatter(f)
+            # Gate on the FRONTMATTER outcome only (not a full-text substring): a
+            # `pending` idea whose body discusses an "outcome: negative" failure mode
+            # must NOT be banlisted.
+            if meta.get("outcome") in ("negative", "mixed"):
+                content = f.read_text()
                 lines = content.split("\n")
-                title = ""
+                title = meta.get("title", "")
                 failure = ""
                 for line in lines:
-                    if line.startswith("title:"):
-                        title = line.split(":", 1)[1].strip().strip('"')
                     if "failure" in line.lower() or "lesson" in line.lower():
                         idx = lines.index(line)
                         failure = "\n".join(lines[idx:idx+3])
@@ -399,7 +400,9 @@ def get_stats(wiki_root: str):
             return 0
         count = 0
         for f in d.glob("*.md"):
-            if f"{field}: {value}" in f.read_text():
+            # Read the FRONTMATTER field only — not a full-text substring, so body
+            # text mentioning e.g. "outcome: negative" can't inflate the count.
+            if _load_paper_frontmatter(f).get(field) == value:
                 count += 1
         return count
 
@@ -1040,6 +1043,196 @@ def add_claim(wiki_root: str, slug: str, name: str, *, description: str = "",
     return page_path
 
 
+_IDEA_OUTCOMES = {
+    "unknown",                 # not yet assessed
+    "pending",                 # proposed / awaiting pilot or experiment
+    "negative",                # tested, failed (feeds the re-ideation banlist)
+    "mixed",                   # partial result (also banlisted)
+    "positive",                # tested, succeeded
+}
+
+_IDEA_STAGES = {"proposed", "active", "piloted", "archived"}
+
+
+def _idea_slugify(name: str, slug: str = "") -> str:
+    """Slug for an idea page (mirrors _claim_slugify): honor an explicit --slug
+    verbatim (sanitized), else fall back to the title keyword extractor."""
+    if slug:
+        s = re.sub(r"[^a-z0-9._-]+", "-", slug.strip().lower()).strip("-")
+        if s:
+            return s
+    return slugify(name).lstrip("_").lstrip("0").strip("_") or "idea"
+
+
+def _render_idea_page(slug, title, description, stage, outcome, thesis, risks,
+                      based_on_ids, target_gap_ids, tags):
+    """Render an ideas/<slug>.md page following the research-wiki schema.
+
+    Mirrors _render_claim_page. The frontmatter `outcome` field is the one the
+    re-ideation banlist + stats read (rebuild_query_pack / get_stats), so it must
+    be one of _IDEA_OUTCOMES. Edges live in graph/edges.jsonl; the frontmatter
+    based_on / target_gaps lists mirror them for human-readable provenance.
+    """
+    lines = ["---"]
+    lines.append("type: idea")
+    lines.append(f"node_id: idea:{slug}")
+    lines.append(f"title: {_yaml_quote(title)}")
+    lines.append(f"stage: {stage}")
+    lines.append(f"outcome: {outcome}")
+    lines.append(f"added: {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}")
+    lines.append("based_on: [" + ", ".join(_yaml_quote(i) for i in based_on_ids) + "]")
+    lines.append("target_gaps: [" + ", ".join(_yaml_quote(i) for i in target_gap_ids) + "]")
+    lines.append("tags: [" + ", ".join(_yaml_quote(t) for t in tags) + "]")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {title}")
+    lines.append("")
+    lines.append(f"**stage:** `{stage}`  ·  **outcome:** `{outcome}`")
+    if description.strip():
+        lines.append("")
+        lines.append(description.strip())
+    lines.append("")
+    lines.append("## Thesis")
+    lines.append(thesis.strip() if thesis.strip() else "_TODO: the core hypothesis / direction._")
+    lines.append("")
+    lines.append("## Key risks")
+    lines.append(risks.strip() if risks.strip() else "_TODO: novelty / feasibility risks._")
+    lines.append("")
+    lines.append("## Connections")
+    lines.append("_Edges are recorded in `graph/edges.jsonl`; summarize here for human readers._")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def upsert_idea(wiki_root: str, slug: str, title: str, *, description: str = "",
+                stage: str = "proposed", outcome: str = "pending",
+                thesis: str = "", risks: str = "",
+                tags: list[str] | None = None,
+                based_on: list[str] | None = None,
+                target_gaps: list[str] | None = None,
+                update_on_exist: bool = False) -> Path:
+    """Create (or update) an ideas/<slug>.md node and wire its edges.
+
+    The idea layer is the research-direction ledger written by /idea-creator after
+    ideation (Phase 7). Mirrors add_claim / ingest_paper:
+      - writes ideas/<slug>.md from the schema above
+      - dedups by slug (update_on_exist=False SKIPS an existing page — so a
+        re-ideation run records NEW ideas without clobbering an existing idea whose
+        outcome /result-to-claim may have already enriched)
+      - records typed edges into graph/edges.jsonl via add_edge:
+          idea --inspired_by--> paper    (--based-on paper:slug)
+          idea --addresses_gap--> gap    (--target-gaps G2,G10)
+      - rebuilds index.md + query_pack.md, appends to log.md
+    `outcome` must be one of _IDEA_OUTCOMES (it drives the re-ideation banlist + stats).
+    NOTE: /result-to-claim updates an idea's outcome by editing the page in place (to
+    preserve the rich body); it must NOT call this with update_on_exist (would clobber).
+    """
+    root = Path(wiki_root)
+    if not (root / "ideas").exists():
+        raise RuntimeError(f"{root} is not an initialized wiki (ideas/ missing). "
+                           f"Run `init` first.")
+    if outcome not in _IDEA_OUTCOMES:
+        raise RuntimeError(f"unknown idea outcome '{outcome}'. "
+                           f"Valid: {sorted(_IDEA_OUTCOMES)}")
+    if stage not in _IDEA_STAGES:
+        raise RuntimeError(f"unknown idea stage '{stage}'. "
+                           f"Valid: {sorted(_IDEA_STAGES)}")
+
+    tags = tags or []
+    slug = _idea_slugify(title, slug)
+    node_id = f"idea:{slug}"
+
+    page_path = root / "ideas" / f"{slug}.md"
+    if page_path.exists() and not update_on_exist:
+        append_log(str(root), f"upsert_idea: skipped existing idea "
+                              f"{page_path.name} (slug dedup)")
+        print(f"Idea already exists: {page_path.name} (slug dedup) — skipping.")
+        return page_path
+    was_update = page_path.exists()
+
+    # Quarantine model-authored body fields before persist (re-read into agent
+    # context via index/query_pack) — same Layer-1 injection hygiene as add_claim.
+    # Title is structural (not quarantined, like add_claim's name). Placeholder
+    # persists; raw text → graph/quarantine.log for human review.
+    if quarantine is not None:
+        _q_hits = []
+
+        def _q(val, field):
+            if not val:
+                return val
+            safe, findings = quarantine(val, scope="strict",
+                                        label=f"idea {slug}.{field}")
+            if findings:
+                _q_hits.append((field, findings, val))
+            return safe
+
+        description = _q(description, "description")
+        thesis = _q(thesis, "thesis")
+        risks = _q(risks, "risks")
+        if _q_hits:
+            qlog = root / "graph" / "quarantine.log"
+            qlog.parent.mkdir(parents=True, exist_ok=True)
+            with open(qlog, "a", encoding="utf-8") as f:
+                for field, findings, raw in _q_hits:
+                    f.write(json.dumps({
+                        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "idea": node_id, "field": field,
+                        "findings": findings, "raw_text": raw,
+                    }, ensure_ascii=False) + "\n")
+            print(f"⚠️  idea field(s) quarantined "
+                  f"({', '.join(f for f, _, _ in _q_hits)}); placeholder persisted, "
+                  f"raw text preserved in graph/quarantine.log for review.",
+                  file=sys.stderr)
+
+    def _norm(target: str, default_prefix: str) -> str:
+        t = target.strip()
+        if not t:
+            return ""
+        if ":" in t:                                  # already a namespaced node_id
+            return t
+        if default_prefix == "gap:" or re.fullmatch(r"[Gg]\d+", t):
+            return f"gap:{t.upper()}" if re.fullmatch(r"[Gg]\d+", t) else f"{default_prefix}{t}"
+        return f"{default_prefix}{t}"
+
+    def _warn_if_dangling(nid: str) -> None:
+        if not nid:
+            return
+        kind, _, rest = nid.partition(":")
+        exists = True
+        if kind == "paper":
+            exists = (root / "papers" / f"{rest}.md").exists()
+        elif kind == "gap":
+            gm = root / "gap_map.md"
+            exists = gm.exists() and re.search(
+                rf"\b{re.escape(rest)}\b", gm.read_text(encoding="utf-8"))
+        if not exists:
+            print(f"⚠️  upsert_idea: edge target {nid} not found in this wiki "
+                  f"(dangling edge recorded — create the node or fix the id).",
+                  file=sys.stderr)
+
+    based_on_ids = [n for n in (_norm(t, "paper:") for t in (based_on or [])) if n]
+    target_gap_ids = [n for n in (_norm(t, "gap:") for t in (target_gaps or [])) if n]
+
+    rendered = _render_idea_page(slug, title, description, stage, outcome, thesis,
+                                 risks, based_on_ids, target_gap_ids, tags)
+    page_path.write_text(rendered)
+
+    # Wire edges (reuse add_edge so dedup + JSONL format match paper/claim edges).
+    for nid in based_on_ids:
+        _warn_if_dangling(nid)
+        add_edge(str(root), node_id, nid, "inspired_by", evidence=f"idea {slug} inspired by paper")
+    for nid in target_gap_ids:
+        _warn_if_dangling(nid)
+        add_edge(str(root), node_id, nid, "addresses_gap", evidence=f"idea {slug} addresses gap")
+
+    rebuild_index(str(root))
+    rebuild_query_pack(str(root))
+    action = "updated" if was_update else "added"
+    append_log(str(root), f"upsert_idea: {action} {node_id} [stage={stage} outcome={outcome}]")
+    print(f"Idea {action}: {page_path} [stage={stage} outcome={outcome}]")
+    return page_path
+
+
 def sync_papers(wiki_root: str, arxiv_ids: list[str], update_on_exist: bool = False) -> None:
     """Batch backfill: ingest many arxiv ids with a SINGLE metadata request.
 
@@ -1210,6 +1403,29 @@ def main():
     p_claim.add_argument("--update-on-exist", action="store_true",
                          help="Overwrite an existing claim instead of skipping (default: skip)")
 
+    # upsert_idea — create/update an idea node (idea-creator Phase 7 write-back)
+    p_idea = subparsers.add_parser("upsert_idea",
+                                   help="Create (or update) an ideas/<slug>.md node")
+    p_idea.add_argument("wiki_root")
+    p_idea.add_argument("--slug", default="",
+                        help="Stable idea id (honored verbatim); else derived from --title")
+    p_idea.add_argument("--title", required=True, help="Human-readable idea title")
+    p_idea.add_argument("--description", default="",
+                        help="One-line description for the index/frontmatter")
+    p_idea.add_argument("--stage", default="proposed",
+                        help="proposed | active | piloted | archived")
+    p_idea.add_argument("--outcome", default="pending",
+                        help="One of: " + ", ".join(sorted(_IDEA_OUTCOMES)))
+    p_idea.add_argument("--thesis", default="", help="Core hypothesis / direction (body)")
+    p_idea.add_argument("--risks", default="", help="Novelty / feasibility risks (body)")
+    p_idea.add_argument("--tags", default="", help="Comma-separated tag list")
+    p_idea.add_argument("--based-on", dest="based_on", default="",
+                        help="Comma-separated paper node_ids/slugs that inspired this idea")
+    p_idea.add_argument("--target-gaps", dest="target_gaps", default="",
+                        help="Comma-separated gap ids this idea addresses, e.g. G2,G10")
+    p_idea.add_argument("--update-on-exist", action="store_true",
+                        help="Overwrite an existing idea instead of skipping (default: skip)")
+
     # sync — batch backfill
     p_sync = subparsers.add_parser("sync",
                                     help="Batch ingest from a list of arXiv IDs")
@@ -1256,6 +1472,14 @@ def main():
                   uses=_split(args.uses), depends_on=_split(args.depends_on),
                   refutes=_split(args.refutes),
                   update_on_exist=args.update_on_exist)
+    elif args.command == "upsert_idea":
+        def _spliti(s: str) -> list[str]:
+            return [x.strip() for x in s.split(",") if x.strip()]
+        upsert_idea(args.wiki_root, args.slug, args.title,
+                    description=args.description, stage=args.stage, outcome=args.outcome,
+                    thesis=args.thesis, risks=args.risks, tags=_spliti(args.tags),
+                    based_on=_spliti(args.based_on), target_gaps=_spliti(args.target_gaps),
+                    update_on_exist=args.update_on_exist)
     elif args.command == "sync":
         ids: list[str] = []
         if args.arxiv_ids:


### PR DESCRIPTION
## What & why

A user reported: **ideas are recorded in the wiki on first generation, but NOT on re-generation** (after updating the prompt). Root cause: idea pages were written **freehand markdown** by the model — a prose step easily skipped on a re-prompt. Unlike papers (`ingest_paper`) and claims (`add_claim`, just shipped in #305), the idea layer had **no deterministic writer**.

This adds `upsert_idea` and makes `/idea-creator` Phase 7 call it, so every generation records reliably. Same pattern + rigor as the claim layer.

## Changes

- **`tools/research_wiki.py`** — `upsert_idea` writer mirroring `add_claim`: writes `ideas/<slug>.md`, validates `outcome` (∈ `{unknown, pending, negative, mixed, positive}`) and `stage`, dedups by slug (**skip-on-exist default** — a re-gen records NEW ideas without clobbering one `/result-to-claim` already enriched), injection-hygiene quarantine of body fields, wires `inspired_by`/`addresses_gap` edges, rebuilds index+query_pack. CLI `upsert_idea`.
- **Reader integrity** (codex-caught): the failed-ideas **banlist** (`rebuild_query_pack`) + `get_stats` now parse the **frontmatter** `outcome` via `_load_paper_frontmatter`, not a full-text substring — so a `pending` idea whose body mentions "outcome: negative" is neither banlisted nor mis-counted. Frontmatter list items are `_yaml_quote`-wrapped to neutralize newline-injection of a second `outcome:` line.
- **`skills/idea-creator/SKILL.md` Phase 7** — deterministic `upsert_idea` call per idea (was freehand). `--outcome pending` at creation; the experiment verdict is set later by `/result-to-claim` (which stays freehand to preserve the rich body — it must NOT call `upsert_idea`).
- **`skills/research-wiki/SKILL.md` Hook 2** — updated to the deterministic command.
- **`check_skills_inventory.py`** drift-check: `upsert_idea` writer ⇔ idea-creator's real invocation (anchored) — can't regress to an orphan writer.
- **`tests/test_research_wiki_ideas.py`** — 13 tests (outcome validation, dedup vs update, edges, banlist, **body-text-not-banlisted**, stage validation, frontmatter-injection neutralized).

## Verification

- 13 idea tests + 51 regression green; `check_skills_inventory.py` consistent; codex-mirror set-test green; lint clean (pre-existing false-positive only).
- **Codex MCP (gpt-5.5 xhigh): 2 rounds** — impl NEEDS-CHANGES (banlist substring + frontmatter injection) → **GO**.
- `/result-to-claim` correctly left freehand for the outcome UPDATE (upsert would clobber the body).

## Scope note

Mainline-only. The 2 edited SKILLs have `skills-codex/` mirrors that are pre-existingly diverged — content-sync is a separate follow-up (not introduced here), consistent with #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)