### PR TITLE
feat: add_experiment — close the last freehand wiki layer (all 4 node types now deterministic)

### DIFF
--- a/skills/research-wiki/SKILL.md
+++ b/skills/research-wiki/SKILL.md
@@ -378,21 +378,28 @@ log "idea-creator wrote N ideas to wiki"
 ### Hook 3: After `/result-to-claim` verdict
 
 ```
-# Create experiment page (the experiment verdict lives HERE)
-exp_id = upsert_experiment(experiment_data)
+# Create/refresh the experiment node FIRST via the deterministic helper (verdict owner
+# → --update-on-exist). This is the experiment BIRTH point. add_edge does NOT verify
+# node existence, so GATE the supports/invalidates edges below on the node having been
+# born (EXP_NODE_OK) — else they'd dangle off a missing exp node.
+EXP_NODE_OK = (python3 "$WIKI_SCRIPT" add_experiment research-wiki/ --slug <exp_id> \
+  --idea idea:<active_idea> --verdict <yes|partial|no> --confidence <high|medium|low> \
+  --metrics <...> --reasoning <...> --provenance <run dir> --update-on-exist) succeeded
+  # writes page + idea--tested_by-->exp edge + rebuilds index/query_pack
 
-# Record empirical support as EDGES ONLY — never overwrite the claim's `status`.
-# A claim's `status` is the PROOF axis (verified / sound-modulo-imports / refuted /
-# unproven / drafted / retracted), owned by /proof-checker (the claim birth point).
-# Experiment support is a SEPARATE axis, carried entirely by supports/invalidates
+# Record empirical support as EDGES ONLY, and ONLY if EXP_NODE_OK — never overwrite the
+# claim's `status`. A claim's `status` is the PROOF axis (verified / sound-modulo-imports
+# / refuted / unproven / drafted / retracted), owned by /proof-checker (the claim birth
+# point). Experiment support is a SEPARATE axis carried entirely by supports/invalidates
 # edges; writing "supported"/"invalidated" into status is rejected by the validator.
-for claim_id in resolved_claims:
-    if verdict == "yes":
-        add_edge(exp_id, claim_id, "supports")
-    elif verdict == "partial":
-        add_edge(exp_id, claim_id, "supports")   # partial — qualify in --evidence
-    else:
-        add_edge(exp_id, claim_id, "invalidates")
+if EXP_NODE_OK:
+    for claim_id in resolved_claims:
+        if verdict == "yes":
+            add_edge(exp_id, claim_id, "supports")
+        elif verdict == "partial":
+            add_edge(exp_id, claim_id, "supports")   # partial — qualify in --evidence
+        else:
+            add_edge(exp_id, claim_id, "invalidates")
 
 # Update idea outcome
 update_idea(active_idea_id, outcome=verdict)

--- a/skills/result-to-claim/SKILL.md
+++ b/skills/result-to-claim/SKILL.md
@@ -242,28 +242,38 @@ WIKI_SCRIPT=".aris/tools/research_wiki.py"
 
 ```
 if research-wiki/ exists:
-    # 1. Create experiment page
-    Create research-wiki/experiments/<exp_id>.md with:
-      - node_id: exp:<id>
-      - idea_id: idea:<active_idea>
-      - date, hardware, duration, metrics
-      - verdict, confidence, reasoning summary
+    # 1. Create/refresh the experiment node FIRST (verdict OWNER → --update-on-exist so
+    #    a re-judge overwrites the stale verdict). The supports/invalidates edges in #2
+    #    point FROM exp:<id>, and add_edge does NOT verify node existence — so GATE those
+    #    edges on the experiment node having been born (EXP_NODE_OK), else they'd dangle
+    #    (the exact bug this closes). On failure: warn, skip the wiki edges, still report.
+    EXP_NODE_OK=0
+    if [ -n "$WIKI_SCRIPT" ]; then
+      if python3 "$WIKI_SCRIPT" add_experiment research-wiki/ \
+           --slug "<exp_id>" --idea "idea:<active_idea>" \
+           --verdict "<yes|partial|no>" --confidence "<high|medium|low>" \
+           --date "<date>" --hardware "<hw>" --duration "<dur>" \
+           --metrics "<key metrics>" --reasoning "<one-line why this verdict>" \
+           --provenance "<EXPERIMENT_AUDIT.md / run dir>" --update-on-exist; then
+        EXP_NODE_OK=1   # page written + idea--tested_by-->exp edge + index/query_pack rebuilt
+      else
+        echo "WARN: add_experiment failed for <exp_id>; skipping wiki edges (verdict still reported)." >&2
+      fi
+    fi
 
-    # 2. Record empirical support as EDGES ONLY — never edit the claim page's `status`
-    #    field. A claim's `status` is the PROOF axis (verified / refuted / unproven /
+    # 2. Record empirical support as EDGES ONLY — and ONLY when the exp node was born
+    #    ([ "$EXP_NODE_OK" = 1 ]), so no edge dangles off a missing node. Never edit the
+    #    claim page's `status`: that is the PROOF axis (verified / refuted / unproven /
     #    sound-modulo-imports / drafted / retracted), owned by /proof-checker (the claim
-    #    birth point). Experiment support is a SEPARATE axis carried by these edges;
-    #    "supported"/"invalidated" are NOT valid claim statuses (the validator rejects them).
-    #    The edge attaches to a claim that should ALREADY be born by /proof-checker.
-    #    add_edge does NOT verify the target exists — a missing claim yields a SILENT
-    #    dangling edge — so ensure /proof-checker ran first; never hand-create the claim here.
-    for each claim resolved by this verdict (edges only if $WIKI_SCRIPT resolved):
+    #    birth point) — "supported"/"invalidated" are NOT valid claim statuses. The claim
+    #    target should ALREADY be born by /proof-checker; add_edge does not verify it.
+    for each claim resolved by this verdict (only if [ "$EXP_NODE_OK" = 1 ]):
         if verdict == "yes":
-            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "<metric>"
+            python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "<metric>"
         elif verdict == "partial":
-            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "partial: <metric>"
+            python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "partial: <metric>"
         else:
-            [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type invalidates --evidence "<why>"
+            python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type invalidates --evidence "<why>"
 
     # 3. Update idea outcome (raw markdown, helper-free)
     Update research-wiki/ideas/<idea_id>.md:

--- a/tests/test_research_wiki_experiments.py
+++ b/tests/test_research_wiki_experiments.py
@@ -1,0 +1,88 @@
+"""Tests for the research-wiki experiment layer — add_experiment (result-to-claim Step 5).
+
+Closes the last freehand wiki layer. The experiment node must EXIST before
+/result-to-claim adds supports/invalidates edges from it (no dangling evidence
+graph). /result-to-claim is the verdict owner → it passes --update-on-exist so a
+re-judge overwrites the stale verdict. Covers verdict/confidence validation, the
+idea--tested_by-->exp edge, skip vs update, slug requirement, and frontmatter safety.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import research_wiki as rw  # noqa: E402
+
+
+class TestExperimentLayer(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        rw.init_wiki(self.root)
+
+    def _page(self, slug):
+        return Path(self.root) / "experiments" / f"{slug}.md"
+
+    def _edges(self):
+        p = Path(self.root) / "graph" / "edges.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()] if p.exists() else []
+
+    def test_creates_page_with_verdict_and_confidence(self):
+        rw.add_experiment(self.root, "exp-001", verdict="partial", confidence="high",
+                          hardware="4xH200", metrics="acc 0.71")
+        fm = self._page("exp-001").read_text()
+        self.assertIn("type: experiment", fm)
+        self.assertIn("node_id: exp:exp-001", fm)
+        self.assertIn("verdict: partial", fm)
+        self.assertIn("confidence: high", fm)
+
+    def test_invalid_verdict_rejected(self):
+        for bad in ("positive", "mixed", "supported", "yes!"):
+            with self.assertRaises(RuntimeError):
+                rw.add_experiment(self.root, f"e-{bad}", verdict=bad)
+
+    def test_invalid_confidence_rejected(self):
+        with self.assertRaises(RuntimeError):
+            rw.add_experiment(self.root, "e-c", confidence="very-high")
+
+    def test_tested_by_edge(self):
+        rw.add_experiment(self.root, "exp-002", idea="my-idea", verdict="yes")
+        kinds = {(e["from"], e["type"], e["to"]) for e in self._edges()}
+        self.assertIn(("idea:my-idea", "tested_by", "exp:exp-002"), kinds)
+
+    def test_skip_on_exist_default(self):
+        rw.add_experiment(self.root, "exp-003", verdict="partial")
+        rw.add_experiment(self.root, "exp-003", verdict="yes")  # skip
+        self.assertIn("verdict: partial", self._page("exp-003").read_text())
+
+    def test_update_on_exist_overwrites_verdict(self):
+        # the verdict owner (/result-to-claim) re-judges → must overwrite the stale verdict
+        rw.add_experiment(self.root, "exp-003", verdict="partial")
+        rw.add_experiment(self.root, "exp-003", verdict="yes", update_on_exist=True)
+        self.assertIn("verdict: yes", self._page("exp-003").read_text())
+
+    def test_empty_slug_rejected(self):
+        with self.assertRaises(RuntimeError):
+            rw.add_experiment(self.root, "   ", verdict="no")
+
+    def test_uninitialized_wiki_raises(self):
+        bare = tempfile.mkdtemp()
+        with self.assertRaises(RuntimeError):
+            rw.add_experiment(bare, "exp-x", verdict="no")
+
+    def test_frontmatter_injection_neutralized(self):
+        # a newline-bearing hardware/date value must not inject a second verdict line
+        rw.add_experiment(self.root, "exp-inj", verdict="no",
+                          hardware="gpu\nverdict: yes")
+        self.assertEqual(rw._load_paper_frontmatter(self._page("exp-inj")).get("verdict"), "no")
+
+    def test_appears_in_index(self):
+        rw.add_experiment(self.root, "exp-idx", verdict="yes")
+        self.assertIn("exp-idx", (Path(self.root) / "index.md").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_skills_inventory.py
+++ b/tools/check_skills_inventory.py
@@ -248,6 +248,15 @@ def check_inventory() -> list[str]:
     require(tool_idea, "tools/research_wiki.py must implement the upsert_idea idea-layer writer + its CLI", failures)
     require(idea_written, "idea-creator/SKILL.md must invoke `upsert_idea` to record ideas (Phase 7) — not just mention it (else ideas are written freehand and skipped on re-gen)", failures)
 
+    # research_wiki.py add_experiment (experiment layer) ⇔ its write-back in
+    # /result-to-claim Step 5. Same orphan-writer guard; closes the last freehand
+    # wiki layer so the supports/invalidates edges never dangle off a missing exp node.
+    r2c = read(SKILLS_ROOT / "result-to-claim" / "SKILL.md")
+    tool_exp = bool(re.search(r"def add_experiment\b", rwiki)) and bool(re.search(r'add_parser\("add_experiment"', rwiki))
+    exp_written = re.search(r'python3\s+"\$WIKI_SCRIPT"\s+add_experiment\b', r2c) is not None
+    require(tool_exp, "tools/research_wiki.py must implement the add_experiment experiment-layer writer + its CLI", failures)
+    require(exp_written, "result-to-claim/SKILL.md must invoke `add_experiment` to create the experiment node (Step 5) — not just mention it (else exp pages are freehand and supports/invalidates edges dangle)", failures)
+
     return failures
 
 

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -1233,6 +1233,148 @@ def upsert_idea(wiki_root: str, slug: str, title: str, *, description: str = "",
     return page_path
 
 
+_EXPERIMENT_VERDICTS = {"yes", "partial", "no"}
+_EXPERIMENT_CONFIDENCE = {"high", "medium", "low"}
+
+
+def _render_experiment_page(slug, title, idea_id, verdict, confidence, date,
+                            hardware, duration, metrics, reasoning, provenance, tags):
+    """Render an experiments/<slug>.md page (mirrors _render_claim_page). All
+    free-form frontmatter values are _yaml_quote-wrapped (newline-injection safe);
+    verdict/confidence are validated enums; metrics/reasoning live in the body."""
+    label = title.strip() or f"Experiment {slug}"
+    lines = ["---"]
+    lines.append("type: experiment")
+    lines.append(f"node_id: exp:{slug}")
+    lines.append(f"title: {_yaml_quote(label)}")
+    lines.append(f"idea_id: {_yaml_quote(idea_id)}")
+    lines.append(f"verdict: {verdict}")
+    lines.append(f"confidence: {confidence}")
+    lines.append(f"date: {_yaml_quote(date)}")
+    lines.append(f"hardware: {_yaml_quote(hardware)}")
+    lines.append(f"duration: {_yaml_quote(duration)}")
+    lines.append(f"provenance: {_yaml_quote(provenance)}")
+    lines.append(f"added: {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}")
+    lines.append("tags: [" + ", ".join(_yaml_quote(t) for t in tags) + "]")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {label}")
+    lines.append("")
+    lines.append(f"**verdict:** `{verdict}`  ·  **confidence:** `{confidence}`"
+                 + (f"  ·  tests `{idea_id}`" if idea_id else ""))
+    lines.append("")
+    lines.append("## Metrics")
+    lines.append(metrics.strip() if metrics.strip() else "_TODO: key metrics._")
+    lines.append("")
+    lines.append("## Reasoning")
+    lines.append(reasoning.strip() if reasoning.strip() else "_TODO: why this verdict._")
+    lines.append("")
+    lines.append("## Connections")
+    lines.append("_Edges are recorded in `graph/edges.jsonl`; summarize here for human readers._")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def add_experiment(wiki_root: str, slug: str, *, title: str = "", idea: str = "",
+                   verdict: str = "no", confidence: str = "medium",
+                   date: str = "", hardware: str = "", duration: str = "",
+                   metrics: str = "", reasoning: str = "", provenance: str = "",
+                   tags: list[str] | None = None,
+                   update_on_exist: bool = False) -> Path:
+    """Create (or update) an experiments/<slug>.md node and wire its edge.
+
+    The experiment layer is the pilot/run ledger written by /result-to-claim (the
+    verdict owner). Mirrors add_claim / upsert_idea:
+      - writes experiments/<slug>.md from the schema
+      - dedups by slug (update_on_exist=False SKIPS; /result-to-claim passes
+        --update-on-exist because re-judging the SAME exp must overwrite the stale
+        verdict, not keep it)
+      - records the idea --tested_by--> exp edge via add_edge (--idea idea:slug)
+      - rebuilds index + query_pack, appends to log
+    `verdict` ∈ _EXPERIMENT_VERDICTS, `confidence` ∈ _EXPERIMENT_CONFIDENCE. Ensures
+    the exp:<id> node EXISTS before /result-to-claim adds supports/invalidates edges
+    FROM it — no dangling evidence-graph edge (edge with no node).
+    """
+    root = Path(wiki_root)
+    if not (root / "experiments").exists():
+        raise RuntimeError(f"{root} is not an initialized wiki (experiments/ missing). "
+                           f"Run `init` first.")
+    if verdict not in _EXPERIMENT_VERDICTS:
+        raise RuntimeError(f"unknown experiment verdict '{verdict}'. "
+                           f"Valid: {sorted(_EXPERIMENT_VERDICTS)}")
+    if confidence not in _EXPERIMENT_CONFIDENCE:
+        raise RuntimeError(f"unknown confidence '{confidence}'. "
+                           f"Valid: {sorted(_EXPERIMENT_CONFIDENCE)}")
+
+    tags = tags or []
+    slug = re.sub(r"[^a-z0-9._-]+", "-", slug.strip().lower()).strip("-")
+    if not slug:
+        raise RuntimeError("experiment slug (exp id) is required and must be non-empty")
+    node_id = f"exp:{slug}"
+    idea_id = idea.strip()
+    if idea_id and ":" not in idea_id:
+        idea_id = f"idea:{idea_id}"
+
+    page_path = root / "experiments" / f"{slug}.md"
+    if page_path.exists() and not update_on_exist:
+        append_log(str(root), f"add_experiment: skipped existing experiment "
+                              f"{page_path.name} (slug dedup)")
+        print(f"Experiment already exists: {page_path.name} (slug dedup) — skipping.")
+        return page_path
+    was_update = page_path.exists()
+
+    # Quarantine model-authored body fields (re-read into context) — same hygiene
+    # as add_claim / upsert_idea. Enum + structural fields are not quarantined.
+    if quarantine is not None:
+        _q_hits = []
+
+        def _q(val, field):
+            if not val:
+                return val
+            safe, findings = quarantine(val, scope="strict",
+                                        label=f"experiment {slug}.{field}")
+            if findings:
+                _q_hits.append((field, findings, val))
+            return safe
+
+        metrics = _q(metrics, "metrics")
+        reasoning = _q(reasoning, "reasoning")
+        if _q_hits:
+            qlog = root / "graph" / "quarantine.log"
+            qlog.parent.mkdir(parents=True, exist_ok=True)
+            with open(qlog, "a", encoding="utf-8") as f:
+                for field, findings, raw in _q_hits:
+                    f.write(json.dumps({
+                        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "experiment": node_id, "field": field,
+                        "findings": findings, "raw_text": raw,
+                    }, ensure_ascii=False) + "\n")
+            print(f"⚠️  experiment field(s) quarantined "
+                  f"({', '.join(f for f, _, _ in _q_hits)}); placeholder persisted, "
+                  f"raw text preserved in graph/quarantine.log for review.",
+                  file=sys.stderr)
+
+    rendered = _render_experiment_page(slug, title, idea_id, verdict, confidence,
+                                       date, hardware, duration, metrics, reasoning,
+                                       provenance, tags)
+    page_path.write_text(rendered)
+
+    # Wire the idea --tested_by--> exp edge (idea side owns it, per the schema).
+    if idea_id:
+        if idea_id.startswith("idea:") and not (root / "ideas" / f"{idea_id.split(':', 1)[1]}.md").exists():
+            print(f"⚠️  add_experiment: idea {idea_id} not found in this wiki "
+                  f"(dangling edge recorded — create the node or fix the id).",
+                  file=sys.stderr)
+        add_edge(str(root), idea_id, node_id, "tested_by", evidence=f"exp {slug} tests idea")
+
+    rebuild_index(str(root))
+    rebuild_query_pack(str(root))
+    action = "updated" if was_update else "added"
+    append_log(str(root), f"add_experiment: {action} {node_id} [verdict={verdict} confidence={confidence}]")
+    print(f"Experiment {action}: {page_path} [verdict={verdict} confidence={confidence}]")
+    return page_path
+
+
 def sync_papers(wiki_root: str, arxiv_ids: list[str], update_on_exist: bool = False) -> None:
     """Batch backfill: ingest many arxiv ids with a SINGLE metadata request.
 
@@ -1426,6 +1568,25 @@ def main():
     p_idea.add_argument("--update-on-exist", action="store_true",
                         help="Overwrite an existing idea instead of skipping (default: skip)")
 
+    # add_experiment — create/update an experiment node (result-to-claim Step 5 #1)
+    p_exp = subparsers.add_parser("add_experiment",
+                                  help="Create (or update) an experiments/<slug>.md node")
+    p_exp.add_argument("wiki_root")
+    p_exp.add_argument("--slug", required=True, help="Stable experiment id, e.g. exp-001")
+    p_exp.add_argument("--title", default="", help="Human-readable label (default: 'Experiment <slug>')")
+    p_exp.add_argument("--idea", default="", help="Idea node_id/slug this experiment tests (wires idea --tested_by--> exp)")
+    p_exp.add_argument("--verdict", default="no", help="One of: " + ", ".join(sorted(_EXPERIMENT_VERDICTS)))
+    p_exp.add_argument("--confidence", default="medium", help="One of: " + ", ".join(sorted(_EXPERIMENT_CONFIDENCE)))
+    p_exp.add_argument("--date", default="", help="Run date")
+    p_exp.add_argument("--hardware", default="", help="Hardware used")
+    p_exp.add_argument("--duration", default="", help="Wall-clock / GPU-hours")
+    p_exp.add_argument("--metrics", default="", help="Key metrics (body)")
+    p_exp.add_argument("--reasoning", default="", help="Why this verdict (body)")
+    p_exp.add_argument("--provenance", default="", help="Run dir / EXPERIMENT_AUDIT pointer (honesty receipt)")
+    p_exp.add_argument("--tags", default="", help="Comma-separated tag list")
+    p_exp.add_argument("--update-on-exist", action="store_true",
+                       help="Overwrite an existing experiment (the verdict owner /result-to-claim passes this on a re-judge)")
+
     # sync — batch backfill
     p_sync = subparsers.add_parser("sync",
                                     help="Batch ingest from a list of arXiv IDs")
@@ -1480,6 +1641,13 @@ def main():
                     thesis=args.thesis, risks=args.risks, tags=_spliti(args.tags),
                     based_on=_spliti(args.based_on), target_gaps=_spliti(args.target_gaps),
                     update_on_exist=args.update_on_exist)
+    elif args.command == "add_experiment":
+        add_experiment(args.wiki_root, args.slug, title=args.title, idea=args.idea,
+                       verdict=args.verdict, confidence=args.confidence, date=args.date,
+                       hardware=args.hardware, duration=args.duration, metrics=args.metrics,
+                       reasoning=args.reasoning, provenance=args.provenance,
+                       tags=[x.strip() for x in args.tags.split(",") if x.strip()],
+                       update_on_exist=args.update_on_exist)
     elif args.command == "sync":
         ids: list[str] = []
         if args.arxiv_ids:


### PR DESCRIPTION
## What

Experiments were the only research-wiki layer still written **freehand** (result-to-claim Step 5 #1). This adds `add_experiment` (mirroring `ingest_paper`/`add_claim`/`upsert_idea`) and wires result-to-claim to it — so **all four node layers (papers · claims · ideas · experiments) now have deterministic writers**.

Primary correctness win (codex-flagged): result-to-claim adds `supports`/`invalidates` edges FROM `exp:<id>`. With freehand creation, a skipped page left **dangling edges off a missing node**. Now the exp node is born first, and the edges are **gated on `EXP_NODE_OK`** (birth success) — `add_edge` doesn't verify nodes, so a failed birth skips the edges (verdict still reported).

## Changes
- **`tools/research_wiki.py`** — `add_experiment`: validates `verdict`∈{yes,partial,no} + `confidence`∈{high,medium,low}, non-empty slug, skip-on-exist default, quarantines metrics/reasoning, **all free-form frontmatter `_yaml_quote`-wrapped** (newline-injection safe), wires `idea --tested_by--> exp`. CLI `add_experiment`.
- **`skills/result-to-claim/SKILL.md`** Step 5 — `add_experiment ... --update-on-exist` (verdict owner); `EXP_NODE_OK` gate on the claim edges.
- **`skills/research-wiki/SKILL.md`** Hook 3 — deterministic call + mirrored `EXP_NODE_OK` gate.
- **`check_skills_inventory.py`** drift-check (anchored). **`tests/test_research_wiki_experiments.py`** — 10 tests.

## Verification
- 10 experiment tests + 33 wiki-layer regression green; drift consistent; mirror set-test green.
- **Codex MCP (gpt-5.5 xhigh): 2 rounds** — impl NEEDS-CHANGES (edge-gate on node birth) → **GO**.

Mainline-only; the skills-codex mirror content-sync (claim/idea/experiment doctrine) is the immediate next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)