### PR TITLE
fix(skills-codex): sync wiki-write doctrine into the Codex mirror (fixes a live contradiction)

### DIFF
--- a/skills/skills-codex/idea-creator/SKILL.md
+++ b/skills/skills-codex/idea-creator/SKILL.md
@@ -258,21 +258,31 @@ Skip this phase entirely if `research-wiki/` does not exist.
 
 This is critical for spiral learning: without it, `ideas/` stays empty and re-ideation has no memory.
 
-For each recommended and eliminated idea:
-
-1. Create or update `research-wiki/ideas/<idea_id>.md`.
-2. Include `node_id`, `stage`, `outcome`, `based_on`, `target_gaps`, hypothesis, proposed method, expected outcome, and pilot results when available.
-3. If `WIKI_SCRIPT` is available, add edges from idea to source papers and target gaps, then rebuild `query_pack.md`.
-4. If `WIKI_SCRIPT` is unavailable, write the idea pages and report that graph edges/query-pack rebuild require ARIS `research_wiki.py`.
-
-Required edge semantics when helper support exists:
+The idea page is written by the **deterministic `upsert_idea` helper** — NOT freehand
+markdown — so **every generation, including a re-run with updated constraints, records
+reliably** (one helper call per idea, not a prose step the model can skip). `upsert_idea`
+writes the page, wires the `inspired_by`/`addresses_gap` edges, and rebuilds index +
+query_pack in a single call. Default **skip-on-exist**: a re-ideation run records NEW
+ideas without clobbering an existing idea whose `outcome` `/result-to-claim` may already
+have enriched. `--outcome` stays `pending` at creation (the experiment verdict is set
+later by `/result-to-claim`, never guessed here). If `WIKI_SCRIPT` is unavailable, the
+ideas are NOT recorded and a single WARN is reported (fix: install ARIS `research_wiki.py`).
 
 ```text
-idea:<id> --inspired_by--> paper:<slug>
-idea:<id> --addresses_gap--> gap:<id>
+if research-wiki/ exists AND WIKI_SCRIPT is available:
+    for each recommended (stage proposed) and eliminated (stage archived) idea:
+        python3 "$WIKI_SCRIPT" upsert_idea research-wiki/ --slug "<stable-idea-id>" \
+             --title "<idea title>" --stage "<proposed|archived>" --outcome pending \
+             --thesis "<core hypothesis / direction>" \
+             --risks "<novelty / feasibility risks; why killed if eliminated>" \
+             --based-on "<paper:slug,paper:slug2>" --target-gaps "<G2,G10>"
+    log: "idea-creator wrote N ideas (M recommended, K eliminated)"
+else if research-wiki/ exists AND WIKI_SCRIPT unavailable:
+    report: ideas NOT recorded — ARIS research_wiki.py unreachable
 ```
 
-Log the update as: `idea-creator wrote N ideas (M recommended, K eliminated)`.
+Edge semantics (wired by `upsert_idea` itself): `idea:<id> --inspired_by--> paper:<slug>`
+and `idea:<id> --addresses_gap--> gap:<id>`.
 
 ## Output Protocols
 

--- a/skills/skills-codex/proof-checker/SKILL.md
+++ b/skills/skills-codex/proof-checker/SKILL.md
@@ -373,6 +373,39 @@ Write `PROOF_CHECK_STATE.json`:
 }
 ```
 
+### Phase 5.5: Research Wiki Claim Ledger (additive; only if a wiki is active)
+
+If — and only if — a `research-wiki/` exists, persist each top-level theorem/headline
+as a **claim node** (the wiki's PROVE/JUDGE ledger). This is the **birth point** for wiki
+claim nodes. It is a **detect-only record, never a verdict**: it never changes the audit's
+`verdict`/`reason_code`, never blocks, and is skipped when `verdict == NOT_APPLICABLE` or no
+wiki is found. The claim's `status` is the **PROOF axis only** ({drafted, unproven,
+sound-modulo-imports, verified, refuted, retracted}); empirical experiment support is a
+separate axis carried by edges (`/result-to-claim`), never written into `status`.
+
+Resolve the helper via the Codex-side chain (skip cleanly if unavailable; the audit is
+already complete):
+```
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+WIKI_SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+[ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+[ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+```
+
+If `research-wiki/` exists and `WIKI_SCRIPT` is available and `verdict != NOT_APPLICABLE`,
+for each top-level theorem map the audit outcome to an honest status — `PASS`/all proofs
+complete → `verified`; closes modulo flagged imports → `sound-modulo-imports`; counterexample
+found or statement judged false → `refuted`; open gap (UNJUSTIFIED, no counterexample) →
+`unproven` (never fake a gap as `refuted`/`verified`) — then record it (idempotent):
+```
+python3 "$WIKI_SCRIPT" add_claim research-wiki/ --slug "<stable-theorem-id>" \
+     --name "<theorem headline>" --status "<mapped status>" \
+     --provenance "<trace_path from PROOF_AUDIT.json>" --statement "<canonical statement>" \
+     --scope "<what it does NOT say; flagged imports>" --update-on-exist
+```
+`add_claim` failure is non-fatal (warn and continue; the audit is unaffected).
+
 ## Key Rules
 
 ### Mathematical rigor

--- a/skills/skills-codex/research-wiki/SKILL.md
+++ b/skills/skills-codex/research-wiki/SKILL.md
@@ -24,7 +24,7 @@ Inspired by [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6
 | **Paper** | `papers/` | `paper:<slug>` | A published or preprint research paper |
 | **Idea** | `ideas/` | `idea:<id>` | A research idea (proposed, tested, or failed) |
 | **Experiment** | `experiments/` | `exp:<id>` | A concrete experiment run with results |
-| **Claim** | `claims/` | `claim:<id>` | A testable scientific claim with evidence status |
+| **Claim** | `claims/` | `claim:<id>` | A theorem/headline with an honest PROOF status — born via `/proof-checker` (see Hook 4) |
 
 ### Typed Relationships (`graph/edges.jsonl`)
 
@@ -226,7 +226,7 @@ Update a specific entity:
 ```
 /research-wiki update paper:chen2025 — relevance: core
 /research-wiki update idea:001 — outcome: negative
-/research-wiki update claim:C1 — status: invalidated
+/research-wiki update claim:C1 — status: refuted
 ```
 
 After any update: rebuild `query_pack.md`, update `log.md`.
@@ -236,7 +236,7 @@ After any update: rebuild `query_pack.md`, update `log.md`.
 Health check the wiki:
 
 1. **Orphan pages** — entities with zero edges
-2. **Stale claims** — claims with `status: reported` older than 14 days
+2. **Stale claims** — claims still `status: drafted` or `status: unproven` older than 14 days
 3. **Contradictions** — claims with both `supports` and `invalidates` edges
 4. **Missing connections** — papers sharing 2+ tags but no explicit relationship
 5. **Dead ideas** — `stage: proposed` ideas that were never tested
@@ -253,7 +253,7 @@ Quick overview:
 Papers: 28 (12 core, 10 related, 6 peripheral)
 Ideas: 7 (2 active, 3 failed, 1 partial, 1 succeeded)
 Experiments: 12
-Claims: 15 (5 supported, 3 invalidated, 7 reported)
+Claims: 15 (8 verified, 4 unproven, 2 refuted, 1 sound-modulo-imports)
 Edges: 64
 Gaps: 8 (3 unresolved)
 Last updated: 2026-04-07T10:12:00Z
@@ -307,35 +307,42 @@ if research-wiki/query_pack.md exists (and < 7 days old):
     still run fresh literature search for last 3-6 months
 ```
 
-**After ideation (THIS IS CRITICAL — without it, ideas/ stays empty):**
+**After ideation (CRITICAL — runs on EVERY generation, incl. a re-run with updated
+constraints): the page write is the deterministic `upsert_idea` helper, not freehand.**
 ```
 for idea in all_generated_ideas (recommended + killed):
-    /research-wiki upsert_idea(idea)
-    for paper_id in idea.based_on:
-        add_edge(idea.node_id, paper_id, "inspired_by")
-    for gap_id in idea.target_gaps:
-        add_edge(idea.node_id, gap_id, "addresses_gap")
-rebuild query_pack
+    python3 "$WIKI_SCRIPT" upsert_idea research-wiki/ --slug <stable-id> --title <title> \
+         --stage <proposed|archived> --outcome pending --thesis <...> --risks <...> \
+         --based-on <paper:slug,...> --target-gaps <G2,...>
+    # one call: writes ideas/<slug>.md, wires inspired_by/addresses_gap edges, rebuilds
+    # index + query_pack, logs. Default skip-on-exist (won't clobber an idea enriched
+    # by /result-to-claim). `outcome` ∈ {unknown,pending,negative,mixed,positive} — the
+    # experiment verdict is set later by /result-to-claim, never guessed at ideation.
 log "idea-creator wrote N ideas to wiki"
 ```
 
 ### Hook 3: After `/result-to-claim` verdict
 
 ```
-# Create experiment page
-exp_id = upsert_experiment(experiment_data)
+# Create/refresh the experiment node FIRST via add_experiment (verdict owner →
+# --update-on-exist). add_edge does NOT verify node existence, so gate the
+# supports/invalidates edges on the node having been born (EXP_NODE_OK).
+EXP_NODE_OK = (python3 "$WIKI_SCRIPT" add_experiment research-wiki/ --slug <exp_id> \
+  --idea idea:<active_idea> --verdict <yes|partial|no> --confidence <high|medium|low> \
+  --metrics <...> --reasoning <...> --provenance <run dir> --update-on-exist) succeeded
 
-# Update each claim's status
-for claim_id in resolved_claims:
-    if verdict == "yes":
-        set_claim_status(claim_id, "supported")
-        add_edge(exp_id, claim_id, "supports")
-    elif verdict == "partial":
-        set_claim_status(claim_id, "partial")
-        add_edge(exp_id, claim_id, "supports")  # partial
-    else:
-        set_claim_status(claim_id, "invalidated")
-        add_edge(exp_id, claim_id, "invalidates")
+# Record empirical support as EDGES ONLY, and ONLY if EXP_NODE_OK — never set a claim's
+# `status`. A claim's `status` is the PROOF axis (verified / sound-modulo-imports /
+# refuted / unproven / drafted / retracted), owned by /proof-checker (Hook 4). The ARIS
+# helper REJECTS "supported"/"partial"/"invalidated" as claim statuses.
+if EXP_NODE_OK:
+    for claim_id in resolved_claims:
+        if verdict == "yes":
+            add_edge(exp_id, claim_id, "supports")
+        elif verdict == "partial":
+            add_edge(exp_id, claim_id, "supports")  # partial — qualify in evidence
+        else:
+            add_edge(exp_id, claim_id, "invalidates")
 
 # Update idea outcome
 update_idea(active_idea_id, outcome=verdict)
@@ -347,6 +354,24 @@ if verdict in ("no", "partial"):
 rebuild query_pack
 log "result-to-claim: exp_id updated, verdict=..."
 ```
+
+### Hook 4: Claim birth — from `/proof-checker` (the ONLY birth point)
+
+Wiki **claim nodes are born here.** `/proof-checker` mints a claim node for each
+top-level theorem/headline after writing `PROOF_AUDIT.json`, stamping an honest
+PROOF-axis `status` and a `provenance` pointer. No other skill creates a claim node:
+`/result-to-claim` (Hook 3) only adds empirical `supports`/`invalidates` edges to an
+already-born claim and never edits its `status`.
+
+```
+python3 "$WIKI_SCRIPT" add_claim research-wiki/ --slug thm-main-ub \
+     --name "Main upper bound" --status verified \
+     --provenance "<proof-checker trace dir>" --statement "..." --update-on-exist
+```
+
+Claim `status` ∈ {`drafted`, `unproven`, `sound-modulo-imports`, `verified`, `refuted`,
+`retracted`} — the **proof axis only**. Empirical support is a separate axis carried by
+edges (Hook 3), never written into `status`.
 
 ## Re-ideation Trigger
 

--- a/skills/skills-codex/result-to-claim/SKILL.md
+++ b/skills/skills-codex/result-to-claim/SKILL.md
@@ -142,34 +142,48 @@ See `shared-references/experiment-integrity.md` for the full integrity protocol.
 
 ```
 if research-wiki/ exists:
-    # 1. Create experiment page
-    Create research-wiki/experiments/<exp_id>.md with:
-      - node_id: exp:<id>
-      - idea_id: idea:<active_idea>
-      - date, hardware, duration, metrics
-      - verdict, confidence, reasoning summary
+    # Resolve the helper (Codex chain). If unavailable, skip wiki writes; still report verdict.
+    ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+    WIKI_SCRIPT=""
+    [ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+    [ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+    [ -n "$WIKI_SCRIPT" ] || echo "WARN: research_wiki.py unreachable; skipping wiki writes (verdict still reported)." >&2
 
-    # 2. Update claim status
-    for each claim resolved by this verdict:
-        if verdict == "yes":
-            Update claim page: status → supported
-            run the installed ARIS research_wiki.py helper to add a supports edge from "exp:<id>" to "claim:<cid>"
-        elif verdict == "partial":
-            Update claim page: status → partial
-            run the installed ARIS research_wiki.py helper to add a partial supports edge from "exp:<id>" to "claim:<cid>"
-        else:
-            Update claim page: status → invalidated
-            run the installed ARIS research_wiki.py helper to add an invalidates edge from "exp:<id>" to "claim:<cid>"
+    # 1. Create/refresh the experiment node FIRST (verdict OWNER → --update-on-exist so a
+    #    re-judge overwrites the stale verdict). The supports/invalidates edges in #2 point
+    #    FROM exp:<id> and add_edge does NOT verify node existence, so only add them if the
+    #    experiment node was born (EXP_NODE_OK); otherwise skip the wiki edges.
+    EXP_NODE_OK=0
+    [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" add_experiment research-wiki/ \
+         --slug "<exp_id>" --idea "idea:<active_idea>" \
+         --verdict "<yes|partial|no>" --confidence "<high|medium|low>" \
+         --date "<date>" --hardware "<hw>" --duration "<dur>" \
+         --metrics "<key metrics>" --reasoning "<one-line why this verdict>" \
+         --provenance "<EXPERIMENT_AUDIT.md / run dir>" --update-on-exist && EXP_NODE_OK=1
 
-    # 3. Update idea outcome
+    # 2. Record empirical support as EDGES ONLY, and ONLY if EXP_NODE_OK. NEVER edit a
+    #    claim page's `status`: that is the PROOF axis (verified / refuted / unproven /
+    #    sound-modulo-imports / drafted / retracted), owned by /proof-checker (the claim
+    #    birth point) — the ARIS helper REJECTS "supported"/"partial"/"invalidated".
+    if [ "$EXP_NODE_OK" = 1 ]:
+        for each claim resolved by this verdict:
+            if verdict == "yes":
+                python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "<metric>"
+            elif verdict == "partial":
+                python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type supports --evidence "partial: <metric>"
+            else:
+                python3 "$WIKI_SCRIPT" add_edge research-wiki/ --from "exp:<id>" --to "claim:<cid>" --type invalidates --evidence "<why>"
+
+    # 3. Update idea outcome (raw markdown, helper-free — preserves the rich idea body)
     Update research-wiki/ideas/<idea_id>.md:
       - outcome: positive | mixed | negative
       - If negative: fill "Failure / Risk Notes" and "Lessons Learned"
       - If positive: fill "Actual Outcome" and "Reusable Components"
 
-    # 4. Rebuild + log
-    rebuild the query pack with the installed ARIS research_wiki.py helper
-    log "result-to-claim: exp:<id> verdict=<verdict> for idea:<idea_id>" with the installed ARIS research_wiki.py helper
+    # 4. Rebuild + log (reflect the new edges; only if WIKI_SCRIPT resolved)
+    [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" rebuild_query_pack research-wiki/
+    [ -n "$WIKI_SCRIPT" ] && python3 "$WIKI_SCRIPT" log research-wiki/ "result-to-claim: exp:<id> verdict=<verdict> for idea:<idea_id>"
 
     # 5. Re-ideation suggestion
     Count failed/partial ideas since last /idea-creator run.

--- a/skills/skills-codex/wiki-enrich/SKILL.md
+++ b/skills/skills-codex/wiki-enrich/SKILL.md
@@ -55,11 +55,12 @@ Resolve `$WIKI_ROOT` and `$WIKI_SCRIPT` (canonical chain — see `shared-referen
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || exit 1
 [ -d research-wiki/ ] || { echo "ERROR: research-wiki/ not found. Run /research-wiki init first." >&2; exit 1; }
 
-ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills.txt 2>/dev/null)}"
-WIKI_SCRIPT=".aris/tools/research_wiki.py"
-[ -f "$WIKI_SCRIPT" ] || WIKI_SCRIPT="tools/research_wiki.py"
-[ -f "$WIKI_SCRIPT" ] || { [ -n "${ARIS_REPO:-}" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"; }
-[ -f "$WIKI_SCRIPT" ] || { echo "ERROR: research_wiki.py not found." >&2; exit 1; }
+ARIS_REPO="${ARIS_REPO:-$(awk -F'\t' '$1=="repo_root"{print $2; exit}' .aris/installed-skills-codex.txt 2>/dev/null)}"
+WIKI_SCRIPT=""
+[ -n "$ARIS_REPO" ] && [ -f "$ARIS_REPO/tools/research_wiki.py" ] && WIKI_SCRIPT="$ARIS_REPO/tools/research_wiki.py"
+[ -z "$WIKI_SCRIPT" ] && [ -f tools/research_wiki.py ] && WIKI_SCRIPT="tools/research_wiki.py"
+[ -z "$WIKI_SCRIPT" ] && [ -f ~/.codex/skills/research-wiki/research_wiki.py ] && WIKI_SCRIPT="$HOME/.codex/skills/research-wiki/research_wiki.py"
+[ -n "$WIKI_SCRIPT" ] || { echo "ERROR: research_wiki.py not found." >&2; exit 1; }
 ```
 
 If either fails, **hard-fail** — this skill manipulates wiki state and must not run blind.
@@ -160,7 +161,7 @@ Write each TODO section's body following these rules:
 | Limitations / Failure Modes | 1-3 bullets | Honest | What the paper explicitly admits OR what's structurally absent (e.g. "no multi-node evaluation", "assumes uniform request length") |
 | Reusable Ingredients | 1-3 bullets | Concrete | Techniques / datasets / insights from this paper that could be ported elsewhere. **Highest value for `/idea-creator` — write carefully.** |
 | Open Questions | 1-2 bullets | Question form | What the paper does NOT answer but raises |
-| Claims | 1 line | Static | If no `claim:` edges in `graph/edges.jsonl` reference this paper, write the literal italic line: `_No claims tracked yet — populate via /result-to-claim._`. Else list claim node IDs. |
+| Claims | 1 line | Static | If no `claim:` edges in `graph/edges.jsonl` reference this paper, write the literal italic line: `_No claims tracked yet — populate via /proof-checker._`. Else list claim node IDs. |
 | Relevance to This Project | 1-2 sentences | Project-contextual | Use `RESEARCH_BRIEF.md` / `AGENTS.md` (or legacy `CLAUDE.md`) / `gap_map.md` to phrase the connection. If no project context, write the literal italic line: `_Project context not yet set — populate RESEARCH_BRIEF.md or gap_map.md to enable this section._` and report. |
 
 **Rules** (Karpathy fidelity):

--- a/tests/test_codex_skill_mirror.py
+++ b/tests/test_codex_skill_mirror.py
@@ -38,6 +38,39 @@ def test_codex_skill_set_matches_mainline() -> None:
     assert main_names == codex_names
 
 
+def test_codex_mirror_wiki_writers_wired() -> None:
+    # Content parity (the name-set test above is necessary but not sufficient): the Codex
+    # mirror must use the deterministic wiki writers and must NOT carry the old empirical-
+    # claim-status contradiction (the SHARED research_wiki.py validator rejects
+    # supported/partial/invalidated as claim statuses, so a mirror that still instructs it
+    # is a live broken path for Codex-CLI users).
+    r2c = read(CODEX_SKILLS / "result-to-claim" / "SKILL.md")
+    assert "add_experiment" in r2c and "EXP_NODE_OK" in r2c, \
+        "mirror result-to-claim must create the exp node via add_experiment + gate edges on EXP_NODE_OK"
+    assert re.search(r"status\s*(?:→|->|:)\s*(supported|partial|invalidated)", r2c) is None, \
+        "mirror result-to-claim must NOT set a claim status to an empirical value"
+    assert "upsert_idea" in read(CODEX_SKILLS / "idea-creator" / "SKILL.md"), \
+        "mirror idea-creator must record ideas via upsert_idea (not freehand)"
+    assert "add_claim" in read(CODEX_SKILLS / "proof-checker" / "SKILL.md"), \
+        "mirror proof-checker must mint claims via add_claim (Phase 5.5 birth point)"
+    we = read(CODEX_SKILLS / "wiki-enrich" / "SKILL.md")
+    assert "populate via /proof-checker" in we and "populate via /result-to-claim" not in we, \
+        "mirror wiki-enrich must point claim-population at /proof-checker"
+    rw = read(CODEX_SKILLS / "research-wiki" / "SKILL.md")
+    assert "set_claim_status" not in rw, \
+        "mirror research-wiki must not set claim status (empirical support is edge-only)"
+    assert "add_claim" in rw, "mirror research-wiki must document the /proof-checker claim birth point (Hook 4)"
+    # No mainline-convention bleed in the synced mirror files: no `.aris/tools` resolver,
+    # no mainline `.aris/installed-skills.txt` manifest, and no bare `research_wiki.py <sub>`
+    # call (Codex global-install won't have it on PATH — must be `python3 "$WIKI_SCRIPT"`).
+    for name in ("result-to-claim", "idea-creator", "proof-checker", "research-wiki", "wiki-enrich"):
+        t = read(CODEX_SKILLS / name / "SKILL.md")
+        assert ".aris/tools" not in t, f"{name} mirror leaked the mainline .aris/tools resolver"
+        assert ".aris/installed-skills.txt" not in t, f"{name} mirror leaked the mainline manifest (use installed-skills-codex.txt)"
+        assert re.search(r"research_wiki\.py\s+(add_claim|add_edge|add_experiment|upsert_idea)", t) is None, \
+            f"{name} mirror has a bare research_wiki.py command (use python3 \"$WIKI_SCRIPT\")"
+
+
 def test_skill_inventory_check_passes() -> None:
     assert check_inventory() == []
 


### PR DESCRIPTION
## Why

`research_wiki.py` (shared by mainline + the Codex mirror) gained deterministic claim/idea/experiment writers in #305/#306/#307, and its validator now **rejects** empirical claim statuses. But the **Codex mirror still instructed setting claim status to `supported/partial/invalidated`** (`skills-codex/result-to-claim`) — a **live broken path** for Codex-CLI users, not just staleness. Codex (gpt-5.5 xhigh) recommended fixing it now.

## What — surgical sync into 5 mirror SKILLs (Codex conventions kept)

Helpers are **shared** (`tools/research_wiki.py`), so this only ports the **SKILL.md wiring** — in the mirror's own convention (`spawn_agent`/`AGENTS.md`/the `$ARIS_REPO/tools → tools → ~/.codex/skills/...` resolver with `installed-skills-codex.txt` backfill), **not** mainline's (`.aris/tools`, `mcp__codex__codex`, `CLAUDE.md`):

- **result-to-claim** — drop the claim-status mutation (edge-only); `add_experiment --update-on-exist` (verdict owner) gated by `EXP_NODE_OK`; added the Codex `$WIKI_SCRIPT` resolver (it had none).
- **idea-creator** — Phase 7 via `upsert_idea` (was freehand → same "re-gen not recorded" fix for Codex-CLI).
- **proof-checker** — new Phase 5.5 claim ledger via `add_claim` (claim birth point) + Codex resolver + honest proof-axis status map.
- **research-wiki** — Hook 2 (`upsert_idea`), Hook 3 (`add_experiment` + `EXP_NODE_OK`, edge-only, no `set_claim_status`), new Hook 4 (claim birth); proof-axis examples.
- **wiki-enrich** — pointer → `/proof-checker`; fixed a pre-existing `.aris/tools` resolver leak → Codex chain.
- **test_codex_skill_mirror.py** — new content assertion: writers wired, contradiction absent, **no mainline-convention bleed** (no `.aris/tools` / `installed-skills.txt` / bare `research_wiki.py` calls).

## Verification
- 17/17 mirror test functions pass; mainline drift consistent; bleed sweep clean.
- **Codex MCP (gpt-5.5 xhigh): 2 rounds** — NEEDS-CHANGES (`.aris/tools` leak + bare calls + weak test) → **GO**.

This closes the mirror-parity follow-up tracked since #305. With this + #305/#306/#307, **mainline and the Codex mirror are now in sync** on all four wiki node layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)