### PR TITLE
docs(readme): feature ARIS-Movie-Director's method figure up top (引流)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/wanshuiyin/ARIS-Movie-Director">
+    <img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/method_figure.png" alt="ARIS-Movie-Director method — the audited spiral: authored source of truth (asset library · outline · storyboard · comic.json) → per-panel image_gen + cross-model panel_gate (blind token-diff, single-vote veto) → research-wiki audit trace → assembly + release" width="100%">
+  </a>
+</p>
+
+> 🧭 *Not just multi-frame movies — the same **audited spiral** generates clean **method / flow diagrams** too: this figure was produced by ARIS-Movie-Director's own `image_gen` + cross-model `panel_gate` loop (same DNA as core ARIS — an authored source of truth, a gate where no step signs off on itself, a research-wiki audit trail).*
+
 <table><tr>
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_audit.webp" alt="ARIS-Movie-Director frame — the evaluator-integrity audit page" width="100%"></a></td>
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_panels.webp" alt="ARIS-Movie-Director frame — a multi-panel scene" width="100%"></a></td>

--- a/README_CN.md
+++ b/README_CN.md
@@ -24,6 +24,14 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/wanshuiyin/ARIS-Movie-Director">
+    <img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/method_figure.png" alt="ARIS-Movie-Director 方法图 —— 受审螺旋：可信源头（asset library · outline · storyboard · comic.json）→ 逐格 image_gen + 跨模型 panel_gate（盲 token-diff、单票否决）→ research-wiki 审计留痕 → 组装与发布" width="100%">
+  </a>
+</p>
+
+> 🧭 *不止做多帧电影 —— 同一套**受审螺旋**也能生成干净的**方法图 / 流程图**：这张图就是 ARIS-Movie-Director 自己的 `image_gen` + 跨模型 `panel_gate` loop 跑出来的（和核心 ARIS 同宗 —— 可信源头、没有哪一步能自己给自己放行的 gate、research-wiki 审计留痕）。*
+
 <table><tr>
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_audit.webp" alt="ARIS-Movie-Director 帧 —— evaluator 诚实度审计页" width="100%"></a></td>
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_panels.webp" alt="ARIS-Movie-Director 帧 —— 多格场景" width="100%"></a></td>


### PR DESCRIPTION
Surfaces the ARIS-Movie-Director **Fig 1** (the method/flow diagram people liked) in the main README's top movie-director section, right after the interactive comic-cover hero.

- **Original, not a screenshot** — referenced via `raw.githubusercontent.com/.../main/docs/method_figure.png` (same pattern as the existing 4 movie-director images; confirmed committed on that repo's `main`, raw URL → HTTP 200).
- **Framing** (the meta hook): the ARIS-Movie-Director audited spiral isn't only for multi-frame movies — it also generates clean **method / flow diagrams**, and *this very figure was produced by its own `image_gen` + cross-model `panel_gate` loop*. Same DNA as core ARIS.
- EN + CN.

Cross-model reviewed (codex gpt-5.5 xhigh, 2 rounds): tightened an overclaim ("loop", not "full pipeline"), placed the figure **after** the interactive hero so it keeps the first-screen spot, fixed a CN colon, EN↔CN parity confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)