### PR TITLE
docs(readme): collapse movie-director frames + trim captions (shorten the section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 🚀 **Beyond 科研 → 任何 "研究"**：[**ARIS-Anything**](https://github.com/wanshuiyin/ARIS-Anything) 把 ARIS 的五步 loop（plan / draft / 对抗审 / 迭代 / 持久化）推广到非学术的结构化研究——投资尽调 / 法律研究 / 市场研究 / 自驱学习 / 调查新闻 / 工程复盘等。
 
-🎬 **ARIS goes multimodal → [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)** — from research & coding into **visual generation**: hand over a fuzzy story, wake up to a **cross-model-audited movie** (reference run = 19 scenes). Long-horizon visual stories drift two ways — 🧠 **long-range forgetting** and 🗣️ **self-approved streaming** (each frame signed off by the model that drew it). ARIS answers with the same DNA: a **research-wiki** for memory + **multi-agent debate** so *no frame signs off on itself*.
+🎬 **ARIS goes multimodal → [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)** — hand over a fuzzy story, wake up to a **cross-model-audited movie** (reference run = 19 scenes). Long-horizon visual stories drift two ways (🧠 **long-range forgetting** · 🗣️ each frame **signed off by the model that drew it**); ARIS answers with the same DNA — a **research-wiki** for memory + **multi-agent debate** so *no frame signs off on itself*.
 
 <p align="center">
   <a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/">
@@ -30,7 +30,10 @@
   </a>
 </p>
 
-> 🧭 *Not just multi-frame movies — the same **audited spiral** generates clean **method / flow diagrams** too: this figure was produced by ARIS-Movie-Director's own `image_gen` + cross-model `panel_gate` loop (same DNA as core ARIS — an authored source of truth, a gate where no step signs off on itself, a research-wiki audit trail). 👉 **The skills + an end-to-end CLI are in [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)** — the [`/movie-pipeline`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/movie-pipeline/SKILL.md) agent workflow with a deterministic CLI core you can run standalone, plus [`/method-figure`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/method-figure/SKILL.md) — the skill that made this figure.*
+> 🧭 *Not just movies — the same **audited spiral** also generates clean **method / flow diagrams**: this very figure was baked by ARIS-Movie-Director's `image_gen` + cross-model `panel_gate` loop. 👉 **Skills + an end-to-end CLI** in [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director): [`/movie-pipeline`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/movie-pipeline/SKILL.md) (agent workflow + standalone deterministic CLI core) and [`/method-figure`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/method-figure/SKILL.md), the skill that made this figure.*
+
+<details>
+<summary>🎞️ <i>A few frames from the reference movie — the story's own integrity beat: a run that <b>reported <code>+6.2</code></b> but <b>really moved <code>+1.4</code></b>.</i> &nbsp;<b><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/">▶ watch all 19 scenes →</a></b></summary>
 
 <table><tr>
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_audit.webp" alt="ARIS-Movie-Director frame — the evaluator-integrity audit page" width="100%"></a></td>
@@ -38,7 +41,7 @@
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_fix.webp" alt="ARIS-Movie-Director frame — the integrity beat (reported +6.2, really moved +1.4)" width="100%"></a></td>
 </tr></table>
 
-> 🎞️ *A few frames from the reference movie — including the story's own integrity beat (a run that **reported `+6.2`** but **really moved `+1.4`**). Image-based today, video next — **[▶ watch all 19 scenes →](https://wanshuiyin.github.io/ARIS-Movie-Director/comic/)***
+</details>
 
 🎯 **准备 2026 AI 秋招？** → [**🌐 ARIS-in-AI-Offer**](https://wanshuiyin.github.io/ARIS-in-AI-Offer/) · [GitHub repo](https://github.com/wanshuiyin/ARIS-in-AI-Offer) · [中文 README](https://github.com/wanshuiyin/ARIS-in-AI-Offer/blob/main/README_CN.md) —— 23 篇双语 ML / LLM / 多模态 / 生成式 / Agent 面试 cheat sheet，每篇 = 公式推导 + 从零 PyTorch + 25 高频面试题（L1 / L2 / L3），全部由 ARIS 的 `/render-html` 自动生成。**希望大家秋招轻松一点 🌱**
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -16,7 +16,7 @@
 
 🚀 **从 科研 → 任何 "研究"**：[**ARIS-Anything**](https://github.com/wanshuiyin/ARIS-Anything) 把 ARIS 的五步 loop（plan / draft / 跨模型对抗审 / 迭代 / 持久化）从学术科研推广到非学术的结构化研究——投资尽调 / 法律研究 / 市场研究 / 自驱学习 / 调查新闻 / 工程复盘等。
 
-🎬 **ARIS 走向多模态 → [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)** —— 从科研、coding 走进**视觉生成**：把模糊的故事丢给 agent，睡醒收一部**跨模型审过的电影**（参考片 = 19 个场景）。长程视觉叙事会两头漂——🧠 **长程遗忘** 和 🗣️ **自审式串行**（每帧由画它的模型自己签收，错误一路累积）。ARIS 用同宗的法宝兜住：**research-wiki** 当记忆、把后面的帧锚回最初的事实，**多智能体对抗审**（跨模型盲转写 + token-diff）确保*没有一帧能自己给自己放行*。
+🎬 **ARIS 走向多模态 → [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)** —— 把模糊的故事丢给 agent，睡醒收一部**跨模型审过的电影**（参考片 = 19 个场景）。长程视觉叙事会两头漂（🧠 **长程遗忘** · 🗣️ 每帧由**画它的模型自己签收**，错误一路累积）；ARIS 用同宗的法宝兜住 —— **research-wiki** 当记忆,**多智能体对抗审**(跨模型盲转写 + token-diff)确保*没有一帧能自己给自己放行*。
 
 <p align="center">
   <a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/">
@@ -30,7 +30,10 @@
   </a>
 </p>
 
-> 🧭 *不止做多帧电影 —— 同一套**受审螺旋**也能生成干净的**方法图 / 流程图**：这张图就是 ARIS-Movie-Director 自己的 `image_gen` + 跨模型 `panel_gate` loop 跑出来的（和核心 ARIS 同宗 —— 可信源头、没有哪一步能自己给自己放行的 gate、research-wiki 审计留痕）。👉 **skills 和端到端 CLI 也都在 [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)** —— [`/movie-pipeline`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/movie-pipeline/SKILL.md) agent 工作流(含可独立运行的确定性 CLI 内核),以及做出这张图的 [`/method-figure`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/method-figure/SKILL.md)。*
+> 🧭 *不止做电影 —— 同一套**受审螺旋**也能生成干净的**方法图 / 流程图**:这张图就是 ARIS-Movie-Director 自己的 `image_gen` + 跨模型 `panel_gate` loop 跑出来的。👉 **skills 和端到端 CLI 都在 [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)**:[`/movie-pipeline`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/movie-pipeline/SKILL.md)(agent 工作流 + 可独立跑的确定性 CLI 内核)和做出这张图的 [`/method-figure`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/method-figure/SKILL.md)。*
+
+<details>
+<summary>🎞️ <i>参考片里的几帧 —— 故事自身的诚实度 beat：一次 <b>号称 <code>+6.2</code></b> 实则 <b>只动了 <code>+1.4</code></b> 的 run。</i> &nbsp;<b><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/">▶ 浏览器看全部 19 个场景 →</a></b></summary>
 
 <table><tr>
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_audit.webp" alt="ARIS-Movie-Director 帧 —— evaluator 诚实度审计页" width="100%"></a></td>
@@ -38,7 +41,7 @@
 <td width="33%"><a href="https://wanshuiyin.github.io/ARIS-Movie-Director/comic/"><img src="https://raw.githubusercontent.com/wanshuiyin/ARIS-Movie-Director/main/docs/preview_fix.webp" alt="ARIS-Movie-Director 帧 —— 诚实度 beat（号称 +6.2，实际只动了 +1.4）" width="100%"></a></td>
 </tr></table>
 
-> 🎞️ *参考片里的几帧 —— 含故事自身的诚实度 beat（一次 **号称 `+6.2`** 实则 **只动了 `+1.4`** 的 run）。现在是图像版，下一步是视频 —— **[▶ 浏览器看全部 19 个场景 →](https://wanshuiyin.github.io/ARIS-Movie-Director/comic/)***
+</details>
 
 🎯 **准备 2026 AI 秋招？** → [**🌐 ARIS-in-AI-Offer 网页版**](https://wanshuiyin.github.io/ARIS-in-AI-Offer/) · [GitHub repo](https://github.com/wanshuiyin/ARIS-in-AI-Offer) · [English](https://github.com/wanshuiyin/ARIS-in-AI-Offer/blob/main/README_EN.md) —— 长文中文 ML / LLM / 多模态 / 生成式 / Agent 面试 cheat sheet，每篇 = 公式推导 + 从零 PyTorch + 25 高频面试题（L1 / L2 / L3），全部由 ARIS 的 `/render-html` 自动生成。**希望大家秋招的时候轻松一点 🌱**
 


### PR DESCRIPTION
The ARIS-Movie-Director top section got long (comic-cover hero + method figure + a 3-up frame table + long captions). This shortens it:

- **Collapse** the 3 reference frames + the 🎞️ caption into a `<details>` — the integrity-beat hook (`reported +6.2` but `really moved +1.4`) and the **▶ watch all 19 scenes** link stay in the `<summary>`, so the collapsed state is still enticing.
- **Trim** the 🎬 intro and the 🧭 method-figure caption (drops a redundant "same DNA…" parenthetical that the figure's alt + intro already cover).
- All links preserved: repo, [`/movie-pipeline`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/movie-pipeline/SKILL.md), [`/method-figure`](https://github.com/wanshuiyin/ARIS-Movie-Director/blob/main/skills/method-figure/SKILL.md), watch-link. EN + CN; `<details>` markup verified balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)