### PR TITLE
fix(install): skip platform auto-detect when --platform is explicit (no misleading warn)

### DIFF
--- a/tools/install_aris.sh
+++ b/tools/install_aris.sh
@@ -287,7 +287,9 @@ PROJECT_PATH="$(abs_path "$PROJECT_PATH")"
 # ─── Platform auto-detect + delegation (before resolve_aris_repo) ─────────────
 # Must happen before resolve_aris_repo because the Codex installer resolves its
 # own repo path (looking for skills/skills-codex instead of just skills/).
-auto_detect_platform "$PROJECT_PATH"
+# Skip auto-detect (and its marker warnings) when --platform is explicit — the
+# override wins anyway, so detecting would only print a misleading "defaulting to …".
+[[ -n "$PLATFORM_OVERRIDE" ]] || auto_detect_platform "$PROJECT_PATH"
 PLATFORM="${PLATFORM_OVERRIDE:-$DETECTED_PLATFORM}"
 if [[ "$PLATFORM" == "codex" ]]; then
     # Validate: claude-only flags are incompatible with codex platform


### PR DESCRIPTION
Follow-up to #212 (the one cosmetic nit). With an explicit `--platform codex|claude`, `auto_detect_platform` still printed a "defaulting to claude" marker warning before the override was applied — behaviour was correct, the message misleading.

One-line guard: `[[ -n "$PLATFORM_OVERRIDE" ]] || auto_detect_platform "$PROJECT_PATH"` — the override wins anyway, so detection (and its warnings) is skipped when it's set. Zero behaviour change without `--platform`. `bash -n` clean; cross-model verified (codex gpt-5.5 xhigh: OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)