### PR TITLE
README: tighten Anti-Autoresearch callout + centered tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 
 🤖 **AI agents:** Read [`AGENT_GUIDE.md`](AGENT_GUIDE.md) instead — structured for LLM consumption, not human browsing.
 
-🛡️ **ARIS audits its own output → now [Anti-Autoresearch](https://github.com/wanshuiyin/Anti-Autoresearch) audits everyone's.** Autoresearch is flooding the review pile with papers that *don't hold up* — numbers no table backs, baselines that aren't there, open-sourced code that won't reproduce its own paper. Anti-Autoresearch points the **same audit DNA** (experiment-audit · paper-claim-audit · citation-audit · kill-argument) **outward** at a third party's submission — a deterministic **evidence ledger** + a **rules-based adjudicator** (the model proposes span-anchored findings, *code* decides the verdict) → a reviewer-ready integrity report. *Self-consistency + fabrication forensics, **not** an AI-text detector.* **别让 autoresearch 跑出来的不靠谱论文成为科研路上的烦恼 —— 同一套审计 DNA 朝外,替审稿人 / AC 一眼看穿自相矛盾与造假。**
+🛡️ **ARIS audits its own output → now [Anti-Autoresearch](https://github.com/wanshuiyin/Anti-Autoresearch) audits everyone's.** It catalogs **27 common autoresearch hack-patterns** (numbers no table backs, missing baselines, code that won't reproduce its own paper, fabricated citations…) and checks a submission for them **end-to-end** with one workflow: evidence ledger → cross-model auditors → a deterministic verdict → a reviewer-ready report. *Self-consistency + fabrication forensics, **not** an AI-text detector.*
+
+<p align="center"><em>The field has put up with unreliable autoresearch long enough — Anti-Autoresearch is the reviewer-side read that finally catches it.</em></p>
 
 🎬 **ARIS goes multimodal → [ARIS-Movie-Director](https://github.com/wanshuiyin/ARIS-Movie-Director)** — hand over a fuzzy story, wake up to a **cross-model-audited movie** (reference run = 19 scenes). Long-horizon visual stories drift two ways (🧠 **long-range forgetting** · 🗣️ each frame **signed off by the model that drew it**); ARIS answers with the same DNA — a **research-wiki** for memory + **multi-agent debate** so *no frame signs off on itself*.
 


### PR DESCRIPTION
Shortens the callout detail (27 hack-patterns + end-to-end workflow) and adds a centered italic English tagline in place of the inline CN line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)