### PR TITLE
fix(paper-poster-html): quote argument-hint so SKILL.md is valid YAML (#324)

### DIFF
--- a/skills/paper-poster-html/SKILL.md
+++ b/skills/paper-poster-html/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster-html
 description: "DEFAULT poster pipeline — build an academic conference poster (ICML/NeurIPS/ICLR/CVPR/...) as a single HTML/CSS file with measurement-driven hard gates, real paper figures, a two-hue design-token system, and print-ready PDF via headless Chromium. Use when the user says \"做海报\", \"poster\", \"conference poster\", \"paper poster\", or asks to design/redo a research poster. Supersedes the retired LaTeX /paper-poster."
-argument-hint: [paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]
+argument-hint: "[paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebFetch, WebSearch, AskUserQuestion, mcp__codex__codex
 ---
 

--- a/skills/skills-codex-gemini-review/paper-poster-html/SKILL.md
+++ b/skills/skills-codex-gemini-review/paper-poster-html/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster-html
 description: "DEFAULT poster pipeline — build an academic conference poster (ICML/NeurIPS/ICLR/CVPR/...) as a single HTML/CSS file with measurement-driven hard gates, real paper figures, a two-hue design-token system, and print-ready PDF via headless Chromium. Use when the user says \"做海报\", \"poster\", \"conference poster\", \"paper poster\", or asks to design/redo a research poster."
-argument-hint: [paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]
+argument-hint: "[paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__gemini-review__review, mcp__gemini-review__review_start, mcp__gemini-review__review_reply_start, mcp__gemini-review__review_status
 ---
 

--- a/skills/skills-codex/paper-poster-html/SKILL.md
+++ b/skills/skills-codex/paper-poster-html/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster-html
 description: "DEFAULT poster pipeline — build an academic conference poster (ICML/NeurIPS/ICLR/CVPR/...) as a single HTML/CSS file with measurement-driven hard gates, real paper figures, a two-hue design-token system, and print-ready PDF via headless Chromium. Use when the user says \"做海报\", \"poster\", \"conference poster\", \"paper poster\", or asks to design/redo a research poster."
-argument-hint: [paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]
+argument-hint: "[paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 


### PR DESCRIPTION
## Problem

`skills/paper-poster-html/SKILL.md` front matter is invalid YAML, so strict parsers (Codex) **skip loading the skill** at startup (reported in #324):

```
⚠ ~\.codex\skills\paper-poster-html\SKILL.md: invalid YAML: did not find expected key ...
```

The offending field:

```yaml
argument-hint: [paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]
```

This is two flow sequences (`[...] [...]`) with `venue: ICLR` / `venue-colors: true` colons inside — not a valid YAML scalar.

## Fix

Quote the value so it's a plain string:

```yaml
argument-hint: "[paper-dir-or-pdf] [— venue: ICLR, canvas: 185x90cm landscape, venue-colors: true]"
```

Applied to all **three** mirror copies that carried the identical line: `skills/paper-poster-html/`, `skills/skills-codex/paper-poster-html/`, `skills/skills-codex-gemini-review/paper-poster-html/`.

## Verification

A full `yaml.safe_load` scan over **all 181 `SKILL.md` files** confirmed these 3 were the *only* invalid ones (every other `argument-hint: [token]` is a valid single-element flow sequence and loads fine). After the fix: **0 invalid**.

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)