### PR TITLE
Fix claude-review subprocess decoding on Windows

### DIFF
--- a/mcp-servers/claude-review/server.py
+++ b/mcp-servers/claude-review/server.py
@@ -287,6 +287,8 @@ def run_claude_review(
             cmd,
             capture_output=True,
             text=True,
+            encoding='utf-8',
+            errors='replace',
             stdin=subprocess.DEVNULL,
             timeout=DEFAULT_TIMEOUT_SEC,
             check=False,
@@ -294,9 +296,9 @@ def run_claude_review(
     except subprocess.TimeoutExpired:
         return None, f"Claude review timed out after {DEFAULT_TIMEOUT_SEC} seconds"
 
-    payload, parse_error = parse_claude_json(result.stdout)
+    payload, parse_error = parse_claude_json(result.stdout or "")
     if parse_error:
-        stderr = result.stderr.strip()
+        stderr = (result.stderr or "").strip()
         message = parse_error if not stderr else f"{parse_error}. stderr: {stderr}"
         return None, message
 
@@ -319,7 +321,7 @@ def run_claude_review(
             payload.get("result")
             or payload.get("error")
             or errors_text
-            or result.stderr.strip()
+            or (result.stderr or "").strip()
             or "Claude review failed"
         )
         return None, message


### PR DESCRIPTION
## Summary
Fixes claude-review crashes on Windows when Claude CLI emits UTF-8 output that Python tries to decode with the system default GBK codec.

Changes:
- Explicitly decode Claude CLI subprocess output as UTF-8 with errors="replace".
- Treat empty stdout as "" before JSON parsing.
- Guard stderr.strip() with (result.stderr or "").strip() to avoid secondary NoneType crashes.

## Motivation
On Windows, background review_start jobs could fail with: UnicodeDecodeError: 'gbk' codec can't decode byte ...
That decode failure left result.stderr as None, and the MCP server then crashed again with: 'NoneType' object has no attribute 'strip'
This made the exposed error misleading and caused review jobs to fail even when the issue was only subprocess output decoding.

## Validation
- python -m py_compile server.py
- Verified review_start + review_status end to end with a minimal prompt.
- Confirmed the fix works in practice on Windows.