### PR TITLE
feat(loops): adversarial default stance, trace-debugging discipline, research-contract wiring

### DIFF
--- a/docs/SESSION_RECOVERY_GUIDE.md
+++ b/docs/SESSION_RECOVERY_GUIDE.md
@@ -110,6 +110,8 @@ On new session or post-compaction recovery:
 The Pipeline Status convention works without any tooling — the LLM just needs to follow the rules in CLAUDE.md. But in practice, LLMs sometimes forget, especially after compaction. Claude Code [hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) can automate the recovery.
 
 > **These hooks are Claude Code-specific.** If you use Cursor, Trae, or other platforms, skip this section — the Pipeline Status convention above is all you need.
+>
+> **They are copy-paste snippets, not shipped automation** — `install_aris.sh` does not create or register them; you set them up manually with the steps below. `session-restore.sh` alone covers ~80% of the value if you only want one.
 
 ### Overview
 

--- a/skills/ablation-planner/SKILL.md
+++ b/skills/ablation-planner/SKILL.md
@@ -22,7 +22,7 @@ Systematically design ablation studies that answer the questions reviewers will 
 ### Step 1: Prepare Context
 
 CC reads available project files to build the full picture:
-- Method description and components (from docs/research_contract.md or project CLAUDE.md)
+- Method description and components (from `idea-stage/docs/research_contract.md`, legacy `docs/research_contract.md`, or project CLAUDE.md)
 - Current experiment results (from EXPERIMENT_LOG.md, EXPERIMENT_TRACKER.md, or W&B)
 - Confirmed and intended claims (from result-to-claim output or project notes)
 - Available compute resources (from CLAUDE.md server config, if present)

--- a/skills/auto-review-loop/SKILL.md
+++ b/skills/auto-review-loop/SKILL.md
@@ -135,14 +135,18 @@ mcp__codex__codex:
     - Raw results (verbatim files, not a summary): <path(s)>
     - Changed since last round: <changed-file paths> — read the diff, not my description
 
-    Please act as a senior ML reviewer (NeurIPS/ICML level).
+    Please act as a senior ML reviewer (NeurIPS/ICML level). Start from the
+    assumption that the work is broken somewhere — your job is to find where.
+    Be adversarial. Trust nothing the author tells you — verify everything
+    yourself.
 
     1. Score this work 1-10 for a top venue
     2. List remaining critical weaknesses (ranked by severity)
     3. For each weakness, specify the MINIMUM fix (experiment, analysis, or reframing)
     4. State clearly: is this READY for submission? Yes/No/Almost
 
-    Be brutally honest. If the work is ready, say so clearly.
+    Be brutally honest. If, after genuinely trying to break it, the work holds
+    up and is ready, say so clearly.
 ```
 
 *For manual backend:* use `mcp__manual_review__review` with the `prompt` text above and `config: {"model_reasoning_effort": "xhigh"}`. Save the returned `threadId`.
@@ -259,6 +263,10 @@ After parsing the assessment, update `REVIEWER_MEMORY.md` in the project root:
 - Append each round, never delete prior rounds (audit trail)
 - If the reviewer's response includes a "Memory update" section, copy it verbatim
 - This file is passed back to the reviewer in the next round's Phase A — it is the reviewer's persistent memory
+- **If the score REGRESSES round-to-round**, don't just write a new memory line:
+  diff the two rounds' raw `.response.md` files in `.aris/traces/` first and find
+  the exact criterion that flipped (see `shared-references/review-tracing.md`
+  § *Debugging With Traces*). The memory file is a summary; the trace is evidence.
 
 #### Phase B.6: Debate Protocol (hard + nightmare only)
 

--- a/skills/experiment-audit/SKILL.md
+++ b/skills/experiment-audit/SKILL.md
@@ -95,8 +95,11 @@ Manual review cannot use Codex-only `model`, `sandbox`, or `cwd`; include the sa
 Use this exact prompt for both backends:
 
 ```
-You are an experiment integrity auditor. Read ALL files listed below
-    and check for the following fraud patterns.
+You are an experiment integrity auditor. Start from the assumption that the
+    evaluation is compromised somewhere — your job is to find where. Be
+    adversarial. Trust nothing the author tells you — verify everything
+    yourself. Read ALL files listed below and check for the following fraud
+    patterns.
 
     Files to read:
     - Evaluation scripts: [list paths]

--- a/skills/experiment-bridge/SKILL.md
+++ b/skills/experiment-bridge/SKILL.md
@@ -72,6 +72,13 @@ Present a brief summary:
 Proceeding to implementation.
 ```
 
+**Research-contract fallback**: if `idea-stage/docs/research_contract.md` does
+not exist yet (idea selected outside `/idea-discovery`, or an older run),
+create it now from `templates/RESEARCH_CONTRACT_TEMPLATE.md` using the selected
+idea + claims from the experiment plan. Downstream `/result-to-claim` and
+`/ablation-planner` read this file as the claims source, and session recovery
+(`docs/SESSION_RECOVERY_GUIDE.md`) depends on it existing.
+
 ### Phase 2: Implement Experiment Code
 
 **If `BASE_REPO` is set** — clone the repo first:
@@ -155,7 +162,9 @@ Wait for completion. Verify:
 
 If sanity fails → **auto-debug before giving up** (max 3 attempts):
 
-1. **Read the error** — parse traceback, stderr, and log files
+1. **Read the error** — parse traceback, stderr, and log files. (The same
+   read-the-primary-artifact discipline applies to surprising REVIEWER verdicts:
+   see `shared-references/review-tracing.md` § *Debugging With Traces*.)
 2. **Diagnose** — classify the failure:
    - OOM → reduce batch size or enable gradient checkpointing
    - ImportError → install missing package

--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -321,6 +321,20 @@ Write `idea-stage/IDEA_CANDIDATES.md` — a lean summary of the top 3-5 survivin
 
 This file is intentionally small (~30 lines) so downstream skills and session recovery can read it without loading the full `idea-stage/IDEA_REPORT.md` (~200+ lines).
 
+### Phase 5.6: Instantiate the Research Contract (always — NOT gated on COMPACT)
+
+When Phase 4 ends with a RECOMMENDED idea, create `idea-stage/docs/research_contract.md`
+from `templates/RESEARCH_CONTRACT_TEMPLATE.md` (resolve the template from the repo
+root or `$ARIS_REPO/templates/`), filling in: the selected idea + selection
+rationale, core claims, minimum convincing evidence, and the next-step pointer.
+Skip only when the run produced no RECOMMENDED idea.
+
+This file is the **focused working contract** for the W1 → W1.5 handoff:
+`/experiment-bridge` implements against it, and `/result-to-claim` +
+`/ablation-planner` read it as the claims source. It is also the #2
+session-recovery file (`docs/SESSION_RECOVERY_GUIDE.md`) — a crashed session
+reloads the ACTIVE idea from this contract instead of the full idea pool.
+
 ## Output Protocols
 
 > Follow these shared protocols for all output files:

--- a/skills/research-review/SKILL.md
+++ b/skills/research-review/SKILL.md
@@ -78,7 +78,10 @@ mcp__codex__codex:
     Read the review brief at <absolute path to RESEARCH_REVIEW_REQUEST.md>.
     Executor notes are not evidence beyond the files they cite, so verify the
     referenced artifacts before judging.
-    Please act as a senior ML reviewer (NeurIPS/ICML level). Identify:
+    Please act as a senior ML reviewer (NeurIPS/ICML level). Start from the
+    assumption that the work is broken somewhere — your job is to find where.
+    Be adversarial. Trust nothing the author tells you — verify everything
+    yourself. Identify:
     1. Logical gaps or unjustified claims
     2. Missing experiments that would strengthen the story
     3. Narrative weaknesses

--- a/skills/result-to-claim/SKILL.md
+++ b/skills/result-to-claim/SKILL.md
@@ -35,7 +35,7 @@ Gather experiment data from whatever sources are available in the project:
 2. **EXPERIMENT_LOG.md**: full results table with baselines and verdicts
 3. **EXPERIMENT_TRACKER.md**: check which experiments are DONE vs still running
 4. **Log files**: `ssh server "tail -100 /path/to/training.log"` if no other source
-5. **docs/research_contract.md**: intended claims and experiment design
+5. **`idea-stage/docs/research_contract.md`** (legacy fallback: `docs/research_contract.md`): intended claims and experiment design
 
 Assemble the key information:
 - What experiments were run (method, dataset, config)

--- a/skills/shared-references/effort-contract.md
+++ b/skills/shared-references/effort-contract.md
@@ -4,6 +4,8 @@
 
 Every ARIS skill accepts an optional `effort` parameter that controls how much work the system does. This affects breadth, depth, iterations, and coverage — but **never** the quality of cross-model review.
 
+> Design stance: the unattended *procedure* (gather → reason → act → verify → repeat) is the engineered artifact, not any single prompt — after Karpathy's "write the loop, not the prompt" (LOOPS.md, *Field Notes on Agents That Run for Days*).
+
 ```
 /any-skill "args" — effort: lite | balanced | max | beast
 ```

--- a/skills/shared-references/review-tracing.md
+++ b/skills/shared-references/review-tracing.md
@@ -148,12 +148,13 @@ its judgment actually changed:
 
 ```bash
 # Diff the raw response bodies across the two calls in question
-diff .aris/traces/<skill>/<run>/002-round-2.response.md \
-     .aris/traces/<skill>/<run>/003-round-3.response.md
+skill=auto-review-loop run=2026-04-15_run01
+diff ".aris/traces/$skill/$run/002-round-2.response.md" \
+     ".aris/traces/$skill/$run/003-round-3.response.md"
 
 # Grep for the sentence where the assessment turned
-grep -n "however\|but\|concern\|missing\|cannot" \
-     .aris/traces/<skill>/<run>/003-round-3.response.md
+grep -En 'however|but|concern|missing|cannot' \
+     ".aris/traces/$skill/$run/003-round-3.response.md"
 ```
 
 The paragraph where the assessment changed **is** the causal explanation for the

--- a/skills/shared-references/review-tracing.md
+++ b/skills/shared-references/review-tracing.md
@@ -138,6 +138,45 @@ After writing a trace, append a compact summary event to `.aris/meta/events.json
 
 This allows `/meta-optimize` to discover traces without reading the full trace files.
 
+## Debugging With Traces
+
+Traces are not only audit evidence — they are the **first place to look when a
+verdict is surprising**: a score regresses round-to-round, two reviewer backends
+disagree, or `/result-to-claim` contradicts an earlier claim. Before re-invoking
+the reviewer for "a better answer", read the raw transcript and find the moment
+its judgment actually changed:
+
+```bash
+# Diff the raw response bodies across the two calls in question
+diff .aris/traces/<skill>/<run>/002-round-2.response.md \
+     .aris/traces/<skill>/<run>/003-round-3.response.md
+
+# Grep for the sentence where the assessment turned
+grep -n "however\|but\|concern\|missing\|cannot" \
+     .aris/traces/<skill>/<run>/003-round-3.response.md
+```
+
+The paragraph where the assessment changed **is** the causal explanation for the
+divergence — cite it, don't guess. Re-running the reviewer without reading the
+trace is tuning by vibe: you get a new opinion, not an explanation.
+
+This is the same muscle ARIS already applies to code failures (the "**Read the
+error** — parse traceback, stderr, and log files" step in `/experiment-bridge`'s
+auto-debug sequence, and `/codex:rescue` reading tracebacks before a retry) —
+applied to saved AI-judgment transcripts instead of stderr. The trace is written
+in English and most of it is the reviewer talking to itself; the discipline is
+identical: read the primary artifact first, then act on the exact divergence
+point rather than re-rolling the dice.
+
+Practical triggers:
+
+| Surprise | Trace move |
+|---|---|
+| Score dropped after a "fix" round | diff the two rounds' `.response.md`; find which criterion flipped |
+| Two backends disagree (codex vs gemini/manual) | grep both responses for the SAME artifact path; compare what each actually read |
+| Reviewer "forgot" an earlier concern | grep prior rounds for the concern keyword; if present-then-absent, cite it in the next prompt instead of restating from memory |
+| Verdict contradicts a deterministic checker | read the request `.md` — was the checker's output actually in the files the reviewer was pointed at? |
+
 ## Privacy
 
 - `.aris/traces/` should be in `.gitignore` — traces are project-local, never committed

--- a/skills/skills-codex/ablation-planner/SKILL.md
+++ b/skills/skills-codex/ablation-planner/SKILL.md
@@ -22,7 +22,7 @@ Systematically design ablation studies that answer the questions reviewers will 
 
 Read available project files to build the full picture:
 
-- Method description and components (from `docs/research_contract.md`, project notes, or method docs)
+- Method description and components (from `idea-stage/docs/research_contract.md`, legacy `docs/research_contract.md`, project notes, or method docs)
 - Current experiment results (from `EXPERIMENT_LOG.md`, `EXPERIMENT_TRACKER.md`, or W&B)
 - Confirmed and intended claims (from `/result-to-claim` output or project notes)
 - Available compute resources (from server notes, run configs, or user-provided budget)

--- a/skills/skills-codex/auto-review-loop/SKILL.md
+++ b/skills/skills-codex/auto-review-loop/SKILL.md
@@ -170,6 +170,10 @@ Pass this file back to the reviewer in the next round so it can track its own su
 Rules:
 - Append each round; never delete prior rounds.
 - If the reviewer response includes a `Memory update` section, copy it verbatim.
+- If the score REGRESSES round-to-round, don't just write a new memory line:
+  diff the two rounds' raw `.response.md` files in `.aris/traces/` first and
+  find the exact criterion that flipped (see `shared-references/review-tracing.md`
+  § *Debugging With Traces*). The memory file is a summary; the trace is evidence.
 - This file is passed back to the reviewer in the next round's Phase A.
 
 #### Phase B.6: Debate Protocol (hard + nightmare only)

--- a/skills/skills-codex/auto-review-loop/SKILL.md
+++ b/skills/skills-codex/auto-review-loop/SKILL.md
@@ -108,14 +108,18 @@ spawn_agent:
     - Raw results (verbatim files, not a summary): <path(s)>
     - Changed since last round: <changed-file paths> — read the diff, not my description
 
-    Please act as a senior ML reviewer (NeurIPS/ICML level).
+    Please act as a senior ML reviewer (NeurIPS/ICML level). Start from the
+    assumption that the work is broken somewhere — your job is to find where.
+    Be adversarial. Trust nothing the author tells you — verify everything
+    yourself.
 
     1. Score this work 1-10 for a top venue
     2. List remaining critical weaknesses (ranked by severity)
     3. For each weakness, specify the MINIMUM fix (experiment, analysis, or reframing)
     4. State clearly: is this READY for submission? Yes/No/Almost
 
-    Be brutally honest. If the work is ready, say so clearly.
+    Be brutally honest. If, after genuinely trying to break it, the work holds
+    up and is ready, say so clearly.
 ```
 
 If this is round 2+, use `send_input` with the saved agent id to maintain continuity.

--- a/skills/skills-codex/experiment-audit/SKILL.md
+++ b/skills/skills-codex/experiment-audit/SKILL.md
@@ -56,8 +56,11 @@ spawn_agent:
   model: gpt-5.5
   reasoning_effort: xhigh
   message: |
-    You are an experiment integrity auditor. Read ALL files listed below
-    and check for the following fraud patterns.
+    You are an experiment integrity auditor. Start from the assumption that the
+    evaluation is compromised somewhere — your job is to find where. Be
+    adversarial. Trust nothing the author tells you — verify everything
+    yourself. Read ALL files listed below and check for the following fraud
+    patterns.
 
     Files to read:
     - Evaluation scripts: [list paths]

--- a/skills/skills-codex/experiment-bridge/SKILL.md
+++ b/skills/skills-codex/experiment-bridge/SKILL.md
@@ -157,7 +157,11 @@ Wait for completion. Verify:
 - GPU memory usage is within bounds
 - Output format matches expectations
 
-If sanity fails → fix the code, re-run. Do not proceed to full deployment with broken code.
+If sanity fails → READ the traceback/stderr/logs first, then fix the code and
+re-run — never re-run unchanged hoping for a different outcome. (The same
+read-the-primary-artifact discipline applies to surprising REVIEWER verdicts:
+see `shared-references/review-tracing.md` § *Debugging With Traces*.) Do not
+proceed to full deployment with broken code.
 
 If the same sanity failure repeats, trigger a second opinion: summarize the plan, code diff, command, logs, backend, and failure, then ask a fresh Codex reviewer agent for a rescue diagnosis. Apply only concrete fixes grounded in the logs.
 

--- a/skills/skills-codex/experiment-bridge/SKILL.md
+++ b/skills/skills-codex/experiment-bridge/SKILL.md
@@ -72,6 +72,11 @@ Present a brief summary:
 Proceeding to implementation.
 ```
 
+**Research-contract fallback**: if `idea-stage/docs/research_contract.md` does
+not exist yet, create it now from `templates/RESEARCH_CONTRACT_TEMPLATE.md`
+using the selected idea + claims from the experiment plan — downstream
+`/result-to-claim` and `/ablation-planner` read it as the claims source.
+
 ### Phase 2: Implement Experiment Code
 
 **If `BASE_REPO` is set** — clone the repo first:

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -296,6 +296,16 @@ Write `idea-stage/IDEA_CANDIDATES.md` — a lean summary of the top 3-5 survivin
 - Next step: /experiment-bridge or /research-refine
 ```
 
+### Phase 5.6: Instantiate the Research Contract (always — NOT gated on COMPACT)
+
+When Phase 4 ends with a RECOMMENDED idea, create `idea-stage/docs/research_contract.md`
+from `templates/RESEARCH_CONTRACT_TEMPLATE.md` (repo root or `$ARIS_REPO/templates/`),
+filling in: the selected idea + selection rationale, core claims, minimum
+convincing evidence, and the next-step pointer. Skip only when the run produced
+no RECOMMENDED idea. `/experiment-bridge` implements against this contract;
+`/result-to-claim` + `/ablation-planner` read it as the claims source; session
+recovery reloads the ACTIVE idea from it instead of the full idea pool.
+
 ## Output Protocols
 
 > Follow these shared protocols for all output files:

--- a/skills/skills-codex/research-review/SKILL.md
+++ b/skills/skills-codex/research-review/SKILL.md
@@ -35,7 +35,10 @@ spawn_agent:
   reasoning_effort: xhigh
   message: |
     [Full research context + specific questions]
-    Please act as a senior ML reviewer (NeurIPS/ICML level). Identify:
+    Please act as a senior ML reviewer (NeurIPS/ICML level). Start from the
+    assumption that the work is broken somewhere — your job is to find where.
+    Be adversarial. Trust nothing the author tells you — verify everything
+    yourself. Identify:
     1. Logical gaps or unjustified claims
     2. Missing experiments that would strengthen the story
     3. Narrative weaknesses

--- a/skills/skills-codex/result-to-claim/SKILL.md
+++ b/skills/skills-codex/result-to-claim/SKILL.md
@@ -27,7 +27,7 @@ Gather experiment data from whatever sources are available in the project:
 2. **EXPERIMENT_LOG.md**: full results table with baselines and verdicts
 3. **EXPERIMENT_TRACKER.md**: check which experiments are DONE vs still running
 4. **Log files**: `ssh server "tail -100 /path/to/training.log"` if no other source
-5. **docs/research_contract.md**: intended claims and experiment design
+5. **`idea-stage/docs/research_contract.md`** (legacy fallback: `docs/research_contract.md`): intended claims and experiment design
 
 Assemble the key information:
 - What experiments were run (method, dataset, config)

--- a/skills/skills-codex/shared-references/effort-contract.md
+++ b/skills/skills-codex/shared-references/effort-contract.md
@@ -4,6 +4,8 @@
 
 Every ARIS skill accepts an optional `effort` parameter that controls how much work the system does. This affects breadth, depth, iterations, and coverage — but **never** the quality of cross-model review.
 
+> Design stance: the unattended *procedure* (gather → reason → act → verify → repeat) is the engineered artifact, not any single prompt — after Karpathy's "write the loop, not the prompt" (LOOPS.md, *Field Notes on Agents That Run for Days*).
+
 ```
 /any-skill "args" — effort: lite | balanced | max | beast
 ```

--- a/skills/skills-codex/shared-references/review-tracing.md
+++ b/skills/skills-codex/shared-references/review-tracing.md
@@ -114,10 +114,11 @@ reviewer for "a better answer", read the raw transcript and find the moment its
 judgment actually changed:
 
 ```bash
-diff .aris/traces/<skill>/<run>/002-round-2.response.md \
-     .aris/traces/<skill>/<run>/003-round-3.response.md
-grep -n "however\|but\|concern\|missing\|cannot" \
-     .aris/traces/<skill>/<run>/003-round-3.response.md
+skill=auto-review-loop run=2026-04-15_run01
+diff ".aris/traces/$skill/$run/002-round-2.response.md" \
+     ".aris/traces/$skill/$run/003-round-3.response.md"
+grep -En 'however|but|concern|missing|cannot' \
+     ".aris/traces/$skill/$run/003-round-3.response.md"
 ```
 
 The paragraph where the assessment changed **is** the causal explanation for the

--- a/skills/skills-codex/shared-references/review-tracing.md
+++ b/skills/skills-codex/shared-references/review-tracing.md
@@ -105,6 +105,27 @@ After writing a trace, append a compact event to `.aris/meta/events.jsonl`:
 {"event":"review_trace","skill":"auto-review-loop","purpose":"round-1-review","agent_id":"...","trace_path":".aris/traces/auto-review-loop/2026-04-15_run01/","status":"ok"}
 ```
 
+## Debugging With Traces
+
+Traces are not only audit evidence — they are the **first place to look when a
+verdict is surprising**: a score regresses round-to-round, two reviewer agents
+disagree, or a claim check contradicts an earlier round. Before re-invoking the
+reviewer for "a better answer", read the raw transcript and find the moment its
+judgment actually changed:
+
+```bash
+diff .aris/traces/<skill>/<run>/002-round-2.response.md \
+     .aris/traces/<skill>/<run>/003-round-3.response.md
+grep -n "however\|but\|concern\|missing\|cannot" \
+     .aris/traces/<skill>/<run>/003-round-3.response.md
+```
+
+The paragraph where the assessment changed **is** the causal explanation for the
+divergence — cite it, don't guess. Re-running the reviewer without reading the
+trace is tuning by vibe: you get a new opinion, not an explanation. Same muscle
+as reading a stack trace before retrying a failed run — the trace is just
+written in English, and most of it is the reviewer talking to itself.
+
 ## Privacy
 
 `.aris/traces/` is project-local and should not be committed. Use `--- trace: off` for strict confidentiality projects.


### PR DESCRIPTION
Four adoptions from Karpathy's *LOOPS.md: Field Notes on Agents That Run for Days*, each closing a gap verified by a two-pass repo audit (survey + adversarial re-check). Mainline and codex-mirror copies updated together.

## 1. Adversarial reviewer stance by default (LOOPS II)
`auto-review-loop` (medium prompt), `research-review` (Step 2), `experiment-audit` (auditor prompt) now open with the assume-broken posture previously gated behind `difficulty: hard/nightmare`: *"Start from the assumption that the work is broken somewhere — your job is to find where. Be adversarial. Trust nothing the author tells you — verify everything yourself."* The honest release valve ("if it holds up after genuinely trying to break it, say so") is preserved so scores don't deflate artificially.

## 2. Debugging With Traces (LOOPS VII)
New section in `shared-references/review-tracing.md`: traces are the first diagnostic corpus, not just audit storage — on a surprising verdict, `diff`/`grep` the raw `.response.md` bodies for the exact judgment-divergence point before re-invoking the reviewer. Includes a surprise→trace-move table. Cross-referenced from `auto-review-loop` Phase B.5 (score regression → diff traces before writing a memory line) and `experiment-bridge`'s Read-the-error step (same muscle, different artifact).

## 3. research_contract.md wiring (docs-vs-reality fix, LOOPS IV adjacent)
`SESSION_RECOVERY_GUIDE.md` promised this file is "created when an idea is selected" — nothing created it (verified: only `result-to-claim`/`ablation-planner` READ it). Now: `idea-discovery` Phase 5.6 (unconditional) instantiates it from the template; `experiment-bridge` Phase 1 has a create-if-missing fallback; guide clarifies the recovery hooks are copy-paste snippets, not shipped automation.

## 4. Attribution (LOOPS I)
One-line design-stance credit in `effort-contract.md` (mechanism was already fully covered; this is provenance only).

## Verification
Inventory consistent · full suite 407 passed / 16 skipped · mirror edits use each file's own idiom (e.g. mirror review-tracing's Debugging-With-Traces drops Claude-Code-only cross-refs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)