### PR TITLE
feat(meta-optimize): harness-diet deletion analysis + named-bottleneck ledger (LOOPS VIII+IX)

### DIFF
--- a/skills/meta-optimize/SKILL.md
+++ b/skills/meta-optimize/SKILL.md
@@ -93,7 +93,18 @@ if [ "$SKILL_INVOCATIONS" -lt 5 ]; then
     echo "⚠️  Insufficient data (<5 skill invocations). Continue using ARIS normally and re-run later."
     exit 0
 fi
+
+# Bottleneck succession: what did the LAST cycle say was the limiting stage?
+BOTTLENECK_LOG=".aris/meta/bottleneck_log.jsonl"
+if [ -f "$BOTTLENECK_LOG" ]; then
+    echo "🧭 Prior cycle's bottleneck: $(tail -1 "$BOTTLENECK_LOG")"
+fi
 ```
+
+If a prior bottleneck entry exists, open the report (Step 5) by stating whether
+that named bottleneck was **resolved** (and by which landed patches) and what it
+has now **moved to** — bottleneck SUCCESSION, not just existence, is the signal
+this ledger exists to carry.
 
 ### Step 1: Analyze Usage Patterns
 
@@ -119,7 +130,40 @@ Read `.aris/meta/events.jsonl` and compute:
 - Where do users interrupt with manual prompts during workflows?
 - What manual corrections do users make most? (These indicate skill gaps.)
 
+**Model-delta analysis (harness diet):**
+- Has the session model (`session_start` events' `model` field) or the pinned
+  reviewer model changed since a skill's SKILL.md was last touched?
+  (`git log -1 --format=%cs -- skills/<skill>/SKILL.md` vs the model-bump date.)
+- If yes, flag every explicit reasoning-scaffolding step, guardrail, and worked
+  example in that SKILL.md as a **DELETION candidate**, not just an addition
+  candidate. The harness exists to compensate for the model; a capability the
+  new model has natively is pure overhead — context-window weight, drift
+  surface, and reading cost with no return. A harness that only ever grows is a
+  harness nobody is re-reading.
+
 Present findings as a structured summary table.
+
+### Step 1.5: Name the Current Bottleneck
+
+Synthesize the Step-1 analyses into **one sentence naming the single
+most-limiting pipeline stage right now** — e.g. "planning", "verification
+quality", "experiment execution reliability", "writing polish" — with the
+supporting evidence. The bottleneck always moves: when coding stops being the
+constraint, planning becomes it; when planning is solved, verification; when
+verification is automated, taste. This step exists to make the CURRENT
+constraint visible, so Step 2's ranked table reads as sub-fixes for one named
+constraint instead of scattered tweaks.
+
+Append the verdict to the append-only ledger `.aris/meta/bottleneck_log.jsonl`
+(same never-mutate discipline as `.aris/runs/<run_id>.iterations.jsonl`):
+
+```bash
+mkdir -p .aris/meta
+printf '%s\n' '{"ts":"2026-07-02T15:00:00+08:00","cycle":3,"bottleneck":"verification quality","evidence":"review rounds plateau at 6/10 while tool failures are rare","top_patch_ids":["P1","P2"]}' \
+  >> .aris/meta/bottleneck_log.jsonl
+```
+
+Never edit or delete prior lines — succession history is the point.
 
 ### Step 2: Identify Optimization Targets
 
@@ -133,7 +177,12 @@ Based on Step 1, rank optimization opportunities by expected impact:
 | 1 | auto-review-loop default threshold | Users override to 7/10 in 60% of runs | Change default from 6/10 to 7/10 | Fewer manual overrides |
 | 2 | experiment-bridge retry count | 40% of runs hit max retries on OOM | Add OOM-specific recovery (reduce batch size) | Fewer failed experiments |
 | 3 | paper-write de-AI patterns | Users manually fix "delve" in 80% of runs | Add "delve" to default watchword list | Fewer manual edits |
+| 4 | experiment-bridge Phase-2 hand-holding steps | Model bump (session_start model changed); scaffold untouched since 2 generations ago; zero tool_failures in the steps it guards | **DELETE steps N–M — the new model does this unprompted** | Smaller harness, less drift surface |
 ```
+
+The Proposed-Change column is explicitly allowed to be a **deletion** — "DELETE
+step N, new model does this for free" is a first-class optimization, ranked by
+the same impact logic as additions.
 
 If `$ARGUMENTS` specifies a target skill, focus analysis on that skill only.
 If `$ARGUMENTS` is empty or "all", analyze all skills with sufficient data.
@@ -211,6 +260,12 @@ Output a structured report:
 **Data**: [N] events, [M] skill invocations, [K] sessions
 **Target**: [skill name or "all"]
 
+## Current Bottleneck
+
+**[one-phrase name]** — [one-line evidence]. Prior cycle's bottleneck: [name —
+resolved by <patch ids> / unresolved / first recorded cycle]. (Ledger:
+`.aris/meta/bottleneck_log.jsonl`)
+
 ## Proposed Changes
 
 ### Change 1: [title]
@@ -262,7 +317,7 @@ never produces the acquittal.
 ## Key Rules
 
 - **Log-driven, not speculative.** Every proposed change must cite specific data from the event log. No "I think this would be better."
-- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills.
+- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills — unless the proposal is a scaffolding **deletion** justified by a documented model-capability delta (cite the model-bump News entry or the `session_start` model change as evidence). Deleting what a newer model now does for free is the one sanctioned large edit; it still goes through the same review + approval gates.
 - **Reviewer-gated.** Every patch goes through cross-model review before recommendation.
 - **Reversible.** Always back up before applying. Always log what changed.
 - **User-approved.** Never auto-apply. Present, explain, let the user decide.
@@ -294,11 +349,16 @@ This skill is NOT part of the standard W1→W1.5→W2→W3→W4 pipeline. It is 
    ```
    📊 ARIS has logged 8 skill runs since last optimization. Run /meta-optimize to check for improvement opportunities.
    ```
-   This is a **suggestion only** — it does not auto-run optimization.
+   It ALSO fires — regardless of invocation count — when the session model has
+   changed since the last optimize (compared against `.aris/meta/.last_optimize_model`):
+   ```
+   🔁 Model changed since last optimization (claude-opus-4-6 → claude-opus-4-8). Run /meta-optimize — a model bump makes existing scaffolding a deletion candidate (harness diet).
+   ```
+   Both are **suggestions only** — they do not auto-run optimization.
 
 3. **Manual trigger**: User runs `/meta-optimize` when they see the reminder or whenever they want.
 
-**After each `/meta-optimize` run**, the skill writes the current timestamp to `.aris/meta/.last_optimize` so the readiness check only counts new invocations.
+**After each `/meta-optimize` run**, the skill writes the current timestamp to `.aris/meta/.last_optimize` and the current session model (latest `session_start` event's `model` field) to `.aris/meta/.last_optimize_model`, so the readiness check can detect both new usage and model bumps.
 
 ## Acknowledgements
 

--- a/skills/meta-optimize/SKILL.md
+++ b/skills/meta-optimize/SKILL.md
@@ -134,11 +134,17 @@ Read `.aris/meta/events.jsonl` and compute:
 - Has the session model (`session_start` events' `model` field) or the pinned
   reviewer model changed since a skill's SKILL.md was last touched?
   (`git log -1 --format=%cs -- skills/<skill>/SKILL.md` vs the model-bump date.)
-- If yes, flag every explicit reasoning-scaffolding step, guardrail, and worked
-  example in that SKILL.md as a **DELETION candidate**, not just an addition
-  candidate. The harness exists to compensate for the model; a capability the
-  new model has natively is pure overhead — context-window weight, drift
-  surface, and reading cost with no return. A harness that only ever grows is a
+- A model bump is a **trigger to re-read, not evidence by itself**. For each
+  reasoning-scaffolding step or worked example in that SKILL.md, a deletion
+  proposal must cite TARGET-SPECIFIC evidence that the new model no longer
+  needs it: a capability-specific release note, or repeated observed behavior
+  in the event log (e.g. zero failures/interventions in the guarded step since
+  the bump). "The model got newer" alone never justifies a deletion.
+- **Never deletion candidates**, regardless of model: privilege boundaries,
+  acceptance/review gates, corpus- and provenance-integrity rules, output
+  contracts, and safety checks. The diet targets model-compensation scaffolding
+  only — a capability the new model has natively is pure overhead (context
+  weight, drift surface, reading cost). A harness that only ever grows is a
   harness nobody is re-reading.
 
 Present findings as a structured summary table.
@@ -159,8 +165,20 @@ Append the verdict to the append-only ledger `.aris/meta/bottleneck_log.jsonl`
 
 ```bash
 mkdir -p .aris/meta
-printf '%s\n' '{"ts":"2026-07-02T15:00:00+08:00","cycle":3,"bottleneck":"verification quality","evidence":"review rounds plateau at 6/10 while tool failures are rare","top_patch_ids":["P1","P2"]}' \
-  >> .aris/meta/bottleneck_log.jsonl
+# json.dumps, NOT hand-interpolated shell strings: bottleneck/evidence are
+# natural language — a stray quote must not break the JSONL (or the shell).
+python3 - <<'PY'
+import json, datetime
+entry = {
+    "ts": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+    "cycle": 3,
+    "bottleneck": "verification quality",
+    "evidence": "review rounds plateau at 6/10 while tool failures are rare",
+    "top_patch_ids": ["P1", "P2"],
+}
+with open(".aris/meta/bottleneck_log.jsonl", "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+PY
 ```
 
 Never edit or delete prior lines — succession history is the point.
@@ -317,7 +335,7 @@ never produces the acquittal.
 ## Key Rules
 
 - **Log-driven, not speculative.** Every proposed change must cite specific data from the event log. No "I think this would be better."
-- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills — unless the proposal is a scaffolding **deletion** justified by a documented model-capability delta (cite the model-bump News entry or the `session_start` model change as evidence). Deleting what a newer model now does for free is the one sanctioned large edit; it still goes through the same review + approval gates.
+- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills — the one sanctioned large edit is a scaffolding **deletion** backed by TARGET-SPECIFIC model-delta evidence (a capability-specific release note, or repeated post-bump event-log behavior showing the scaffold is unused — the model name changing is a trigger to look, never sufficient evidence). Privilege boundaries, acceptance gates, corpus/provenance rules, output contracts, and safety checks are never deletion candidates. Deletions go through the same review + approval gates as everything else.
 - **Reviewer-gated.** Every patch goes through cross-model review before recommendation.
 - **Reversible.** Always back up before applying. Always log what changed.
 - **User-approved.** Never auto-apply. Present, explain, let the user decide.

--- a/skills/skills-codex/meta-optimize/SKILL.md
+++ b/skills/skills-codex/meta-optimize/SKILL.md
@@ -81,7 +81,35 @@ Read `.aris/meta/events.jsonl` and compute:
 - Where do users interrupt with manual prompts during workflows?
 - What manual corrections do users make most? (These indicate skill gaps.)
 
+**Model-delta analysis (harness diet):**
+- Has the session model or the pinned reviewer model changed since a skill's
+  SKILL.md was last touched? If yes, flag every explicit reasoning-scaffolding
+  step, guardrail, and worked example in that SKILL.md as a **DELETION
+  candidate**, not just an addition candidate. The harness exists to compensate
+  for the model; a capability the new model has natively is pure overhead. A
+  harness that only ever grows is a harness nobody is re-reading.
+
 Present findings as a structured summary table.
+
+### Step 1.5: Name the Current Bottleneck
+
+Synthesize the Step-1 analyses into **one sentence naming the single
+most-limiting pipeline stage right now** — e.g. "planning", "verification
+quality", "experiment execution reliability", "writing polish" — with evidence.
+The bottleneck always moves: coding → planning → verification → taste. Step 2's
+ranked table should read as sub-fixes for this one named constraint.
+
+Append the verdict to the append-only ledger `.aris/meta/bottleneck_log.jsonl`
+(never edit or delete prior lines — succession history is the point):
+
+```bash
+mkdir -p .aris/meta
+printf '%s\n' '{"ts":"2026-07-02T15:00:00+08:00","cycle":3,"bottleneck":"verification quality","evidence":"review rounds plateau at 6/10 while tool failures are rare","top_patch_ids":["P1","P2"]}' \
+  >> .aris/meta/bottleneck_log.jsonl
+```
+
+On the next run, read the last line first and open the report by stating
+whether that bottleneck was resolved and what it has moved to.
 
 ### Step 2: Identify Optimization Targets
 
@@ -95,7 +123,11 @@ Based on Step 1, rank optimization opportunities by expected impact:
 | 1 | auto-review-loop default threshold | Users override to 7/10 in 60% of runs | Change default from 6/10 to 7/10 | Fewer manual overrides |
 | 2 | experiment-bridge retry count | 40% of runs hit max retries on OOM | Add OOM-specific recovery (reduce batch size) | Fewer failed experiments |
 | 3 | paper-write de-AI patterns | Users manually fix "delve" in 80% of runs | Add "delve" to default watchword list | Fewer manual edits |
+| 4 | experiment-bridge Phase-2 hand-holding steps | Model bump; scaffold untouched for 2 generations; zero failures in the guarded steps | **DELETE steps N–M — the new model does this unprompted** | Smaller harness, less drift surface |
 ```
+
+The Proposed-Change column is explicitly allowed to be a **deletion** — "DELETE
+step N, new model does this for free" is a first-class optimization.
 
 If `$ARGUMENTS` specifies a target skill, focus analysis on that skill only.
 If `$ARGUMENTS` is empty or "all", analyze all skills with sufficient data.
@@ -161,6 +193,12 @@ Output a structured report:
 **Data**: [N] events, [M] skill invocations, [K] sessions
 **Target**: [skill name or "all"]
 
+## Current Bottleneck
+
+**[one-phrase name]** — [one-line evidence]. Prior cycle's bottleneck: [name —
+resolved by <patch ids> / unresolved / first recorded cycle]. (Ledger:
+`.aris/meta/bottleneck_log.jsonl`)
+
 ## Proposed Changes
 
 ### Change 1: [title]
@@ -199,7 +237,7 @@ If user runs `/meta-optimize apply [N]`:
 ## Key Rules
 
 - **Log-driven, not speculative.** Every proposed change must cite specific data from the event log. No "I think this would be better."
-- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills.
+- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills — unless the proposal is a scaffolding **deletion** justified by a documented model-capability delta; deleting what a newer model now does for free is the one sanctioned large edit, and it still goes through the same review + approval gates.
 - **Reviewer-gated.** Every patch goes through cross-model review before recommendation.
 - **Reversible.** Always back up before applying. Always log what changed.
 - **User-approved.** Never auto-apply. Present, explain, let the user decide.

--- a/skills/skills-codex/meta-optimize/SKILL.md
+++ b/skills/skills-codex/meta-optimize/SKILL.md
@@ -83,11 +83,14 @@ Read `.aris/meta/events.jsonl` and compute:
 
 **Model-delta analysis (harness diet):**
 - Has the session model or the pinned reviewer model changed since a skill's
-  SKILL.md was last touched? If yes, flag every explicit reasoning-scaffolding
-  step, guardrail, and worked example in that SKILL.md as a **DELETION
-  candidate**, not just an addition candidate. The harness exists to compensate
-  for the model; a capability the new model has natively is pure overhead. A
-  harness that only ever grows is a harness nobody is re-reading.
+  SKILL.md was last touched? A model bump is a **trigger to re-read, not
+  evidence by itself**: a deletion proposal must cite TARGET-SPECIFIC evidence
+  (a capability-specific release note, or repeated post-bump event-log behavior
+  showing the scaffold is unused). **Never deletion candidates**: privilege
+  boundaries, acceptance/review gates, corpus/provenance rules, output
+  contracts, safety checks. The diet targets model-compensation scaffolding
+  only — a capability the new model has natively is pure overhead. A harness
+  that only ever grows is a harness nobody is re-reading.
 
 Present findings as a structured summary table.
 
@@ -104,8 +107,20 @@ Append the verdict to the append-only ledger `.aris/meta/bottleneck_log.jsonl`
 
 ```bash
 mkdir -p .aris/meta
-printf '%s\n' '{"ts":"2026-07-02T15:00:00+08:00","cycle":3,"bottleneck":"verification quality","evidence":"review rounds plateau at 6/10 while tool failures are rare","top_patch_ids":["P1","P2"]}' \
-  >> .aris/meta/bottleneck_log.jsonl
+# json.dumps, NOT hand-interpolated shell strings: bottleneck/evidence are
+# natural language — a stray quote must not break the JSONL (or the shell).
+python3 - <<'PY'
+import json, datetime
+entry = {
+    "ts": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+    "cycle": 3,
+    "bottleneck": "verification quality",
+    "evidence": "review rounds plateau at 6/10 while tool failures are rare",
+    "top_patch_ids": ["P1", "P2"],
+}
+with open(".aris/meta/bottleneck_log.jsonl", "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+PY
 ```
 
 On the next run, read the last line first and open the report by stating
@@ -237,7 +252,7 @@ If user runs `/meta-optimize apply [N]`:
 ## Key Rules
 
 - **Log-driven, not speculative.** Every proposed change must cite specific data from the event log. No "I think this would be better."
-- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills — unless the proposal is a scaffolding **deletion** justified by a documented model-capability delta; deleting what a newer model now does for free is the one sanctioned large edit, and it still goes through the same review + approval gates.
+- **Minimal patches.** Change one thing at a time. Don't rewrite entire skills — the one sanctioned large edit is a scaffolding **deletion** backed by TARGET-SPECIFIC model-delta evidence (capability-specific release note, or repeated post-bump event-log behavior; a model-name change alone is never sufficient). Privilege boundaries, acceptance gates, corpus/provenance rules, output contracts, and safety checks are never deletion candidates. Deletions go through the same review + approval gates.
 - **Reviewer-gated.** Every patch goes through cross-model review before recommendation.
 - **Reversible.** Always back up before applying. Always log what changed.
 - **User-approved.** Never auto-apply. Present, explain, let the user decide.

--- a/tools/meta_opt/check_ready.sh
+++ b/tools/meta_opt/check_ready.sh
@@ -54,3 +54,27 @@ fi
 if [ "$SINCE_LAST" -ge 5 ]; then
     echo "📊 ARIS has logged $SINCE_LAST skill runs since last optimization. Run /meta-optimize to check for improvement opportunities."
 fi
+
+# Model-delta trigger (harness diet): a model bump makes existing scaffolding a
+# deletion candidate, independent of usage volume. /meta-optimize records the
+# session model at each run in .last_optimize_model; compare against the LATEST
+# session_start event's model. Absent files (older installs, no session_start
+# yet) silently skip.
+LAST_MODEL_FILE="$ARIS_META_DIR/.last_optimize_model"
+if [ -f "$LAST_MODEL_FILE" ]; then
+    CURRENT_MODEL=$(awk '
+        /"event": *"session_start"/ {
+            if (match($0, /"model": *"[^"]+"/)) {
+                m = substr($0, RSTART, RLENGTH)
+                sub(/^"model": *"/, "", m)
+                sub(/"$/, "", m)
+                latest = m
+            }
+        }
+        END { if (latest != "") print latest }
+    ' "$EVENTS_FILE")
+    LAST_MODEL=$(cat "$LAST_MODEL_FILE")
+    if [ -n "$CURRENT_MODEL" ] && [ -n "$LAST_MODEL" ] && [ "$CURRENT_MODEL" != "$LAST_MODEL" ]; then
+        echo "🔁 Model changed since last optimization ($LAST_MODEL → $CURRENT_MODEL). Run /meta-optimize — a model bump makes existing scaffolding a deletion candidate (harness diet)."
+    fi
+fi


### PR DESCRIPTION
Two LOOPS.md adoptions targeting the audit-verified gaps in ARIS's self-improvement loop: it was structurally **additive-only** (every worked example raises thresholds or adds recovery; Key Rules discouraged large rewrites; skill count only grows) and it **never names the current constraint** (both "change direction" mechanisms — meta-optimize's backlog and iteration_log's stall-pivot — count signals without diagnosing which stage binds).

## VIII — Delete the harness
- **Step 1 "Model-delta analysis"**: model bump since a SKILL.md was last touched ⇒ its scaffolding becomes a *deletion* candidate set.
- **Step 2 table**: worked DELETE row; deletions are first-class proposals.
- **Key Rules**: "Don't rewrite entire skills" keeps its force but gains the one sanctioned exception — scaffolding deletion with documented model-delta evidence. Same cross-model review + `/meta-apply` human landing gate as all patches (the human-in-loop invariant is untouched).
- **check_ready.sh**: fires on model change regardless of usage volume (`.aris/meta/.last_optimize_model`); legacy installs without the file silently skip. Tested 3 ways + bash 3.2 `-n`.

## IX — The bottleneck always moves
- **Step 1.5 "Name the Current Bottleneck"**: one sentence naming the single most-limiting stage, with evidence, appended to append-only `.aris/meta/bottleneck_log.jsonl` (modeled on iteration_log's ledger discipline).
- **Step 0 + Step 5**: each run reads the prior entry and the report opens with bottleneck **succession** (was A, resolved by X, now B) — so the ranked table becomes sub-fixes for one named constraint.

Codex mirror's meta-optimize carries the same changes in its own idiom.

## Verification
Inventory consistent · full suite 406 passed / 16 skipped · check_ready.sh manual 3-case test (fires on delta / silent on same-model / silent+no-crash on legacy) · `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)