### PR TITLE
feat(loops): restart doctrine — discard-and-reimplement as a peer move, with hard state boundary (LOOPS V)

### DIFF
--- a/skills/dse-loop/SKILL.md
+++ b/skills/dse-loop/SKILL.md
@@ -271,8 +271,13 @@ If the context window compacts mid-run, the loop recovers from `DSE_STATE.json` 
   the suspect — **discard and reimplement the run/parse script cleanly from the spec**
   (a peer move to another patch; delete only the script, never `dse_log.csv` /
   `dse_results/`; see `shared-references/external-cadence.md` § *Let a broken attempt
-  restart, not just patch*). If a clean reimplement crashes the same way, stop and
-  report — the spec or the environment is then in question, which is what needs the human
+  restart, not just patch*). **Before resuming the sweep, re-validate metric
+  comparability**: re-parse one COMPLETED iteration's raw output from
+  `dse_results/outputs/iter_N/` with the new parser and confirm it reproduces that row of
+  `dse_log.csv`; on mismatch, either fix the parser or re-parse and flag all affected
+  rows — never mix two parsing semantics in one log. If a clean reimplement crashes the
+  same way, stop and report — the spec or the environment is then in question, which is
+  what needs the human
 
 ## Example Invocations
 

--- a/skills/dse-loop/SKILL.md
+++ b/skills/dse-loop/SKILL.md
@@ -267,7 +267,12 @@ If the context window compacts mid-run, the loop recovers from `DSE_STATE.json` 
 - **Keep raw outputs** — save each run's full output in `dse_results/outputs/iter_N/`
 - **Constraint violations are not improvements** — a design point that violates constraints is never "best", regardless of the metric
 - If a run crashes, log the error, skip that point, and continue with the next
-- If the same crash repeats 3 times with different configs, stop and report the issue
+- If the same crash repeats 3 times with different configs, the harness code itself is
+  the suspect — **discard and reimplement the run/parse script cleanly from the spec**
+  (a peer move to another patch; delete only the script, never `dse_log.csv` /
+  `dse_results/`; see `shared-references/external-cadence.md` § *Let a broken attempt
+  restart, not just patch*). If a clean reimplement crashes the same way, stop and
+  report — the spec or the environment is then in question, which is what needs the human
 
 ## Example Invocations
 

--- a/skills/experiment-bridge/SKILL.md
+++ b/skills/experiment-bridge/SKILL.md
@@ -160,7 +160,8 @@ Wait for completion. Verify:
 - GPU memory usage is within bounds
 - Output format matches expectations
 
-If sanity fails → **auto-debug before giving up** (max 3 attempts):
+If sanity fails → **auto-debug before giving up**. Budget: up to **2 patch
+attempts** on the same failure, then up to **2 clean reimplements** (4 total):
 
 1. **Read the error** — parse traceback, stderr, and log files. (The same
    read-the-primary-artifact discipline applies to surprising REVIEWER verdicts:
@@ -175,14 +176,19 @@ If sanity fails → **auto-debug before giving up** (max 3 attempts):
 4. **Attempt 2+ still failing? → Call in Codex rescue** (if Codex plugin installed):
    Before the next retry, invoke `/codex:rescue` to get a second opinion on the root cause. Codex independently reads the code and error logs — it may spot issues Claude missed (wrong tensor shapes, subtle import shadowing, config mismatches, etc.). Apply its suggested fix, then re-run.
    - If `/codex:rescue` is not available (plugin not installed), continue with Claude's own diagnosis
-5. **Patches stacking on the same failure? → Discard and reimplement cleanly.**
-   Rewriting the failing script from `EXPERIMENT_PLAN.md` / the research contract is a
-   PEER move to another patch, not a last resort — a third patch on top of two wrong
-   ones is usually worse than a clean rebuild. Delete ONLY the attempt's own
-   code/scaffolding; the plan, `EXPERIMENT_TRACKER.md`, collected data, and results are
-   never deletable (see `shared-references/external-cadence.md` § *Let a broken attempt
-   restart, not just patch*). A reimplement consumes one retry slot.
-6. **Still failing after 3 attempts (patches + reimplements combined)?** → stop, report the failure with all attempted fixes and error logs. Two clean reimplements failing the SAME way usually means the plan or the environment is wrong — say so explicitly in the report, because that (not the broken build itself) is what needs the human. Do not proceed with broken code.
+5. **Both patch attempts failed on the same failure? → Discard and reimplement cleanly**
+   (up to 2 reimplements). Rewriting the failing script from `EXPERIMENT_PLAN.md` / the
+   research contract is a PEER move to another patch, not a last resort — a third patch
+   on top of two wrong ones is usually worse than a clean rebuild. Delete ONLY the
+   attempt's own code/scaffolding (scripts this phase generated); the plan,
+   `EXPERIMENT_TRACKER.md`, user-authored project source, collected data, and results
+   are never deletable (see `shared-references/external-cadence.md` § *Let a broken
+   attempt restart, not just patch*).
+6. **Budget exhausted (2 patches + 2 reimplements), or two reimplements failed the SAME
+   way?** → stop, report the failure with all attempted fixes and error logs. Two clean
+   reimplements failing identically usually means the plan or the environment is wrong —
+   say so explicitly in the report, because that (not the broken build itself) is what
+   needs the human. Do not proceed with broken code.
 
 > Never give up on the first failure. Most experiment crashes are fixable without human intervention.
 

--- a/skills/experiment-bridge/SKILL.md
+++ b/skills/experiment-bridge/SKILL.md
@@ -175,7 +175,14 @@ If sanity fails → **auto-debug before giving up** (max 3 attempts):
 4. **Attempt 2+ still failing? → Call in Codex rescue** (if Codex plugin installed):
    Before the next retry, invoke `/codex:rescue` to get a second opinion on the root cause. Codex independently reads the code and error logs — it may spot issues Claude missed (wrong tensor shapes, subtle import shadowing, config mismatches, etc.). Apply its suggested fix, then re-run.
    - If `/codex:rescue` is not available (plugin not installed), continue with Claude's own diagnosis
-5. **Still failing after 3 attempts?** → stop, report the failure with all attempted fixes and error logs. Do not proceed with broken code.
+5. **Patches stacking on the same failure? → Discard and reimplement cleanly.**
+   Rewriting the failing script from `EXPERIMENT_PLAN.md` / the research contract is a
+   PEER move to another patch, not a last resort — a third patch on top of two wrong
+   ones is usually worse than a clean rebuild. Delete ONLY the attempt's own
+   code/scaffolding; the plan, `EXPERIMENT_TRACKER.md`, collected data, and results are
+   never deletable (see `shared-references/external-cadence.md` § *Let a broken attempt
+   restart, not just patch*). A reimplement consumes one retry slot.
+6. **Still failing after 3 attempts (patches + reimplements combined)?** → stop, report the failure with all attempted fixes and error logs. Two clean reimplements failing the SAME way usually means the plan or the environment is wrong — say so explicitly in the report, because that (not the broken build itself) is what needs the human. Do not proceed with broken code.
 
 > Never give up on the first failure. Most experiment crashes are fixable without human intervention.
 

--- a/skills/experiment-queue/SKILL.md
+++ b/skills/experiment-queue/SKILL.md
@@ -89,15 +89,19 @@ jobs:
 ```
 pending → running → completed
                  ↘ failed_oom → pending (after delay) [retry up to N]
-                 ↘ failed_other → stuck (needs manual inspection; before handing
-                    over, if the same failure repeats across jobs, try ONE clean
-                    reimplement of the job script from the plan — a peer move to
-                    patching; delete only the script, never queue state / logs /
-                    results (external-cadence.md § "Let a broken attempt restart,
-                    not just patch"). Reserve "stuck" for contract/environment
-                    doubts, not merely broken job code)
+                 ↘ failed_other → stuck (needs manual inspection)
 stale_screen_detected → cleaned → pending
 ```
+
+> **Operator note on `stuck` (the agent's move, not the queue's):** the queue
+> deterministically parks `failed_other` jobs as `stuck` — that part is code and
+> unchanged. Before handing a `stuck` batch to the human, the OPERATING AGENT
+> should check: if the same failure repeats across jobs, try ONE clean
+> reimplement of the **agent-generated wrapper/attempt script only** — never
+> user/project source (`run_*.py` you didn't write), the manifest, queue state,
+> logs, or results (see `shared-references/external-cadence.md` § *Let a broken
+> attempt restart, not just patch*). Reserve the human handoff for
+> contract/environment doubts, not merely broken attempt code.
 
 ### Wave Orchestration
 

--- a/skills/experiment-queue/SKILL.md
+++ b/skills/experiment-queue/SKILL.md
@@ -89,7 +89,13 @@ jobs:
 ```
 pending → running → completed
                  ↘ failed_oom → pending (after delay) [retry up to N]
-                 ↘ failed_other → stuck (needs manual inspection)
+                 ↘ failed_other → stuck (needs manual inspection; before handing
+                    over, if the same failure repeats across jobs, try ONE clean
+                    reimplement of the job script from the plan — a peer move to
+                    patching; delete only the script, never queue state / logs /
+                    results (external-cadence.md § "Let a broken attempt restart,
+                    not just patch"). Reserve "stuck" for contract/environment
+                    doubts, not merely broken job code)
 stale_screen_detected → cleaned → pending
 ```
 

--- a/skills/shared-references/external-cadence.md
+++ b/skills/shared-references/external-cadence.md
@@ -244,6 +244,35 @@ cross-model jury, acceptance-gate.md). Why structure over tactics: when a task s
 repeatedly inside one frame, the decisive gain comes from correcting the frame itself, not
 from tuning parameters harder within it.
 
+## Let a broken attempt restart, not just patch
+
+The stall ladder above pivots *direction*; this section is the level below it — a single
+implementation/debug attempt (a build, a training script, an eval harness) that keeps
+failing while the loop is still running. The repo's historical convention was "patch N
+times, then stop and report to a human." That misroutes the escalation: a broken build is
+squarely the executor's job, and the missing move is the RESTART.
+
+- **Discard-and-reimplement is a peer move to another patch, not a last resort.** After
+  1–2 targeted patches fail on the same failure, rewriting the failing piece cleanly from
+  the contract/plan is usually cheaper and more reliable than a third patch on top of two
+  wrong ones — patched-code archaeology is how attempts rot. Treat "delete the attempt
+  and rebuild from the spec" as a normal option at every retry decision, and prefer it
+  once patches start stacking.
+- **Escalate to a human only when the CONTRACT is in question** — the plan/spec is
+  missing, ambiguous, or looks wrong — not merely because the current attempt is broken.
+  "The build is broken" is the executor's problem; "the plan may be wrong" is the human's.
+- **Hard boundary — what a restart may delete.** Only the current attempt's own
+  code/scaffolding (scripts it wrote, configs it generated, its build artifacts). NEVER
+  deletable in a restart: the contract/plan (`research_contract.md`,
+  `EXPERIMENT_PLAN.md`, `PAPER_PLAN.md`), progress ledgers (`EXPERIMENT_TRACKER.md`,
+  iteration/bottleneck ledgers, `*_STATE.json`, `.aris/traces/`), collected data, and
+  completed results. The restart rebuilds the code FROM those files; deleting them
+  defeats the restart. When in doubt whether a path is "attempt" or "state," it is state
+  — keep it.
+- **Restart is bounded like any other move.** A restart consumes a retry-budget slot; two
+  clean reimplements failing the SAME way means the failure is probably in the contract
+  or the environment — which IS the human-escalation trigger above.
+
 ## Required components (when you add external cadence to a skill)
 
 1. **Waits on an external fact, not a self-verdict.** State the fact in

--- a/skills/skills-codex/dse-loop/SKILL.md
+++ b/skills/skills-codex/dse-loop/SKILL.md
@@ -257,7 +257,12 @@ If the context window compacts mid-run, the loop recovers from `DSE_STATE.json` 
 - **Keep raw outputs** — save each run's full output in `dse_results/outputs/iter_N/`
 - **Constraint violations are not improvements** — a design point that violates constraints is never "best", regardless of the metric
 - If a run crashes, log the error, skip that point, and continue with the next
-- If the same crash repeats 3 times with different configs, stop and report the issue
+- If the same crash repeats 3 times with different configs, the harness code itself is
+  the suspect — **discard and reimplement the run/parse script cleanly from the spec**
+  (a peer move to another patch; delete only the script, never `dse_log.csv` /
+  `dse_results/`; per mainline `external-cadence.md`, "Let a broken attempt restart, not
+  just patch"). If a clean reimplement crashes the same way, stop and report — the spec
+  or the environment is then in question, which is what needs the human
 
 ## Example Invocations
 

--- a/skills/skills-codex/dse-loop/SKILL.md
+++ b/skills/skills-codex/dse-loop/SKILL.md
@@ -261,8 +261,12 @@ If the context window compacts mid-run, the loop recovers from `DSE_STATE.json` 
   the suspect — **discard and reimplement the run/parse script cleanly from the spec**
   (a peer move to another patch; delete only the script, never `dse_log.csv` /
   `dse_results/`; per mainline `external-cadence.md`, "Let a broken attempt restart, not
-  just patch"). If a clean reimplement crashes the same way, stop and report — the spec
-  or the environment is then in question, which is what needs the human
+  just patch"). **Before resuming the sweep, re-validate metric comparability**: re-parse
+  one COMPLETED iteration's raw output from `dse_results/outputs/iter_N/` with the new
+  parser and confirm it reproduces that row of `dse_log.csv`; on mismatch, fix the parser
+  or re-parse and flag all affected rows — never mix two parsing semantics in one log. If
+  a clean reimplement crashes the same way, stop and report — the spec or the environment
+  is then in question, which is what needs the human
 
 ## Example Invocations
 

--- a/skills/skills-codex/experiment-bridge/SKILL.md
+++ b/skills/skills-codex/experiment-bridge/SKILL.md
@@ -160,8 +160,14 @@ Wait for completion. Verify:
 If sanity fails → READ the traceback/stderr/logs first, then fix the code and
 re-run — never re-run unchanged hoping for a different outcome. (The same
 read-the-primary-artifact discipline applies to surprising REVIEWER verdicts:
-see `shared-references/review-tracing.md` § *Debugging With Traces*.) Do not
-proceed to full deployment with broken code.
+see `shared-references/review-tracing.md` § *Debugging With Traces*.) After 1–2
+failed patches on the same failure, **discard and reimplement the failing
+script cleanly from the plan** — a peer move to another patch, not a last
+resort; delete only the attempt's own code, never the plan / tracker / data /
+results (per mainline `external-cadence.md`, "Let a broken attempt restart, not
+just patch"). Two clean reimplements failing the same way put the plan or the
+environment in question — report that explicitly. Do not proceed to full
+deployment with broken code.
 
 If the same sanity failure repeats, trigger a second opinion: summarize the plan, code diff, command, logs, backend, and failure, then ask a fresh Codex reviewer agent for a rescue diagnosis. Apply only concrete fixes grounded in the logs.
 

--- a/skills/skills-codex/experiment-queue/SKILL.md
+++ b/skills/skills-codex/experiment-queue/SKILL.md
@@ -80,7 +80,13 @@ jobs:
 ```
 pending → running → completed
                  ↘ failed_oom → pending (after delay) [retry up to N]
-                 ↘ failed_other → stuck (needs manual inspection)
+                 ↘ failed_other → stuck (needs manual inspection; before handing
+                    over, if the same failure repeats across jobs, try ONE clean
+                    reimplement of the job script from the plan — a peer move to
+                    patching; delete only the script, never queue state / logs /
+                    results (per mainline external-cadence.md, "Let a broken
+                    attempt restart, not just patch"). Reserve "stuck" for
+                    contract/environment doubts, not merely broken job code)
 stale_screen_detected → cleaned → pending
 ```
 

--- a/skills/skills-codex/experiment-queue/SKILL.md
+++ b/skills/skills-codex/experiment-queue/SKILL.md
@@ -80,15 +80,19 @@ jobs:
 ```
 pending → running → completed
                  ↘ failed_oom → pending (after delay) [retry up to N]
-                 ↘ failed_other → stuck (needs manual inspection; before handing
-                    over, if the same failure repeats across jobs, try ONE clean
-                    reimplement of the job script from the plan — a peer move to
-                    patching; delete only the script, never queue state / logs /
-                    results (per mainline external-cadence.md, "Let a broken
-                    attempt restart, not just patch"). Reserve "stuck" for
-                    contract/environment doubts, not merely broken job code)
+                 ↘ failed_other → stuck (needs manual inspection)
 stale_screen_detected → cleaned → pending
 ```
+
+> **Operator note on `stuck` (the agent's move, not the queue's):** the queue
+> deterministically parks `failed_other` jobs as `stuck` — that part is code and
+> unchanged. Before handing a `stuck` batch to the human, the OPERATING AGENT
+> should check: if the same failure repeats across jobs, try ONE clean
+> reimplement of the **agent-generated wrapper/attempt script only** — never
+> user/project source, the manifest, queue state, logs, or results (per mainline
+> `external-cadence.md`, "Let a broken attempt restart, not just patch").
+> Reserve the human handoff for contract/environment doubts, not merely broken
+> attempt code.
 
 ### Wave Orchestration
 


### PR DESCRIPTION
Adopts LOOPS V ("let the loop restart"). The audit found the OPPOSITE convention encoded in three independent places — `experiment-bridge`, `dse-loop`, `experiment-queue` all treat incremental patching as the only in-loop move and escalate to a human *because* execution stayed broken, which is exactly the misrouted escalation Karpathy warns about ("insert a human only when the contract itself is wrong, not when the build is").

## Doctrine (new section in `shared-references/external-cadence.md`)
Placed directly under the stall→pivot ladder (that one pivots **direction**; this governs a single failing **attempt**):
- **Discard-and-reimplement from the contract/plan is a peer move to another patch** — after 1–2 failed patches on the same failure, a clean rebuild usually beats a third patch on two wrong ones.
- **Human escalation is for contract doubts**, not broken builds.
- **Hard boundary**: a restart may delete only the attempt's own code. Contract/plan files, progress ledgers, `*_STATE.json`, traces, data, results — never. When in doubt, it's state.
- **Bounded**: restarts consume retry slots; two clean reimplements failing the same way ⇒ the contract/environment is in question ⇒ NOW it's the human's.

## Wiring (mainline + codex mirror)
- `experiment-bridge` Phase 3: new step 5 (reimplement) between codex-rescue and stop-report; the final report must name the plan/environment as the open question.
- `dse-loop`: same-crash-3× now tries a clean harness-script reimplement before reporting.
- `experiment-queue`: `stuck` reserved for contract/environment doubts; repeated same-shape failures get ONE clean reimplement first.
- Mirror copies cite "mainline `external-cadence.md`" in prose (the mirror doesn't carry the file — the PR #329 parity guard enforces this exact form; guard is green).

## Verification
Inventory consistent · full suite 406 passed / 16 skipped · mirror parity guard 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)