### PR TITLE
feat(loops): taste-calibration protocol — weighted axes + reference anchoring (LOOPS VI)

### DIFF
--- a/skills/paper-poster-html/SKILL.md
+++ b/skills/paper-poster-html/SKILL.md
@@ -193,7 +193,16 @@ pdftoppm -r 100 poster_html/poster_preview.pdf poster_html/review_full -png -f 1
 # plus 2-4 region crops at higher res (header / one column / equations) via PIL
 ```
 
-Score strictly 1–10. **Critical caps**: < 2 real paper figures → ≤ 3; broken canvas /
+**Calibrate first** (`../shared-references/taste-calibration.md`): if
+`references/good/` + `references/bad/` exist under this skill dir (or the
+project supplies its own pair), score those 3+3 reference posters on the axes
+below BEFORE the target, anchoring the scale; if no reference sets exist,
+proceed uncalibrated and mark `CALIBRATION: none` — never fabricate anchor
+scores. Axes (weights sum 1.0): Design 0.35 · Craft 0.30 · Functionality 0.20 ·
+Originality 0.15; composite maps onto the 1–10 scale below.
+
+Score strictly 1–10. **Critical caps** (hard floors — a calibrated composite
+never overrides them): < 2 real paper figures → ≤ 3; broken canvas /
 clipped content / unreadable math → ≤ 4; ≥ 4 visible hue families or gradient-heavy
 header → ≤ 4; large blank cards or columns → ≤ 5; fabricated visual claim → ≤ 3.
 Checks: posterly-showcase gestalt (would this hang next to a professionally designed
@@ -205,6 +214,8 @@ narrative. Output format:
 
 ```
 SCORE: N/10
+CALIBRATION: anchored | none
+GAP: <which reference poster the target falls short of / exceeds, on which axis, and why — one paragraph; omit only when CALIBRATION: none>
 CAPS_TRIGGERED: ...
 TOP_ISSUES: (max 3)
 ALLOWED_FIX_TYPE per issue: token | component | rebalance | asset | template/canvas

--- a/skills/paper-poster-html/SKILL.md
+++ b/skills/paper-poster-html/SKILL.md
@@ -194,12 +194,16 @@ pdftoppm -r 100 poster_html/poster_preview.pdf poster_html/review_full -png -f 1
 ```
 
 **Calibrate first** (`../shared-references/taste-calibration.md`): if
-`references/good/` + `references/bad/` exist under this skill dir (or the
-project supplies its own pair), score those 3+3 reference posters on the axes
-below BEFORE the target, anchoring the scale; if no reference sets exist,
-proceed uncalibrated and mark `CALIBRATION: none` — never fabricate anchor
-scores. Axes (weights sum 1.0): Design 0.35 · Craft 0.30 · Functionality 0.20 ·
-Originality 0.15; composite maps onto the 1–10 scale below.
+**human-curated** `references/good/` + `references/bad/` exist under this skill
+dir (or the project supplies its own pair), score those 3+3 reference posters
+on the axes below BEFORE the target, anchoring the scale. Never select, search
+for, or generate anchors yourself; if no reference sets exist, proceed
+uncalibrated and mark `CALIBRATION: none` — never fabricate anchor scores.
+Axes (weights sum 1.0): Design 0.35 · Craft 0.30 · Functionality 0.20 ·
+Originality 0.15. Mapping: `SCORE = min(round(1 + 9 × COMPOSITE), lowest
+triggered cap)` — caps apply AFTER the mapping, and the loop's `Score ≥ 9`
+threshold below always reads this final capped `SCORE`, never the raw
+composite.
 
 Score strictly 1–10. **Critical caps** (hard floors — a calibrated composite
 never overrides them): < 2 real paper figures → ≤ 3; broken canvas /
@@ -213,7 +217,8 @@ serif-body/sans-display pairing, no gradient kitsch, component consistency, 60-s
 narrative. Output format:
 
 ```
-SCORE: N/10
+SCORE: N/10            (= min(round(1 + 9 × COMPOSITE), lowest cap); drives the loop)
+COMPOSITE: 0.xx        (weighted; list the four per-axis scores)
 CALIBRATION: anchored | none
 GAP: <which reference poster the target falls short of / exceeds, on which axis, and why — one paragraph; omit only when CALIBRATION: none>
 CAPS_TRIGGERED: ...

--- a/skills/research-refine/SKILL.md
+++ b/skills/research-refine/SKILL.md
@@ -377,6 +377,11 @@ Bundle contents:
 
     **OVERALL SCORE** (1-10): Weighted toward Problem Fidelity, Method Specificity, Contribution Quality, and Frontier Leverage.
     Use this weighting: Problem Fidelity 15%, Method Specificity 25%, Contribution Quality 25%, Frontier Leverage 15%, Feasibility 10%, Validation Focus 5%, Venue Readiness 5%.
+    (This weighted-axis rubric is the repo's working precedent for
+    `shared-references/taste-calibration.md`; if curated known-good/known-bad
+    past proposals are available — e.g. from research-wiki's accepted/rejected
+    idea history — score 3 of each on these axes FIRST to anchor the scale, and
+    name in the review which anchor the proposal sits closest to.)
 
     For each dimension scoring < 7, provide:
     - The specific weakness

--- a/skills/shared-references/taste-calibration.md
+++ b/skills/shared-references/taste-calibration.md
@@ -1,0 +1,80 @@
+# Taste Calibration Protocol
+
+> Subjective quality is gradable **if you write the taste down and anchor the
+> scale**. The model will not invent taste; it will only converge toward the
+> taste you described — so the whole game is (1) a weighted rubric worth
+> converging to, and (2) reference anchors that pin what "good" and "slop"
+> actually look like. (After Karpathy's LOOPS.md VI, "score the subjective".)
+
+Use this protocol whenever a skill grades an artifact on axes that are matters
+of judgment — visual design, writing elegance, proposal quality — rather than
+machine-checkable facts. It layers ON TOP of any deterministic gates the skill
+already has (hard caps, measurement gates); it never replaces them.
+
+## 1. Named axes with explicit numeric weights
+
+Define 2–6 named axes and give each an explicit weight; weights sum to 1.0.
+Model the table on `research-refine`'s working precedent (its Phase 2 uses
+15/25/25/15/10/5/5% across seven axes):
+
+```markdown
+| Axis          | Weight | What it measures                                  |
+|---------------|:------:|---------------------------------------------------|
+| Design        |  0.35  | hierarchy, spacing, restraint, gestalt            |
+| Originality   |  0.15  | distinct voice vs template sameness               |
+| Craft         |  0.30  | detail quality: typography, alignment, math, figs |
+| Functionality |  0.20  | does it do its job (readable at distance, ...)    |
+```
+
+Score each axis 0–1 (or 1–10 rescaled). Composite = Σ weightᵢ · axisᵢ. A single
+holistic number without named weighted axes is not this protocol.
+
+## 2. Calibrate on reference anchors BEFORE scoring the target
+
+The grader first scores **3 known-good and 3 known-bad reference exemplars** on
+the same axes, so the scale is anchored to concrete artifacts instead of the
+grader's free-floating prior.
+
+- The invoking skill supplies the reference paths — convention:
+  `<skill-dir>/references/good/` and `<skill-dir>/references/bad/` (images,
+  PDFs, or text artifacts of the same kind as the target). Project-local
+  references may override the skill-local set.
+- The grader is TOLD which set is which ("these three are good, these three are
+  slop") — calibration is about anchoring the scale, not blind classification.
+- Sanity check: if the calibrated scores don't separate the sets (a "bad"
+  exemplar scores at or above a "good" one on the composite), the rubric is
+  broken — fix the rubric before trusting any target score.
+
+**Graceful degradation:** if no reference sets exist, proceed with the weighted
+rubric alone, but the output MUST carry `calibration: none` so a downstream
+reader never mistakes an unanchored score for an anchored one. Do not fabricate
+or hallucinate reference scores.
+
+## 3. Output contract
+
+```
+COMPOSITE: 0.xx            (weighted; also give per-axis scores)
+CALIBRATION: anchored | none
+GAP: <one mandatory paragraph naming WHICH reference exemplar(s) the target
+     falls short of or exceeds, on WHICH axes, and why — "0.71 because the
+     figure hierarchy matches good/poster_B but the typography is closer to
+     bad/poster_A's crowding" — never just a number>
+```
+
+The GAP paragraph is what makes the score actionable: converging toward the
+described taste requires knowing where the artifact sits relative to the
+anchors, not just its scalar.
+
+## 4. Interaction with existing gates and the jury
+
+- **Deterministic caps stay hard floors.** A calibrated composite never
+  overrides a measurement gate or critical cap (e.g. paper-poster-html's
+  "< 2 real figures → ≤ 3"). Compute caps first; the composite lives under
+  them.
+- **Calibration ≠ acquittal.** A taste score produced by the executor's own
+  model family is a Type-A signal (drives the fix loop). Wherever a skill's
+  acceptance requires a cross-model verdict, that requirement is unchanged
+  (`acceptance-gate.md`).
+- **Rubric drift is meta-optimize's job.** If users repeatedly override
+  calibrated scores, the rubric or the anchors are wrong — that's an event-log
+  signal for `/meta-optimize`, not a reason to hand-tweak scores per run.

--- a/skills/shared-references/taste-calibration.md
+++ b/skills/shared-references/taste-calibration.md
@@ -13,7 +13,7 @@ already has (hard caps, measurement gates); it never replaces them.
 
 ## 1. Named axes with explicit numeric weights
 
-Define 2–6 named axes and give each an explicit weight; weights sum to 1.0.
+Define 2–7 named axes and give each an explicit weight; weights sum to 1.0.
 Model the table on `research-refine`'s working precedent (its Phase 2 uses
 15/25/25/15/10/5/5% across seven axes):
 
@@ -35,10 +35,13 @@ The grader first scores **3 known-good and 3 known-bad reference exemplars** on
 the same axes, so the scale is anchored to concrete artifacts instead of the
 grader's free-floating prior.
 
-- The invoking skill supplies the reference paths — convention:
-  `<skill-dir>/references/good/` and `<skill-dir>/references/bad/` (images,
-  PDFs, or text artifacts of the same kind as the target). Project-local
-  references may override the skill-local set.
+- References are **pre-existing, human-curated files** — the executor never
+  selects, generates, or searches for anchors itself (an executor-picked anchor
+  set just smuggles the free-floating prior back in). The invoking skill
+  supplies the paths — convention: `<skill-dir>/references/good/` and
+  `<skill-dir>/references/bad/` (images, PDFs, or text artifacts of the same
+  kind as the target). Project-local references may override the skill-local
+  set.
 - The grader is TOLD which set is which ("these three are good, these three are
   slop") — calibration is about anchoring the scale, not blind classification.
 - Sanity check: if the calibrated scores don't separate the sets (a "bad"
@@ -72,9 +75,11 @@ anchors, not just its scalar.
   "< 2 real figures → ≤ 3"). Compute caps first; the composite lives under
   them.
 - **Calibration ≠ acquittal.** A taste score produced by the executor's own
-  model family is a Type-A signal (drives the fix loop). Wherever a skill's
-  acceptance requires a cross-model verdict, that requirement is unchanged
-  (`acceptance-gate.md`).
+  model family may DRIVE the fix loop (rank issues, decide what to patch next)
+  but can never acquit: wherever a skill's acceptance requires a cross-model
+  verdict, that requirement is unchanged. (Per `acceptance-gate.md`'s taxonomy
+  a model-assigned score is a semantic judgment — calibration narrows its
+  variance; it does not make it machine-checkable.)
 - **Rubric drift is meta-optimize's job.** If users repeatedly override
   calibrated scores, the rubric or the anchors are wrong — that's an event-log
   signal for `/meta-optimize`, not a reason to hand-tweak scores per run.

--- a/skills/skills-codex/paper-poster-html/SKILL.md
+++ b/skills/skills-codex/paper-poster-html/SKILL.md
@@ -227,7 +227,16 @@ pdftoppm -r 100 poster_html/poster_preview.pdf poster_html/review_full -png -f 1
 # plus 2-4 region crops at higher res (header / one column / equations) via PIL
 ```
 
-Score strictly 1–10. **Critical caps**: < 2 real paper figures → ≤ 3; broken canvas /
+**Calibrate first** (per mainline `taste-calibration.md`): if `references/good/`
++ `references/bad/` exist under this skill dir (or the project supplies its own
+pair), score those 3+3 reference posters on the axes below BEFORE the target,
+anchoring the scale; if no reference sets exist, proceed uncalibrated and mark
+`CALIBRATION: none` — never fabricate anchor scores. Axes (weights sum 1.0):
+Design 0.35 · Craft 0.30 · Functionality 0.20 · Originality 0.15; composite
+maps onto the 1–10 scale below.
+
+Score strictly 1–10. **Critical caps** (hard floors — a calibrated composite
+never overrides them): < 2 real paper figures → ≤ 3; broken canvas /
 clipped content / unreadable math → ≤ 4; ≥ 4 visible hue families or gradient-heavy
 header → ≤ 4; large blank cards or columns → ≤ 5; fabricated visual claim → ≤ 3.
 Checks: posterly-showcase gestalt (would this hang next to a professionally designed
@@ -239,6 +248,8 @@ narrative. Output format:
 
 ```
 SCORE: N/10
+CALIBRATION: anchored | none
+GAP: <which reference poster the target falls short of / exceeds, on which axis, and why — one paragraph; omit only when CALIBRATION: none>
 CAPS_TRIGGERED: ...
 TOP_ISSUES: (max 3)
 ALLOWED_FIX_TYPE per issue: token | component | rebalance | asset | template/canvas

--- a/skills/skills-codex/paper-poster-html/SKILL.md
+++ b/skills/skills-codex/paper-poster-html/SKILL.md
@@ -227,13 +227,16 @@ pdftoppm -r 100 poster_html/poster_preview.pdf poster_html/review_full -png -f 1
 # plus 2-4 region crops at higher res (header / one column / equations) via PIL
 ```
 
-**Calibrate first** (per mainline `taste-calibration.md`): if `references/good/`
-+ `references/bad/` exist under this skill dir (or the project supplies its own
-pair), score those 3+3 reference posters on the axes below BEFORE the target,
-anchoring the scale; if no reference sets exist, proceed uncalibrated and mark
-`CALIBRATION: none` — never fabricate anchor scores. Axes (weights sum 1.0):
-Design 0.35 · Craft 0.30 · Functionality 0.20 · Originality 0.15; composite
-maps onto the 1–10 scale below.
+**Calibrate first** (per mainline `taste-calibration.md`): if **human-curated**
+`references/good/` + `references/bad/` exist under this skill dir (or the
+project supplies its own pair), score those 3+3 reference posters on the axes
+below BEFORE the target, anchoring the scale. Never select, search for, or
+generate anchors yourself; if no reference sets exist, proceed uncalibrated and
+mark `CALIBRATION: none` — never fabricate anchor scores. Axes (weights sum
+1.0): Design 0.35 · Craft 0.30 · Functionality 0.20 · Originality 0.15.
+Mapping: `SCORE = min(round(1 + 9 × COMPOSITE), lowest triggered cap)` — caps
+apply AFTER the mapping, and the loop's `Score ≥ 9` threshold always reads this
+final capped `SCORE`, never the raw composite.
 
 Score strictly 1–10. **Critical caps** (hard floors — a calibrated composite
 never overrides them): < 2 real paper figures → ≤ 3; broken canvas /
@@ -247,7 +250,8 @@ serif-body/sans-display pairing, no gradient kitsch, component consistency, 60-s
 narrative. Output format:
 
 ```
-SCORE: N/10
+SCORE: N/10            (= min(round(1 + 9 × COMPOSITE), lowest cap); drives the loop)
+COMPOSITE: 0.xx        (weighted; list the four per-axis scores)
 CALIBRATION: anchored | none
 GAP: <which reference poster the target falls short of / exceeds, on which axis, and why — one paragraph; omit only when CALIBRATION: none>
 CAPS_TRIGGERED: ...

--- a/skills/skills-codex/research-refine/SKILL.md
+++ b/skills/skills-codex/research-refine/SKILL.md
@@ -338,6 +338,10 @@ spawn_agent:
 
     **OVERALL SCORE** (1-10): Weighted toward Problem Fidelity, Method Specificity, Contribution Quality, and Frontier Leverage.
     Use this weighting: Problem Fidelity 15%, Method Specificity 25%, Contribution Quality 25%, Frontier Leverage 15%, Feasibility 10%, Validation Focus 5%, Venue Readiness 5%.
+    (This weighted-axis rubric is the working precedent for mainline
+    `taste-calibration.md`; if curated known-good/known-bad past proposals are
+    available, score 3 of each on these axes FIRST to anchor the scale, and
+    name in the review which anchor the proposal sits closest to.)
 
     For each dimension scoring < 7, provide:
     - The specific weakness


### PR DESCRIPTION
Adopts LOOPS VI ("score the subjective: calibrate on three reference sites the evaluator is told are good and three it is told are slop"). Audit finding: ARIS has scoring machinery everywhere — `research-refine` even carries a genuine percentage-weighted 7-axis composite — but **no skill anchors its grader to known-good/known-bad exemplars**, so every subjective scale free-floats on the model's prior.

## New `shared-references/taste-calibration.md`
- **Weighted axes**: 2–6 named axes, explicit weights summing to 1.0 (table format = research-refine's working precedent).
- **Anchor step**: grade 3 known-good + 3 known-bad reference exemplars on the same axes *before* the target (`<skill-dir>/references/{good,bad}/`, project override allowed). If anchors don't separate → the rubric is broken; fix the rubric first.
- **Graceful degradation**: no references → uncalibrated scoring allowed but output carries `CALIBRATION: none`; fabricating anchor scores is forbidden.
- **Output contract**: composite + per-axis + mandatory **GAP paragraph** naming which anchor the artifact falls short of / exceeds, on which axis — the actionable part.
- **Boundaries**: deterministic caps stay hard floors; a same-family taste score is Type-A (drives, never acquits); repeated user overrides of calibrated scores = meta-optimize signal, not per-run tweaking.

## Wiring
- `paper-poster-html` Phase 5: calibration preamble, Design 0.35 · Craft 0.30 · Functionality 0.20 · Originality 0.15, `CALIBRATION`/`GAP` output fields, caps labeled hard floors.
- `research-refine` Phase 2: anchor note (research-wiki accepted/rejected idea history as natural anchor source).
- Codex mirrors: same content, prose "mainline `taste-calibration.md`" citations (mirror doesn't carry the file — parity-guard-enforced form).

## Verification
Inventory consistent · full suite 407 passed / 16 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)