### PR TITLE
feat(paper-writing): negotiated acceptance contract before writing (LOOPS III)

### DIFF
--- a/skills/paper-writing/SKILL.md
+++ b/skills/paper-writing/SKILL.md
@@ -40,7 +40,7 @@ This pipeline accepts one of:
 
 1. **`NARRATIVE_REPORT.md`** (best) — structured research narrative with claims, experiments, results, figures
 2. **Research direction + experiment results** — the skill will help draft the narrative first
-3. **Existing `PAPER_PLAN.md`** — skip Phase 1, start from Phase 2
+3. **Existing `PAPER_PLAN.md`** — skip Phase 1, start from **Phase 1.5** (the contract negotiation still runs; only resuming a genuine pre-1.5 legacy run may skip it, and then Phase 6.0's row 0 records "no contract")
 
 The more detailed the input (especially figure descriptions and quantitative results), the better the output.
 
@@ -213,16 +213,23 @@ contract is what gets graded.)
        followed by your numbered revision demands if no.
    ```
 
+   A reply with a missing or malformed `CONTRACT_ACCEPTED:` line is treated as
+   `no`; request a corrected verdict via `codex-reply` — that correction
+   exchange does not consume a negotiation round.
+
 3. **Iterate.** On `no`, revise the contract per the demands and resubmit via
    `mcp__codex__codex-reply` (same thread — the negotiation is one
    conversation). **Max 3 rounds.**
 
 4. **Fallback — never stall the pipeline.** If round 3 still ends in `no`:
    record the unresolved demands verbatim in a "## Disputed" section of the
-   contract, mark it `status: contested`, present the dispute at the next
-   checkpoint (the human is the tie-breaker — this is exactly the "insert a
-   human when the CONTRACT is wrong" trigger), and proceed. A contested
-   contract still gates Phase 6.0 on its UNDISPUTED assertions.
+   contract and mark it `status: contested`. A contested contract is precisely
+   the "insert a human when the CONTRACT is wrong" trigger, so it OVERRIDES
+   `AUTO_PROCEED` for this one decision: pause and present the dispute for a
+   human tie-break. If no human responds (unattended/overnight run), proceed —
+   but a contested contract caps the outcome: Phase 6.0 gates on the UNDISPUTED
+   assertions and the Final Report must set `Submission-ready: no` with the
+   dispute reproduced verbatim; the tie-break happens when the human returns.
 
 **Output:** `PAPER_ACCEPTANCE_CONTRACT.md` (`status: accepted | contested`,
 round count, reviewer thread id). The contract is FROZEN once accepted —
@@ -604,7 +611,10 @@ skipping audits while claiming to have run them.
    [ ] 3. /citation-audit       → paper/CITATION_AUDIT.json
    [ ] 4. Resolve $AUDIT_VERIFIER per integration-contract.md §2 (Policy A),
           then: bash "$AUDIT_VERIFIER" paper/ --assurance submission
-   [ ] 5. Block Final Report iff verifier exit code != 0
+   [ ] 5. Block Final Report iff verifier exit code != 0 OR row 0 found a
+          violated undisputed assertion. (TWO separate gates: row 0 is graded
+          by instruction against the contract; the verifier checks audit JSONs
+          only — verify_paper_audits.sh does NOT read the contract.)
 ```
 
 > The resolver in "Running the verifier" below tries

--- a/skills/paper-writing/SKILL.md
+++ b/skills/paper-writing/SKILL.md
@@ -169,8 +169,70 @@ If `— style-ref: <source>` was passed in `$ARGUMENTS` and the helper succeeded
 Shall I proceed with figure generation?
 ```
 
-- **User approves** (or AUTO_PROCEED=true) → proceed to Phase 2.
+- **User approves** (or AUTO_PROCEED=true) → proceed to Phase 1.5.
 - **User requests changes** → adjust plan and re-present.
+
+### Phase 1.5: Negotiated Acceptance Contract (before any writing)
+
+The plan says what the paper will contain; the CONTRACT says what "done" means
+— a checklist of testable assertions, negotiated ADVERSARIALLY before the first
+section is written, and graded at the end. (The plan is the boundary; the
+contract is what gets graded.)
+
+1. **Executor proposes.** From `PAPER_PLAN.md` + `NARRATIVE_REPORT.md`, draft
+   `PAPER_ACCEPTANCE_CONTRACT.md`: **10–20 testable assertions** covering —
+   every headline claim has a named evidence source (file/table); every
+   number in the abstract traces to a results file; scope qualifiers the title
+   /abstract must carry; figures that must exist and what each must show;
+   section-level completeness (e.g. "limitations names ≥2 real limitations,
+   not hedges"); venue constraints (page limit, anonymization). Each assertion
+   must be CHECKABLE by reading the final PDF + results files — no vibes
+   ("writing is clear" is not an assertion; "every acronym is defined at first
+   use" is). Fewer than ~10 assertions and the gate rubber-stamps; beyond ~20
+   the negotiation stalls on trivia.
+
+2. **Reviewer pushes back** (fresh thread — the negotiation is adversarial):
+
+   ```
+   mcp__codex__codex:
+     config: {"model_reasoning_effort": "xhigh"}
+     prompt: |
+       You are negotiating the acceptance contract for a paper BEFORE it is
+       written. Read these files directly:
+       - Plan: <abs path>/PAPER_PLAN.md
+       - Proposed contract: <abs path>/PAPER_ACCEPTANCE_CONTRACT.md
+       - Evidence inventory: <abs path>/NARRATIVE_REPORT.md (+ results/ paths)
+
+       Push back on the contract, not the plan: (a) assertions that are
+       untestable or vibes — demand a checkable rewrite; (b) missing
+       assertions — claims in the plan that no assertion covers, numbers with
+       no traceability assertion, foreseeable overclaim risks with no scope
+       assertion; (c) assertions the evidence inventory cannot possibly
+       satisfy — flag now, not after writing. End with exactly one line:
+       CONTRACT_ACCEPTED: yes    or    CONTRACT_ACCEPTED: no
+       followed by your numbered revision demands if no.
+   ```
+
+3. **Iterate.** On `no`, revise the contract per the demands and resubmit via
+   `mcp__codex__codex-reply` (same thread — the negotiation is one
+   conversation). **Max 3 rounds.**
+
+4. **Fallback — never stall the pipeline.** If round 3 still ends in `no`:
+   record the unresolved demands verbatim in a "## Disputed" section of the
+   contract, mark it `status: contested`, present the dispute at the next
+   checkpoint (the human is the tie-breaker — this is exactly the "insert a
+   human when the CONTRACT is wrong" trigger), and proceed. A contested
+   contract still gates Phase 6.0 on its UNDISPUTED assertions.
+
+**Output:** `PAPER_ACCEPTANCE_CONTRACT.md` (`status: accepted | contested`,
+round count, reviewer thread id). The contract is FROZEN once accepted —
+Phases 2–5 implement against it; they do not edit it. If writing reveals an
+assertion is genuinely wrong (not merely inconvenient), that is a contract
+question: surface it at a checkpoint, don't silently rewrite.
+
+**Boundary:** `/paper-claim-audit` (Phases 4.7, 5.5) stays zero-context — the
+contract is a WRITER-side gate and is never passed to the claim auditor (its
+independence is the point; two different nets).
 
 ### Phase 2: Figure Generation
 
@@ -531,6 +593,12 @@ skipping audits while claiming to have run them.
 
 ```
 📋 Submission audits required before Final Report:
+   [ ] 0. PAPER_ACCEPTANCE_CONTRACT.md (Phase 1.5): re-read every assertion
+          against the final PDF + results files; each → satisfied / violated /
+          disputed-at-negotiation. ANY violated undisputed assertion blocks the
+          Final Report until fixed or the human explicitly waives it (waivers
+          recorded in the contract file). Contract absent (pre-1.5 run) → mark
+          "no contract" and continue.
    [ ] 1. /proof-checker        → paper/PROOF_AUDIT.json
    [ ] 2. /paper-claim-audit    → paper/PAPER_CLAIM_AUDIT.json
    [ ] 3. /citation-audit       → paper/CITATION_AUDIT.json
@@ -648,6 +716,7 @@ or directly if `assurance=draft`)
 |-------|--------|--------|
 | 0. Assurance Setup | ✅ | paper/.aris/assurance.txt = [draft\|submission] |
 | 1. Paper Plan | ✅ | PAPER_PLAN.md |
+| 1.5 Acceptance Contract | [accepted\|contested\|no contract] ([N] rounds) | PAPER_ACCEPTANCE_CONTRACT.md |
 | 2. Figures | ✅ | figures/ ([N] auto + [M] manual) |
 | 3. LaTeX Writing | ✅ | paper/sections/*.tex ([N] sections, [M] citations) |
 | 4. Compilation | ✅ | paper/main.pdf ([X] pages) |

--- a/skills/skills-codex/paper-writing/SKILL.md
+++ b/skills/skills-codex/paper-writing/SKILL.md
@@ -40,7 +40,7 @@ This pipeline accepts one of:
 
 1. **`NARRATIVE_REPORT.md`** (best) — structured research narrative with claims, experiments, results, figures
 2. **Research direction + experiment results** — the skill will help draft the narrative first
-3. **Existing `PAPER_PLAN.md`** — skip Phase 1, start from Phase 2
+3. **Existing `PAPER_PLAN.md`** — skip Phase 1, start from **Phase 1.5** (the contract negotiation still runs; only resuming a genuine pre-1.5 legacy run may skip it, and then Phase 6.0's row 0 records "no contract")
 
 The more detailed the input (especially figure descriptions and quantitative results), the better the output.
 
@@ -148,18 +148,23 @@ contract is what gets graded.)
    numbers, foreseeable overclaims with no scope assertion); (c) assertions
    the evidence cannot possibly satisfy — flag now, not after writing. It must
    end with exactly one line: `CONTRACT_ACCEPTED: yes` or
-   `CONTRACT_ACCEPTED: no` plus numbered revision demands.
+   `CONTRACT_ACCEPTED: no` plus numbered revision demands. A reply with a
+   missing or malformed verdict line is treated as `no`; request a corrected
+   verdict as a follow-up — the correction exchange does not consume a round.
 
 3. **Iterate.** On `no`, revise per the demands and resubmit as a follow-up in
    the SAME reviewer thread (the negotiation is one conversation). **Max 3
    rounds.**
 
 4. **Fallback — never stall the pipeline.** Round 3 still `no` → record the
-   unresolved demands verbatim in a "## Disputed" section, mark
-   `status: contested`, surface the dispute at the next checkpoint (the human
-   is the tie-breaker — the "insert a human when the CONTRACT is wrong"
-   trigger), and proceed. A contested contract still gates Phase 6 on its
-   UNDISPUTED assertions.
+   unresolved demands verbatim in a "## Disputed" section and mark
+   `status: contested`. A contested contract is precisely the "insert a human
+   when the CONTRACT is wrong" trigger, so it OVERRIDES `AUTO_PROCEED` for this
+   one decision: pause and present the dispute for a human tie-break. If no
+   human responds (unattended run), proceed — but a contested contract caps the
+   outcome: Phase 6 gates on the UNDISPUTED assertions and the Final Report
+   must set `Submission-ready: no` with the dispute reproduced verbatim; the
+   tie-break happens when the human returns.
 
 **Output:** `PAPER_ACCEPTANCE_CONTRACT.md` (`status: accepted | contested`,
 round count, reviewer thread/agent id). FROZEN once accepted — Phases 2–5
@@ -493,7 +498,10 @@ skipping audits while claiming to have run them.
    [ ] 3. /citation-audit       → paper/CITATION_AUDIT.json
    [ ] 4. Resolve $AUDIT_VERIFIER per integration-contract §2 (Policy A),
           then: bash "$AUDIT_VERIFIER" paper/ --assurance submission
-   [ ] 5. Block Final Report iff verifier exit code != 0
+   [ ] 5. Block Final Report iff verifier exit code != 0 OR row 0 found a
+          violated undisputed assertion. (TWO separate gates: row 0 is graded
+          by instruction against the contract; the verifier checks audit JSONs
+          only — verify_paper_audits.sh does NOT read the contract.)
 ```
 
 > `<ARIS_REPO>` placeholder — replace with the absolute path to your ARIS

--- a/skills/skills-codex/paper-writing/SKILL.md
+++ b/skills/skills-codex/paper-writing/SKILL.md
@@ -120,8 +120,55 @@ Invoke `/paper-plan` to create the structural outline:
 Shall I proceed with figure generation?
 ```
 
-- **User approves** (or AUTO_PROCEED=true) → proceed to Phase 2.
+- **User approves** (or AUTO_PROCEED=true) → proceed to Phase 1.5.
 - **User requests changes** → adjust plan and re-present.
+
+### Phase 1.5: Negotiated Acceptance Contract (before any writing)
+
+The plan says what the paper will contain; the CONTRACT says what "done" means
+— a checklist of testable assertions, negotiated ADVERSARIALLY before the first
+section is written, and graded at the end. (The plan is the boundary; the
+contract is what gets graded.)
+
+1. **Executor proposes.** From `PAPER_PLAN.md` + `NARRATIVE_REPORT.md`, draft
+   `PAPER_ACCEPTANCE_CONTRACT.md`: **10–20 testable assertions** — every
+   headline claim has a named evidence source; every abstract number traces to
+   a results file; scope qualifiers the title/abstract must carry; figures
+   that must exist and what each must show; section-level completeness; venue
+   constraints. Each assertion must be CHECKABLE by reading the final PDF +
+   results files — no vibes ("writing is clear" is not an assertion; "every
+   acronym is defined at first use" is). Fewer than ~10 rubber-stamps; beyond
+   ~20 stalls on trivia.
+
+2. **Reviewer pushes back.** Spawn a FRESH reviewer agent (xhigh reasoning)
+   pointed at `PAPER_PLAN.md`, `PAPER_ACCEPTANCE_CONTRACT.md`, and the evidence
+   inventory (`NARRATIVE_REPORT.md` + results paths). Its brief: push back on
+   the contract, not the plan — (a) untestable/vibes assertions → demand a
+   checkable rewrite; (b) missing assertions (uncovered claims, untraced
+   numbers, foreseeable overclaims with no scope assertion); (c) assertions
+   the evidence cannot possibly satisfy — flag now, not after writing. It must
+   end with exactly one line: `CONTRACT_ACCEPTED: yes` or
+   `CONTRACT_ACCEPTED: no` plus numbered revision demands.
+
+3. **Iterate.** On `no`, revise per the demands and resubmit as a follow-up in
+   the SAME reviewer thread (the negotiation is one conversation). **Max 3
+   rounds.**
+
+4. **Fallback — never stall the pipeline.** Round 3 still `no` → record the
+   unresolved demands verbatim in a "## Disputed" section, mark
+   `status: contested`, surface the dispute at the next checkpoint (the human
+   is the tie-breaker — the "insert a human when the CONTRACT is wrong"
+   trigger), and proceed. A contested contract still gates Phase 6 on its
+   UNDISPUTED assertions.
+
+**Output:** `PAPER_ACCEPTANCE_CONTRACT.md` (`status: accepted | contested`,
+round count, reviewer thread/agent id). FROZEN once accepted — Phases 2–5
+implement against it, never edit it; a genuinely-wrong assertion is a contract
+question for a checkpoint, not a silent rewrite.
+
+**Boundary:** the claim audit (Phases 4.7 / 5.5) stays zero-context — the
+contract is a WRITER-side gate, never passed to the claim auditor (two
+different nets by design).
 
 ### Phase 2: Figure Generation
 
@@ -435,6 +482,12 @@ skipping audits while claiming to have run them.
 
 ```
 📋 Submission audits required before Final Report:
+   [ ] 0. PAPER_ACCEPTANCE_CONTRACT.md (Phase 1.5): re-read every assertion
+          against the final PDF + results files; each → satisfied / violated /
+          disputed-at-negotiation. ANY violated undisputed assertion blocks the
+          Final Report until fixed or the human explicitly waives it (waivers
+          recorded in the contract file). Contract absent (pre-1.5 run) → mark
+          "no contract" and continue.
    [ ] 1. /proof-checker        → paper/PROOF_AUDIT.json
    [ ] 2. /paper-claim-audit    → paper/PAPER_CLAIM_AUDIT.json
    [ ] 3. /citation-audit       → paper/CITATION_AUDIT.json
@@ -551,6 +604,7 @@ or directly if `assurance=draft`)
 |-------|--------|--------|
 | 0. Assurance Setup | ✅ | paper/.aris/assurance.txt = [draft\|submission] |
 | 1. Paper Plan | ✅ | PAPER_PLAN.md |
+| 1.5 Acceptance Contract | [accepted\|contested\|no contract] ([N] rounds) | PAPER_ACCEPTANCE_CONTRACT.md |
 | 2. Figures | ✅ | figures/ ([N] auto + [M] manual) |
 | 3. LaTeX Writing | ✅ | paper/sections/*.tex ([N] sections, [M] citations) |
 | 4. Compilation | ✅ | paper/main.pdf ([X] pages) |


### PR DESCRIPTION
Adopts LOOPS III ("negotiate the contract first") — the practice Karpathy singles out as the one change that moved his runs "from broken demos to working products". The audit (two-pass, adversarially verified) found ARIS's paper path strictly linear: plan → write → audit-after-the-fact. `PAPER_PLAN.md` gets one review, nothing is negotiated *before* generation and graded *after*, and `paper-claim-audit` deliberately excludes the plan from its inputs.

## Phase 1.5 — Negotiated Acceptance Contract (new, between plan approval and figure generation)
- **Executor proposes** `PAPER_ACCEPTANCE_CONTRACT.md`: 10–20 **testable** assertions (claim→named-evidence-source, abstract-number traceability, mandatory scope qualifiers, required figures, section completeness, venue constraints). Admissibility bar: checkable against the final PDF + results files. "Writing is clear" is not an assertion; "every acronym defined at first use" is.
- **Fresh codex thread pushes back** — on the contract, not the plan: untestable assertions, uncovered claims, assertions the evidence can't possibly satisfy. Ends `CONTRACT_ACCEPTED: yes|no`; revisions via `codex-reply` in the same thread; **max 3 rounds**.
- **Anti-stall fallback**: still `no` after 3 rounds → dispute recorded verbatim, `status: contested`, surfaced at the next human checkpoint (the human is the tie-breaker — precisely the "insert a human when the CONTRACT is wrong" trigger), pipeline proceeds gating on undisputed assertions.
- Contract **frozen** once accepted; Phases 2–5 implement against it.

## Phase 6.0 pre-flight — the contract is what gets graded
New row 0: re-read every assertion against the final PDF + results; any violated undisputed assertion blocks the Final Report unless explicitly waived by the human (waiver recorded). Pre-1.5 runs degrade gracefully ("no contract").

## Boundaries
- `/paper-claim-audit` stays zero-context (writer-side gate ≠ auditor input; two independent nets).
- Codex mirror carries the phase in its own idiom; Pipeline Summary tables updated in both.

## Verification
Inventory consistent · full suite 407 passed / 16 skipped · parity guard 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)