### PR TITLE
feat(meta-optimize): skill-description trigger-rate measurement (measure-only)

### DIFF
--- a/skills/meta-optimize/SKILL.md
+++ b/skills/meta-optimize/SKILL.md
@@ -147,6 +147,25 @@ Read `.aris/meta/events.jsonl` and compute:
   weight, drift surface, reading cost). A harness that only ever grows is a
   harness nobody is re-reading.
 
+**Trigger-rate analysis (optional, measured — not from the event log):**
+- The event log shows which skills were USED, not which were WANTED-but-omitted
+  — the omission failure mode (Claude Code passing over the right skill when the
+  installed list is long) is invisible to it. `tools/meta_opt/trigger_eval.py`
+  measures it directly: `claude -p` probes with paraphrased-intent queries run
+  from a neutral cwd (so the realistic long installed corpus is loaded), scored
+  as trigger / confusion(→which skill) / miss.
+- Run it when a specific skill is suspected of under- or mis-triggering, or as a
+  before/after check around a description edit:
+  `python3 tools/meta_opt/trigger_eval.py --eval-file tools/meta_opt/trigger_evals.sample.json --skills <name> --samples 2`
+- The **confusion matrix is the signal**, not just the rate: a query that keeps
+  landing on a sibling skill means the two descriptions overlap on that intent —
+  the fix is disambiguation, not "make the description pushier".
+- **Measure-only, evidence not verdict.** A low trigger rate is an INPUT to a
+  Step-2 proposal (which lands only via `/meta-apply`), never a self-applied
+  description rewrite. Trigger rate is model-dependent, so compare like with
+  like (record the probe model) and treat it as a proxy — it measures selection
+  under a query set, not the full long-list omission problem.
+
 Present findings as a structured summary table.
 
 ### Step 1.5: Name the Current Bottleneck

--- a/skills/skills-codex/meta-optimize/SKILL.md
+++ b/skills/skills-codex/meta-optimize/SKILL.md
@@ -92,6 +92,16 @@ Read `.aris/meta/events.jsonl` and compute:
   only — a capability the new model has natively is pure overhead. A harness
   that only ever grows is a harness nobody is re-reading.
 
+**Trigger-rate analysis (measured, not from the event log):** the log shows
+which skills were USED, not which were WANTED-but-omitted. Mainline ships
+`tools/meta_opt/trigger_eval.py`, which measures Claude Code's skill triggering
+via `claude -p` probes (trigger / confusion / miss). It is Claude-Code-specific
+— there is no equivalent `codex` skill-selection probe yet, so for a Codex
+executor treat trigger-rate as a mainline signal, not a step you run here.
+Measure-only regardless: a low rate is INPUT to a proposal, never a self-applied
+rewrite; the confusion matrix (which sibling a query lands on) points at
+disambiguation, not "make it pushier".
+
 Present findings as a structured summary table.
 
 ### Step 1.5: Name the Current Bottleneck

--- a/tests/test_trigger_eval.py
+++ b/tests/test_trigger_eval.py
@@ -56,9 +56,17 @@ class ClassifyTest(unittest.TestCase):
         self.assertEqual(out, "trigger")
         self.assertEqual(detail, "check-gpu")
 
-    def test_plugin_namespaced_target_matches_on_tail(self):
-        out, _ = TE.classify([("Skill", {"skill": "myplugin:check-gpu"})], "check-gpu")
+    def test_plugin_namespaced_target_matches_on_tail_but_is_tagged(self):
+        out, detail = TE.classify([("Skill", {"skill": "myplugin:check-gpu"})], "check-gpu")
         self.assertEqual(out, "trigger")
+        # namespaced match must be surfaced distinctly, not silently == exact
+        self.assertIn("namespaced", detail)
+        self.assertIn("myplugin:check-gpu", detail)
+
+    def test_namespaced_target_does_not_tail_match(self):
+        # if the TARGET itself is namespaced, don't fuzzy-tail-match a bare id
+        out, _ = TE.classify([("Skill", {"skill": "check-gpu"})], "plug:check-gpu")
+        self.assertEqual(out, "confusion")
 
     def test_different_skill_is_confusion_with_name(self):
         out, detail = TE.classify([("Skill", {"skill": "vast-gpu"})], "check-gpu")
@@ -103,6 +111,46 @@ class AggregateTest(unittest.TestCase):
     def test_all_errors_gives_none_rate_not_zerodiv(self):
         recs = [{"skill": "s", "query": "q", "outcome": "error", "detail": "x"}]
         self.assertIsNone(TE.aggregate(recs)["s"]["trigger_rate"])
+
+
+class StreamErrorTest(unittest.TestCase):
+    def test_max_turns_termination_is_NOT_a_real_error(self):
+        # the probe deliberately caps at 1 turn; error_max_turns is the expected
+        # successful ending, not a failure — must be gradeable.
+        stream = "\n".join([
+            _assistant_event([_skill_use("check-gpu")]),
+            json.dumps({"type": "result", "is_error": True, "subtype": "error_max_turns"}),
+        ])
+        self.assertFalse(TE._stream_real_error(stream))
+        self.assertTrue(TE._stream_has_assistant(stream))
+
+    def test_genuine_error_subtype_is_detected(self):
+        stream = json.dumps({"type": "result", "is_error": True,
+                             "subtype": "error_during_execution"})
+        self.assertTrue(TE._stream_real_error(stream))
+
+    def test_clean_success_result_is_not_error(self):
+        stream = "\n".join([
+            _assistant_event([_skill_use("check-gpu")]),
+            json.dumps({"type": "result", "subtype": "success", "is_error": False}),
+        ])
+        self.assertFalse(TE._stream_real_error(stream))
+        self.assertTrue(TE._stream_has_assistant(stream))
+
+    def test_no_assistant_turn_detected(self):
+        stream = "\n".join([json.dumps({"type": "system", "subtype": "init"}),
+                            json.dumps({"type": "result", "subtype": "success"})])
+        self.assertFalse(TE._stream_has_assistant(stream))
+
+
+class DenyToolsTest(unittest.TestCase):
+    def test_stateful_tools_are_denied(self):
+        # the safety invariant: side-effecting tools are on the deny list
+        for t in ("Bash", "Write", "Edit"):
+            self.assertIn(t, TE._DENY_TOOLS)
+        # the tools we SCORE on must NOT be denied (or we'd never see a trigger)
+        for t in ("Skill", "Read"):
+            self.assertNotIn(t, TE._DENY_TOOLS)
 
 
 class SampleEvalFileTest(unittest.TestCase):

--- a/tests/test_trigger_eval.py
+++ b/tests/test_trigger_eval.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/meta_opt/trigger_eval.py — the pure stream-parse /
+classify / aggregate logic. No live `claude` subprocess is invoked (the probe
+layer is I/O and not unit-tested here); these lock the grading semantics that
+turn a raw stream into a trigger/confusion/miss verdict.
+
+Run: python3 tests/test_trigger_eval.py   (also pytest-compatible)
+"""
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "trigger_eval", REPO / "tools" / "meta_opt" / "trigger_eval.py")
+TE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TE)
+
+
+def _assistant_event(content_blocks):
+    return json.dumps({"type": "assistant", "message": {"content": content_blocks}})
+
+
+def _skill_use(skill_name):
+    return {"type": "tool_use", "name": "Skill", "input": {"skill": skill_name}}
+
+
+def _read_use(path):
+    return {"type": "tool_use", "name": "Read", "input": {"file_path": path}}
+
+
+class ParseStreamTest(unittest.TestCase):
+    def test_extracts_tool_uses_across_lines(self):
+        stream = "\n".join([
+            json.dumps({"type": "system", "subtype": "init"}),
+            _assistant_event([{"type": "text", "text": "ok"}, _skill_use("check-gpu")]),
+            "not json noise on stderr",
+            json.dumps({"type": "result", "subtype": "success"}),
+        ])
+        uses = TE.parse_stream_tool_uses(stream)
+        self.assertEqual(uses, [("Skill", {"skill": "check-gpu"})])
+
+    def test_skips_malformed_and_non_assistant(self):
+        stream = "\n".join(["", "{bad json", json.dumps({"type": "user"}),
+                            _assistant_event([_read_use("/x/skills/foo/SKILL.md")])])
+        self.assertEqual(TE.parse_stream_tool_uses(stream),
+                         [("Read", {"file_path": "/x/skills/foo/SKILL.md"})])
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_skill_call_for_target_is_trigger(self):
+        out, detail = TE.classify([("Skill", {"skill": "check-gpu"})], "check-gpu")
+        self.assertEqual(out, "trigger")
+        self.assertEqual(detail, "check-gpu")
+
+    def test_plugin_namespaced_target_matches_on_tail(self):
+        out, _ = TE.classify([("Skill", {"skill": "myplugin:check-gpu"})], "check-gpu")
+        self.assertEqual(out, "trigger")
+
+    def test_different_skill_is_confusion_with_name(self):
+        out, detail = TE.classify([("Skill", {"skill": "vast-gpu"})], "check-gpu")
+        self.assertEqual(out, "confusion")
+        self.assertEqual(detail, "vast-gpu")
+
+    def test_reading_target_skill_md_is_trigger(self):
+        out, _ = TE.classify(
+            [("Read", {"file_path": "/home/u/.claude/skills/research-lit/SKILL.md"})],
+            "research-lit")
+        self.assertEqual(out, "trigger")
+
+    def test_no_skill_engagement_is_miss(self):
+        out, _ = TE.classify([("Bash", {"command": "ls"})], "check-gpu")
+        self.assertEqual(out, "miss")
+        self.assertEqual(TE.classify([], "check-gpu")[0], "miss")
+
+    def test_first_skill_call_decides(self):
+        # a confusion followed by the correct skill still counts as confusion:
+        # the model reached for the wrong skill first.
+        out, detail = TE.classify(
+            [("Skill", {"skill": "vast-gpu"}), ("Skill", {"skill": "check-gpu"})],
+            "check-gpu")
+        self.assertEqual((out, detail), ("confusion", "vast-gpu"))
+
+
+class AggregateTest(unittest.TestCase):
+    def test_rate_excludes_errors_from_denominator(self):
+        recs = [
+            {"skill": "s", "query": "q1", "outcome": "trigger", "detail": "s"},
+            {"skill": "s", "query": "q1", "outcome": "miss", "detail": ""},
+            {"skill": "s", "query": "q2", "outcome": "confusion", "detail": "other"},
+            {"skill": "s", "query": "q2", "outcome": "error", "detail": "boom"},
+        ]
+        agg = TE.aggregate(recs)["s"]
+        # graded = 3 (error excluded); triggers = 1 → 0.333
+        self.assertEqual(agg["trigger_rate"], 0.333)
+        self.assertEqual(agg["probes"], 4)
+        self.assertEqual(agg["errors"], 1)
+        self.assertEqual(agg["confusions"], {"other": 1})
+
+    def test_all_errors_gives_none_rate_not_zerodiv(self):
+        recs = [{"skill": "s", "query": "q", "outcome": "error", "detail": "x"}]
+        self.assertIsNone(TE.aggregate(recs)["s"]["trigger_rate"])
+
+
+class SampleEvalFileTest(unittest.TestCase):
+    def test_sample_file_is_valid_and_well_formed(self):
+        data = json.loads(
+            (REPO / "tools" / "meta_opt" / "trigger_evals.sample.json").read_text())
+        skills = {k: v for k, v in data.items() if not k.startswith("_")}
+        self.assertTrue(skills)
+        for name, queries in skills.items():
+            self.assertIsInstance(queries, list, name)
+            self.assertTrue(queries, f"{name} has no queries")
+            for q in queries:
+                self.assertIsInstance(q, str)
+                self.assertTrue(q.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/meta_opt/trigger_eval.py
+++ b/tools/meta_opt/trigger_eval.py
@@ -12,22 +12,28 @@ EVIDENCE for a /meta-optimize proposal (which lands only via the human-gated
 too.
 
 How it works (adapted from Anthropic's Claude Science `skill-creator`
-run_eval.py, Apache-2.0; ported off its host.* runtime):
+run_eval.py — Apache-2.0; ported off its host.* runtime onto plain `claude -p`):
 - For each (skill, query), run `claude -p <query> --output-format stream-json
-  --max-turns 1` as a subprocess FROM A NEUTRAL TEMP CWD. The user-level
-  ~/.claude/skills corpus is loaded as usual, so the measurement happens under
-  the REALISTIC long installed list — the exact condition under which
-  omission happens (an isolated one-skill sandbox would trivially inflate
-  trigger rates).
+  --max-turns 1 --permission-mode plan --disallowed-tools Bash Write Edit …`
+  as a subprocess FROM A NEUTRAL TEMP CWD. The user-level ~/.claude/skills
+  corpus is loaded as usual, so the measurement happens under the REALISTIC
+  long installed list — the exact condition under which omission happens (an
+  isolated one-skill sandbox would trivially inflate trigger rates).
 - Parse the stream for the first assistant turn's tool_use blocks. A `Skill`
   tool call with input.skill == target counts as a TRIGGER; a Skill call for a
   different skill is a CONFUSION (recorded by name — the confusion matrix is
   the interesting part for the long-list problem); no Skill call is a MISS.
   Reading the target's SKILL.md via the Read tool counts as a trigger too
   (secondary signal).
-- `--max-turns 1` + no --allowedTools: the tool call is captured from the
-  assistant message BEFORE any permission gate, is auto-denied by -p mode, and
-  the run ends. Nothing executes; each probe costs one short model turn.
+- SAFETY: `--permission-mode plan` blocks every side-effecting tool (Bash,
+  Write, Edit, …) from executing, so a probed skill's own commands (e.g.
+  check-gpu's ssh, vast-gpu's rentals) do NOT run — we observe only which tool
+  the model REACHED FOR. The read-only tools we score on (a `Skill` load, a
+  `Read` of a SKILL.md) may execute, and both are side-effect-free.
+  `--disallowed-tools` denies the stateful tools explicitly as belt-and-braces,
+  and `--no-session-persistence` avoids leaving session artifacts. This is a
+  measurement, not a sandbox — it does not stop the user's own SessionStart
+  hooks (their normal per-session behavior), it stops the PROBED WORK.
 
 Query-set methodology (see trigger_evals.sample.json): queries must PARAPHRASE
 user intent, never quote the description's own trigger phrases verbatim — a
@@ -81,17 +87,24 @@ def parse_stream_tool_uses(stream_text: str):
 def classify(tool_uses, target_skill: str):
     """Classify one probe run: ('trigger'|'confusion'|'miss', detail).
 
-    Trigger: a Skill call for the target, or a Read of the target's SKILL.md.
+    Trigger: a Skill call for the target (exact id, or a `plugin:target`
+    namespaced form — the latter tagged in detail so a namespaced match is
+    never silently indistinguishable from an exact one), or a Read of the
+    target's SKILL.md.
     Confusion: the FIRST Skill call named a different skill (detail = its name).
     Miss: no skill engagement at all.
     """
     for name, inp in tool_uses:
         if name == "Skill":
             invoked = (inp.get("skill") or "").strip()
-            # plugin-namespaced form "plugin:skill" — compare the tail
-            tail = invoked.split(":")[-1]
-            if tail == target_skill:
+            if invoked == target_skill:
                 return "trigger", invoked
+            # plugin-namespaced form "plugin:skill": a trigger only if the tail
+            # equals the target AND the target itself is bare (not namespaced),
+            # surfaced distinctly so a human can spot a plugin/bare collision.
+            if ":" in invoked and invoked.split(":")[-1] == target_skill \
+                    and ":" not in target_skill:
+                return "trigger", f"{invoked} (namespaced→{target_skill})"
             return "confusion", invoked
         if name == "Read":
             path = str(inp.get("file_path") or "")
@@ -128,10 +141,61 @@ def aggregate(records):
 
 # ------------------------------------------------------------------- probing
 
+# Stateful tools that must never execute during a probe (belt-and-braces on top
+# of --permission-mode plan, which already blocks side-effecting tools).
+_DENY_TOOLS = ["Bash", "Write", "Edit", "NotebookEdit", "WebFetch"]
+
+
+# `--max-turns 1` deliberately caps the probe at one turn, so the CLI ends with
+# result subtype `error_max_turns` and a NONZERO exit — that is the EXPECTED,
+# successful termination for a probe, NOT a failure. Only other errors (auth,
+# startup/hook failure, execution error) count as a real error.
+_EXPECTED_TERMINATION = "error_max_turns"
+
+
+def _stream_real_error(stream_text: str) -> bool:
+    """True iff the stream carries a genuine terminal error — an `is_error`
+    result whose subtype is NOT the expected max-turns cap. Auth/hook failures
+    that still emit JSON are caught here so they are graded `error`, never a
+    `miss` that would silently corrupt the trigger rate."""
+    for line in stream_text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("type") == "result" and ev.get("is_error") \
+                and ev.get("subtype") != _EXPECTED_TERMINATION:
+            return True
+    return False
+
+
+def _stream_has_assistant(stream_text: str) -> bool:
+    """True iff the model produced at least one assistant turn — i.e. the probe
+    ran far enough to be gradeable (even if it then hit the max-turns cap)."""
+    for line in stream_text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            if json.loads(line).get("type") == "assistant":
+                return True
+        except json.JSONDecodeError:
+            continue
+    return False
+
+
 def run_probe(query: str, model: str | None, timeout: int, cwd: str) -> str:
-    """One `claude -p` probe; returns raw stream-json text. Raises on failure."""
+    """One `claude -p` probe; returns raw stream-json text. Raises RuntimeError
+    on a REAL failure (genuine error event, or nonzero exit with no assistant
+    turn at all) so the caller records `error` rather than a rate-corrupting
+    `miss`. The expected max-turns termination (nonzero exit + assistant turn
+    present) is a normal, gradeable result."""
     cmd = ["claude", "-p", "--output-format", "stream-json", "--verbose",
-           "--max-turns", "1"]
+           "--max-turns", "1", "--permission-mode", "plan",
+           "--no-session-persistence", "--disallowed-tools", *_DENY_TOOLS]
     if model:
         cmd += ["--model", model]
     # Allow nesting claude -p inside a Claude Code session (same pattern as the
@@ -139,10 +203,14 @@ def run_probe(query: str, model: str | None, timeout: int, cwd: str) -> str:
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
     result = subprocess.run(cmd, input=query, capture_output=True, text=True,
                             env=env, timeout=timeout, cwd=cwd)
-    if result.returncode != 0 and not result.stdout.strip():
-        raise RuntimeError(f"claude -p exited {result.returncode}: "
-                           f"{result.stderr.strip()[:300]}")
-    return result.stdout
+    if _stream_real_error(result.stdout):
+        raise RuntimeError("claude -p stream carried a terminal error result event")
+    if _stream_has_assistant(result.stdout):
+        return result.stdout                       # gradeable (max-turns cap is fine)
+    if result.returncode != 0:                     # no assistant turn AND failed = real
+        raise RuntimeError(f"claude -p exited {result.returncode} with no assistant "
+                           f"turn: {result.stderr.strip()[:300]}")
+    return result.stdout                            # clean, no tool call → graded miss
 
 
 def main(argv=None) -> int:
@@ -151,8 +219,10 @@ def main(argv=None) -> int:
                     help='JSON: {"<skill>": ["query", ...], ...}')
     ap.add_argument("--skills", default="",
                     help="comma-separated subset of skills to probe (default: all in file)")
-    ap.add_argument("--samples", type=int, default=1,
-                    help="probes per query (trigger behavior is stochastic; 2-3 for stability)")
+    ap.add_argument("--samples", type=int, default=3,
+                    help="probes per query (trigger behavior is stochastic; the "
+                         "default 3 matches the upstream eval — samples=1 is too "
+                         "noisy to act on)")
     ap.add_argument("--model", default=None,
                     help="model override for probes (default: claude CLI default). "
                          "NB: trigger behavior is model-dependent — compare like with like.")

--- a/tools/meta_opt/trigger_eval.py
+++ b/tools/meta_opt/trigger_eval.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""trigger_eval.py — measure whether a skill's `description` actually triggers.
+
+ARIS's known pain: with 80+ skills installed, Claude Code sometimes fails to
+invoke the right skill for a query it should handle — and until now the only
+lever (the frontmatter `description`) was tuned by pure judgment, with zero
+measurement. This tool turns trigger behavior into a number.
+
+MEASURE-ONLY BY DESIGN. It never rewrites a description. Its report is
+EVIDENCE for a /meta-optimize proposal (which lands only via the human-gated
+/meta-apply) — "a loop can drive, never acquit" applies to description tuning
+too.
+
+How it works (adapted from Anthropic's Claude Science `skill-creator`
+run_eval.py, Apache-2.0; ported off its host.* runtime):
+- For each (skill, query), run `claude -p <query> --output-format stream-json
+  --max-turns 1` as a subprocess FROM A NEUTRAL TEMP CWD. The user-level
+  ~/.claude/skills corpus is loaded as usual, so the measurement happens under
+  the REALISTIC long installed list — the exact condition under which
+  omission happens (an isolated one-skill sandbox would trivially inflate
+  trigger rates).
+- Parse the stream for the first assistant turn's tool_use blocks. A `Skill`
+  tool call with input.skill == target counts as a TRIGGER; a Skill call for a
+  different skill is a CONFUSION (recorded by name — the confusion matrix is
+  the interesting part for the long-list problem); no Skill call is a MISS.
+  Reading the target's SKILL.md via the Read tool counts as a trigger too
+  (secondary signal).
+- `--max-turns 1` + no --allowedTools: the tool call is captured from the
+  assistant message BEFORE any permission gate, is auto-denied by -p mode, and
+  the run ends. Nothing executes; each probe costs one short model turn.
+
+Query-set methodology (see trigger_evals.sample.json): queries must PARAPHRASE
+user intent, never quote the description's own trigger phrases verbatim — a
+query containing the literal trigger string is trivially positive and measures
+nothing. Optional negative queries (expect: none) measure false-triggering.
+
+Usage:
+  python3 tools/meta_opt/trigger_eval.py --eval-file tools/meta_opt/trigger_evals.sample.json \\
+      [--skills check-gpu,research-lit] [--samples 2] [--model haiku] \\
+      [--out .aris/meta/trigger_report.json] [--timeout 120]
+
+Exit code: 0 on completed run (regardless of rates), 2 on setup error.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+# ---------------------------------------------------------------- pure logic
+
+def parse_stream_tool_uses(stream_text: str):
+    """Extract (tool_name, tool_input) pairs from `claude -p` stream-json output.
+
+    Each line is a JSON event; assistant events carry message.content lists in
+    which tool_use blocks appear. Malformed lines are skipped (the stream can
+    interleave non-JSON stderr noise when things go wrong).
+    """
+    uses = []
+    for line in stream_text.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("type") != "assistant":
+            continue
+        content = (ev.get("message") or {}).get("content") or []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                uses.append((block.get("name") or "", block.get("input") or {}))
+    return uses
+
+
+def classify(tool_uses, target_skill: str):
+    """Classify one probe run: ('trigger'|'confusion'|'miss', detail).
+
+    Trigger: a Skill call for the target, or a Read of the target's SKILL.md.
+    Confusion: the FIRST Skill call named a different skill (detail = its name).
+    Miss: no skill engagement at all.
+    """
+    for name, inp in tool_uses:
+        if name == "Skill":
+            invoked = (inp.get("skill") or "").strip()
+            # plugin-namespaced form "plugin:skill" — compare the tail
+            tail = invoked.split(":")[-1]
+            if tail == target_skill:
+                return "trigger", invoked
+            return "confusion", invoked
+        if name == "Read":
+            path = str(inp.get("file_path") or "")
+            if f"/skills/{target_skill}/SKILL.md" in path:
+                return "trigger", path
+    return "miss", ""
+
+
+def aggregate(records):
+    """records: list of {skill, query, outcome, detail} → per-skill summary."""
+    out = {}
+    for r in records:
+        s = out.setdefault(r["skill"], {
+            "probes": 0, "triggers": 0, "misses": 0, "errors": 0,
+            "confusions": {}, "queries": {},
+        })
+        s["probes"] += 1
+        q = s["queries"].setdefault(r["query"], {"trigger": 0, "confusion": 0,
+                                                 "miss": 0, "error": 0})
+        q[r["outcome"]] += 1
+        if r["outcome"] == "trigger":
+            s["triggers"] += 1
+        elif r["outcome"] == "miss":
+            s["misses"] += 1
+        elif r["outcome"] == "error":
+            s["errors"] += 1
+        elif r["outcome"] == "confusion":
+            s["confusions"][r["detail"]] = s["confusions"].get(r["detail"], 0) + 1
+    for s in out.values():
+        graded = s["probes"] - s["errors"]
+        s["trigger_rate"] = round(s["triggers"] / graded, 3) if graded else None
+    return out
+
+
+# ------------------------------------------------------------------- probing
+
+def run_probe(query: str, model: str | None, timeout: int, cwd: str) -> str:
+    """One `claude -p` probe; returns raw stream-json text. Raises on failure."""
+    cmd = ["claude", "-p", "--output-format", "stream-json", "--verbose",
+           "--max-turns", "1"]
+    if model:
+        cmd += ["--model", model]
+    # Allow nesting claude -p inside a Claude Code session (same pattern as the
+    # Apache-2.0 source): the CLAUDECODE guard is for interactive terminals.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+    result = subprocess.run(cmd, input=query, capture_output=True, text=True,
+                            env=env, timeout=timeout, cwd=cwd)
+    if result.returncode != 0 and not result.stdout.strip():
+        raise RuntimeError(f"claude -p exited {result.returncode}: "
+                           f"{result.stderr.strip()[:300]}")
+    return result.stdout
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Measure skill-description trigger rates.")
+    ap.add_argument("--eval-file", required=True,
+                    help='JSON: {"<skill>": ["query", ...], ...}')
+    ap.add_argument("--skills", default="",
+                    help="comma-separated subset of skills to probe (default: all in file)")
+    ap.add_argument("--samples", type=int, default=1,
+                    help="probes per query (trigger behavior is stochastic; 2-3 for stability)")
+    ap.add_argument("--model", default=None,
+                    help="model override for probes (default: claude CLI default). "
+                         "NB: trigger behavior is model-dependent — compare like with like.")
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--out", default=".aris/meta/trigger_report.json")
+    args = ap.parse_args(argv)
+
+    try:
+        evals = json.loads(Path(args.eval_file).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"ERROR: cannot read eval file: {e}", file=sys.stderr)
+        return 2
+    subset = {s.strip() for s in args.skills.split(",") if s.strip()}
+    targets = {k: v for k, v in evals.items()
+               if (not subset or k in subset) and not k.startswith("_")}
+    if not targets:
+        print("ERROR: no skills selected", file=sys.stderr)
+        return 2
+
+    records = []
+    # Neutral cwd: no project-level .claude/, so probes see exactly the
+    # user-level installed corpus — the realistic long list.
+    with tempfile.TemporaryDirectory(prefix="trigger-eval-") as neutral_cwd:
+        for skill, queries in targets.items():
+            for query in queries:
+                for _ in range(args.samples):
+                    try:
+                        stream = run_probe(query, args.model, args.timeout, neutral_cwd)
+                        outcome, detail = classify(parse_stream_tool_uses(stream), skill)
+                    except (RuntimeError, subprocess.TimeoutExpired) as e:
+                        outcome, detail = "error", str(e)[:200]
+                    records.append({"skill": skill, "query": query,
+                                    "outcome": outcome, "detail": detail})
+                    print(f"  [{outcome:9}] {skill} ← {query[:60]!r}"
+                          + (f" → {detail}" if outcome == "confusion" else ""))
+
+    summary = aggregate(records)
+    report = {"model": args.model or "cli-default", "samples": args.samples,
+              "skills": summary, "records": records}
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print("\nskill                          rate   probes  confusions")
+    for name, s in sorted(summary.items()):
+        conf = ", ".join(f"{k}×{v}" for k, v in
+                         sorted(s["confusions"].items(), key=lambda kv: -kv[1])) or "-"
+        rate = "n/a " if s["trigger_rate"] is None else f"{s['trigger_rate']:.2f}"
+        print(f"{name:30} {rate}   {s['probes']:4}    {conf}")
+    print(f"\nreport → {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/meta_opt/trigger_evals.sample.json
+++ b/tools/meta_opt/trigger_evals.sample.json
@@ -1,0 +1,28 @@
+{
+  "_README": "Query set for trigger_eval.py. Keys are skill names; values are user-intent queries that SHOULD trigger that skill. RULE: paraphrase intent, never quote the skill's own trigger phrases verbatim — a query containing the literal description trigger string is trivially positive and measures nothing. Prefix a skill key with '_' to comment it out. For negative testing (measuring FALSE triggering), add queries under a skill that should NOT fire and read the confusion matrix in the report. This sample covers a few well-scoped skills; extend per the skill you're tuning.",
+  "check-gpu": [
+    "is anything running on the servers right now?",
+    "how busy are my remote machines?",
+    "which cards are free before I launch a job"
+  ],
+  "research-lit": [
+    "find me recent papers on this topic",
+    "what has been published about diffusion language models lately",
+    "pull together related work for my intro section"
+  ],
+  "novelty-check": [
+    "has anyone already done this idea?",
+    "is my approach actually new or is it in the literature already",
+    "check if this contribution is novel before I build it"
+  ],
+  "citation-audit": [
+    "make sure every reference in my paper is real and correctly attributed",
+    "verify the bibliography before submission",
+    "did I hallucinate any citations in this draft"
+  ],
+  "kill-argument": [
+    "what is the single strongest reason a reviewer would reject this paper",
+    "give me the harshest rebuttal my theory paper would face",
+    "simulate reviewer 2's most damaging objection"
+  ]
+}


### PR DESCRIPTION
Second (and final) portable borrow from the AcademicForge / Claude Science evaluation — codex-ranked #2. Closes ARIS's long-standing "no way to measure whether a skill's `description` actually triggers" gap (memory: `skill-desc-trim-conservative`).

## Problem
80+ skills installed → Claude Code sometimes passes over the right one. The only lever is the frontmatter `description`, tuned by pure judgment. The `.aris/meta/events.jsonl` log shows which skills were USED, never which were WANTED-but-omitted — the omission failure mode is invisible to it.

## `tools/meta_opt/trigger_eval.py`
For each `(skill, query)`: `claude -p --output-format stream-json --max-turns 1` from a **neutral temp cwd** (so the realistic long user-level corpus loads — an isolated one-skill sandbox would inflate the rate), parse the first assistant turn's `tool_use` blocks, score **trigger / confusion(→which sibling) / miss**. Nothing executes (`--max-turns 1` + `-p` auto-denies the captured call). Adapted from Anthropic's Claude Science `skill-creator/run_eval.py` (Apache-2.0), ported off `host.*` onto plain `claude -p`.

```
python3 tools/meta_opt/trigger_eval.py --eval-file tools/meta_opt/trigger_evals.sample.json --skills research-lit --samples 2
```

## Design constraints (all honored)
- **Measure-only.** Never rewrites a description. Output is EVIDENCE for a Step-2 `/meta-optimize` proposal that lands only via human-gated `/meta-apply` — "a loop can drive, never acquit."
- **The confusion matrix is the signal**, not just the rate: a query landing on a sibling ⇒ overlapping descriptions ⇒ disambiguate, don't "make it pushier".
- **Proxy, model-dependent**: trigger rate measures selection under a query set, not the full long-list omission problem; record the probe model, compare like with like. Sample file mandates paraphrased queries (never quote the description's own trigger phrases verbatim).

## Wiring
meta-optimize Step 1 gains an optional measured arm (mainline). The codex mirror notes it as Claude-Code-specific (no `codex` skill-selection probe yet) rather than porting a `claude -p` step into a Codex-executor skill.

## Ships
`trigger_eval.py` · `trigger_evals.sample.json` (5 skills) · `tests/test_trigger_eval.py` (11 tests over pure parse/classify/aggregate — no live claude in CI). Live smoke: check-gpu 3/3 on paraphrased queries.

## Verification
Inventory consistent · full suite 418 passed / 16 skipped · parity guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)