### PR TITLE
feat(citation-discipline,paper-figure): two output-discipline slices from Claude Science

### DIFF
--- a/skills/paper-figure/SKILL.md
+++ b/skills/paper-figure/SKILL.md
@@ -179,7 +179,11 @@ for script in gen_fig*.py; do
 done
 ```
 
-Verify all output files exist and are non-empty.
+Verify all output files exist and are non-empty. Then **render-then-verify**:
+re-open each RENDERED PDF/PNG (not the script) and self-check — no clipped
+labels, no legend covering data, every number/label readable at final print
+size. This self-check happens BEFORE the Step 7 review, so the reviewer's
+budget goes to substance, not to catching clipped axes.
 
 ### Step 6: Generate LaTeX Include Snippets
 
@@ -241,13 +245,14 @@ a clean result, but a deliberate, stated alternative may override them.
       difference in the caption
 - [ ] **State n and what was held fixed** — every panel with a summary mark
       says n and the unit of replication (panel or caption)
-- [ ] **Render-then-verify** — re-open the RENDERED PDF/PNG (not the script)
-      before hand-off: no clipped labels, no legend covering data, every
-      number/label readable at final print size. Step 7's reviewer must see an
-      already-self-checked render
+- [ ] **Render-then-verify** — the Step-5 self-check on the RENDERED PDF/PNG
+      (not the script) actually happened: no clipped labels, no legend covering
+      data, every number/label readable at final print size
 
 **Guidance — strong defaults (from pedrohcgs/claude-code-my-workflow), a
-deliberate stated alternative may override:**
+deliberate stated alternative may override — EXCEPT items that Key Rules below
+make hard (vector-PDF output and no-titles-inside-figures are Key Rules: treat
+those two as binding, not overridable):**
 
 - [ ] Font size readable at printed paper size (not too small)
 - [ ] Colors distinguishable in grayscale (print-friendly)

--- a/skills/paper-figure/SKILL.md
+++ b/skills/paper-figure/SKILL.md
@@ -220,7 +220,34 @@ mcp__codex__codex:
 
 ### Step 8: Quality Checklist
 
-Before finishing, verify each figure (from pedrohcgs/claude-code-my-workflow):
+The checklist is PARTITIONED (pattern from Anthropic's Claude Science
+`figure-style` skill, Apache-2.0): **correctness rules always bind** — they are
+about whether the figure tells the truth, have no aesthetic content, and no
+style choice may override them; **guidance rules are defaults** — they produce
+a clean result, but a deliberate, stated alternative may override them.
+
+**Correctness — always binds, verify against the DATA before the render:**
+
+- [ ] **Excluded data never enters summaries** — a row excluded/flagged in the
+      source either disappears entirely or is drawn visibly distinct (open /
+      hatched marker, named in the key); it never feeds a mean/CI plotted
+      alongside included rows
+- [ ] **Captions and any claim-like title text are tested against EVERY plotted
+      row** — if one category contradicts the claim, qualify it ("on 3 of 4
+      benchmarks") or downgrade to a description; a figure that overclaims is
+      wrong even if it renders beautifully
+- [ ] **Comparable conditions only** — arms measured under different N / budget
+      / protocol are not drawn as visual peers; separate them or mark the
+      difference in the caption
+- [ ] **State n and what was held fixed** — every panel with a summary mark
+      says n and the unit of replication (panel or caption)
+- [ ] **Render-then-verify** — re-open the RENDERED PDF/PNG (not the script)
+      before hand-off: no clipped labels, no legend covering data, every
+      number/label readable at final print size. Step 7's reviewer must see an
+      already-self-checked render
+
+**Guidance — strong defaults (from pedrohcgs/claude-code-my-workflow), a
+deliberate stated alternative may override:**
 
 - [ ] Font size readable at printed paper size (not too small)
 - [ ] Colors distinguishable in grayscale (print-friendly)

--- a/skills/shared-references/citation-discipline.md
+++ b/skills/shared-references/citation-discipline.md
@@ -554,6 +554,27 @@ Before treating a citation as complete, verify:
 - [ ] the specific claim you cite is actually supported by the paper,
 - [ ] any unresolved uncertainty is marked with `[VERIFY]` or an explicit placeholder.
 
+## Output Discipline: Verification Lives in the Trace, Not in Prose
+
+Two rules on how verification shows up in what the reader sees (adapted from
+Anthropic's Claude Science `literature-review` skill, Apache-2.0):
+
+- **Never write a "citations verified" line in the output.** Not as an opener,
+  not as a footer, not as a subtitle — "All DOIs verified", "no retraction
+  flags", "bibliography checked" are process narration. Verification is
+  something that happens in your tool trace (the `verify_papers` run, the DBLP
+  lookups, the audit JSON); the reader infers it from citations that resolve
+  and claims that hold up. A reply or section whose content is "I verified
+  things" is not content. (ARIS-specific: the machine-readable verification
+  record belongs in the audit artifact — `CITATION_AUDIT.json`, traces — never
+  as reassurance prose in the paper or report body.)
+- **A style/consistency lint runs ONCE, as a lint — not as a loop-until-clean
+  gate.** Run it on the full draft, fix what it lists in a single editing
+  pass, and move on; do not re-run until it returns clean. A lint that becomes
+  a convergence loop burns rounds polishing cosmetics while real
+  (cross-model-review) gates wait. Quality/correctness convergence belongs to
+  the reviewer loops, not to lints.
+
 ## Bottom Line
 
 **When a citation is uncertain, leave an explicit gap instead of silently inventing metadata.**

--- a/skills/skills-codex/paper-figure/SKILL.md
+++ b/skills/skills-codex/paper-figure/SKILL.md
@@ -177,7 +177,11 @@ for script in gen_fig*.py; do
 done
 ```
 
-Verify all output files exist and are non-empty.
+Verify all output files exist and are non-empty. Then **render-then-verify**:
+re-open each RENDERED PDF/PNG (not the script) and self-check — no clipped
+labels, no legend covering data, every number/label readable at final print
+size. This self-check happens BEFORE the Step 7 review, so the reviewer's
+budget goes to substance, not to catching clipped axes.
 
 ### Step 6: Generate LaTeX Include Snippets
 
@@ -239,13 +243,14 @@ a clean result, but a deliberate, stated alternative may override them.
       difference in the caption
 - [ ] **State n and what was held fixed** — every panel with a summary mark
       says n and the unit of replication (panel or caption)
-- [ ] **Render-then-verify** — re-open the RENDERED PDF/PNG (not the script)
-      before hand-off: no clipped labels, no legend covering data, every
-      number/label readable at final print size. Step 7's reviewer must see an
-      already-self-checked render
+- [ ] **Render-then-verify** — the Step-5 self-check on the RENDERED PDF/PNG
+      (not the script) actually happened: no clipped labels, no legend covering
+      data, every number/label readable at final print size
 
 **Guidance — strong defaults (from pedrohcgs/claude-code-my-workflow), a
-deliberate stated alternative may override:**
+deliberate stated alternative may override — EXCEPT items that Key Rules below
+make hard (vector-PDF output and no-titles-inside-figures are Key Rules: treat
+those two as binding, not overridable):**
 
 - [ ] Font size readable at printed paper size (not too small)
 - [ ] Colors distinguishable in grayscale (print-friendly)

--- a/skills/skills-codex/paper-figure/SKILL.md
+++ b/skills/skills-codex/paper-figure/SKILL.md
@@ -218,7 +218,34 @@ spawn_agent:
 
 ### Step 8: Quality Checklist
 
-Before finishing, verify each figure (from pedrohcgs/claude-code-my-workflow):
+The checklist is PARTITIONED (pattern from Anthropic's Claude Science
+`figure-style` skill, Apache-2.0): **correctness rules always bind** — they are
+about whether the figure tells the truth, have no aesthetic content, and no
+style choice may override them; **guidance rules are defaults** — they produce
+a clean result, but a deliberate, stated alternative may override them.
+
+**Correctness — always binds, verify against the DATA before the render:**
+
+- [ ] **Excluded data never enters summaries** — a row excluded/flagged in the
+      source either disappears entirely or is drawn visibly distinct (open /
+      hatched marker, named in the key); it never feeds a mean/CI plotted
+      alongside included rows
+- [ ] **Captions and any claim-like title text are tested against EVERY plotted
+      row** — if one category contradicts the claim, qualify it ("on 3 of 4
+      benchmarks") or downgrade to a description; a figure that overclaims is
+      wrong even if it renders beautifully
+- [ ] **Comparable conditions only** — arms measured under different N / budget
+      / protocol are not drawn as visual peers; separate them or mark the
+      difference in the caption
+- [ ] **State n and what was held fixed** — every panel with a summary mark
+      says n and the unit of replication (panel or caption)
+- [ ] **Render-then-verify** — re-open the RENDERED PDF/PNG (not the script)
+      before hand-off: no clipped labels, no legend covering data, every
+      number/label readable at final print size. Step 7's reviewer must see an
+      already-self-checked render
+
+**Guidance — strong defaults (from pedrohcgs/claude-code-my-workflow), a
+deliberate stated alternative may override:**
 
 - [ ] Font size readable at printed paper size (not too small)
 - [ ] Colors distinguishable in grayscale (print-friendly)

--- a/skills/skills-codex/shared-references/citation-discipline.md
+++ b/skills/skills-codex/shared-references/citation-discipline.md
@@ -426,6 +426,27 @@ Before treating a citation as complete, verify:
 - [ ] the specific claim you cite is actually supported by the paper,
 - [ ] any unresolved uncertainty is marked with `[VERIFY]` or an explicit placeholder.
 
+## Output Discipline: Verification Lives in the Trace, Not in Prose
+
+Two rules on how verification shows up in what the reader sees (adapted from
+Anthropic's Claude Science `literature-review` skill, Apache-2.0):
+
+- **Never write a "citations verified" line in the output.** Not as an opener,
+  not as a footer, not as a subtitle — "All DOIs verified", "no retraction
+  flags", "bibliography checked" are process narration. Verification is
+  something that happens in your tool trace (the `verify_papers` run, the DBLP
+  lookups, the audit JSON); the reader infers it from citations that resolve
+  and claims that hold up. A reply or section whose content is "I verified
+  things" is not content. (ARIS-specific: the machine-readable verification
+  record belongs in the audit artifact — `CITATION_AUDIT.json`, traces — never
+  as reassurance prose in the paper or report body.)
+- **A style/consistency lint runs ONCE, as a lint — not as a loop-until-clean
+  gate.** Run it on the full draft, fix what it lists in a single editing
+  pass, and move on; do not re-run until it returns clean. A lint that becomes
+  a convergence loop burns rounds polishing cosmetics while real
+  (cross-model-review) gates wait. Quality/correctness convergence belongs to
+  the reviewer loops, not to lints.
+
 ## Bottom Line
 
 **When a citation is uncertain, leave an explicit gap instead of silently inventing metadata.**


### PR DESCRIPTION
The final two (tiny, codex-adjudicated) portable slices from the AcademicForge / Claude Science evaluation. Both applied to mainline + codex mirror.

## 1. `citation-discipline.md` — verification lives in the trace, not in prose
From Claude Science `literature-review` (Apache-2.0):
- **Never** write a "citations verified / no retraction flags" line anywhere in output — that's process narration; verification happens in the tool trace and the audit artifacts (`CITATION_AUDIT.json`), and the reader infers it from citations that resolve. ARIS's machine-readable record lives in audits, never as reassurance prose in the paper body.
- A style/consistency **lint runs once** (fix in a single pass, move on) — never a loop-until-clean gate; convergence belongs to the cross-model reviewer loops.

## 2. `paper-figure` Step 8 — correctness vs guidance partition
From Claude Science `figure-style` (Apache-2.0): the checklist now separates **correctness (always binds — about whether the figure tells the truth)** from **guidance (strong defaults a deliberate alternative may override)**. New correctness rows: excluded data never enters plotted summaries; captions/claim-titles tested against every plotted row (qualify or downgrade); comparable conditions only; state n; render-then-verify on the actual PDF/PNG before the Step-7 reviewer sees it. The existing pedrohcgs style items are preserved as guidance.

## Verification
Inventory consistent · full suite 424 passed / 16 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)