### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #358)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Example skill structure:
 ---
 name: my-skill
 description: What this skill does
-argument-hint: [optional-argument-hint]
+argument-hint: "[optional-argument-hint]"
 allowed-tools: Read, Write, Bash(*)
 ---
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -39,7 +39,7 @@ Skill 结构示例：
 ---
 name: my-skill
 description: 这个 Skill 的功能
-argument-hint: [可选参数提示]
+argument-hint: "[可选参数提示]"
 allowed-tools: Read, Write, Bash(*)
 ---
 

--- a/skills/ablation-planner/SKILL.md
+++ b/skills/ablation-planner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ablation-planner
 description: "Use when main results pass result-to-claim (claim_supported=yes or partial) and ablation studies are needed for paper submission."
-argument-hint: [method-description-or-claim]
+argument-hint: "[method-description-or-claim]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/alphaxiv/SKILL.md
+++ b/skills/alphaxiv/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: alphaxiv
 description: Quick single-paper lookup via AlphaXiv LLM-optimized summaries with tiered source fallback. Use when user says "explain this paper", "summarize paper", pastes an arXiv/AlphaXiv URL, or provides a bare arXiv ID for quick understanding - not for broad literature search.
-argument-hint: [arxiv-id-or-url]
+argument-hint: "[arxiv-id-or-url]"
 allowed-tools: Bash(*), Read, Write, Glob
 ---
 

--- a/skills/analyze-results/SKILL.md
+++ b/skills/analyze-results/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-results
 description: Analyze ML experiment results, compute statistics, generate comparison tables and insights. Use when user says "analyze results", "compare", or needs to interpret experimental data.
-argument-hint: [results-path-or-description]
+argument-hint: "[results-path-or-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit
 ---
 

--- a/skills/arxiv/SKILL.md
+++ b/skills/arxiv/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: arxiv
 description: Search, download, and summarize academic papers from arXiv. Use when user says "search arxiv", "download paper", "fetch arxiv", "arxiv search", "get paper pdf", or wants to find and save papers from arXiv to the local paper library.
-argument-hint: [query-or-arxiv-id]
+argument-hint: "[query-or-arxiv-id]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/auto-review-loop-llm/SKILL.md
+++ b/skills/auto-review-loop-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-review-loop-llm
 description: Autonomous research review loop using any OpenAI-compatible LLM API. Configure via llm-chat MCP server or environment variables. Trigger with "auto review loop llm" or "llm review".
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Skill
 ---
 

--- a/skills/auto-review-loop-minimax/SKILL.md
+++ b/skills/auto-review-loop-minimax/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-review-loop-minimax
 description: Autonomous multi-round research review loop using MiniMax API. Use when you want to use MiniMax instead of Codex MCP for external review. Trigger with "auto review loop minimax" or "minimax review".
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Skill
 ---
 

--- a/skills/auto-review-loop/SKILL.md
+++ b/skills/auto-review-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-review-loop
 description: Autonomous multi-round research review loop. Repeatedly reviews via external reviewer backend (Codex or manual), implements fixes, and re-reviews until positive assessment or max rounds reached. Use when user says "auto review loop", "review until it passes", or wants autonomous iterative improvement.
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Skill, mcp__codex__codex, mcp__codex__codex-reply, mcp__manual_review__review, mcp__manual_review__review_reply
 ---
 

--- a/skills/claims-drafting/SKILL.md
+++ b/skills/claims-drafting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claims-drafting
 description: "Draft patent claims for an invention. Use when user says \"撰写权利要求\", \"draft claims\", \"写权利要求书\", \"claim drafting\", or wants to create patent claims. The core skill of the patent pipeline."
-argument-hint: [invention-disclosure-path]
+argument-hint: "[invention-disclosure-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/deepxiv/SKILL.md
+++ b/skills/deepxiv/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepxiv
 description: Search and progressively read open-access academic papers through DeepXiv. Use when the user wants layered paper access, section-level reading, trending papers, or DeepXiv-backed literature retrieval.
-argument-hint: [query-or-paper-id]
+argument-hint: "[query-or-paper-id]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/dse-loop/SKILL.md
+++ b/skills/dse-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dse-loop
 description: "Autonomous design space exploration loop for computer architecture and EDA. Runs a program, analyzes results, tunes parameters, and iterates until objective is met or timeout. Use when user says \"DSE\", \"design space exploration\", \"sweep parameters\", \"optimize\", \"find best config\", or wants iterative parameter tuning."
-argument-hint: [task-description — include program, parameters, objective, and timeout]
+argument-hint: "[task-description — include program, parameters, objective, and timeout]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit
 ---
 

--- a/skills/embodiment-description/SKILL.md
+++ b/skills/embodiment-description/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: embodiment-description
 description: "Write detailed embodiment descriptions for patent specifications. Use when user says \"撰写实施例\", \"write embodiment\", \"实施例描述\", \"detailed description\", or wants to describe how to practice an invention."
-argument-hint: [claims-path-or-embodiment-details]
+argument-hint: "[claims-path-or-embodiment-details]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: exa-search
 description: AI-powered web search via Exa with content extraction. Use when user says "exa search", "web search with content", "find similar pages", or needs broad web results beyond academic databases (arXiv, Semantic Scholar).
-argument-hint: [search-query-or-url]
+argument-hint: "[search-query-or-url]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/experiment-audit/SKILL.md
+++ b/skills/experiment-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment-audit
 description: "Audit experiment integrity before claiming results. Uses cross-model review (external reviewer backend) to check for fake ground truth, score normalization fraud, phantom results, and insufficient scope. Use when user says \"审计实验\", \"check experiment integrity\", \"audit results\", \"实验诚实度\", or after experiments complete before writing claims."
-argument-hint: [experiment-dir-or-results-path]
+argument-hint: "[experiment-dir-or-results-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__codex__codex, mcp__codex__codex-reply, mcp__manual_review__review, mcp__manual_review__review_reply
 ---
 

--- a/skills/experiment-bridge/SKILL.md
+++ b/skills/experiment-bridge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment-bridge
 description: "Workflow 1.5: Bridge between idea discovery and auto review. Reads EXPERIMENT_PLAN.md, implements experiment code, deploys to GPU, collects initial results. Use when user says \"实现实验\", \"implement experiments\", \"bridge\", \"从计划到跑实验\", \"deploy the plan\", or has an experiment plan ready to execute."
-argument-hint: [experiment-plan-path-or-topic]
+argument-hint: "[experiment-plan-path-or-topic]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/experiment-queue/SKILL.md
+++ b/skills/experiment-queue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment-queue
 description: SSH job queue for multi-seed/multi-config ML experiments with OOM-aware retry, stale-screen cleanup, and wave-transition race prevention. Use when user says "batch experiments", "队列实验", "run grid", "multi-seed sweep", "auto-chain experiments", or when /run-experiment is insufficient for 10+ jobs that need orchestration.
-argument-hint: [manifest-or-grid-spec]
+argument-hint: "[manifest-or-grid-spec]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Skill(run-experiment), Skill(monitor-experiment)
 ---
 

--- a/skills/feishu-notify/SKILL.md
+++ b/skills/feishu-notify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: feishu-notify
 description: "Send notifications to Feishu/Lark. Internal utility used by other skills, or manually via /feishu-notify. Use when user says \"发飞书\", \"notify feishu\", or other skills need to send status updates."
-argument-hint: [message-text]
+argument-hint: "[message-text]"
 allowed-tools: Bash(curl *), Bash(cat *), Read, Glob
 ---
 

--- a/skills/figure-description/SKILL.md
+++ b/skills/figure-description/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: figure-description
 description: "Process user-provided patent figures and generate formal drawing descriptions. Use when user says \"附图处理\", \"figure description\", \"附图说明\", \"drawings description\", or wants to describe patent figures with reference numerals."
-argument-hint: [figure-directory-or-figure-list]
+argument-hint: "[figure-directory-or-figure-list]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/skills/figure-spec/SKILL.md
+++ b/skills/figure-spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: figure-spec
 description: "Generate deterministic publication-quality architecture, workflow, and pipeline diagrams from structured JSON (FigureSpec) into editable SVG. Use when user says \"架构图\", \"workflow 图\", \"pipeline 图\", \"确定性矢量图\", \"figure spec\", \"draw architecture\", or needs precise, editable, publication-ready vector diagrams. Preferred over AI illustration for formal architecture/workflow figures."
-argument-hint: [description-of-diagram]
+argument-hint: "[description-of-diagram]"
 allowed-tools: Bash(*), Read, Write, Edit
 ---
 

--- a/skills/formula-derivation/SKILL.md
+++ b/skills/formula-derivation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: formula-derivation
 description: Structures and derives research formulas when the user wants to 推导公式, build a theory line, organize assumptions, turn scattered equations into a coherent derivation, or rewrite theory notes into a paper-ready formula document. Use when the derivation target is not yet fully fixed, the main object still needs to be chosen, or the user needs a coherent derivation package rather than a finished theorem proof.
-argument-hint: [problem-goal-current-formulas-or-notes]
+argument-hint: "[problem-goal-current-formulas-or-notes]"
 allowed-tools: Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/gemini-search/SKILL.md
+++ b/skills/gemini-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gemini-search
 description: Search research papers via Gemini for broad literature discovery. Use when user says "gemini search", "gemini papers", "search with gemini", or wants AI-powered literature discovery beyond arXiv/Semantic Scholar indexes.
-argument-hint: [search-query]
+argument-hint: "[search-query]"
 allowed-tools: Bash(*), Read, Write, mcp__gemini-cli__*
 ---
 

--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idea-creator
 description: Generate and rank research ideas given a broad direction. Use when user says "找idea", "brainstorm ideas", "generate research ideas", "what can we work on", or wants to explore a research area for publishable directions.
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply, mcp__manual_review__review, mcp__manual_review__review_reply
 ---
 

--- a/skills/idea-discovery-robot/SKILL.md
+++ b/skills/idea-discovery-robot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idea-discovery-robot
 description: "Workflow 1 adaptation for robotics and embodied AI. Orchestrates robotics-aware literature survey, idea generation, novelty check, and critical review to go from a broad robotics direction to benchmark-grounded, simulation-first ideas. Use when user says \"robotics idea discovery\", \"机器人找idea\", \"embodied AI idea\", \"机器人方向探索\", \"sim2real 选题\", or wants ideas for manipulation, locomotion, navigation, drones, humanoids, or general robot learning."
-argument-hint: [robotics-direction]
+argument-hint: "[robotics-direction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idea-discovery
 description: "Workflow 1: Full idea discovery pipeline to go from a broad research direction to validated, pilot-tested ideas. Use when user says \"找idea全流程\", \"idea discovery pipeline\", \"从零开始找方向\", or wants the complete idea exploration workflow."
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Skill, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/integrity-forensics/SKILL.md
+++ b/skills/integrity-forensics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: integrity-forensics
 description: "Run the Anti-Autoresearch integrity-forensics sweep (span-anchored evidence ledger → GPT auditors propose findings → deterministic rules-only adjudicator) against a paper via a SHA-pinned thin launcher — then convert the verdict into a typed policy gate (BLOCK/WARN/NO_NEW_BLOCKER) and an append-only obligations ledger. Use when user says \"integrity forensics\", \"forensic audit this paper\", \"投稿前自查诚信\", \"审这篇论文的诚信\", or says \"anti-autoresearch\" when the upstream repo's own skills are not installed. Also invoked by /paper-writing (submission self-forensics, default ON), /peer-review (forensic appendix), /resubmit-pipeline."
-argument-hint: [paper-dir | pdf | arxiv-id]
+argument-hint: "[paper-dir | pdf | arxiv-id]"
 allowed-tools: Bash(*), Read, Write, Grep, Glob, mcp__codex__codex
 ---
 

--- a/skills/invention-structuring/SKILL.md
+++ b/skills/invention-structuring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: invention-structuring
 description: "Structure a raw invention idea into a formal invention disclosure. Use when user says \"构建发明\", \"structure invention\", \"发明构建\", \"invention disclosure\", or wants to formalize a rough idea into a patent-ready structure."
-argument-hint: [invention-description-or-brief-path]
+argument-hint: "[invention-description-or-brief-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__codex__codex
 ---
 

--- a/skills/jurisdiction-format/SKILL.md
+++ b/skills/jurisdiction-format/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: jurisdiction-format
 description: "Compile patent application into jurisdiction-specific filing format. Use when user says \"格式转换\", \"jurisdiction format\", \"国家格式\", \"compile patent\", or wants formatted patent documents for CN/US/EP filing."
-argument-hint: [patent-directory-or-jurisdiction]
+argument-hint: "[patent-directory-or-jurisdiction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/kill-argument/SKILL.md
+++ b/skills/kill-argument/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kill-argument
 description: "Two-thread adversarial review: a fresh reviewer constructs the strongest 200-word rejection memo, then a second fresh reviewer defends the paper point-by-point and surfaces still-unresolved critical issues. Use when user says \"kill argument\", \"adversarial review\", \"hostile review\", \"rebuttal preparation\", \"reviewer-2 simulation\", or before submitting a theory paper that has already passed standard review rounds."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__codex__codex
 ---
 

--- a/skills/mermaid-diagram/SKILL.md
+++ b/skills/mermaid-diagram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mermaid-diagram
 description: "Generate Mermaid diagrams from user requirements. Supports flowcharts, sequence diagrams, class diagrams, ER diagrams, Gantt charts, and 18 more diagram types."
-argument-hint: [diagram description or requirements]
+argument-hint: "[diagram description or requirements]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep
 ---
 

--- a/skills/meta-apply/SKILL.md
+++ b/skills/meta-apply/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meta-apply
 description: "Privileged applier that LANDS meta-optimize / corpus-audit patches the user approved — the ONLY skill permitted to mutate the skill corpus from a self-modification proposal, with cross-model jury and human approval at landing. Use when the user says \"meta apply\", \"/meta-apply\", \"land the staged patches\", \"应用优化\", after a /meta-optimize run."
-argument-hint: [patch-number-or-all]
+argument-hint: "[patch-number-or-all]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/meta-optimize/SKILL.md
+++ b/skills/meta-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meta-optimize
 description: "Analyze ARIS usage logs and propose optimizations to SKILL.md files, reviewer prompts, and workflow defaults. Outer-loop harness optimization inspired by Meta-Harness (Lee et al., 2026). Use when user says \"优化技能\", \"meta optimize\", \"improve skills\", \"分析使用记录\", or wants to optimize ARIS's own harness components based on accumulated experience."
-argument-hint: [target-skill-or-all]
+argument-hint: "[target-skill-or-all]"
 allowed-tools: Bash(*), Read, Grep, Glob, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/monitor-experiment/SKILL.md
+++ b/skills/monitor-experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: monitor-experiment
 description: Monitor running experiments, check progress, collect results. Use when user says "check results", "is it done", "monitor", or wants experiment output.
-argument-hint: [server-alias or screen-name]
+argument-hint: "[server-alias or screen-name]"
 allowed-tools: Bash(ssh *), Bash(echo *), Read, Write, Edit
 ---
 

--- a/skills/novelty-check/SKILL.md
+++ b/skills/novelty-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: novelty-check
 description: Verify research idea novelty against recent literature. Use when user says "查新", "novelty check", "有没有人做过", "check novelty", or wants to verify a research idea is novel before implementing.
-argument-hint: [method-or-idea-description]
+argument-hint: "[method-or-idea-description]"
 allowed-tools: WebSearch, WebFetch, Grep, Read, Glob, mcp__codex__codex
 ---
 

--- a/skills/openalex/SKILL.md
+++ b/skills/openalex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openalex
 description: Search academic papers via OpenAlex API for open citation data, institutional affiliations, and funding information. Use when user says "openalex search", "search openalex", "open citation graph", or wants comprehensive academic metadata beyond arXiv/Semantic Scholar.
-argument-hint: [search-query]
+argument-hint: "[search-query]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/overleaf-sync/SKILL.md
+++ b/skills/overleaf-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: overleaf-sync
 description: "Two-way sync between a local paper directory and an Overleaf project, so ARIS audit/edit workflows stay on the local copy while collaborators edit in the Overleaf web UI. Use when user says \"同步 overleaf\", \"overleaf sync\", \"推送到 overleaf\", \"connect overleaf\", \"Overleaf 桥接\", \"pull overleaf\", \"push overleaf\", or wants to bridge their ARIS paper directory with an Overleaf project."
-argument-hint: [setup <project-id> | pull | push | status]
+argument-hint: "[setup <project-id> | pull | push | status]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write
 ---
 

--- a/skills/paper-claim-audit/SKILL.md
+++ b/skills/paper-claim-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-claim-audit
 description: "Zero-context verification that every number, comparison, and scope claim in the paper matches raw result files. Uses a fresh cross-model reviewer with NO prior context to prevent confirmation bias. Use when user says \"审查论文数据\", \"check paper claims\", \"verify numbers\", \"论文数字核对\", or before submission to ensure paper-to-evidence fidelity."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__codex__codex
 ---
 

--- a/skills/paper-compile/SKILL.md
+++ b/skills/paper-compile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-compile
 description: "Compile LaTeX paper to PDF, fix errors, and verify output. Use when user says \"编译论文\", \"compile paper\", \"build PDF\", \"生成PDF\", or wants to compile LaTeX into a submission-ready PDF."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/paper-figure/SKILL.md
+++ b/skills/paper-figure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-figure
 description: "Generate publication-quality figures and tables from experiment results. Use when user says \"画图\", \"作图\", \"generate figures\", \"paper figures\", or needs plots for a paper."
-argument-hint: [figure-plan-or-data-path]
+argument-hint: "[figure-plan-or-data-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/paper-illustration-image2/SKILL.md
+++ b/skills/paper-illustration-image2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-illustration-image2
 description: "Generate publication-quality academic illustrations through a local Codex app-server bridge that uses Codex native image generation. This is a separate experimental alternative to `paper-illustration`, intended for Claude Code users who want a GPT-image-style renderer without modifying the original skill."
-argument-hint: [description-or-method-file]
+argument-hint: "[description-or-method-file]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, mcp__codex-image2__generate, mcp__codex-image2__generate_start, mcp__codex-image2__generate_status, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/paper-poster/SKILL.md
+++ b/skills/paper-poster/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster
 description: "DEPRECATED — superseded by /paper-poster-html. Kept only as a redirect for muscle memory; do not use for new posters."
-argument-hint: [paper-dir-or-pdf]
+argument-hint: "[paper-dir-or-pdf]"
 allowed-tools: Read
 ---
 

--- a/skills/patent-novelty-check/SKILL.md
+++ b/skills/patent-novelty-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: patent-novelty-check
 description: "Assess patent novelty and non-obviousness against prior art. Use when user says \"专利查新\", \"patent novelty\", \"可专利性评估\", \"patentability check\", or wants to evaluate if an invention is patentable."
-argument-hint: [invention-description-or-brief-path]
+argument-hint: "[invention-description-or-brief-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, mcp__codex__codex
 ---
 

--- a/skills/patent-pipeline/SKILL.md
+++ b/skills/patent-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: patent-pipeline
 description: "Full patent drafting pipeline from invention description to jurisdiction-formatted filing documents. Supports CN (CNIPA), US (USPTO), EP (EPO). Supports invention patents and utility models. Use when user says \"写专利\", \"patent pipeline\", \"专利申请\", \"draft patent\", \"写权利要求书\", or wants to draft a complete patent application."
-argument-hint: [invention-description — jurisdiction]
+argument-hint: "[invention-description — jurisdiction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Skill, mcp__codex__codex
 ---
 

--- a/skills/patent-review/SKILL.md
+++ b/skills/patent-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: patent-review
 description: "Get an external patent examiner review of a patent application. Use when user says \"专利审查\", \"patent review\", \"审查意见\", \"examiner review\", or wants critical feedback on patent claims and specification."
-argument-hint: [patent-directory-or-scope]
+argument-hint: "[patent-directory-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/pixel-art/SKILL.md
+++ b/skills/pixel-art/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pixel-art
 description: Generate pixel art SVG illustrations for READMEs, docs, or slides. Use when user says "画像素图", "pixel art", "make an SVG illustration", "README hero image", or wants a cute visual.
-argument-hint: [description of what to draw]
+argument-hint: "[description of what to draw]"
 allowed-tools: Write, Edit, Read, Bash(open *)
 ---
 

--- a/skills/prior-art-search/SKILL.md
+++ b/skills/prior-art-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prior-art-search
 description: "Search patent databases and academic literature for prior art relevant to an invention. Use when user says \"现有技术检索\", \"prior art search\", \"专利检索\", \"check patents\", or wants to find relevant prior art."
-argument-hint: [invention-description-or-path]
+argument-hint: "[invention-description-or-path]"
 allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write
 ---
 

--- a/skills/proof-writer/SKILL.md
+++ b/skills/proof-writer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: proof-writer
 description: Writes rigorous mathematical proofs for ML/AI theory. Use when asked to prove a theorem, lemma, proposition, or corollary, fill in missing proof steps, formalize a proof sketch, 补全证明, 写证明, 证明某个命题, or determine whether a claimed proof can actually be completed under the stated assumptions.
-argument-hint: [theorem-statement-and-assumptions]
+argument-hint: "[theorem-statement-and-assumptions]"
 allowed-tools: Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/qzcli/SKILL.md
+++ b/skills/qzcli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qzcli
 description: Manage GPU compute jobs on the Qizhi (启智) platform using qzcli — a kubectl-style CLI tool. Use when user says "qzcli", "启智平台", "submit job", "stop job", "查计算组", "avail", "list jobs", "batch submit", or needs to manage distributed training jobs on a Qizhi instance.
-argument-hint: [login|avail|list|create|stop <job-id>|batch|status|watch]
+argument-hint: "[login|avail|list|create|stop <job-id>|batch|status|watch]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/rebuttal/SKILL.md
+++ b/skills/rebuttal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rebuttal
 description: "Workflow 4: Submission rebuttal pipeline. Parses external reviews, enforces coverage and grounding, drafts a safe text-only rebuttal under venue limits, and manages follow-up rounds. Use when user says \"rebuttal\", \"reply to reviewers\", \"ICML rebuttal\", \"OpenReview response\", or wants to answer external reviews safely."
-argument-hint: [paper-path-or-review-bundle]
+argument-hint: "[paper-path-or-review-bundle]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Skill, mcp__codex__codex, mcp__codex__codex-reply, mcp__manual_review__review, mcp__manual_review__review_reply
 ---
 

--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-lit
 description: Search and analyze research papers, find related work, summarize key ideas. Use when user says "find papers", "related work", "literature review", "what does this paper say", or needs to understand academic papers.
-argument-hint: [paper-topic-or-url]
+argument-hint: "[paper-topic-or-url]"
 allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write, Agent, mcp__zotero__*, mcp__obsidian-vault__*
 ---
 

--- a/skills/research-review/SKILL.md
+++ b/skills/research-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-review
 description: Get a deep critical review of research from an external reviewer backend (Codex or manual). Use when user says "review my research", "help me review", "get external review", or wants critical feedback on research ideas, papers, or experimental results.
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply, mcp__manual_review__review, mcp__manual_review__review_reply
 ---
 

--- a/skills/research-wiki/SKILL.md
+++ b/skills/research-wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-wiki
 description: "Persistent research knowledge base that accumulates papers, ideas, experiments, claims, and their relationships across the entire research lifecycle. Inspired by Karpathy's LLM Wiki pattern. Use when user says \"知识库\", \"research wiki\", \"add paper\", \"wiki query\", \"查知识库\", or wants to build/query a persistent field map."
-argument-hint: [subcommand: init|ingest|sync|query|update|lint|stats]
+argument-hint: "[subcommand: init|ingest|sync|query|update|lint|stats]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/result-to-claim/SKILL.md
+++ b/skills/result-to-claim/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: result-to-claim
 description: Use when experiments complete to judge what claims the results support, what they don't, and what evidence is still missing. Codex MCP evaluates results against intended claims and routes to next action (pivot, supplement, or confirm). Use after experiments finish — before writing the paper or running ablations.
-argument-hint: [experiment-description-or-wandb-run]
+argument-hint: "[experiment-description-or-wandb-run]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-experiment
 description: Deploy and run ML experiments on local, remote, Vast.ai, or Modal serverless GPU. Use when user says "run experiment", "deploy to server", "跑实验", or needs to launch training jobs.
-argument-hint: [experiment-description]
+argument-hint: "[experiment-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Skill(serverless-modal)
 ---
 

--- a/skills/serverless-modal/SKILL.md
+++ b/skills/serverless-modal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: serverless-modal
 description: "Run GPU workloads on Modal — training, fine-tuning, inference, batch processing. Zero-config serverless: no SSH, no Docker, auto scale-to-zero. Use when user says \"modal run\", \"modal training\", \"modal inference\", \"deploy to modal\", \"need a GPU\", \"run on modal\", \"serverless GPU\", or needs remote GPU compute."
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write
 ---
 

--- a/skills/skills-codex-gemini-review/paper-slides/SKILL.md
+++ b/skills/skills-codex-gemini-review/paper-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-slides
 description: "Generate conference presentation slides (beamer LaTeX → PDF + editable PPTX) from a compiled paper, with speaker notes and full talk script. Use when user says \"做PPT\", \"做幻灯片\", \"make slides\", \"conference talk\", \"presentation slides\", \"生成slides\", \"写演讲稿\", or wants beamer slides for a conference talk."
-argument-hint: [paper-directory-or-talk-length]
+argument-hint: "[paper-directory-or-talk-length]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, mcp__gemini-review__review, mcp__gemini-review__review_start, mcp__gemini-review__review_reply_start, mcp__gemini-review__review_status
 ---
 

--- a/skills/skills-codex/alphaxiv/SKILL.md
+++ b/skills/skills-codex/alphaxiv/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: alphaxiv
 description: Quick single-paper lookup via AlphaXiv LLM-optimized summaries with tiered source fallback. Use when user says "explain this paper", "summarize paper", pastes an arXiv/AlphaXiv URL, or provides a bare arXiv ID for quick understanding - not for broad literature search.
-argument-hint: [arxiv-id-or-url]
+argument-hint: "[arxiv-id-or-url]"
 allowed-tools: Bash(*), Read, Write, Glob
 ---
 

--- a/skills/skills-codex/claims-drafting/SKILL.md
+++ b/skills/skills-codex/claims-drafting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claims-drafting
 description: "Draft patent claims for an invention. Use when user says \"撰写权利要求\", \"draft claims\", \"写权利要求书\", \"claim drafting\", or wants to create patent claims. The core skill of the patent pipeline."
-argument-hint: [invention-disclosure-path]
+argument-hint: "[invention-disclosure-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/skills/skills-codex/embodiment-description/SKILL.md
+++ b/skills/skills-codex/embodiment-description/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: embodiment-description
 description: "Write detailed embodiment descriptions for patent specifications. Use when user says \"撰写实施例\", \"write embodiment\", \"实施例描述\", \"detailed description\", or wants to describe how to practice an invention."
-argument-hint: [claims-path-or-embodiment-details]
+argument-hint: "[claims-path-or-embodiment-details]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/exa-search/SKILL.md
+++ b/skills/skills-codex/exa-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: exa-search
 description: AI-powered web search via Exa with content extraction. Use when user says "exa search", "web search with content", "find similar pages", or needs broad web results beyond academic databases (arXiv, Semantic Scholar).
-argument-hint: [search-query-or-url]
+argument-hint: "[search-query-or-url]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/skills-codex/experiment-audit/SKILL.md
+++ b/skills/skills-codex/experiment-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment-audit
 description: "Audit experiment integrity before claiming results. Uses fresh-agent GPT-5.6-Sol review (same-family provisional in the base Codex mirror) to check for fake ground truth, score normalization fraud, phantom results, and insufficient scope. Use when user says \"审计实验\", \"check experiment integrity\", \"audit results\", \"实验诚实度\", or after experiments complete before writing claims."
-argument-hint: [experiment-dir-or-results-path]
+argument-hint: "[experiment-dir-or-results-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/experiment-queue/SKILL.md
+++ b/skills/skills-codex/experiment-queue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment-queue
 description: SSH job queue for multi-seed/multi-config ML experiments with OOM-aware retry, stale-screen cleanup, and wave-transition race prevention. Use when user says "batch experiments", "队列实验", "run grid", "multi-seed sweep", "auto-chain experiments", or when /run-experiment is insufficient for 10+ jobs that need orchestration.
-argument-hint: [manifest-or-grid-spec]
+argument-hint: "[manifest-or-grid-spec]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Skill(run-experiment), Skill(monitor-experiment)
 ---
 

--- a/skills/skills-codex/figure-description/SKILL.md
+++ b/skills/skills-codex/figure-description/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: figure-description
 description: "Process user-provided patent figures and generate formal drawing descriptions. Use when user says \"附图处理\", \"figure description\", \"附图说明\", \"drawings description\", or wants to describe patent figures with reference numerals."
-argument-hint: [figure-directory-or-figure-list]
+argument-hint: "[figure-directory-or-figure-list]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/skills/skills-codex/figure-spec/SKILL.md
+++ b/skills/skills-codex/figure-spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: figure-spec
 description: "Generate deterministic publication-quality architecture, workflow, and pipeline diagrams from structured JSON (FigureSpec) into editable SVG. Use when user says \"架构图\", \"workflow 图\", \"pipeline 图\", \"确定性矢量图\", \"figure spec\", \"draw architecture\", or needs precise, editable, publication-ready vector diagrams. Preferred over AI illustration for formal architecture/workflow figures."
-argument-hint: [description-of-diagram]
+argument-hint: "[description-of-diagram]"
 allowed-tools: Bash(*), Read, Write, Edit
 ---
 

--- a/skills/skills-codex/formula-derivation/SKILL.md
+++ b/skills/skills-codex/formula-derivation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: formula-derivation
 description: Structures and derives research formulas when the user wants to 推导公式, build a theory line, organize assumptions, turn scattered equations into a coherent derivation, or rewrite theory notes into a paper-ready formula document. Use when the derivation target is not yet fully fixed, the main object still needs to be chosen, or the user needs a coherent derivation package rather than a finished theorem proof.
-argument-hint: [problem-goal-current-formulas-or-notes]
+argument-hint: "[problem-goal-current-formulas-or-notes]"
 allowed-tools: Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/gemini-search/SKILL.md
+++ b/skills/skills-codex/gemini-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gemini-search
 description: Search research papers via Gemini for broad literature discovery. Use when user says "gemini search", "gemini papers", "search with gemini", or wants AI-powered literature discovery beyond arXiv/Semantic Scholar indexes.
-argument-hint: [search-query]
+argument-hint: "[search-query]"
 allowed-tools: Bash(*), Read, Write, mcp__gemini-cli__*
 ---
 

--- a/skills/skills-codex/integrity-forensics/SKILL.md
+++ b/skills/skills-codex/integrity-forensics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: integrity-forensics
 description: "Run the Anti-Autoresearch integrity-forensics DETERMINISTIC slice (numeric core + rules-only adjudicator) against a paper via a SHA-pinned thin launcher, then convert the verdict into a typed policy gate (BLOCK/WARN/NO_NEW_BLOCKER) and an append-only obligations ledger. Codex-native limitation: upstream ships no Codex-native auditor pack, so the full nine-dimension semantic sweep requires a Claude Code session — this pack runs the honestly-scoped deterministic-only mode (it can flag, it can never say CLEAN). Use when user says \"integrity forensics\", \"forensic audit this paper\", \"投稿前自查诚信\"."
-argument-hint: [paper-dir | pdf | arxiv-id]
+argument-hint: "[paper-dir | pdf | arxiv-id]"
 ---
 
 # Integrity Forensics — thin launcher (Codex-native: deterministic slice)

--- a/skills/skills-codex/invention-structuring/SKILL.md
+++ b/skills/skills-codex/invention-structuring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: invention-structuring
 description: "Structure a raw invention idea into a formal invention disclosure. Use when user says \"构建发明\", \"structure invention\", \"发明构建\", \"invention disclosure\", or wants to formalize a rough idea into a patent-ready structure."
-argument-hint: [invention-description-or-brief-path]
+argument-hint: "[invention-description-or-brief-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/jurisdiction-format/SKILL.md
+++ b/skills/skills-codex/jurisdiction-format/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: jurisdiction-format
 description: "Compile patent application into jurisdiction-specific filing format. Use when user says \"格式转换\", \"jurisdiction format\", \"国家格式\", \"compile patent\", or wants formatted patent documents for CN/US/EP filing."
-argument-hint: [patent-directory-or-jurisdiction]
+argument-hint: "[patent-directory-or-jurisdiction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/kill-argument/SKILL.md
+++ b/skills/skills-codex/kill-argument/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kill-argument
 description: "Two-thread adversarial review: a fresh reviewer constructs the strongest 200-word rejection memo, then a second fresh reviewer defends the paper point-by-point and surfaces still-unresolved critical issues. Use when user says \"kill argument\", \"adversarial review\", \"hostile review\", \"rebuttal preparation\", \"reviewer-2 simulation\", or before submitting a theory paper that has already passed standard review rounds."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, spawn_agent
 ---
 

--- a/skills/skills-codex/meta-apply/SKILL.md
+++ b/skills/skills-codex/meta-apply/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meta-apply
 description: "Privileged applier that LANDS meta-optimize / corpus-audit patches the user approved, with a fresh landing review and human approval. Base Codex review is same-family provisional. Use when the user says \"meta apply\", \"/meta-apply\", \"land the staged patches\", \"应用优化\", after a /meta-optimize run."
-argument-hint: [patch-number-or-all]
+argument-hint: "[patch-number-or-all]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/meta-optimize/SKILL.md
+++ b/skills/skills-codex/meta-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meta-optimize
 description: "Analyze ARIS usage logs and propose optimizations to SKILL.md files, reviewer prompts, and workflow defaults. Outer-loop harness optimization inspired by Meta-Harness (Lee et al., 2026). Use when user says \"优化技能\", \"meta optimize\", \"improve skills\", \"分析使用记录\", or wants to optimize ARIS's own harness components based on accumulated experience."
-argument-hint: [target-skill-or-all]
+argument-hint: "[target-skill-or-all]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/openalex/SKILL.md
+++ b/skills/skills-codex/openalex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openalex
 description: Search academic papers via OpenAlex API for open citation data, institutional affiliations, and funding information. Use when user says "openalex search", "search openalex", "open citation graph", or wants comprehensive academic metadata beyond arXiv/Semantic Scholar.
-argument-hint: [search-query]
+argument-hint: "[search-query]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/skills-codex/overleaf-sync/SKILL.md
+++ b/skills/skills-codex/overleaf-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: overleaf-sync
 description: "Two-way sync between a local paper directory and an Overleaf project, so ARIS audit/edit workflows stay on the local copy while collaborators edit in the Overleaf web UI. Use when user says \"同步 overleaf\", \"overleaf sync\", \"推送到 overleaf\", \"connect overleaf\", \"Overleaf 桥接\", \"pull overleaf\", \"push overleaf\", or wants to bridge their ARIS paper directory with an Overleaf project."
-argument-hint: [setup <project-id> | pull | push | status]
+argument-hint: "[setup <project-id> | pull | push | status]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write
 ---
 

--- a/skills/skills-codex/paper-claim-audit/SKILL.md
+++ b/skills/skills-codex/paper-claim-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-claim-audit
 description: "Zero-context verification that every number, comparison, and scope claim in the paper matches raw result files. Uses a fresh Codex reviewer with no prior context; base output is same-family provisional. Use when user says \"审查论文数据\", \"check paper claims\", \"verify numbers\", \"论文数字核对\", or before submission to ensure paper-to-evidence fidelity."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/paper-illustration-image2/SKILL.md
+++ b/skills/skills-codex/paper-illustration-image2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-illustration-image2
 description: "Generate publication-quality academic illustrations through a local Codex app-server bridge that uses Codex native image generation. This is a separate experimental alternative to `paper-illustration`, intended for Claude Code users who want a GPT-image-style renderer without modifying the original skill."
-argument-hint: [description-or-method-file]
+argument-hint: "[description-or-method-file]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, mcp__codex-image2__generate, mcp__codex-image2__generate_start, mcp__codex-image2__generate_status, spawn_agent, send_input
 ---
 

--- a/skills/skills-codex/paper-poster/SKILL.md
+++ b/skills/skills-codex/paper-poster/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-poster
 description: "DEPRECATED — superseded by /paper-poster-html. Kept only as a redirect for muscle memory; do not use for new posters."
-argument-hint: [paper-dir-or-pdf]
+argument-hint: "[paper-dir-or-pdf]"
 allowed-tools: Read
 ---
 

--- a/skills/skills-codex/paper-slides/SKILL.md
+++ b/skills/skills-codex/paper-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-slides
 description: "Generate conference presentation slides (beamer LaTeX → PDF + editable PPTX) from a compiled paper, with speaker notes and full talk script. Use when user says \"做PPT\", \"做幻灯片\", \"make slides\", \"conference talk\", \"presentation slides\", \"生成slides\", \"写演讲稿\", or wants beamer slides for a conference talk."
-argument-hint: [paper-directory-or-talk-length]
+argument-hint: "[paper-directory-or-talk-length]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/paper-writing/SKILL.md
+++ b/skills/skills-codex/paper-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-writing
 description: "Workflow 3: Full paper writing pipeline that goes from a narrative report to a polished, submission-ready PDF. Use when user says \"写论文全流程\", \"write paper pipeline\", \"从报告到PDF\", \"paper writing\", or wants the complete paper generation workflow."
-argument-hint: [narrative-report-path-or-topic]
+argument-hint: "[narrative-report-path-or-topic]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Skill
 ---
 

--- a/skills/skills-codex/patent-novelty-check/SKILL.md
+++ b/skills/skills-codex/patent-novelty-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: patent-novelty-check
 description: "Assess patent novelty and non-obviousness against prior art. Use when user says \"专利查新\", \"patent novelty\", \"可专利性评估\", \"patentability check\", or wants to evaluate if an invention is patentable."
-argument-hint: [invention-description-or-brief-path]
+argument-hint: "[invention-description-or-brief-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/skills/skills-codex/patent-pipeline/SKILL.md
+++ b/skills/skills-codex/patent-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: patent-pipeline
 description: "Full patent drafting pipeline from invention description to jurisdiction-formatted filing documents. Supports CN (CNIPA), US (USPTO), EP (EPO). Supports invention patents and utility models. Use when user says \"写专利\", \"patent pipeline\", \"专利申请\", \"draft patent\", \"写权利要求书\", or wants to draft a complete patent application."
-argument-hint: [invention-description — jurisdiction]
+argument-hint: "[invention-description — jurisdiction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Skill
 ---
 

--- a/skills/skills-codex/patent-review/SKILL.md
+++ b/skills/skills-codex/patent-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: patent-review
 description: "Get an external patent examiner review of a patent application. Use when user says \"专利审查\", \"patent review\", \"审查意见\", \"examiner review\", or wants critical feedback on patent claims and specification."
-argument-hint: [patent-directory-or-scope]
+argument-hint: "[patent-directory-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit
 ---
 

--- a/skills/skills-codex/prior-art-search/SKILL.md
+++ b/skills/skills-codex/prior-art-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prior-art-search
 description: "Search patent databases and academic literature for prior art relevant to an invention. Use when user says \"现有技术检索\", \"prior art search\", \"专利检索\", \"check patents\", or wants to find relevant prior art."
-argument-hint: [invention-description-or-path]
+argument-hint: "[invention-description-or-path]"
 allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write
 ---
 

--- a/skills/skills-codex/proof-checker/SKILL.md
+++ b/skills/skills-codex/proof-checker/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: proof-checker
 description: Rigorous mathematical proof verification and fixing workflow. Reads a LaTeX proof, identifies gaps via fresh-agent Codex GPT-5.6-Sol ultra review, fixes each gap with full derivations, re-reviews, and generates an audit report. Base review is same-family provisional. Use when user says "检查证明", "verify proof", "proof check", "审证明", "check this proof", or wants rigorous mathematical verification of a theory paper.
-argument-hint: [path-to-tex-file or proof-description]
+argument-hint: "[path-to-tex-file or proof-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit
 ---
 

--- a/skills/skills-codex/qzcli/SKILL.md
+++ b/skills/skills-codex/qzcli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qzcli
 description: Manage GPU compute jobs on the Qizhi (启智) platform using qzcli — a kubectl-style CLI tool. Use when user says "qzcli", "启智平台", "submit job", "stop job", "查计算组", "avail", "list jobs", "batch submit", or needs to manage distributed training jobs on a Qizhi instance.
-argument-hint: [login|avail|list|create|stop <job-id>|batch|status|watch]
+argument-hint: "[login|avail|list|create|stop <job-id>|batch|status|watch]"
 allowed-tools: Bash(*), Read, Write
 ---
 

--- a/skills/skills-codex/rebuttal/SKILL.md
+++ b/skills/skills-codex/rebuttal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rebuttal
 description: "Workflow 4: Submission rebuttal pipeline. Parses external reviews, enforces coverage and grounding, drafts a safe text-only rebuttal under venue limits, and manages follow-up rounds. Use when user says \"rebuttal\", \"reply to reviewers\", \"ICML rebuttal\", \"OpenReview response\", or wants to answer external reviews safely."
-argument-hint: [paper-path-or-review-bundle]
+argument-hint: "[paper-path-or-review-bundle]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Skill
 ---
 

--- a/skills/skills-codex/research-wiki/SKILL.md
+++ b/skills/skills-codex/research-wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-wiki
 description: "Persistent research knowledge base that accumulates papers, ideas, experiments, claims, and their relationships across the entire research lifecycle. Inspired by Karpathy's LLM Wiki pattern. Use when user says \"知识库\", \"research wiki\", \"add paper\", \"wiki query\", \"查知识库\", or wants to build/query a persistent field map."
-argument-hint: [subcommand: init|ingest|sync|query|update|lint|stats]
+argument-hint: "[subcommand: init|ingest|sync|query|update|lint|stats]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/skills/skills-codex/result-to-claim/SKILL.md
+++ b/skills/skills-codex/result-to-claim/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: result-to-claim
 description: Use when experiments complete to judge what claims the results support, what they don't, and what evidence is still missing. A secondary Codex agent evaluates results against intended claims and routes to next action (pivot, supplement, or confirm). Use after experiments finish — before writing the paper or running ablations.
-argument-hint: [experiment-description-or-wandb-run]
+argument-hint: "[experiment-description-or-wandb-run]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit
 ---
 

--- a/skills/skills-codex/serverless-modal/SKILL.md
+++ b/skills/skills-codex/serverless-modal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: serverless-modal
 description: "Run GPU workloads on Modal — training, fine-tuning, inference, batch processing. Zero-config serverless: no SSH, no Docker, auto scale-to-zero. Use when user says \"modal run\", \"modal training\", \"modal inference\", \"deploy to modal\", \"need a GPU\", \"run on modal\", \"serverless GPU\", or needs remote GPU compute."
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write
 ---
 

--- a/skills/skills-codex/specification-writing/SKILL.md
+++ b/skills/skills-codex/specification-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specification-writing
 description: "Write the full patent specification from claims and invention disclosure. Use when user says \"撰写说明书\", \"write specification\", \"写说明书\", \"patent description\", or wants to draft the complete patent specification."
-argument-hint: [claims-path]
+argument-hint: "[claims-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Skill, WebSearch, WebFetch
 ---
 

--- a/skills/skills-codex/training-check/SKILL.md
+++ b/skills/skills-codex/training-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: training-check
 description: "Interactively monitor training metrics from the current Codex session, periodically checking WandB or fallback logs for NaN, divergence, plateaus, and broken runs."
-argument-hint: [wandb-run-or-monitoring-brief]
+argument-hint: "[wandb-run-or-monitoring-brief]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/vast-gpu/SKILL.md
+++ b/skills/skills-codex/vast-gpu/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vast-gpu
 description: "Rent, manage, and destroy GPU instances on vast.ai. Use when user says \"rent gpu\", \"vast.ai\", \"rent a server\", \"cloud gpu\", or needs on-demand GPU without owning hardware."
-argument-hint: [task-description or action]
+argument-hint: "[task-description or action]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/skills-codex/writing-systems-papers/SKILL.md
+++ b/skills/skills-codex/writing-systems-papers/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: writing-systems-papers
 description: "Paragraph-level structural blueprint for 10-12 page systems papers targeting OSDI, SOSP, ASPLOS, NSDI, and EuroSys. Provides page allocation, paragraph templates, and writing patterns. Use when user says \"写系统论文\", \"systems paper structure\", \"OSDI paper\", \"SOSP paper\", or wants fine-grained structural guidance for a systems conference submission."
-argument-hint: [venue-or-section]
+argument-hint: "[venue-or-section]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/skills/specification-writing/SKILL.md
+++ b/skills/specification-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specification-writing
 description: "Write the full patent specification from claims and invention disclosure. Use when user says \"撰写说明书\", \"write specification\", \"写说明书\", \"patent description\", or wants to draft the complete patent specification."
-argument-hint: [claims-path]
+argument-hint: "[claims-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Skill, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/training-check/SKILL.md
+++ b/skills/training-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: training-check
 description: Periodically check WandB metrics during training to catch problems early (NaN, loss divergence, idle GPUs). Avoids wasting GPU hours on broken runs. Use when training is running and you want automated health checks.
-argument-hint: [wandb-run-path]
+argument-hint: "[wandb-run-path]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 ---
 

--- a/skills/vast-gpu/SKILL.md
+++ b/skills/vast-gpu/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vast-gpu
 description: "Rent, manage, and destroy GPU instances on vast.ai. Use when user says \"rent gpu\", \"vast.ai\", \"rent a server\", \"cloud gpu\", or needs on-demand GPU without owning hardware."
-argument-hint: [task-description or action]
+argument-hint: "[task-description or action]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/writing-systems-papers/SKILL.md
+++ b/skills/writing-systems-papers/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: writing-systems-papers
 description: "Paragraph-level structural blueprint for 10-12 page systems papers targeting OSDI, SOSP, ASPLOS, NSDI, and EuroSys. Provides page allocation, paragraph templates, and writing patterns. Use when user says \"写系统论文\", \"systems paper structure\", \"OSDI paper\", \"SOSP paper\", or wants fine-grained structural guidance for a systems conference submission."
-argument-hint: [venue-or-section]
+argument-hint: "[venue-or-section]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 ---
 


### PR DESCRIPTION
Closes #358.

## Summary

Purely mechanical single-character transform to 97 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (97)

- `skills/skills-codex/paper-slides/SKILL.md`
- `skills/training-check/SKILL.md`
- `skills/figure-spec/SKILL.md`
- `skills/experiment-audit/SKILL.md`
- `skills/specification-writing/SKILL.md`
- `skills/kill-argument/SKILL.md`
- `skills/skills-codex/patent-pipeline/SKILL.md`
- `skills/proof-writer/SKILL.md`
- `skills/feishu-notify/SKILL.md`
- `skills/paper-claim-audit/SKILL.md`
- `skills/integrity-forensics/SKILL.md`
- `skills/skills-codex/exa-search/SKILL.md`
- `CONTRIBUTING.md`
- `skills/experiment-bridge/SKILL.md`
- `skills/claims-drafting/SKILL.md`
- `skills/skills-codex/gemini-search/SKILL.md`
- `skills/skills-codex/alphaxiv/SKILL.md`
- `skills/skills-codex/patent-novelty-check/SKILL.md`
- `skills/paper-illustration-image2/SKILL.md`
- `skills/experiment-queue/SKILL.md`
- `skills/rebuttal/SKILL.md`
- `skills/skills-codex/serverless-modal/SKILL.md`
- `skills/auto-review-loop-minimax/SKILL.md`
- `skills/skills-codex/experiment-queue/SKILL.md`
- `skills/monitor-experiment/SKILL.md`
- `skills/figure-description/SKILL.md`
- `skills/gemini-search/SKILL.md`
- `skills/pixel-art/SKILL.md`
- `skills/skills-codex/result-to-claim/SKILL.md`
- `skills/result-to-claim/SKILL.md`
- `skills/idea-creator/SKILL.md`
- `skills/skills-codex/vast-gpu/SKILL.md`
- `skills/idea-discovery/SKILL.md`
- `skills/vast-gpu/SKILL.md`
- `CONTRIBUTING_CN.md`
- `skills/mermaid-diagram/SKILL.md`
- `skills/skills-codex/paper-claim-audit/SKILL.md`
- `skills/skills-codex/qzcli/SKILL.md`
- `skills/skills-codex/jurisdiction-format/SKILL.md`
- `skills/patent-review/SKILL.md`
- `skills/skills-codex/specification-writing/SKILL.md`
- `skills/skills-codex/paper-writing/SKILL.md`
- `skills/qzcli/SKILL.md`
- `skills/meta-optimize/SKILL.md`
- `skills/jurisdiction-format/SKILL.md`
- `skills/meta-apply/SKILL.md`
- `skills/idea-discovery-robot/SKILL.md`
- `skills/skills-codex/writing-systems-papers/SKILL.md`
- `skills/skills-codex/kill-argument/SKILL.md`
- `skills/analyze-results/SKILL.md`
- `skills/skills-codex/paper-illustration-image2/SKILL.md`
- `skills/research-lit/SKILL.md`
- `skills/formula-derivation/SKILL.md`
- `skills/skills-codex/figure-spec/SKILL.md`
- `skills/paper-poster/SKILL.md`
- `skills/prior-art-search/SKILL.md`
- `skills/skills-codex/meta-optimize/SKILL.md`
- `skills/dse-loop/SKILL.md`
- `skills/skills-codex/meta-apply/SKILL.md`
- `skills/paper-compile/SKILL.md`
- `skills/skills-codex/research-wiki/SKILL.md`
- `skills/deepxiv/SKILL.md`
- `skills/patent-novelty-check/SKILL.md`
- `skills/run-experiment/SKILL.md`
- `skills/novelty-check/SKILL.md`
- `skills/skills-codex/proof-checker/SKILL.md`
- `skills/skills-codex/prior-art-search/SKILL.md`
- `skills/paper-figure/SKILL.md`
- `skills/ablation-planner/SKILL.md`
- `skills/skills-codex/overleaf-sync/SKILL.md`
- `skills/auto-review-loop/SKILL.md`
- `skills/invention-structuring/SKILL.md`
- `skills/serverless-modal/SKILL.md`
- `skills/skills-codex/paper-poster/SKILL.md`
- `skills/research-wiki/SKILL.md`
- `skills/alphaxiv/SKILL.md`
- `skills/openalex/SKILL.md`
- `skills/skills-codex/invention-structuring/SKILL.md`
- `skills/skills-codex-gemini-review/paper-slides/SKILL.md`
- `skills/skills-codex/experiment-audit/SKILL.md`
- `skills/skills-codex/formula-derivation/SKILL.md`
- `skills/patent-pipeline/SKILL.md`
- `skills/skills-codex/patent-review/SKILL.md`
- `skills/arxiv/SKILL.md`
- `skills/skills-codex/openalex/SKILL.md`
- `skills/skills-codex/figure-description/SKILL.md`
- `skills/skills-codex/rebuttal/SKILL.md`
- `skills/skills-codex/claims-drafting/SKILL.md`
- `skills/embodiment-description/SKILL.md`
- `skills/overleaf-sync/SKILL.md`
- `skills/skills-codex/embodiment-description/SKILL.md`
- `skills/skills-codex/training-check/SKILL.md`
- `skills/auto-review-loop-llm/SKILL.md`
- `skills/writing-systems-papers/SKILL.md`
- `skills/skills-codex/integrity-forensics/SKILL.md`
- `skills/research-review/SKILL.md`
- `skills/exa-search/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- Regression sweep: no unquoted-bracket `argument-hint:` lines remain in these files
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
