### PR TITLE
docs: point Quick Start at selective install; fix stale --apply comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,10 +399,12 @@ Two outputs: `PASTE_READY.txt` (exact char count, paste to venue) + `REBUTTAL_DR
 git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git
 bash Auto-claude-code-research-in-sleep/tools/install_aris.sh ~/your-project   # symlinks ARIS skills into <project>/.claude/skills/
 # (prefer a global install instead? cp -r Auto-claude-code-research-in-sleep/skills/* ~/.claude/skills/)
+# (don't need all 80? --list-groups / --groups X,Y / --skills X — see "Selective install" below)
 
 # 1b. Update later (when upstream changes)
 cd Auto-claude-code-research-in-sleep && git pull
 bash tools/smart_update.sh --apply   # updates safe skills, flags your personal customizations
+# (NEW upstream skills need confirmation — --add-new to accept all non-interactively)
 
 # Optional Codex mirror managed project install
 bash tools/install_aris_codex.sh ~/your-codex-project
@@ -1536,7 +1538,8 @@ git pull
 
 # 🧠 Smart update (recommended) — analyzes what's safe to update
 bash tools/smart_update.sh          # dry-run: shows what would change
-bash tools/smart_update.sh --apply  # apply: adds new + updates safe ones
+bash tools/smart_update.sh --apply  # apply: updates safe ones; NEW upstream skills prompt
+                                     # one-by-one on a TTY, or use --add-new / --skip-new
 
 # Manual options (if you prefer):
 # cp -r skills/* ~/.claude/skills/       # Option A: overwrite all

--- a/README_CN.md
+++ b/README_CN.md
@@ -366,6 +366,7 @@ ARIS 读论文 → 找弱点 → 克隆代码 → 针对*那些*弱点用*那套
 git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git
 bash Auto-claude-code-research-in-sleep/tools/install_aris.sh ~/your-project   # 把 ARIS skill symlink 进 <project>/.claude/skills/
 # （想全局安装？cp -r Auto-claude-code-research-in-sleep/skills/* ~/.claude/skills/）
+# （不需要全部 80 个？--list-groups / --groups X,Y / --skills X —— 见下方"选择性安装"）
 
 # 可选：Codex mirror 项目级受管安装
 bash Auto-claude-code-research-in-sleep/tools/install_aris_codex.sh ~/your-codex-project


### PR DESCRIPTION
## Summary
- Quick Start's install/update commands (EN + CN) predate #366 and never mentioned the new `--list-groups`/`--groups`/`--skills`/`--add-new`/`--skip-new` options — added one-line pointers at the point of first contact, to the full example that already exists further down both READMEs.
- Fixed a comment that went stale post-#366: `# apply: adds new + updates safe ones` is no longer accurate — a non-interactive `--apply` run *skips* new upstream skills by default (three-state new-skill policy), it does not add them.

## Validation
- `python3 -m pytest tests/ -q` → 525 passed, 16 skipped
- `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)