### PR TITLE
fix: tolerate unsupported picker cursor visibility

### DIFF
--- a/tests/test_skill_picker.py
+++ b/tests/test_skill_picker.py
@@ -7,9 +7,12 @@ end-to-end tests drive the real curses UI through a pty via expect
 """
 import importlib.util
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PICKER = REPO_ROOT / "tools" / "skill_picker.py"
@@ -105,6 +108,52 @@ class ModelTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 2)
         self.assertFalse(out.exists())
+
+    def test_run_picker_continues_when_cursor_visibility_is_unsupported(self):
+        class FakeCursesError(Exception):
+            pass
+
+        class FakeScreen:
+            def keypad(self, enabled):
+                self.keypad_enabled = enabled
+
+            def getmaxyx(self):
+                return 24, 80
+
+            def erase(self):
+                pass
+
+            def addnstr(self, *args):
+                pass
+
+            def refresh(self):
+                pass
+
+            def getch(self):
+                return 10
+
+        def curs_set(_visibility):
+            raise FakeCursesError("curs_set() returned ERR")
+
+        fake_curses = SimpleNamespace(
+            A_BOLD=1,
+            A_NORMAL=0,
+            A_REVERSE=2,
+            KEY_DOWN=258,
+            KEY_ENTER=343,
+            KEY_NPAGE=338,
+            KEY_PPAGE=339,
+            KEY_UP=259,
+            curs_set=curs_set,
+            error=FakeCursesError,
+            wrapper=lambda callback: callback(FakeScreen()),
+        )
+        rows = sp.build_rows(self.groups, self.skills, ["alpha"])
+
+        with mock.patch.dict(sys.modules, {"curses": fake_curses}):
+            confirmed = sp.run_picker(rows, set())
+
+        self.assertTrue(confirmed)
 
 
 @unittest.skipUnless(Path("/usr/bin/expect").exists(), "expect not available")

--- a/tools/skill_picker.py
+++ b/tools/skill_picker.py
@@ -140,7 +140,11 @@ def run_picker(rows, selected):  # pragma: no cover — curses UI, tested via pt
     import curses
 
     def main(stdscr):
-        curses.curs_set(0)
+        # Some terminals support curses drawing but not cursor visibility changes.
+        try:
+            curses.curs_set(0)
+        except curses.error:
+            pass
         stdscr.keypad(True)
         cursor, offset = 0, 0
         while True:


### PR DESCRIPTION
## Summary

- keep the curses checkbox picker usable when a terminal supports drawing but rejects cursor visibility changes
- treat `curses.curs_set(0)` as an optional visual enhancement while preserving the existing fallback for other curses failures
- add a focused regression test that reproduces the `curs_set() returned ERR` behavior observed in Windows Git Bash

## Motivation

On some Windows Git Bash terminals, the interactive installer currently abandons the full checkbox picker and falls back to per-group prompts because hiding the cursor returns `ERR`. Cursor visibility does not affect picker functionality, so this cosmetic capability should not disable the otherwise working interface.

## Testing

- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m pytest tests/test_skill_picker.py -q` — 9 passed, 3 skipped
- `git diff --check`
- manually verified the installer checkbox interface in Windows Git Bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)