### PR TITLE
feat(idea-discovery): add per-stage evidence gate

### DIFF
--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -70,7 +70,9 @@ At the end of Phase 5, run:
 ```
 
 The gate writes its result to `gates.idea-discovery-evidence` in the run state.
-On `PASS`, it records deterministic acceptance for each completed phase. On a
+On `PASS`, it records the gate verdict under `gates.idea-discovery-evidence` —
+per-phase acceptance stays with each stage's own cross-model or deterministic
+gate (the evidence gate proves execution, never quality). On a
 non-zero exit, it writes explicit `BLOCKED: <stage> evidence missing` lines to
 the report; do not present the workflow as complete. On `— resume <run_id>`,
 start from the first non-terminal phase and re-run the gate before finalizing.

--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -33,8 +33,47 @@ Each phase builds on the previous one's output. The final deliverables are a val
 - **COMPACT = false** — When `true`, generate compact summary files for short-context models and session recovery. Writes `idea-stage/IDEA_CANDIDATES.md` (top 3-5 ideas only) at the end of this workflow. Downstream skills read this instead of the full `idea-stage/IDEA_REPORT.md`.
 - **RENDER_HTML = true** — When `true` (default), auto-render `idea-stage/IDEA_REPORT.md` to HTML at workflow end via `/render-html`. Uses `--no-review` (the source MD already went through novelty + cross-model review during Phase 3). Set `false` to skip, or pass `— render html: false`.
 - **REF_PAPER = false** — Reference paper to base ideas on. Accepts: local PDF path, arXiv URL, or any paper URL. When set, the paper is summarized first (`idea-stage/REF_PAPER_SUMMARY.md`), then idea generation uses it as context. Combine with `base repo` for "improve this paper with this codebase" workflows.
+- **RESUMABLE = true** — Record stage evidence under `.aris/runs/<run_id>.json` and require a deterministic evidence gate before declaring the final report complete.
 
 > 💡 These are defaults. Override by telling the skill, e.g., `/idea-discovery "topic" — ref paper: https://arxiv.org/abs/2406.04329` or `/idea-discovery "topic" — compact: true`.
+
+## Per-stage evidence gate (`RESUMABLE = true`)
+
+Resolve `run_state.py` and `idea_discovery_gate.py` through the same canonical
+helper chain used by `/research-pipeline`: `.aris/tools/` → `tools/` →
+`$ARIS_REPO/tools/` → `~/.aris/repo/tools/`. If either helper is unavailable,
+the final report is `BLOCKED`; do not silently continue without a state record.
+
+For a new run, derive `<run_id>` from the direction slug and date, then start
+this ordered state record:
+
+```text
+research-lit,idea-creator,novelty-check,research-review,research-refine-pipeline
+```
+
+For each phase, mark `running` on entry and `done --artifact <path>` only after
+its artifact is present. Use these artifact locators so the final gate can
+check the canonical report rather than scattered scratch files:
+
+| Phase | Artifact locator |
+|---|---|
+| `research-lit` | `idea-stage/IDEA_REPORT.md#literature-landscape` |
+| `idea-creator` | `idea-stage/IDEA_REPORT.md#ranked-ideas` |
+| `novelty-check` | `idea-stage/IDEA_REPORT.md#novelty-verification` |
+| `research-review` | `idea-stage/IDEA_REPORT.md#external-critical-review` |
+| `research-refine-pipeline` | `refine-logs/FINAL_PROPOSAL.md` |
+
+At the end of Phase 5, run:
+
+```text
+<resolved-python> <resolved-idea_discovery_gate.py> . <run_id> --report idea-stage/IDEA_REPORT.md
+```
+
+The gate writes its result to `gates.idea-discovery-evidence` in the run state.
+On `PASS`, it records deterministic acceptance for each completed phase. On a
+non-zero exit, it writes explicit `BLOCKED: <stage> evidence missing` lines to
+the report; do not present the workflow as complete. On `— resume <run_id>`,
+start from the first non-terminal phase and re-run the gate before finalizing.
 
 ## Pipeline
 
@@ -275,6 +314,12 @@ Finalize `idea-stage/IDEA_REPORT.md` with all accumulated information:
 ## Ranked Ideas
 [from Phase 2, updated with Phase 3-4 results]
 
+## Novelty Verification
+[from Phase 3]
+
+## External Critical Review
+[from Phase 4]
+
 ### 🏆 Idea 1: [title] — RECOMMENDED
 - Pilot: POSITIVE (+X%)
 - Novelty: CONFIRMED (closest: [paper], differentiation: [what's different])
@@ -297,6 +342,9 @@ Finalize `idea-stage/IDEA_REPORT.md` with all accumulated information:
 - [ ] /auto-review-loop to iterate until submission-ready
 - [ ] Or invoke /research-pipeline for the complete end-to-end flow
 ```
+
+Before presenting this report as complete, run the per-stage evidence gate
+above. A `BLOCKED` gate result is part of the report, not a warning to omit.
 
 ### Phase 5.5: Write Compact Files (when COMPACT = true)
 

--- a/skills/shared-references/resumable-runs.md
+++ b/skills/shared-references/resumable-runs.md
@@ -7,6 +7,10 @@ live complaint in issue #272: "the survey run failed — can it continue from th
 last task?"). `tools/run_state.py` fixes that: a run is an **ordered list of
 phases with status**, persisted at `<root>/.aris/runs/<run_id>.json`.
 
+Workflow-level deterministic checks are recorded separately under `gates` in
+the same state file. A gate may emit `PASS` or `BLOCKED` with durable reasons;
+it does not replace the per-phase acceptance record.
+
 ## The one idea that makes this ARIS, not just "reopen the session"
 
 Resumption is not "reopen the id" — it is **resolve FORWARD to where progress
@@ -62,10 +66,11 @@ triggers resume, it does not own the verdict).
 ## Helper API / CLI
 
 ```
-from run_state import start_run, set_status, accept, resume_point
+from run_state import start_run, set_status, accept, record_gate_result, resume_point
 start_run(root, run_id, phases)                 # phases: ["W1","W1.5","W2","W3"]
 set_status(root, run_id, phase, "running"|"done"|"failed", artifact=path)
 accept(root, run_id, phase, verdict_id, reviewer)   # the ONLY path to `accepted`
+record_gate_result(root, run_id, gate, "PASS"|"BLOCKED", reasons)
 resume_point(root, run_id)  # -> first NON-TERMINAL phase ({accepted,skipped} skipped), or None
 ```
 

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -69,7 +69,9 @@ python3 <resolved-idea_discovery_gate.py> . <run_id> --report idea-stage/IDEA_RE
 ```
 
 The gate writes its result to `gates.idea-discovery-evidence` in the run state.
-On `PASS`, it records deterministic acceptance for each completed phase. On a
+On `PASS`, it records the gate verdict under `gates.idea-discovery-evidence` —
+per-phase acceptance stays with each stage's own cross-model or deterministic
+gate (the evidence gate proves execution, never quality). On a
 non-zero exit, it writes explicit `BLOCKED: <stage> evidence missing` lines to
 the report; do not present the workflow as complete. On `— resume <run_id>`,
 start from the first non-terminal phase and re-run the gate before finalizing.

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -31,8 +31,48 @@ Each phase builds on the previous one's output. The final deliverables are a val
 - **OUTPUT_DIR = `idea-stage/`** — All idea-stage outputs go here. Create the directory if it doesn't exist.
 - **REF_PAPER = false** — Reference paper to base ideas on. Accepts a local PDF path, arXiv URL, or paper URL. When set, summarize it first and use it as idea-generation context.
 - **RENDER_HTML = true** — When `true` (default), auto-render `idea-stage/IDEA_REPORT.md` to HTML at workflow end via `/render-html`. Uses `--no-review` because the source already received novelty + same-family provisional review. Set `false` to skip.
+- **RESUMABLE = true** — Record stage evidence under `.aris/runs/<run_id>.json` and require a deterministic evidence gate before declaring the final report complete.
 
 > 💡 These are defaults. Override by telling the skill, e.g., `/idea-discovery "topic" — ref paper: https://arxiv.org/abs/2406.04329` or `/idea-discovery "topic" — compact: true`.
+
+## Per-stage evidence gate (`RESUMABLE = true`)
+
+Resolve `run_state.py` and `idea_discovery_gate.py` from the Codex manifest
+using the same resolver pattern as `/research-pipeline`. If either helper is
+unavailable, the final report is `BLOCKED`; do not silently continue without a
+state record.
+
+For a new run, derive `<run_id>` from the direction slug and date, then start
+this ordered state record with `--executor codex-gpt-5.6-sol
+--provisional-advances`:
+
+```text
+research-lit,idea-creator,novelty-check,research-review,research-refine-pipeline
+```
+
+For each phase, mark `running` on entry and `done --artifact <path>` only after
+its artifact is present. Use these artifact locators so the final gate can
+check the canonical report rather than scattered scratch files:
+
+| Phase | Artifact locator |
+|---|---|
+| `research-lit` | `idea-stage/IDEA_REPORT.md#literature-landscape` |
+| `idea-creator` | `idea-stage/IDEA_REPORT.md#ranked-ideas` |
+| `novelty-check` | `idea-stage/IDEA_REPORT.md#novelty-verification` |
+| `research-review` | `idea-stage/IDEA_REPORT.md#external-critical-review` |
+| `research-refine-pipeline` | `refine-logs/FINAL_PROPOSAL.md` |
+
+At the end of Phase 5, run:
+
+```text
+python3 <resolved-idea_discovery_gate.py> . <run_id> --report idea-stage/IDEA_REPORT.md
+```
+
+The gate writes its result to `gates.idea-discovery-evidence` in the run state.
+On `PASS`, it records deterministic acceptance for each completed phase. On a
+non-zero exit, it writes explicit `BLOCKED: <stage> evidence missing` lines to
+the report; do not present the workflow as complete. On `— resume <run_id>`,
+start from the first non-terminal phase and re-run the gate before finalizing.
 
 ## Pipeline
 
@@ -258,6 +298,12 @@ Finalize `idea-stage/IDEA_REPORT.md` with all accumulated information:
 ## Ranked Ideas
 [from Phase 2, updated with Phase 3-4 results]
 
+## Novelty Verification
+[from Phase 3]
+
+## External Critical Review
+[from Phase 4]
+
 ### 🏆 Idea 1: [title] — RECOMMENDED
 - Pilot: POSITIVE (+X%)
 - Novelty: CONFIRMED (closest: [paper], differentiation: [what's different])
@@ -280,6 +326,9 @@ Finalize `idea-stage/IDEA_REPORT.md` with all accumulated information:
 - [ ] /auto-review-loop to iterate until submission-ready
 - [ ] Or invoke /research-pipeline for the complete end-to-end flow
 ```
+
+Before presenting this report as complete, run the per-stage evidence gate
+above. A `BLOCKED` gate result is part of the report, not a warning to omit.
 
 ### Phase 5.5: Write Compact Files (when COMPACT = true)
 

--- a/skills/skills-codex/shared-references/resumable-runs.md
+++ b/skills/skills-codex/shared-references/resumable-runs.md
@@ -14,6 +14,10 @@ live complaint in issue #272: "the survey run failed — can it continue from th
 last task?"). `tools/run_state.py` fixes that: a run is an **ordered list of
 phases with status**, persisted at `<root>/.aris/runs/<run_id>.json`.
 
+Workflow-level deterministic checks are recorded separately under `gates` in
+the same state file. A gate may emit `PASS` or `BLOCKED` with durable reasons;
+it does not replace the per-phase acceptance record.
+
 ## The one idea that makes this ARIS, not just "reopen the session"
 
 Resumption is not "reopen the id" — it is **resolve FORWARD to where progress
@@ -73,10 +77,11 @@ triggers resume, it does not own the verdict).
 ## Helper API / CLI
 
 ```
-from run_state import start_run, set_status, accept, resume_point
+from run_state import start_run, set_status, accept, record_gate_result, resume_point
 start_run(root, run_id, phases)                 # phases: ["W1","W1.5","W2","W3"]
 set_status(root, run_id, phase, "running"|"done"|"failed", artifact=path)
 accept(root, run_id, phase, verdict_id, reviewer)   # the ONLY path to `accepted`
+record_gate_result(root, run_id, gate, "PASS"|"BLOCKED", reasons)
 mark_provisional(root, run_id, phase, verdict_id, reviewer)  # same-family terminal receipt
 resume_point(root, run_id)  # -> first NON-TERMINAL phase, or None
 ```

--- a/tests/test_idea_discovery_gate.py
+++ b/tests/test_idea_discovery_gate.py
@@ -1,0 +1,151 @@
+"""Tests for the deterministic evidence gate used by /idea-discovery."""
+
+import sys
+import tempfile
+from pathlib import Path
+
+
+TOOLS = Path(__file__).resolve().parents[1] / "tools"
+REPO_ROOT = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+import idea_discovery_gate as gate  # noqa: E402
+import run_state  # noqa: E402
+
+
+def _write(root: Path, relative: str, text: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _complete_run(root: Path, run_id: str = "idea-run") -> None:
+    run_state.start_run(root, run_id, list(gate.REQUIRED_PHASES))
+    _write(
+        root,
+        "idea-stage/IDEA_REPORT.md",
+        """# Idea Discovery Report
+
+## Literature Landscape
+
+## Ranked Ideas
+
+## Novelty Verification
+
+## External Critical Review
+""",
+    )
+    _write(root, "refine-logs/FINAL_PROPOSAL.md", "# Final Proposal\n")
+    artifacts = {
+        "research-lit": "idea-stage/IDEA_REPORT.md#literature-landscape",
+        "idea-creator": "idea-stage/IDEA_REPORT.md#ranked-ideas",
+        "novelty-check": "idea-stage/IDEA_REPORT.md#novelty-verification",
+        "research-review": "idea-stage/IDEA_REPORT.md#external-critical-review",
+        "research-refine-pipeline": "refine-logs/FINAL_PROPOSAL.md",
+    }
+    for phase, artifact in artifacts.items():
+        run_state.set_status(root, run_id, phase, "done", artifact=artifact)
+
+
+def test_gate_accepts_complete_evidence_and_records_pass():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "PASS"
+        state = run_state.load_run(root, "idea-run")
+        assert state["gates"][gate.GATE_NAME]["verdict"] == "PASS"
+        assert all(phase["status"] == "accepted" for phase in state["phases"])
+        report = (root / "idea-stage/IDEA_REPORT.md").read_text(encoding="utf-8")
+        assert "## Evidence Gate" in report
+        assert "**Status:** PASS" in report
+
+
+def test_gate_blocks_missing_phase_and_writes_visible_report_section():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        run_state.start_run(root, "idea-run", ["research-lit"])
+        _write(root, "idea-stage/IDEA_REPORT.md", "# Idea Discovery Report\n")
+        run_state.set_status(
+            root,
+            "idea-run",
+            "research-lit",
+            "done",
+            artifact="idea-stage/IDEA_REPORT.md",
+        )
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "BLOCKED"
+        assert "idea-creator evidence missing (phase not recorded)" in result.reasons
+        state = run_state.load_run(root, "idea-run")
+        assert state["gates"][gate.GATE_NAME]["verdict"] == "BLOCKED"
+        report = (root / "idea-stage/IDEA_REPORT.md").read_text(encoding="utf-8")
+        assert "BLOCKED: idea-creator evidence missing (phase not recorded)" in report
+
+
+def test_gate_blocks_missing_report_section_without_duplicate_gate_block():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        report_path = root / "idea-stage/IDEA_REPORT.md"
+        report_path.write_text("# Idea Discovery Report\n## Literature Landscape\n", encoding="utf-8")
+
+        first = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+        second = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert first.verdict == second.verdict == "BLOCKED"
+        report = report_path.read_text(encoding="utf-8")
+        assert report.count(gate.START_MARKER) == 1
+        assert "BLOCKED: idea-creator evidence missing (section absent: #ranked-ideas)" in report
+
+
+def test_gate_blocks_artifact_outside_project_root():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        run_state.set_status(
+            root,
+            "idea-run",
+            "research-lit",
+            "done",
+            artifact="../outside.md",
+        )
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "BLOCKED"
+        assert any("artifact escapes project root" in reason for reason in result.reasons)
+
+
+def test_gate_downgrades_to_blocked_when_acceptance_cannot_be_recorded(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+
+        def reject_accept(*args, **kwargs):
+            raise ValueError("simulated acceptance failure")
+
+        monkeypatch.setattr(gate.run_state, "accept", reject_accept)
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "BLOCKED"
+        state = run_state.load_run(root, "idea-run")
+        assert state["gates"][gate.GATE_NAME]["verdict"] == "BLOCKED"
+        assert "BLOCKED: gate acceptance failed: simulated acceptance failure" in (
+            root / "idea-stage/IDEA_REPORT.md"
+        ).read_text(encoding="utf-8")
+
+
+def test_idea_discovery_mirrors_require_the_evidence_gate():
+    paths = (
+        REPO_ROOT / "skills" / "idea-discovery" / "SKILL.md",
+        REPO_ROOT / "skills" / "skills-codex" / "idea-discovery" / "SKILL.md",
+    )
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "Per-stage evidence gate" in text
+        assert "idea_discovery_gate.py" in text
+        assert "BLOCKED: <stage> evidence missing" in text
+        assert "research-refine-pipeline" in text

--- a/tests/test_idea_discovery_gate.py
+++ b/tests/test_idea_discovery_gate.py
@@ -56,7 +56,10 @@ def test_gate_accepts_complete_evidence_and_records_pass():
         assert result.verdict == "PASS"
         state = run_state.load_run(root, "idea-run")
         assert state["gates"][gate.GATE_NAME]["verdict"] == "PASS"
-        assert all(phase["status"] == "accepted" for phase in state["phases"])
+        # The gate proves execution evidence only — it must NOT upgrade the
+        # semantic phases to `accepted` (resumable-runs.md: done-but-not-
+        # accepted marks a stage whose own audit is still pending).
+        assert all(phase["status"] == "done" for phase in state["phases"])
         report = (root / "idea-stage/IDEA_REPORT.md").read_text(encoding="utf-8")
         assert "## Evidence Gate" in report
         assert "**Status:** PASS" in report
@@ -119,23 +122,20 @@ def test_gate_blocks_artifact_outside_project_root():
         assert any("artifact escapes project root" in reason for reason in result.reasons)
 
 
-def test_gate_downgrades_to_blocked_when_acceptance_cannot_be_recorded(monkeypatch):
+def test_gate_never_calls_accept(monkeypatch):
+    # Doctrine: the gate records its verdict under gates.<name> and must not
+    # confer phase-level acceptance — that belongs to each stage's own gate.
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         _complete_run(root)
 
-        def reject_accept(*args, **kwargs):
-            raise ValueError("simulated acceptance failure")
+        def forbidden_accept(*args, **kwargs):
+            raise AssertionError("gate must not call run_state.accept")
 
-        monkeypatch.setattr(gate.run_state, "accept", reject_accept)
+        monkeypatch.setattr(gate.run_state, "accept", forbidden_accept)
         result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
 
-        assert result.verdict == "BLOCKED"
-        state = run_state.load_run(root, "idea-run")
-        assert state["gates"][gate.GATE_NAME]["verdict"] == "BLOCKED"
-        assert "BLOCKED: gate acceptance failed: simulated acceptance failure" in (
-            root / "idea-stage/IDEA_REPORT.md"
-        ).read_text(encoding="utf-8")
+        assert result.verdict == "PASS"
 
 
 def test_idea_discovery_mirrors_require_the_evidence_gate():

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -275,6 +275,32 @@ def test_state_is_valid_json_on_disk():
         assert rs._find_phase(state, "W1")["artifact"] == "x/y.md"
 
 
+def test_record_gate_result_is_persisted_with_reasons():
+    with _tmp() as d:
+        rs.start_run(d, "run-a", PHASES)
+        state = rs.record_gate_result(
+            d,
+            "run-a",
+            "idea-discovery-evidence",
+            "BLOCKED",
+            ["research-lit evidence missing"],
+        )
+        gate = state["gates"]["idea-discovery-evidence"]
+        assert gate["verdict"] == "BLOCKED"
+        assert gate["reasons"] == ["research-lit evidence missing"]
+
+
+def test_record_gate_result_rejects_unknown_verdict():
+    with _tmp() as d:
+        rs.start_run(d, "run-a", PHASES)
+        try:
+            rs.record_gate_result(d, "run-a", "gate", "WARN", [])
+            raised = False
+        except ValueError:
+            raised = True
+        assert raised
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     passed = failed = 0

--- a/tools/idea_discovery_gate.py
+++ b/tools/idea_discovery_gate.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Deterministically gate Idea Discovery reports on recorded stage evidence."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import run_state
+except ImportError:  # package import: ``from tools import idea_discovery_gate``
+    from tools import run_state
+
+
+GATE_NAME = "idea-discovery-evidence"
+REQUIRED_PHASES = (
+    "research-lit",
+    "idea-creator",
+    "novelty-check",
+    "research-review",
+    "research-refine-pipeline",
+)
+START_MARKER = "<!-- ARIS_IDEA_DISCOVERY_EVIDENCE_GATE:START -->"
+END_MARKER = "<!-- ARIS_IDEA_DISCOVERY_EVIDENCE_GATE:END -->"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    verdict: str
+    reasons: tuple[str, ...]
+
+
+def _artifact_target(root: Path, artifact: str) -> tuple[Path, str | None]:
+    path_text, separator, anchor = artifact.partition("#")
+    if not path_text:
+        raise ValueError("artifact path is empty")
+    candidate = (root / path_text).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"artifact escapes project root: {artifact}") from exc
+    return candidate, anchor if separator else None
+
+
+def _heading_slugs(path: Path) -> set[str]:
+    headings = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"^#{1,6}\s+(.+?)\s*#*\s*$", line)
+        if not match:
+            continue
+        text = match.group(1).strip().lower()
+        slug = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+        headings.add(re.sub(r"[\s-]+", "-", slug).strip("-"))
+    return headings
+
+
+def evaluate(root: str | Path, state: dict) -> GateResult:
+    """Check that every required stage has completed, durable evidence."""
+    project_root = Path(root).resolve()
+    phases = {phase["phase"]: phase for phase in state.get("phases", [])}
+    reasons: list[str] = []
+
+    for name in REQUIRED_PHASES:
+        phase = phases.get(name)
+        if phase is None:
+            reasons.append(f"{name} evidence missing (phase not recorded)")
+            continue
+        if phase.get("status") not in {"done", "accepted", "provisional"}:
+            reasons.append(
+                f"{name} evidence missing (status={phase.get('status', 'unknown')})"
+            )
+            continue
+        artifact = phase.get("artifact")
+        if not artifact:
+            reasons.append(f"{name} evidence missing (artifact not recorded)")
+            continue
+        try:
+            artifact_path, anchor = _artifact_target(project_root, artifact)
+        except ValueError as exc:
+            reasons.append(f"{name} evidence missing ({exc})")
+            continue
+        if not artifact_path.is_file():
+            reasons.append(f"{name} evidence missing (artifact absent: {artifact})")
+            continue
+        if anchor and anchor not in _heading_slugs(artifact_path):
+            reasons.append(f"{name} evidence missing (section absent: #{anchor})")
+
+    return GateResult("PASS" if not reasons else "BLOCKED", tuple(reasons))
+
+
+def _gate_section(result: GateResult) -> str:
+    lines = [START_MARKER, "## Evidence Gate", f"**Status:** {result.verdict}", ""]
+    if result.verdict == "PASS":
+        lines.append("All required stage records, artifacts, and report sections are present.")
+    else:
+        lines.append("The workflow is not complete. Required stage evidence is missing:")
+        lines.extend(f"- BLOCKED: {reason}" for reason in result.reasons)
+    lines.extend([END_MARKER, ""])
+    return "\n".join(lines)
+
+
+def write_report_gate(root: str | Path, report: str | Path, result: GateResult) -> Path:
+    project_root = Path(root).resolve()
+    report_path = (project_root / report).resolve()
+    try:
+        report_path.relative_to(project_root)
+    except ValueError as exc:
+        raise ValueError(f"report escapes project root: {report}") from exc
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    original = report_path.read_text(encoding="utf-8") if report_path.exists() else "# Idea Discovery Report\n"
+    section = _gate_section(result)
+    pattern = re.compile(
+        rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}\n?",
+        flags=re.DOTALL,
+    )
+    if pattern.search(original):
+        updated = pattern.sub(section, original)
+    else:
+        updated = original.rstrip() + "\n\n" + section
+    report_path.write_text(updated, encoding="utf-8")
+    return report_path
+
+
+def run(root: str | Path, run_id: str, report: str | Path) -> GateResult:
+    try:
+        state = run_state.load_run(str(root), run_id)
+    except FileNotFoundError:
+        result = GateResult("BLOCKED", ("run state missing",))
+        write_report_gate(root, report, result)
+        return result
+
+    result = evaluate(root, state)
+    if result.verdict == "PASS":
+        try:
+            for phase in REQUIRED_PHASES:
+                current = next(item for item in state["phases"] if item["phase"] == phase)
+                if current["status"] == "accepted":
+                    continue
+                artifact = current["artifact"]
+                run_state.accept(
+                    str(root),
+                    run_id,
+                    phase,
+                    verdict_id=f"{GATE_NAME}:{artifact}",
+                    reviewer="deterministic:idea_discovery_gate.py",
+                )
+        except (FileNotFoundError, KeyError, ValueError) as exc:
+            result = GateResult("BLOCKED", (f"gate acceptance failed: {exc}",))
+    run_state.record_gate_result(str(root), run_id, GATE_NAME, result.verdict, list(result.reasons))
+    write_report_gate(root, report, result)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root")
+    parser.add_argument("run_id")
+    parser.add_argument("--report", default="idea-stage/IDEA_REPORT.md")
+    args = parser.parse_args()
+
+    try:
+        result = run(args.root, args.run_id, args.report)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    for reason in result.reasons:
+        print(f"BLOCKED: {reason}")
+    if result.verdict == "PASS":
+        print("PASS: idea-discovery evidence gate")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/idea_discovery_gate.py
+++ b/tools/idea_discovery_gate.py
@@ -134,22 +134,12 @@ def run(root: str | Path, run_id: str, report: str | Path) -> GateResult:
         return result
 
     result = evaluate(root, state)
-    if result.verdict == "PASS":
-        try:
-            for phase in REQUIRED_PHASES:
-                current = next(item for item in state["phases"] if item["phase"] == phase)
-                if current["status"] == "accepted":
-                    continue
-                artifact = current["artifact"]
-                run_state.accept(
-                    str(root),
-                    run_id,
-                    phase,
-                    verdict_id=f"{GATE_NAME}:{artifact}",
-                    reviewer="deterministic:idea_discovery_gate.py",
-                )
-        except (FileNotFoundError, KeyError, ValueError) as exc:
-            result = GateResult("BLOCKED", (f"gate acceptance failed: {exc}",))
+    # The gate's verdict lives ONLY in gates.<GATE_NAME>. It must not mark the
+    # semantic phases `accepted`: per resumable-runs.md, file-exists evidence
+    # can accept a purely mechanical phase, while these five stages carry
+    # quality semantics whose acceptance belongs to their own cross-model or
+    # stage-level deterministic gates — and resume relies on done-but-not-
+    # accepted to know a stage still needs its audit.
     run_state.record_gate_result(str(root), run_id, GATE_NAME, result.verdict, list(result.reasons))
     write_report_gate(root, report, result)
     return result

--- a/tools/run_state.py
+++ b/tools/run_state.py
@@ -59,6 +59,7 @@ except ImportError:  # pragma: no cover - Windows
     fcntl = None  # type: ignore
 
 EXECUTOR_STATUSES = {"pending", "running", "done", "failed", "skipped"}
+GATE_VERDICTS = {"PASS", "BLOCKED"}
 # Statuses resume ALWAYS skips. `provisional` is deliberately NOT here: whether a
 # same-family provisional verdict may advance a run is a PER-RUN POLICY
 # (`policy.provisional_advances`, default False). The Codex-native mirror sets it
@@ -155,6 +156,7 @@ def start_run(root: str, run_id: str, phases: list[str], executor: Optional[str]
             "policy": {"provisional_advances": bool(provisional_advances)},
             "created": _now(),
             "updated": _now(),
+            "gates": {},
             "phases": [{"phase": ph, "status": "pending", "artifact": None,
                         "verdict_id": None, "reviewer": None,
                         "reviewer_family": None, "review_independence": None,
@@ -164,6 +166,40 @@ def start_run(root: str, run_id: str, phases: list[str], executor: Optional[str]
         }
         _save(root, run_id, state)
         return state
+
+
+def record_gate_result(
+    root: str,
+    run_id: str,
+    gate: str,
+    verdict: str,
+    reasons: list[str],
+) -> dict:
+    """Persist a deterministic gate result alongside phase state.
+
+    Gates do not replace per-phase acceptance. They make workflow-level checks
+    auditable, including a visible BLOCKED result when required evidence is
+    missing.
+    """
+    if not gate:
+        raise ValueError("gate name must be non-empty")
+    if verdict not in GATE_VERDICTS:
+        raise ValueError(f"gate verdict must be one of {sorted(GATE_VERDICTS)}")
+    with _lock(root, run_id):
+        state = _load(root, run_id)
+        gates = state.setdefault("gates", {})
+        gates[gate] = {
+            "verdict": verdict,
+            "reasons": list(reasons),
+            "updated": _now(),
+        }
+        _save(root, run_id, state)
+        return state
+
+
+def load_run(root: str, run_id: str) -> dict:
+    """Return the persisted state for a run without mutating it."""
+    return _load(root, run_id)
 
 
 def _find_phase(state: dict, phase: str) -> dict:


### PR DESCRIPTION
## Summary

Adds a deterministic per-stage evidence gate for `/idea-discovery`.

- Records workflow-level `PASS` / `BLOCKED` gate results in the existing `.aris/runs/<run_id>.json` state.
- Adds `tools/idea_discovery_gate.py` to require recorded evidence for `research-lit`, `idea-creator`, `novelty-check`, `research-review`, and `research-refine-pipeline`.
- Writes a visible `BLOCKED: <stage> evidence missing` section into `idea-stage/IDEA_REPORT.md` and exits non-zero when evidence is absent.
- On success, records deterministic acceptance for the validated phases.
- Updates mainline and Codex mirrors, plus the shared resumable-run contract.

## Why

`/idea-discovery` could previously skip a sub-skill yet still emit a complete-looking report. The gate makes missing artifacts and report sections explicit instead of silently proceeding.

## Validation

- `python -m pytest tests/test_run_state.py tests/test_idea_discovery_gate.py tests/test_codex_skill_mirror.py tests/test_skill_groups.py` (52 passed)
- `python -m py_compile tools/run_state.py tools/idea_discovery_gate.py`
- `python tools/check_skills_inventory.py`
- `git diff --check`

## Scope

Focused follow-up for #285. Reuses the existing `run_state.py` state machine rather than adding a parallel workflow-state format.