### PR TITLE
fix: UTF-8 the research wiki (#385); warn instead of silently missing the local paper library (#384)

### DIFF
--- a/skills/research-lit/SKILL.md
+++ b/skills/research-lit/SKILL.md
@@ -135,7 +135,13 @@ Before searching online, check if the user already has relevant papers locally:
 
 5. **Build local knowledge base**: Compile summaries into a "papers you already have" section. This becomes the starting point — external search fills the gaps.
 
-> 📚 If no local papers are found, skip to Step 1. If the user has a comprehensive local collection, the external search can be more targeted (focus on what's missing).
+> 📚 If the user has a comprehensive local collection, the external search can be more targeted (focus on what's missing).
+>
+> ⚠️ **If all three PAPER_LIBRARY paths miss, say so before moving on** — do not skip silently. A user whose PDFs live in a reference manager (Zotero, Mendeley, ...) otherwise assumes `— sources: all` covered them. Emit:
+>
+> `WARN: local contributed nothing — no PDFs found in papers/, literature/, or a configured paper library. To include yours, add a "## Paper Library" heading to CLAUDE.md followed by the directory path.`
+>
+> Then continue to Step 1.
 
 ### Step 1: Search (external)
 - Use WebSearch to find recent papers on the topic

--- a/skills/research-wiki/SKILL.md
+++ b/skills/research-wiki/SKILL.md
@@ -454,6 +454,7 @@ The system suggests but does not auto-trigger. User decides.
 - **query_pack.md is hard-budgeted** at 8000 chars. Deterministic generation, not open-ended summarization.
 - **Append to log.md for every mutation.** The log is the audit trail.
 - **Reviewer independence applies.** When the wiki is read by cross-model review skills, pass file paths only — do not summarize wiki content for the reviewer.
+- **The wiki is UTF-8.** All wiki files are read and written as UTF-8 so a `research-wiki/` stays portable across platforms and collaborators. A wiki created by an older ARIS on a non-UTF-8 locale (e.g. cp936 on Chinese Windows) must be converted to UTF-8 once — back it up first; the helper reports the offending file by name instead of guessing.
 
 ## Acknowledgements
 

--- a/skills/skills-codex/research-lit/SKILL.md
+++ b/skills/skills-codex/research-lit/SKILL.md
@@ -144,7 +144,13 @@ Before searching online, check if the user already has relevant papers locally:
 
 5. **Build local knowledge base**: Compile summaries into a "papers you already have" section. This becomes the starting point — external search fills the gaps.
 
-> 📚 If no local papers are found, skip to Step 1. If the user has a comprehensive local collection, the external search can be more targeted (focus on what's missing).
+> 📚 If the user has a comprehensive local collection, the external search can be more targeted (focus on what's missing).
+>
+> ⚠️ **If all three PAPER_LIBRARY paths miss, say so before moving on** — do not skip silently. A user whose PDFs live in a reference manager (Zotero, Mendeley, ...) otherwise assumes `— sources: all` covered them. Emit:
+>
+> `WARN: local contributed nothing — no PDFs found in papers/, literature/, or a configured paper library. To include yours, add a "## Paper Library" heading to AGENTS.md followed by the directory path.`
+>
+> Then continue to Step 1.
 
 ### Step 1: Search (external)
 - Use WebSearch to find recent papers on the topic

--- a/tests/test_research_wiki_encoding.py
+++ b/tests/test_research_wiki_encoding.py
@@ -1,0 +1,44 @@
+"""The wiki is UTF-8 on every platform (issue #385).
+
+Before this was fixed, most file ops in research_wiki.py inherited the platform
+default encoding. On a cp936 (Chinese Windows) locale that wrote the wiki in GBK:
+the directory could not be shared with collaborators on other platforms, and
+rebuild_index crashed the moment any external tool rewrote a file as UTF-8.
+
+These tests reproduce the reported failure — non-ASCII content written, then read
+back — rather than probing exotic encodings.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import research_wiki as rw  # noqa: E402
+
+NON_ASCII = "中文证据 · café ✓"
+
+
+class TestWikiEncoding(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        rw.init_wiki(self.root)
+
+    def test_non_ascii_edge_evidence_is_written_as_utf8(self):
+        rw.add_edge(self.root, "paper:a", "paper:b", "extends", evidence=NON_ASCII)
+        raw = (Path(self.root) / "graph" / "edges.jsonl").read_bytes()
+        # Decodes as UTF-8 (would raise on a GBK-written file) and survives the trip.
+        record = json.loads(raw.decode("utf-8").strip().split("\n")[-1])
+        self.assertEqual(record["evidence"], NON_ASCII)
+
+    def test_rebuild_index_reads_a_utf8_wiki(self):
+        rw.add_edge(self.root, "paper:a", "paper:b", "extends", evidence=NON_ASCII)
+        # The reported crash: UnicodeDecodeError under a non-UTF-8 default locale.
+        rw.rebuild_index(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -117,18 +117,18 @@ def init_wiki(wiki_root: str):
         path = root / f
         if not path.exists():
             if f == "index.md":
-                path.write_text("# Research Wiki Index\n\n_Auto-generated. Do not edit._\n")
+                path.write_text("# Research Wiki Index\n\n_Auto-generated. Do not edit._\n", encoding="utf-8")
             elif f == "log.md":
-                path.write_text("# Research Wiki Log\n\n_Append-only timeline._\n")
+                path.write_text("# Research Wiki Log\n\n_Append-only timeline._\n", encoding="utf-8")
             elif f == "gap_map.md":
-                path.write_text("# Gap Map\n\n_Field gaps with stable IDs._\n")
+                path.write_text("# Gap Map\n\n_Field gaps with stable IDs._\n", encoding="utf-8")
             elif f == "query_pack.md":
-                path.write_text("# Query Pack\n\n_Auto-generated for /idea-creator. Max 8000 chars._\n")
+                path.write_text("# Query Pack\n\n_Auto-generated for /idea-creator. Max 8000 chars._\n", encoding="utf-8")
 
     # Create empty edges file
     edges_path = root / "graph" / "edges.jsonl"
     if not edges_path.exists():
-        edges_path.write_text("")
+        edges_path.write_text("", encoding="utf-8")
 
     append_log(wiki_root, "Wiki initialized")
     print(f"Research wiki initialized at {root}")
@@ -153,7 +153,7 @@ def add_edge(wiki_root: str, from_id: str, to_id: str, edge_type: str, evidence:
     # Dedup check
     existing_edges = []
     if edges_path.exists():
-        for line in edges_path.read_text().strip().split("\n"):
+        for line in edges_path.read_text(encoding="utf-8").strip().split("\n"):
             if line.strip():
                 try:
                     existing_edges.append(json.loads(line))
@@ -197,7 +197,7 @@ def add_edge(wiki_root: str, from_id: str, to_id: str, edge_type: str, evidence:
         "added": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
-    with open(edges_path, "a") as f:
+    with open(edges_path, "a", encoding="utf-8") as f:
         f.write(json.dumps(edge, ensure_ascii=False) + "\n")
 
     print(f"Edge added: {from_id} --{edge_type}--> {to_id}")
@@ -214,7 +214,7 @@ def rebuild_query_pack(wiki_root: str, max_chars: int = 8000):
     # Deterministic, no LLM.
     brief_path = root.parent / "RESEARCH_BRIEF.md"
     if brief_path.exists():
-        raw = brief_path.read_text()
+        raw = brief_path.read_text(encoding="utf-8")
 
         # Parse ## sections from the brief
         sections_map: dict[str, str] = {}
@@ -276,7 +276,7 @@ def rebuild_query_pack(wiki_root: str, max_chars: int = 8000):
     # 2. Gap map (1200 chars)
     gap_path = root / "gap_map.md"
     if gap_path.exists():
-        gaps = gap_path.read_text()[:1200]
+        gaps = gap_path.read_text(encoding="utf-8")[:1200]
         if gaps.strip() and gaps.strip() != "# Gap Map\n\n_Field gaps with stable IDs._":
             sections.append(f"## Open Gaps\n{gaps}\n")
 
@@ -290,7 +290,7 @@ def rebuild_query_pack(wiki_root: str, max_chars: int = 8000):
             # `pending` idea whose body discusses an "outcome: negative" failure mode
             # must NOT be banlisted.
             if meta.get("outcome") in ("negative", "mixed"):
-                content = f.read_text()
+                content = f.read_text(encoding="utf-8")
                 lines = content.split("\n")
                 title = meta.get("title", "")
                 failure = ""
@@ -309,7 +309,7 @@ def rebuild_query_pack(wiki_root: str, max_chars: int = 8000):
     if papers_dir.exists():
         paper_summaries = []
         for f in sorted(papers_dir.glob("*.md")):
-            content = f.read_text()
+            content = f.read_text(encoding="utf-8")
             # Extract one-line thesis and key fields
             node_id = ""
             title = ""
@@ -335,7 +335,7 @@ def rebuild_query_pack(wiki_root: str, max_chars: int = 8000):
     edges_path = root / "graph" / "edges.jsonl"
     if edges_path.exists():
         edges = []
-        for line in edges_path.read_text().strip().split("\n"):
+        for line in edges_path.read_text(encoding="utf-8").strip().split("\n"):
             if line.strip():
                 try:
                     edges.append(json.loads(line))
@@ -382,7 +382,7 @@ def rebuild_query_pack(wiki_root: str, max_chars: int = 8000):
             )
 
     pack_path = root / "query_pack.md"
-    pack_path.write_text(pack)
+    pack_path.write_text(pack, encoding="utf-8")
     print(f"query_pack.md rebuilt: {len(pack)} chars")
 
 
@@ -414,7 +414,7 @@ def get_stats(wiki_root: str):
     edges_path = root / "graph" / "edges.jsonl"
     edge_count = 0
     if edges_path.exists():
-        edge_count = sum(1 for line in edges_path.read_text().strip().split("\n") if line.strip())
+        edge_count = sum(1 for line in edges_path.read_text(encoding="utf-8").strip().split("\n") if line.strip())
 
     print(f"📚 Research Wiki Stats")
     print(f"Papers:      {papers}")
@@ -600,7 +600,17 @@ def _load_paper_frontmatter(path: Path) -> dict:
     """Parse the YAML-ish frontmatter of a wiki paper page. Returns {} on failure."""
     if not path.exists():
         return {}
-    text = path.read_text()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        # A wiki written by an older ARIS on a non-UTF-8 locale (e.g. cp936).
+        # Fail loudly and name the file — silently replacing bytes would corrupt
+        # a store whose whole point is faithful accumulation.
+        raise SystemExit(
+            f"ERROR: {path} is not valid UTF-8.\n"
+            "  This wiki was likely written by an older ARIS on a non-UTF-8 locale.\n"
+            "  Convert the file to UTF-8 (back it up first), then re-run."
+        )
     m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
     if not m:
         return {}
@@ -618,7 +628,7 @@ def _find_existing_page_by_arxiv(wiki_root: Path, arxiv_id: str) -> Path | None:
     if not papers.exists():
         return None
     for p in papers.glob("*.md"):
-        text = p.read_text()
+        text = p.read_text(encoding="utf-8")
         # Match either the frontmatter line or a URL reference
         if re.search(r'arxiv:\s*["\']?' + re.escape(arxiv_id) + r'["\']?', text):
             return p
@@ -803,7 +813,7 @@ def ingest_paper(wiki_root: str, *, arxiv_id: str = "", title: str = "",
             was_update = False
 
     rendered = _render_paper_page(meta, slug, thesis, tags)
-    page_path.write_text(rendered)
+    page_path.write_text(rendered, encoding="utf-8")
 
     # Rebuild derived artifacts
     rebuild_index(str(root))
@@ -971,7 +981,7 @@ def add_claim(wiki_root: str, slug: str, name: str, *, description: str = "",
 
     rendered = _render_claim_page(slug, name, description, status, provenance,
                                   statement, scope, evidence, tags)
-    page_path.write_text(rendered)
+    page_path.write_text(rendered, encoding="utf-8")
 
     # Wire edges. Reuse add_edge so dedup, evidence quarantine, and the JSONL
     # format are all identical to paper/idea edges.
@@ -1215,7 +1225,7 @@ def upsert_idea(wiki_root: str, slug: str, title: str, *, description: str = "",
 
     rendered = _render_idea_page(slug, title, description, stage, outcome, thesis,
                                  risks, based_on_ids, target_gap_ids, tags)
-    page_path.write_text(rendered)
+    page_path.write_text(rendered, encoding="utf-8")
 
     # Wire edges (reuse add_edge so dedup + JSONL format match paper/claim edges).
     for nid in based_on_ids:
@@ -1357,7 +1367,7 @@ def add_experiment(wiki_root: str, slug: str, *, title: str = "", idea: str = ""
     rendered = _render_experiment_page(slug, title, idea_id, verdict, confidence,
                                        date, hardware, duration, metrics, reasoning,
                                        provenance, tags)
-    page_path.write_text(rendered)
+    page_path.write_text(rendered, encoding="utf-8")
 
     # Wire the idea --tested_by--> exp edge (idea side owns it, per the schema).
     if idea_id:
@@ -1436,7 +1446,7 @@ def rebuild_index(wiki_root: str) -> None:
             lines.extend(entries)
             lines.append("")
 
-    (root / "index.md").write_text("\n".join(lines) + "\n")
+    (root / "index.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def append_log(wiki_root: str, message: str):
@@ -1446,10 +1456,10 @@ def append_log(wiki_root: str, message: str):
     entry = f"- `{ts}` {message}\n"
 
     if log_path.exists():
-        with open(log_path, "a") as f:
+        with open(log_path, "a", encoding="utf-8") as f:
             f.write(entry)
     else:
-        log_path.write_text(f"# Research Wiki Log\n\n{entry}")
+        log_path.write_text(f"# Research Wiki Log\n\n{entry}", encoding="utf-8")
 
 
 def main():
@@ -1657,7 +1667,7 @@ def main():
             if not fp.exists():
                 print(f"--from-file not found: {fp}", file=sys.stderr)
                 sys.exit(2)
-            for line in fp.read_text().splitlines():
+            for line in fp.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line and not line.startswith("#"):
                     ids.append(line)

--- a/tools/verify_papers.py
+++ b/tools/verify_papers.py
@@ -205,7 +205,7 @@ def load_cache(path: Path, ttl_days: int) -> dict[str, dict[str, Any]]:
     if not path or not path.is_file():
         return {}
     try:
-        raw = json.loads(path.read_text())
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
     now = time.time()
@@ -217,7 +217,7 @@ def save_cache(path: Path, cache: dict[str, dict[str, Any]]) -> None:
     if not path:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(cache, ensure_ascii=False, indent=2))
+    path.write_text(json.dumps(cache, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -491,14 +491,14 @@ def parse_input(args: argparse.Namespace) -> list[PaperInput]:
         if args.input == "-":
             raw = sys.stdin.read()
         else:
-            raw = Path(args.input).read_text()
+            raw = Path(args.input).read_text(encoding="utf-8")
         data = json.loads(raw)
         return [PaperInput(**d) for d in data]
     if args.arxiv_ids:
         ids = [x.strip() for x in args.arxiv_ids.split(",") if x.strip()]
         return [PaperInput(id=f"arxiv-{i}", arxiv_id=x) for i, x in enumerate(ids)]
     if args.titles_file:
-        path = sys.stdin if args.titles_file == "-" else open(args.titles_file)
+        path = sys.stdin if args.titles_file == "-" else open(args.titles_file, encoding="utf-8")
         try:
             titles = [line.strip() for line in path if line.strip()]
         finally:
@@ -603,7 +603,7 @@ def main() -> int:
 
     payload = json.dumps(output, indent=2, ensure_ascii=False)
     if args.output and args.output != "-":
-        Path(args.output).write_text(payload)
+        Path(args.output).write_text(payload, encoding="utf-8")
     else:
         print(payload)
     return 0


### PR DESCRIPTION
Two reported bugs from @LIMMIL7, both verified in the code before fixing.

## #385 — `research-wiki/` was locale-bound

`tools/research_wiki.py` performed ~30 text file operations and passed `encoding=` on 6. Everything else inherited the platform default, so on a cp936 locale the wiki was written in GBK — unusable by collaborators on other platforms, and `rebuild_index` crashed with `UnicodeDecodeError` once any external tool rewrote a file as UTF-8.

- All text ops now pass `encoding="utf-8"`. The arXiv HTTP `resp.read()` deliberately stays raw bytes (it feeds an XML parser).
- `tools/verify_papers.py` is in the same class (persistent cache + user-specified JSON report, both `ensure_ascii=False`) and is fixed alongside.
- **Scope discriminator is `ensure_ascii=False`, not the raw op count.** `watchdog.py` has 13 unannotated ops but writes JSON with the default `ensure_ascii=True`, so its content is pure ASCII; the two remaining unannotated opens in `iteration_log.py` / `run_state.py` are lock files that never carry content. Left untouched on purpose.
- **No `errors="replace"`.** Silently swapping bytes for `U+FFFD` corrupts a store whose whole purpose is faithful accumulation. Instead `_load_paper_frontmatter` catches `UnicodeDecodeError` and exits naming the file and the remedy, so a legacy wiki gets a clear message rather than a traceback.
- One line in the research-wiki SKILL records the UTF-8 invariant and the one-time conversion for legacy wikis. No migration machinery, no fingerprinting.

## #384 — the local paper library failed silently

`/research-lit` resolves `PAPER_LIBRARY` from `papers/`, `literature/`, or a `## Paper Library` heading in `CLAUDE.md`. Neither installer ever mentions the third option, and when all three missed, Step 0c said "skip to Step 1" — silently. A user whose PDFs live in Zotero/Mendeley runs `— sources: all`, gets nothing from `local`, and is never told. The reporter measured 82 of ~120 PDFs matching their topic once the path was configured, including work no other source surfaced.

Step 0c now emits a warning naming the one-line fix before continuing. Chosen over an installer probe deliberately: the defect is silence rather than missing automation, the warning fires exactly when the user is doing literature search and can act on it, and a candidate-path list (`~/Zotero/storage`, ...) would need writing twice (bash + PowerShell) and would guess wrong for many setups. The Codex mirror carries the same warning against `AGENTS.md`.

## Verification

- New `tests/test_research_wiki_encoding.py` reproduces the reported failure (non-ASCII edge evidence round-trips as UTF-8; `rebuild_index` reads it back). Confirmed to **fail** when the fix is reverted under a `C` locale, and pass after.
- End-to-end: `add_edge` with Chinese + accented + symbol content writes valid UTF-8 and `rebuild_index` exits 0.
- `check_skills_inventory.py` clean; full suite 532 passed (the 3 `manual_review` HTTP failures are pre-existing on `main` in this environment, unrelated).

Closes #385
Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)