### PR TITLE
fix(research-wiki): keep non-ASCII letters in slugs so Chinese papers stop silently colliding

### DIFF
--- a/tests/test_research_wiki_encoding.py
+++ b/tests/test_research_wiki_encoding.py
@@ -40,5 +40,35 @@ class TestWikiEncoding(unittest.TestCase):
         rw.rebuild_index(self.root)
 
 
+class TestSlugifyKeepsNonAsciiLetters(unittest.TestCase):
+    """Non-ASCII titles used to collapse to `<year>_untitled`, so a second paper
+    by the same author in the same year was silently dropped as a duplicate."""
+
+    def test_two_chinese_papers_get_distinct_slugs(self):
+        a = rw.slugify("扩散语言模型的表征视角", "张三", 2026)
+        b = rw.slugify("图神经网络的可解释性研究", "张三", 2026)
+        self.assertNotEqual(a, b)
+        self.assertNotIn("untitled", a)
+
+    def test_ascii_titles_slugify_exactly_as_before(self):
+        # Locking the pre-existing behavior: these strings must not drift.
+        self.assertEqual(
+            rw.slugify("Attention Is All You Need", "Vaswani", 2017),
+            "vaswani2017_attention_all_you",
+        )
+        self.assertEqual(
+            rw.slugify("BERT: Pre-training of Deep Bidirectional Transformers", "Devlin", 2019),
+            "devlin2019_bert_pretraining_deep",
+        )
+
+    def test_second_chinese_paper_is_actually_ingested(self):
+        root = tempfile.mkdtemp()
+        rw.init_wiki(root)
+        rw.ingest_paper(root, title="扩散语言模型的表征视角", authors="张三", year=2026)
+        rw.ingest_paper(root, title="图神经网络的可解释性研究", authors="张三", year=2026)
+        pages = list((Path(root) / "papers").glob("*.md"))
+        self.assertEqual(len(pages), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -50,6 +50,7 @@ import os
 import re
 import sys
 import time
+import unicodedata
 import urllib.request
 import urllib.error
 import xml.etree.ElementTree as ET
@@ -93,14 +94,29 @@ def _arxiv_user_agent() -> str:
 
 
 def slugify(title: str, author_last: str = "", year: int = 0) -> str:
-    """Generate a canonical slug: author_last + year + keyword."""
-    # Extract first meaningful word from title
+    """Generate a canonical slug: author_last + year + keyword.
+
+    Letters outside ASCII are kept. Stripping them used to collapse every
+    Chinese paper to `<year>_untitled`, so two different papers by the same
+    author in the same year produced the same slug and the second was silently
+    dropped as a duplicate. ASCII titles and authors slugify exactly as before.
+    """
     stop_words = {"a", "an", "the", "of", "for", "in", "on", "with", "via", "and", "to", "by"}
-    words = re.sub(r"[^a-z0-9\s]", "", title.lower()).split()
+    # `[^\w\s]|_` keeps letters/digits in any script while still dropping the
+    # underscore that \w would otherwise let through (ASCII behavior unchanged).
+    normalized_title = unicodedata.normalize("NFC", title.lower())
+    words = re.sub(r"[^\w\s]|_", "", normalized_title, flags=re.UNICODE).split()
     keywords = [w for w in words if w not in stop_words and len(w) > 2]
     keyword = "_".join(keywords[:3]) if keywords else "untitled"
+    # Scripts without spaces yield one long token; cap it so the filename stays sane.
+    if not keyword.isascii():
+        keyword = keyword[:48]
 
-    author = re.sub(r"[^a-z]", "", author_last.lower()) if author_last else "unknown"
+    if author_last:
+        normalized_author = unicodedata.normalize("NFC", author_last.lower())
+        author = "".join(ch for ch in normalized_author if ch.isalpha())
+    else:
+        author = "unknown"
     yr = str(year) if year else "0000"
     return f"{author}{yr}_{keyword}"
 


### PR DESCRIPTION
Found while verifying #386 (the UTF-8 fix for #385) end to end: the wiki now *stores* Chinese correctly, but it was still silently **dropping** Chinese papers one layer up.

## The bug

`slugify()` stripped every non-ASCII character from both the title and the author:

```python
words  = re.sub(r"[^a-z0-9\s]", "", title.lower()).split()   # CJK -> nothing
author = re.sub(r"[^a-z]", "", author_last.lower())          # 张三 -> ""
```

So every Chinese paper collapsed to the same slug shape:

```
slugify("扩散语言模型的表征视角", "张三", 2026)   -> 2026_untitled
slugify("图神经网络的可解释性研究", "张三", 2026) -> 2026_untitled
```

`ingest_paper` dedups by slug, so the second paper was reported as `Paper already ingested (slug dedup) — skipping`. A Chinese-language literature sweep kept only the **first** paper per (author, year) and said nothing — same silent-loss class as #384.

Reproduced before the fix:

```
$ research_wiki.py ingest_paper ... --title "扩散语言模型的表征视角" --authors "张三" --year 2026
Paper ingested: papers/2026_untitled.md
$ research_wiki.py ingest_paper ... --title "图神经网络的可解释性研究" --authors "张三" --year 2026
Paper already ingested: 2026_untitled.md (slug dedup) — skipping.
$ ls papers/
2026_untitled.md
```

After:

```
Paper ingested: papers/张三2026_扩散语言模型的表征视角.md
Paper ingested: papers/张三2026_图神经网络的可解释性研究.md
```

## The fix

- Title regex keeps word characters in **any** script. `[^\w\s]|_` rather than plain `[^\w\s]` — `\w` would otherwise start admitting the underscore and change existing ASCII output.
- Author keeps any alphabetic character, so `张三` survives and `Müller` stops being mangled to `mller`.
- Both sides NFC-normalized so the same name typed two ways yields one slug.
- A non-ASCII keyword is capped at 48 characters, since scripts without spaces produce a single long token and the slug becomes a filename.

**No hashing, no collision registry.** The slug stays human-readable and derived only from the paper's own metadata.

## Compatibility

ASCII titles and authors slugify **byte-identically** — locked by a test that pins two known slugs. Verified across a spread of real titles before/after; the only changes are the non-ASCII cases (which were broken) and accented Latin names like `Müller` (which were mangled).

Papers already ingested keep their slugs and edges. Only newly ingested non-ASCII papers get the corrected id, so nothing dangles.

## Verification

- 3 new tests: two Chinese papers get distinct slugs, ASCII slugs are pinned against drift, and the second Chinese paper is genuinely written to disk.
- `check_skills_inventory.py` clean; suite 524 passed (`manual_review` HTTP tests deselected — pre-existing environment failures on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)