### PR TITLE
chore: bump ANTI_AR_COMMIT to the reporting-model upstream

### DIFF
--- a/skills/integrity-forensics/SKILL.md
+++ b/skills/integrity-forensics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrity-forensics
-description: "Run the Anti-Autoresearch integrity-forensics sweep (span-anchored evidence ledger → GPT auditors propose findings → deterministic rules-only adjudicator) against a paper via a SHA-pinned thin launcher — then convert the verdict into a typed policy gate (BLOCK/WARN/NO_NEW_BLOCKER) and an append-only obligations ledger. Use when user says \"integrity forensics\", \"forensic audit this paper\", \"投稿前自查诚信\", \"审这篇论文的诚信\", or says \"anti-autoresearch\" when the upstream repo's own skills are not installed. Also invoked by /paper-writing (submission self-forensics, default ON), /peer-review (forensic appendix), /resubmit-pipeline."
+description: "Run the Anti-Autoresearch integrity-forensics sweep (span-anchored evidence ledger → GPT auditors propose findings → a rules-only reporter that lists every proposal with what the auditor said about it) against a paper via a SHA-pinned thin launcher — then convert the verdict into a typed policy gate (BLOCK/WARN/NO_NEW_BLOCKER) and an append-only obligations ledger. Use when user says \"integrity forensics\", \"forensic audit this paper\", \"投稿前自查诚信\", \"审这篇论文的诚信\", or says \"anti-autoresearch\" when the upstream repo's own skills are not installed. Also invoked by /paper-writing (submission self-forensics, default ON), /peer-review (forensic appendix), /resubmit-pipeline."
 argument-hint: "[paper-dir | pdf | arxiv-id]"
 allowed-tools: Bash(*), Read, Write, Grep, Glob, mcp__codex__codex
 ---
@@ -12,7 +12,7 @@ Audit target: **$ARGUMENTS**
 > **What this is.** ARIS generates papers; [Anti-Autoresearch](https://github.com/wanshuiyin/Anti-Autoresearch)
 > is its outward-pointed dual — reviewer-side integrity forensics (46 patterns
 > across 8 families, deterministic GRIM/GRIMMER/statcheck core, span-anchored
-> claims, a rules-only adjudicator that owns the verdict). This skill is a
+> claims, a rules-only reporter that summarizes rather than adjudicates). This skill is a
 > **thin launcher**: it pins an upstream commit, validates the pin with the
 > upstream eval gate, delegates execution unchanged, and post-processes the
 > verdict into ARIS's policy vocabulary. It vendors nothing and forks nothing.
@@ -25,7 +25,7 @@ Audit target: **$ARGUMENTS**
 ## Constants
 
 - **ANTI_AR_REPO = `https://github.com/wanshuiyin/Anti-Autoresearch.git`**
-- **ANTI_AR_COMMIT = `d8f510c49c29ccb5f98ecb1f8e397a7a27eb97c4`** — the SHA-pin.
+- **ANTI_AR_COMMIT = `98a75fc1252937e700ff98f261db716781e51fa4`** — the SHA-pin.
   The launcher NEVER tracks upstream HEAD; bumping this constant is a reviewed
   change (see Pin-bump checklist).
 - **CLONE_DIR = `~/.claude/anti-autoresearch`** — the pinned working copy.
@@ -44,7 +44,7 @@ Audit target: **$ARGUMENTS**
 
 ```bash
 CLONE_DIR="$HOME/.claude/anti-autoresearch"
-ANTI_AR_COMMIT="d8f510c49c29ccb5f98ecb1f8e397a7a27eb97c4"
+ANTI_AR_COMMIT="98a75fc1252937e700ff98f261db716781e51fa4"
 
 if [ ! -d "$CLONE_DIR/.git" ]; then
     git clone --no-checkout https://github.com/wanshuiyin/Anti-Autoresearch.git "$CLONE_DIR"
@@ -96,7 +96,7 @@ end on the target. Two wrapper rules — the ONLY things this launcher adds:
    serial execution, and its own model pins — do not alter them).
 
 Everything else — the evidence ledger, coverage.json state machine, the nine
-auditor dimensions, the refutation pass, the deterministic adjudication — is
+auditor dimensions, the refutation pass, the deterministic summary — is
 upstream's contract. **Never rewrite, soften, or re-map its outputs**
 (`report.json` + `REPORT.md`, verdict ∈ CLEAN_GIVEN_EVIDENCE / SOFT_FLAGS /
 HARD_FLAGS / REVIEW_UNAVAILABLE). The observability level (L0/L1/L2) is
@@ -117,9 +117,9 @@ The gate translates the verdict into policy WITHOUT re-labeling it:
 
 | upstream verdict | policy |
 |---|---|
-| `HARD_FLAGS` | **BLOCK** |
+| `HARD_FLAGS` | **BLOCK** — an auditor proposed something critical and it is on the table for you to read; never "the machine found fraud" |
 | `REVIEW_UNAVAILABLE` | **BLOCK** — an incomplete sweep cannot wave a paper through |
-| `SOFT_FLAGS` | **WARN** — human disposition |
+| `SOFT_FLAGS` | **WARN** — human disposition. Read the never-ran list too: the upstream verdict folds incompleteness in only when it would otherwise be clean, so a WARN can sit on top of a sweep where verdict-bearing dimensions never ran. `evaluate` and `fresh` both print those dimensions |
 | `CLEAN_GIVEN_EVIDENCE` | **NO_NEW_BLOCKER** — *never* called PASS or accepted: it means "no flag found in the evidence at hand", not an acquittal |
 | anything else | **BLOCK** (fail closed) |
 
@@ -152,7 +152,15 @@ distinction is informational, not a loophole.
 
 ## Step 3 — Fix what it found (obligations, not a polish loop)
 
-Every OPEN obligation gets FIXED — through the right door:
+Every OPEN obligation gets DISPOSITIONED — fixed, or explicitly waived. Upstream now
+reports every proposal an auditor made rather than deciding which ones do not count, so
+expect more obligations than a pre-2026-08 sweep opened, and expect some of them to be
+proposals you disagree with. **`waive` is a first-class, expected outcome** — "a model
+proposed this and I, the human, judge it wrong" is a normal disposition here, not a last
+resort. Weigh each one against the report's columns: `Anchored`, `Observability`,
+`FP-risk`, `Surface`, `Ext-check`.
+
+For the ones that are real, use the right door:
 
 | Finding family | Repair route |
 |---|---|
@@ -212,9 +220,10 @@ verdict — decides whether the gate opens.
 - **Protocol** (instruction-graded, deliberately): that the sweep actually ran
   at the pinned clone against this paper. The gate raises the bar —
   structural floor (a report must name its adjudicator and carry a coverage
-  map), stale-report mtime guard — but true content-binding needs upstream to
-  stamp a paper fingerprint into `report.json` (tracked as an upstream
-  issue). Likewise `human:` / `checker:` / `cross-family-review:` labels are
+  map), stale-report mtime guard — and that is where it stops. There is no
+  cryptographic binding between the report and the paper, deliberately: this is
+  a research-workflow gate, not a provenance system, and the honest statement is
+  that a determined executor can hand it a stale report. Likewise `human:` / `checker:` / `cross-family-review:` labels are
   accountability, not authentication: a false label is an explicit,
   permanent false record.
 - **Out of scope**: a party rewriting the `.aris/` artifacts consistently with
@@ -232,6 +241,20 @@ verdict — decides whether the gate opens.
 3. Old findings/obligations stay valid (fingerprints are span/hash-based, not
    id-based) — but findings produced by an older adjudicator must be
    **re-audited, not re-adjudicated** (upstream's own migration rule).
+4. Tell users when a bump changes how much they must disposition. `fresh`
+   rejects every stored `gate.json` at the old pin with `PIN_MISMATCH`, so a
+   bump already forces a re-sweep for everyone — bundle upstream changes behind
+   ONE bump rather than two, or the re-sweep cost is paid twice.
+
+> **2026-08 bump (`98a75fc`) — expect more open obligations.** Upstream moved
+> from adjudicating proposals to reporting them: findings its FP-risk,
+> observability, surface and needs-external-check gates used to demote to `info`
+> now arrive above info, so they open obligations. Nothing got worse in the
+> paper; more of what the auditors said is now visible. Waiving a proposal you
+> judge wrong is the expected disposition, and the report's per-finding columns
+> (`Anchored`, `Observability`, `FP-risk`, `Surface`, `Ext-check`) are what you
+> weigh. Upstream also deleted its report self-binding hashes in the same window
+> — nothing here ever consumed them.
 
 ## Codex-native note (mirror)
 

--- a/skills/paper-writing/SKILL.md
+++ b/skills/paper-writing/SKILL.md
@@ -591,11 +591,18 @@ not silently skip the default-ON gate):
   citations → `/citation-audit`; proof → `/proof-checker`; scope/baseline/
   eval-design → `/auto-review-loop` as reviewer input, or the human.
 - Close obligations ONLY via `forensics_gate.py resolve` (typed, hashed
-  evidence) or a human `waive`. **Never edit the paper with the objective
-  "make the sweep stop flagging"** — a vanished-but-unresolved finding keeps
-  the gate closed (`UNRESOLVED_DISAPPEARANCE`).
+  evidence) or a human `waive`. Since 2026-08 upstream reports every proposal an
+  auditor made rather than deciding which ones do not count, so expect more
+  obligations and expect some to be proposals you judge wrong — `waive` with a
+  reason is the normal disposition for those, not a last resort. **Never edit the
+  paper with the objective "make the sweep stop flagging"** — a
+  vanished-but-unresolved finding keeps the gate closed
+  (`UNRESOLVED_DISAPPEARANCE`).
 - `WARN` (SOFT_FLAGS / open non-critical obligations): proceed, but the Final
-  Report must list them under `Forensics`.
+  Report must list them under `Forensics` — including the dimensions the sweep
+  never ran, which `evaluate` and `fresh` both print. A WARN can sit on top of an
+  incomplete sweep: upstream folds incompleteness into the verdict only when it
+  would otherwise read clean.
 - Zero-weight AIS style impressions: FYI only — may feed
   `/auto-paper-improvement-loop` context, never gate.
 

--- a/skills/skills-codex-gemini-review/paper-writing/SKILL.md
+++ b/skills/skills-codex-gemini-review/paper-writing/SKILL.md
@@ -215,7 +215,7 @@ Invoke `/auto-paper-improvement-loop` to polish the paper:
 Same contract as the base Codex pack (`skills-codex/paper-writing` Phase 5.9,
 which this overlay does not change): the executor here is Codex, so only
 upstream's **deterministic-only slice** of `/integrity-forensics` is runnable
-(numeric core + rules-only adjudicator — it can flag, it can never say
+(numeric core + rules-only reporter — it can flag, it can never say
 CLEAN), OFF unless the CURRENT `$ARGUMENTS` contains `— self_forensics:
 true`. If opted in: run the launcher on `paper/` (absolute path), then before
 the Final Report require `python3 "$GATE_HELPER" fresh --paper-dir paper/

--- a/skills/skills-codex/integrity-forensics/SKILL.md
+++ b/skills/skills-codex/integrity-forensics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrity-forensics
-description: "Run the Anti-Autoresearch integrity-forensics DETERMINISTIC slice (numeric core + rules-only adjudicator) against a paper via a SHA-pinned thin launcher, then convert the verdict into a typed policy gate (BLOCK/WARN/NO_NEW_BLOCKER) and an append-only obligations ledger. Codex-native limitation: upstream ships no Codex-native auditor pack, so the full nine-dimension semantic sweep requires a Claude Code session — this pack runs the honestly-scoped deterministic-only mode (it can flag, it can never say CLEAN). Use when user says \"integrity forensics\", \"forensic audit this paper\", \"投稿前自查诚信\"."
+description: "Run the Anti-Autoresearch integrity-forensics DETERMINISTIC slice (numeric core + rules-only reporter) against a paper via a SHA-pinned thin launcher, then convert the verdict into a typed policy gate (BLOCK/WARN/NO_NEW_BLOCKER) and an append-only obligations ledger. Codex-native limitation: upstream ships no Codex-native auditor pack, so the full nine-dimension semantic sweep requires a Claude Code session — this pack runs the honestly-scoped deterministic-only mode (it can flag, it can never say CLEAN). Use when user says \"integrity forensics\", \"forensic audit this paper\", \"投稿前自查诚信\"."
 argument-hint: "[paper-dir | pdf | arxiv-id]"
 ---
 
@@ -13,7 +13,7 @@ Audit target: **$ARGUMENTS**
 > reviewer knobs**. The one Codex-native difference: upstream's nine auditor
 > skills are Claude-Code contracts, so this pack runs upstream's
 > **deterministic-only mode** — the numeric forensic core (GRIM / GRIMMER /
-> statcheck / delta arithmetic) plus the rules-only adjudicator with an
+> statcheck / delta arithmetic) plus the rules-only reporter with an
 > all-`review_unavailable` coverage map. That mode is honestly scoped by
 > upstream: it can raise HARD/SOFT flags; it can NEVER return
 > `CLEAN_GIVEN_EVIDENCE`. Translating upstream's reviewer calls into
@@ -22,7 +22,7 @@ Audit target: **$ARGUMENTS**
 ## Constants
 
 - **ANTI_AR_REPO = `https://github.com/wanshuiyin/Anti-Autoresearch.git`**
-- **ANTI_AR_COMMIT = `d8f510c49c29ccb5f98ecb1f8e397a7a27eb97c4`** — never
+- **ANTI_AR_COMMIT = `98a75fc1252937e700ff98f261db716781e51fa4`** — never
   tracks HEAD; bumping is a reviewed change (mainline Pin-bump checklist).
 - **CLONE_DIR = `~/.claude/anti-autoresearch`**
 - **NO REVIEWER KNOBS** — and no `— effort:` mapping onto upstream settings.
@@ -31,7 +31,7 @@ Audit target: **$ARGUMENTS**
 
 ```bash
 CLONE_DIR="$HOME/.claude/anti-autoresearch"
-ANTI_AR_COMMIT="d8f510c49c29ccb5f98ecb1f8e397a7a27eb97c4"
+ANTI_AR_COMMIT="98a75fc1252937e700ff98f261db716781e51fa4"
 if [ ! -d "$CLONE_DIR/.git" ]; then
     git clone --no-checkout https://github.com/wanshuiyin/Anti-Autoresearch.git "$CLONE_DIR"
 fi

--- a/skills/skills-codex/resubmit-pipeline/SKILL.md
+++ b/skills/skills-codex/resubmit-pipeline/SKILL.md
@@ -305,7 +305,7 @@ Verifies no Phase 2 microedit accidentally introduced a numerical claim that's n
 **Integrity forensics re-run** (opt-in here: `— self_forensics: true`): the
 mainline pipeline defaults to an Anti-Autoresearch re-sweep after microedits;
 in a Codex-native session only upstream's **deterministic-only slice** is
-runnable (numeric core + rules-only adjudicator — it can flag, it can never
+runnable (numeric core + rules-only reporter — it can flag, it can never
 say CLEAN), so it is off unless requested. If opted in, run
 `/integrity-forensics` on `$NEW_VENUE_DIR/` AFTER all microedits (never
 between rounds — its One Forbidden Loop), gate `BLOCK` → stop before the

--- a/tools/forensics_gate.py
+++ b/tools/forensics_gate.py
@@ -156,9 +156,10 @@ def _assert_report_not_stale(report_path, paper_dir):
     """A report older than any audited paper file was generated BEFORE those
     edits — folding or gating it would bind new text to a sweep that never saw
     it. Refuse (fail closed); re-run the sweep instead. NOTE this is an mtime
-    net for the honest resumed-run case, not proof of provenance — true
-    content binding needs upstream to stamp a paper fingerprint into
-    report.json (filed upstream)."""
+    net for the honest resumed-run case, not proof of provenance. That is where
+    it stops on purpose: this is a research-workflow gate, not a provenance
+    system, and upstream deliberately removed its report fingerprints in 2026-08
+    because nothing consumed them."""
     rep_mtime = os.path.getmtime(report_path)
     for root, dirs, files in os.walk(paper_dir, followlinks=True):
         dirs[:] = [x for x in dirs if not x.startswith(".")]


### PR DESCRIPTION
Moves the pin from `d8f510c` to `98a75fc`, past both upstream merges: the deleted report self-binding hashes ([Anti-Autoresearch#19](https://github.com/wanshuiyin/Anti-Autoresearch/pull/19)) and the reporting model ([#20](https://github.com/wanshuiyin/Anti-Autoresearch/pull/20)).

**One bump, not two.** `fresh` rejects every stored `gate.json` at the old pin with `PIN_MISMATCH` before it checks anything else, so each bump already forces a re-sweep for every user. Bundling both upstream changes behind a single bump means that cost is paid once.

## Zero Python logic changes on this side

`forensics_gate.py`'s `_severity()` already reads `_severity_final or severity`, and upstream kept both that field and the four verdict tokens, so the gate's decision path is untouched. The only code change is its docstring: the note saying true content-binding "needs upstream to stamp a paper fingerprint into `report.json` (filed upstream)" described a feature upstream has now **deleted**, because nothing consumed it. The honest statement is that the mtime net is where this stops — a research-workflow gate, not a provenance system.

`GATE_VERSION` deliberately **not** bumped: `fresh` rejects a version mismatch before anything else, which would invalidate stored gates this change has nothing to say about.

## Prose that moves with the pin

- **`/integrity-forensics`** — upstream is a rules-only **reporter**, not an adjudicator that owns the verdict. `HARD_FLAGS` now means *an auditor proposed something critical and it is on your table to read*, never "the machine found fraud". `SOFT_FLAGS` gains the honest caveat that a WARN can sit on top of a sweep where verdict-bearing dimensions never ran, pointing at the never-ran list that `evaluate` and `fresh` now print. Step 3 promotes `waive` from last resort to a **first-class outcome** — "a model proposed this and I, the human, judge it wrong" is now a normal disposition. The Trust boundary drops its promise of future content-binding.
- **`/paper-writing` Phase 5.9** — same waive framing; the Final Report's `Forensics:` line must name the never-ran dimensions alongside the open obligations.
- The three codex mirrors and the catalog description follow.
- The **Pin-bump checklist** gains a step about telling users when a bump changes their disposition load, plus a release note for this one.

## What users will notice

**More open obligations.** Findings that upstream's FP-risk, observability, surface and needs-external-check gates used to demote to `info` now arrive above info, so they open obligations. Nothing got worse in the paper — more of what the auditors said is visible. Waiving a proposal you judge wrong is the expected disposition, and the report's per-finding columns (`Anchored`, `Observability`, `FP-risk`, `Surface`, `Ext-check`) are what you weigh.

## Validation

610 passed, 17 skipped; `check_skills_inventory.py` consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
