### PR TITLE
chore: catch ANTI_AR_COMMIT up to b47af6f

### DIFF
--- a/skills/integrity-forensics/SKILL.md
+++ b/skills/integrity-forensics/SKILL.md
@@ -25,7 +25,7 @@ Audit target: **$ARGUMENTS**
 ## Constants
 
 - **ANTI_AR_REPO = `https://github.com/wanshuiyin/Anti-Autoresearch.git`**
-- **ANTI_AR_COMMIT = `98a75fc1252937e700ff98f261db716781e51fa4`** — the SHA-pin.
+- **ANTI_AR_COMMIT = `b47af6f983b38347b6d2110379e266400597cf66`** — the SHA-pin.
   The launcher NEVER tracks upstream HEAD; bumping this constant is a reviewed
   change (see Pin-bump checklist).
 - **CLONE_DIR = `~/.claude/anti-autoresearch`** — the pinned working copy.
@@ -44,7 +44,7 @@ Audit target: **$ARGUMENTS**
 
 ```bash
 CLONE_DIR="$HOME/.claude/anti-autoresearch"
-ANTI_AR_COMMIT="98a75fc1252937e700ff98f261db716781e51fa4"
+ANTI_AR_COMMIT="b47af6f983b38347b6d2110379e266400597cf66"
 
 if [ ! -d "$CLONE_DIR/.git" ]; then
     git clone --no-checkout https://github.com/wanshuiyin/Anti-Autoresearch.git "$CLONE_DIR"

--- a/skills/skills-codex/integrity-forensics/SKILL.md
+++ b/skills/skills-codex/integrity-forensics/SKILL.md
@@ -22,7 +22,7 @@ Audit target: **$ARGUMENTS**
 ## Constants
 
 - **ANTI_AR_REPO = `https://github.com/wanshuiyin/Anti-Autoresearch.git`**
-- **ANTI_AR_COMMIT = `98a75fc1252937e700ff98f261db716781e51fa4`** — never
+- **ANTI_AR_COMMIT = `b47af6f983b38347b6d2110379e266400597cf66`** — never
   tracks HEAD; bumping is a reviewed change (mainline Pin-bump checklist).
 - **CLONE_DIR = `~/.claude/anti-autoresearch`**
 - **NO REVIEWER KNOBS** — and no `— effort:` mapping onto upstream settings.
@@ -31,7 +31,7 @@ Audit target: **$ARGUMENTS**
 
 ```bash
 CLONE_DIR="$HOME/.claude/anti-autoresearch"
-ANTI_AR_COMMIT="98a75fc1252937e700ff98f261db716781e51fa4"
+ANTI_AR_COMMIT="b47af6f983b38347b6d2110379e266400597cf66"
 if [ ! -d "$CLONE_DIR/.git" ]; then
     git clone --no-checkout https://github.com/wanshuiyin/Anti-Autoresearch.git "$CLONE_DIR"
 fi


### PR DESCRIPTION
Two upstream changes landed after [#394](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/pull/394) bumped the pin to `98a75fc`, so the pin lagged by two commits within the same hour:

- **[Anti-Autoresearch#21](https://github.com/wanshuiyin/Anti-Autoresearch/pull/21)** — the deterministic-only fallback ran two of its four checkers, and the adjudication step's glob would have dropped the other two's output anyway, so GRIM / GRIMMER / variance-impossibility / statcheck never ran in that mode. **This one matters here**: the Codex-native path *is* the deterministic-only mode.
- **[Anti-Autoresearch#22](https://github.com/wanshuiyin/Anti-Autoresearch/pull/22)** — deleted the counter-check's demotion capability, which could never fire (`may_demote` was `False` on every entry). No behaviour change; it stops `report.schema.json` describing auto-clearing that does not happen.

## Why this is not a second re-sweep

The bump-once rule exists because `fresh` rejects every stored `gate.json` at an older pin with `PIN_MISMATCH`, forcing a re-sweep for everyone. **#394 has not shipped in a release yet, so no user has paid that cost.** Landing this now collapses both bumps into the single re-sweep users were always going to do.

## Validation

610 passed, 17 skipped; `check_skills_inventory.py` consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
