### PR TITLE
feat: bound what a reviewer may propose, at the sites where it proposes mechanism

### DIFF
--- a/skills/auto-review-loop/SKILL.md
+++ b/skills/auto-review-loop/SKILL.md
@@ -387,6 +387,26 @@ mcp__codex__codex:
 
     Be brutally honest. If, after genuinely trying to break it, the work holds
     up and is ready, say so clearly.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 *For manual backend:* use `mcp__manual_review__review` with the `prompt` text above and `config: {"model_reasoning_effort": "xhigh", "executor_model": "<actual executor model>", "require_reviewer_model": true}`. Save the returned `threadId`.
@@ -428,6 +448,26 @@ mcp__codex__codex:
        or patterns you want to track in future rounds.
 
     Be brutally honest. Actively look for things the author might be hiding.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 ##### Nightmare — Codex Exec (GPT reads repo directly)
@@ -463,6 +503,26 @@ OUTPUT FORMAT:
 - Memory update: [new suspicions and patterns to track next round]
 
 Be adversarial. Trust nothing the author tells you — verify everything yourself.
+
+=== SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+Report anything that is actually wrong here — including a rare-looking case, if
+this repo actually produces it. Then keep the fix in scope:
+1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+   welcome; over-defense is not. Assume a cooperating operator on their own
+   machine — a malicious local user is NOT in the threat model.
+2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+   Reporting a real defect in hashing code that already exists is fine.
+3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+   layers, or wrappers added for cases that do not occur in practice.
+4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+   millisecond races are out of scope unless you can show the case arises here.
+5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+   judgement. A clear sentence a human reads beats a scored table nobody
+   maintains.
+Exception: code that runs remote commands, starts a network service, or installs
+an MCP server runs on the user's machine with their credentials — trust-boundary
+findings there are in scope and the default is strict.
+Say plainly when something is correct. Do not manufacture findings.
 PROMPT
 )" --skip-git-repo-check 2>&1
 ```
@@ -955,6 +1015,26 @@ cat <<'ARIS_ROUND_INSTRUCTIONS'
 Please re-score and re-assess. Are the remaining concerns addressed?
 Same format: Score, Verdict, Remaining Weaknesses, Minimum Fixes.
 
+=== SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+Report anything that is actually wrong here — including a rare-looking case, if
+this repo actually produces it. Then keep the fix in scope:
+1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+   welcome; over-defense is not. Assume a cooperating operator on their own
+   machine — a malicious local user is NOT in the threat model.
+2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+   Reporting a real defect in hashing code that already exists is fine.
+3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+   layers, or wrappers added for cases that do not occur in practice.
+4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+   millisecond races are out of scope unless you can show the case arises here.
+5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+   judgement. A clear sentence a human reads beats a scored table nobody
+   maintains.
+Exception: code that runs remote commands, starts a network service, or installs
+an MCP server runs on the user's machine with their credentials — trust-boundary
+findings there are in scope and the default is strict.
+Say plainly when something is correct. Do not manufacture findings.
+
 At the end of your review, include a Memory Update section — this will
 be passed back to you next round.
 ARIS_ROUND_INSTRUCTIONS
@@ -977,6 +1057,26 @@ copilot --agent "$REVIEWER_PROFILE" --model "$REVIEWER_MODEL" \
 
     Please re-score and re-assess. Are the remaining concerns addressed?
     Same format: Score, Verdict, Remaining Weaknesses, Minimum Fixes.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 ## Review Tracing

--- a/skills/experiment-bridge/SKILL.md
+++ b/skills/experiment-bridge/SKILL.md
@@ -140,6 +140,26 @@ mcp__codex__codex:
     6. Any potential issues (OOM risk, numerical instability, missing seeds)?
 
     For each issue found, specify: CRITICAL / MAJOR / MINOR and the exact fix.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 **On review results:**

--- a/skills/meta-apply/SKILL.md
+++ b/skills/meta-apply/SKILL.md
@@ -39,9 +39,13 @@ never silently apply:
    NOT codex-reply; `model: gpt-5.6-sol`, `config: {"model_reasoning_effort": "ultra"}`, `sandbox: read-only`,
    paths-only per [`reviewer-independence.md`](../shared-references/reviewer-independence.md))
    on the staged `.diff` + its target. Ask: *does this change improve the harness without
-   regressions; PASS or KILL + one-line reason.* **KILL ⇒ refuse.** The human cannot
-   override a KILL — they may only pick among jury-PASSED survivors. (A loop can DRIVE;
-   only the cross-model jury can ACQUIT.)
+   regressions; PASS or KILL + one-line reason.* Include the scope-limits block from
+   [`review-scope-limits.md`](../shared-references/review-scope-limits.md) in that prompt:
+   this jury judges ARIS's own mechanism, so an over-defensive KILL permanently blocks a
+   good patch. Note the block bans *proposing new* hash binding — it is not a reason to
+   KILL a patch that touches the existing provenance stamp. **KILL ⇒ refuse.** The human
+   cannot override a KILL — they may only pick among jury-PASSED survivors. (A loop can
+   DRIVE; only the cross-model jury can ACQUIT.)
 3. **Author ≠ reviewer family.** The author is the producer's executor model; the reviewer
    is the codex model that just judged it. Run `provenance.py assert_cross_family` — if it
    raises (same family / unknown), refuse. (Here it always holds: producer=Claude,

--- a/skills/meta-optimize/SKILL.md
+++ b/skills/meta-optimize/SKILL.md
@@ -284,6 +284,26 @@ mcp__codex__codex:
     4. Score 1-10: should this be applied?
     
     If score < 7, explain what additional evidence would be needed.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 ### Step 5: Present Results

--- a/skills/paper-writing/SKILL.md
+++ b/skills/paper-writing/SKILL.md
@@ -215,6 +215,26 @@ contract is what gets graded.)
        satisfy — flag now, not after writing. End with exactly one line:
        CONTRACT_ACCEPTED: yes    or    CONTRACT_ACCEPTED: no
        followed by your numbered revision demands if no.
+
+       === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+       Report anything that is actually wrong here — including a rare-looking case, if
+       this repo actually produces it. Then keep the fix in scope:
+       1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+          welcome; over-defense is not. Assume a cooperating operator on their own
+          machine — a malicious local user is NOT in the threat model.
+       2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+          Reporting a real defect in hashing code that already exists is fine.
+       3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+          layers, or wrappers added for cases that do not occur in practice.
+       4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+          millisecond races are out of scope unless you can show the case arises here.
+       5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+          judgement. A clear sentence a human reads beats a scored table nobody
+          maintains.
+       Exception: code that runs remote commands, starts a network service, or installs
+       an MCP server runs on the user's machine with their credentials — trust-boundary
+       findings there are in scope and the default is strict.
+       Say plainly when something is correct. Do not manufacture findings.
    ```
 
    A reply with a missing or malformed `CONTRACT_ACCEPTED:` line is treated as

--- a/skills/shared-references/review-scope-limits.md
+++ b/skills/shared-references/review-scope-limits.md
@@ -1,0 +1,77 @@
+# Review Scope Limits — what a reviewer may propose
+
+ARIS is a research-workflow tool. Its reviewers exist to find what is **actually
+wrong**, not to harden a codebase against what is not happening.
+
+This contract is about what a reviewer may **propose**. It never limits what a
+reviewer may **look for** — see *Find vs propose* below.
+
+## The block
+
+Every reviewer prompt that can result in a proposed change to code, prompts, or
+mechanism carries this verbatim:
+
+```
+=== SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+Report anything that is actually wrong here — including a rare-looking case, if
+this repo actually produces it. Then keep the fix in scope:
+1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+   welcome; over-defense is not. Assume a cooperating operator on their own
+   machine — a malicious local user is NOT in the threat model.
+2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+   Reporting a real defect in hashing code that already exists is fine.
+3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+   layers, or wrappers added for cases that do not occur in practice.
+4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+   millisecond races are out of scope unless you can show the case arises here.
+5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+   judgement. A clear sentence a human reads beats a scored table nobody
+   maintains.
+Exception: code that runs remote commands, starts a network service, or installs
+an MCP server runs on the user's machine with their credentials — trust-boundary
+findings there are in scope and the default is strict.
+Say plainly when something is correct. Do not manufacture findings.
+```
+
+## Find vs propose
+
+These limits bound the **fix**, never the **search**. A reviewer should still
+report:
+
+- a bug that only fires on an unusual input, **if that input actually occurs**
+  here (a documented example that produces it counts as occurring);
+- a real defect in existing hash/fingerprint code — the ban is on *proposing new*
+  binding, not on reading what exists;
+- a case where the code and its own documentation disagree.
+
+Worded the wrong way, "no corner cases" would suppress real findings. The test is
+not *how rare does this sound*, it is **does this happen here**.
+
+## The one exception
+
+Code that **executes remote commands, starts a network service, or installs an
+MCP server** is different. Trust-boundary findings there are in scope and the
+default is strict — that code runs on a user's GPU box with their credentials.
+`/experiment-queue`, `/run-experiment`, `/vast-gpu`, `/serverless-modal`,
+`mcp-servers/*` and the installers are the surfaces this covers.
+
+## Why this exists
+
+Not a style preference. Measured over one day of real maintenance review
+(2026-08-10, ~10 rounds of gpt-5.6-sol at xhigh/ultra), every discarded proposal
+fell in these categories: adding hash binding to a gate that already had four
+layers, adding a lint to mechanize a rule the corpus deliberately keeps as prose,
+adding a dual-spelling compatibility layer for what was a typo, and hardening a
+race that closes in milliseconds. None was self-limiting; each had to be refused
+by hand.
+
+The same reviewer, in the same rounds, found five genuine defects that had shipped
+— including one that killed every job in the experiment queue at 60 seconds. The
+reviewer is worth its cost. This contract is how that value arrives without the
+tax.
+
+## Related
+
+- [`acceptance-gate.md`](acceptance-gate.md) — what a reviewer verdict may and may not settle.
+- [`reviewer-independence.md`](reviewer-independence.md) — what the reviewer is allowed to see.
+- [`reviewer-routing.md`](reviewer-routing.md) — which backend, which effort tier.

--- a/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
+++ b/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
@@ -85,7 +85,7 @@ Long-running loops may hit the context window limit, triggering automatic compac
 In addition to the overwritable state file, maintain an **append-only** acquittal log at `review-stage/ACQUITTAL_LOG.jsonl`. Each line is a standalone JSON object recording an acquitting positive verdict:
 
 ```jsonl
-{"run_id":"run_20260713_a1b2c3d4","round":3,"backend":"codex","effort":"xhigh","verdict":"ready","score":7.5,"trace_id":"trace_20260713_run03","timestamp":"2026-07-13T14:22:00Z"}
+{"run_id":"run_20260713_a1b2c3d4","round":3,"backend":"claude-review","effort":"high-rigor","verdict":"ready","score":7.5,"trace_id":"trace_20260713_run03","timestamp":"2026-07-13T14:22:00Z"}
 ```
 
 **Rules (non-negotiable):**
@@ -188,7 +188,7 @@ Use the same `mcp__claude-review__review_start` / `mcp__claude-review__review_re
 
 ##### Nightmare — Independent Repository Review
 
-Use everything in hard mode, then ask an additional fresh adversarial reviewer to verify claims against repository files, logs, result files, and paper drafts instead of trusting executor summaries. Preserve the fresh review as a separate raw response and trace.
+Use everything in hard mode, then ask an additional fresh adversarial reviewer to verify claims against repository files, logs, result files, and paper drafts instead of trusting executor summaries. Preserve the fresh review as a separate raw response and trace. That reviewer is fresh, so it does not inherit the scope limits from the medium/hard prompt — repeat the block from [`review-scope-limits.md`](../shared-references/review-scope-limits.md) in its prompt. This is the mode with the widest repository access and the one most likely to propose defensive scaffolding.
 
 #### Phase B: Parse Assessment
 
@@ -368,7 +368,7 @@ This is the authoritative record. Do NOT truncate or paraphrase.]
 
 **If score >= 6 AND verdict ∈ {"ready", "almost"}:** append an acquittal line to `review-stage/ACQUITTAL_LOG.jsonl`:
 ```
-{"run_id":"<current-run_id>","round":<N>,"backend":"codex","effort":"xhigh","verdict":"<ready|almost>","score":<score>,"trace_id":"<skill>/<YYYY-MM-DD>_run<NN>","timestamp":"<ISO8601>"}
+{"run_id":"<current-run_id>","round":<N>,"backend":"claude-review","effort":"high-rigor","verdict":"<ready|almost>","score":<score>,"trace_id":"<skill>/<YYYY-MM-DD>_run<NN>","timestamp":"<ISO8601>"}
 ```
 Use `>>` (append), never `>`. The `trace_id` must be the actual trace directory relative to `.aris/traces/` (for example `auto-review-loop/2026-07-13_run01`), not a fabricated `trace_...` identifier.
 
@@ -481,7 +481,7 @@ The following test cases validate the `run_id` + append-only acquittal receipt m
 
 ### Test 2: Stale Completed State — Old Run's Acquittal Does NOT Satisfy New Run
 
-**Setup:** Run 1 (run_id=`run_20260713_aaaaaaaa`) completes with `status: "completed"` and writes acquittal: `{"run_id":"run_20260713_aaaaaaaa","backend":"codex","verdict":"ready","score":7}` to `ACQUITTAL_LOG.jsonl`. Then a fresh-start invocation generates run_id=`run_20260713_bbbbbbbb`.
+**Setup:** Run 1 (run_id=`run_20260713_aaaaaaaa`) completes with `status: "completed"` and writes acquittal: `{"run_id":"run_20260713_aaaaaaaa","backend":"claude-review","verdict":"ready","score":7}` to `ACQUITTAL_LOG.jsonl`. Then a fresh-start invocation generates run_id=`run_20260713_bbbbbbbb`.
 
 **Action:** Run 2 round 1 returns score=5, verdict="not ready". Continue to round 2, score=8, verdict="ready".
 

--- a/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
+++ b/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
@@ -37,12 +37,13 @@ Autonomously iterate: review → implement fixes → re-review, until the extern
 
 ## Claude-Aligned Reviewer Memory and Debate
 
-Maintain `review-stage/REVIEWER_MEMORY.md` regardless of `REVIEWER_DIFFICULTY` (Phase B.5 runs for all modes, including `medium`). For `hard` and `nightmare`, additionally prepend memory to each reviewer call and require a `Memory update` section.
+Maintain `review-stage/REVIEWER_MEMORY.md` in all difficulty modes. Phase B.5 appends the reviewer's raw response and memory update regardless of `REVIEWER_DIFFICULTY`.
 
 - Before each reviewer call, prepend the full `REVIEWER_MEMORY.md` contents under `## Your Reviewer Memory (persistent across rounds)`.
 - Tell the reviewer to check whether prior suspicions were genuinely addressed or merely sidestepped.
 - Require a `Memory update` section in the reviewer response.
 - After Phase B, copy the `Memory update` into `REVIEWER_MEMORY.md` before writing `REVIEW_STATE.json`.
+- For `difficulty: hard` and `difficulty: nightmare`, additionally use the **Debate Protocol** after a critical review.
 - In `nightmare`, launch an additional fresh adversarial reviewer with direct repository/file-reading instructions. It should read `NARRATIVE_REPORT.md` or `review-stage/AUTO_REVIEW.md` for the author's claims, then verify those claims against code, logs, result files, and paper drafts instead of trusting executor summaries.
 
 ## Instructions
@@ -62,6 +63,7 @@ Long-running loops may hit the context window limit, triggering automatic compac
 
 ```json
 {
+  "run_id": "run_20260713_a1b2c3d4",
   "round": 2,
   "threadId": "019cd392-...",
   "status": "in_progress",
@@ -72,9 +74,29 @@ Long-running loops may hit the context window limit, triggering automatic compac
 }
 ```
 
-**Write this file at the end of every Phase E** (after documenting the round). Overwrite each time — only the latest state matters.
+- **`run_id`** — Globally unique per invocation. Generated on fresh start as `run_<YYYYMMDD>_<8-char-hex>` (e.g., `run_20260713_a1b2c3d4`). Preserved across round writes. On resume, read from state file unchanged. This binds all round state and acquittal receipts to one run.
+
+**Write this file at the end of every Phase E** (after documenting the round). Overwrite each time — only the latest round's state matters. The `run_id` field MUST persist unchanged across overwrites within the same run.
 
 **On completion** (positive assessment or max rounds), set `"status": "completed"` so future invocations don't accidentally resume a finished loop.
+
+### Append-Only Acquittal Receipt
+
+In addition to the overwritable state file, maintain an **append-only** acquittal log at `review-stage/ACQUITTAL_LOG.jsonl`. Each line is a standalone JSON object recording an acquitting positive verdict:
+
+```jsonl
+{"run_id":"run_20260713_a1b2c3d4","round":3,"backend":"codex","effort":"xhigh","verdict":"ready","score":7.5,"trace_id":"trace_20260713_run03","timestamp":"2026-07-13T14:22:00Z"}
+```
+
+**Rules (non-negotiable):**
+
+| Rule | Detail |
+|------|--------|
+| **Append-only** | Never delete, never truncate, never overwrite lines. Only `>>`. |
+| **When to write** | At the end of Phase E, immediately after a positive verdict (score >= 6 AND verdict ∈ {"ready", "almost"}). |
+| **`run_id` binding** | Every acquittal line carries the current `run_id`. Only entries whose `run_id` matches the current run are valid acquittals for stop decisions. |
+| **Trace linkage** | `trace_id` MUST reference a trace artifact in `.aris/traces/`. |
+| **No overwrite** | `REVIEW_STATE.json` is overwritten each round. `ACQUITTAL_LOG.jsonl` is NEVER overwritten — it is the permanent, cumulative record.
 
 ## Workflow
 
@@ -82,10 +104,14 @@ Long-running loops may hit the context window limit, triggering automatic compac
 
 1. **Check for `review-stage/REVIEW_STATE.json`** *(fall back to `./REVIEW_STATE.json` if not found — legacy path)*:
    - If neither path exists: **fresh start** (normal case, identical to behavior before this feature existed)
-   - If it exists AND `status` is `"completed"`: **fresh start** (previous loop finished normally)
+     - **Generate `run_id`**: `run_<YYYYMMDD>_<8-char-hex>` (e.g., `run_20260713_a1b2c3d4`). This run_id persists across all round writes and binds acquittal receipts to this invocation.
+   - If it exists AND `status` is `"completed"`: **fresh start** (previous loop finished normally — but its `ACQUITTAL_LOG.jsonl` entries are retained as an audit trail with their own `run_id`, and are NOT valid for the current run's stop gate)
+     - **Generate a new `run_id`** for this invocation.
    - If it exists AND `status` is `"in_progress"` AND `timestamp` is older than 24 hours: **fresh start** (stale state from a killed/abandoned run — delete the file and start over)
+     - **Generate a new `run_id`** for this invocation.
    - If it exists AND `status` is `"in_progress"` AND `timestamp` is within 24 hours: **resume**
-     - Read the state file to recover `round`, `threadId`, `last_score`, `pending_experiments`
+     - Read the state file to recover `run_id`, `round`, `threadId`, `last_score`, `pending_experiments`
+     - **Legacy backward compat**: if `run_id` is absent from the state file (pre-run_id era), generate a new `run_id` and log: "No run_id in legacy state file; assigned run_<...> for this resume."
      - Read `review-stage/AUTO_REVIEW.md` to restore full context of prior rounds *(fall back to `./AUTO_REVIEW.md`)*
      - If `pending_experiments` is non-empty, check if they have completed (e.g., check screen sessions)
      - Resume from the next round (round = saved round + 1)
@@ -130,6 +156,26 @@ mcp__claude-review__review_start:
 
     Be brutally honest. If, after genuinely trying to break it, the work holds
     up and is ready, say so clearly.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
@@ -186,9 +232,9 @@ Rules:
 
 #### Phase B.5.1: Stop-Evaluation Gate
 
-**STOP CONDITION**: If score >= 6 AND verdict ∈ {"ready", "almost"} (exact match — "not ready" does NOT qualify) → stop loop, document final state. This evaluation runs AFTER Phase B.5 so the terminal-round memory is always appended to REVIEWER_MEMORY.md before exit, including for medium-mode terminal rounds.
+**STOP CONDITION**: If score >= 6 AND verdict ∈ {"ready", "almost"} (exact match — "not ready" does NOT qualify), decide to stop and continue through Phase E. **Do not write a receipt here**; Phase E is the single append site.
 
-> **Ordering regression guard**: Any future edit that moves the stop gate before the memory update (Phase B.5) MUST keep it here or later. A positive terminal round in any difficulty mode (including medium) must first persist its reviewer memory so the loop's final state is complete. The mainline SKILL.md (`skills/auto-review-loop/SKILL.md`) places the gate at Phase B.5.1; this mirror must stay in sync.
+This evaluation runs AFTER Phase B.5 so the terminal-round memory is always appended to REVIEWER_MEMORY.md before exit.
 
 #### Phase B.6: Debate Protocol (hard + nightmare only)
 
@@ -318,7 +364,13 @@ This is the authoritative record. Do NOT truncate or paraphrase.]
 - [continuing to round N+1 / stopping]
 ```
 
-**Write `review-stage/REVIEW_STATE.json`** with current round, completed threadId, score, verdict, and any pending experiments.
+**Write `review-stage/REVIEW_STATE.json`** with current `run_id`, round, completed threadId, score, verdict, and any pending experiments. The `run_id` field MUST persist unchanged from initialization; do NOT regenerate it per round.
+
+**If score >= 6 AND verdict ∈ {"ready", "almost"}:** append an acquittal line to `review-stage/ACQUITTAL_LOG.jsonl`:
+```
+{"run_id":"<current-run_id>","round":<N>,"backend":"codex","effort":"xhigh","verdict":"<ready|almost>","score":<score>,"trace_id":"<skill>/<YYYY-MM-DD>_run<NN>","timestamp":"<ISO8601>"}
+```
+Use `>>` (append), never `>`. The `trace_id` must be the actual trace directory relative to `.aris/traces/` (for example `auto-review-loop/2026-07-13_run01`), not a fabricated `trace_...` identifier.
 
 **Append to `findings.md`** (when `COMPACT = true`): one-line entry per key finding this round.
 
@@ -391,6 +443,60 @@ mcp__claude-review__review_reply_start:
 
     Please re-score and re-assess. Are the remaining concerns addressed?
     Same format: Score, Verdict, Remaining Weaknesses, Minimum Fixes.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 After this start call, immediately save the returned `jobId` and poll `mcp__claude-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
+
+## Acquittal Gate Test Specifications
+
+The following test cases validate the `run_id` + append-only acquittal receipt mechanism.
+
+### Test 1: Fresh Start — Codex Acquits
+
+**Setup:** Delete `review-stage/REVIEW_STATE.json` and `review-stage/ACQUITTAL_LOG.jsonl`. Run review.
+
+**Action:** Codex round 1 returns score=7, verdict="ready".
+
+**Expected:** Phase E writes acquittal line to `ACQUITTAL_LOG.jsonl` with current `run_id`. Loop stops.
+
+### Test 2: Stale Completed State — Old Run's Acquittal Does NOT Satisfy New Run
+
+**Setup:** Run 1 (run_id=`run_20260713_aaaaaaaa`) completes with `status: "completed"` and writes acquittal: `{"run_id":"run_20260713_aaaaaaaa","backend":"codex","verdict":"ready","score":7}` to `ACQUITTAL_LOG.jsonl`. Then a fresh-start invocation generates run_id=`run_20260713_bbbbbbbb`.
+
+**Action:** Run 2 round 1 returns score=5, verdict="not ready". Continue to round 2, score=8, verdict="ready".
+
+**Expected:** Run 2's acquittal line has `run_id=run_20260713_bbbbbbbb`. The old acquittal with `run_id=run_20260713_aaaaaaaa` is an audit artifact only. The stop gate for run 2 uses the current-run acquittal.
+
+### Test 3: Legacy State File — No run_id Field
+
+**Setup:** Create a `REVIEW_STATE.json` with `status: "in_progress"`, a fresh timestamp, but NO `run_id` field. Resume.
+
+**Expected:** Initialization detects missing `run_id` and generates one. Log: "No run_id in legacy state file; assigned run_<...> for this resume."
+
+### Test 4: Append-Only Integrity
+
+**Setup:** Run 1 reaches a positive verdict, appends one receipt, and stops. Start Run 2 with a new `run_id`; it also reaches a positive verdict and appends one receipt.
+
+**Action:** After the loop, inspect `ACQUITTAL_LOG.jsonl`.
+
+**Expected:** File contains exactly 2 lines with different run IDs. Run 1's line remains unchanged after Run 2 appends; a stopped loop cannot continue to a later positive round.

--- a/skills/skills-codex-gemini-review/auto-review-loop/SKILL.md
+++ b/skills/skills-codex-gemini-review/auto-review-loop/SKILL.md
@@ -86,6 +86,26 @@ mcp__gemini-review__review_start:
     4. State clearly: is this READY for submission? Yes/No/Almost
 
     Be brutally honest. If the work is ready, say so clearly.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 After this start call, immediately save the returned `jobId` and poll `mcp__gemini-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.
@@ -251,6 +271,26 @@ mcp__gemini-review__review_reply_start:
 
     Please re-score and re-assess. Are the remaining concerns addressed?
     Same format: Score, Verdict, Remaining Weaknesses, Minimum Fixes.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 After this start call, immediately save the returned `jobId` and poll `mcp__gemini-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the reviewer output, and save the completed `threadId` for any follow-up round.

--- a/skills/skills-codex/auto-review-loop/SKILL.md
+++ b/skills/skills-codex/auto-review-loop/SKILL.md
@@ -182,7 +182,7 @@ Use the same `spawn_agent` / `send_input` route as medium, but prepend the full 
 
 ##### Nightmare — Independent Repository Review
 
-Use everything in hard mode, then ask an additional fresh adversarial reviewer to verify claims against repository files, logs, result files, and paper drafts instead of trusting executor summaries. Preserve the fresh review as a separate raw response and trace.
+Use everything in hard mode, then ask an additional fresh adversarial reviewer to verify claims against repository files, logs, result files, and paper drafts instead of trusting executor summaries. Preserve the fresh review as a separate raw response and trace. That reviewer is fresh, so it does not inherit the scope limits from the medium/hard prompt — repeat the block from [`review-scope-limits.md`](../shared-references/review-scope-limits.md) in its prompt. This is the mode with the widest repository access and the one most likely to propose defensive scaffolding.
 
 #### Phase B: Parse Assessment
 

--- a/skills/skills-codex/auto-review-loop/SKILL.md
+++ b/skills/skills-codex/auto-review-loop/SKILL.md
@@ -152,6 +152,26 @@ spawn_agent:
 
     Be brutally honest. If, after genuinely trying to break it, the work holds
     up and is ready, say so clearly.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 If this is round 2+, use `send_input` with the saved agent id to maintain continuity.
@@ -415,6 +435,26 @@ send_input:
 
     Please re-score and re-assess. Are the remaining concerns addressed?
     Same format: Score, Verdict, Remaining Weaknesses, Minimum Fixes.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 ## Acquittal Gate Test Specifications

--- a/skills/skills-codex/experiment-bridge/SKILL.md
+++ b/skills/skills-codex/experiment-bridge/SKILL.md
@@ -140,6 +140,26 @@ spawn_agent:
     - BLOCKING issues that must be fixed before deployment
     - NON-BLOCKING issues that can wait
     - Suggested patches or checks
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 If BLOCKING issues are found, fix them and re-run this review once before Phase 3. Save the reviewer response and any fixes in `refine-logs/EXPERIMENT_CODE_REVIEW.md`. If reviewer delegation is unavailable, run the same checklist locally and mark the review `[local-only]`.

--- a/skills/skills-codex/meta-apply/SKILL.md
+++ b/skills/skills-codex/meta-apply/SKILL.md
@@ -44,7 +44,11 @@ never silently apply:
    reviewer via `spawn_agent` (`reasoning_effort: ultra`, read-only, paths-only per
    [`reviewer-independence.md`](../shared-references/reviewer-independence.md)) on the
    staged `.diff` + its target. Ask: *does this change improve the harness without
-   regressions; PASS or KILL + one-line reason.* **KILL ⇒ refuse.** The human cannot
+   regressions; PASS or KILL + one-line reason.* Include the scope-limits block from
+   [`review-scope-limits.md`](../shared-references/review-scope-limits.md): this jury
+   judges ARIS's own mechanism, so an over-defensive KILL permanently blocks a good
+   patch. The block bans *proposing new* hash binding — it is not a reason to KILL a
+   patch that touches the existing provenance stamp. **KILL ⇒ refuse.** The human cannot
    override a KILL — they may only pick among reviewer-PASSED survivors.
 3. **Record the review class honestly.** Base Codex review is same-family and
    lands only with `stamp-provisional`; it can complete this explicit

--- a/skills/skills-codex/meta-optimize/SKILL.md
+++ b/skills/skills-codex/meta-optimize/SKILL.md
@@ -213,6 +213,26 @@ spawn_agent:
     4. Score 1-10: should this be applied?
     
     If score < 7, explain what additional evidence would be needed.
+
+    === SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+    Report anything that is actually wrong here — including a rare-looking case, if
+    this repo actually produces it. Then keep the fix in scope:
+    1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+       welcome; over-defense is not. Assume a cooperating operator on their own
+       machine — a malicious local user is NOT in the threat model.
+    2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+       Reporting a real defect in hashing code that already exists is fine.
+    3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+       layers, or wrappers added for cases that do not occur in practice.
+    4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+       millisecond races are out of scope unless you can show the case arises here.
+    5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+       judgement. A clear sentence a human reads beats a scored table nobody
+       maintains.
+    Exception: code that runs remote commands, starts a network service, or installs
+    an MCP server runs on the user's machine with their credentials — trust-boundary
+    findings there are in scope and the default is strict.
+    Say plainly when something is correct. Do not manufacture findings.
 ```
 
 ### Step 5: Present Results

--- a/skills/skills-codex/paper-writing/SKILL.md
+++ b/skills/skills-codex/paper-writing/SKILL.md
@@ -156,6 +156,9 @@ contract is what gets graded.)
    `CONTRACT_ACCEPTED: no` plus numbered revision demands. A reply with a
    missing or malformed verdict line is treated as `no`; request a corrected
    verdict as a follow-up — the correction exchange does not consume a round.
+   Include the scope-limits block from
+   [`review-scope-limits.md`](../shared-references/review-scope-limits.md) in the
+   brief.
 
 3. **Iterate.** On `no`, revise per the demands and resubmit as a follow-up in
    the SAME reviewer thread (the negotiation is one conversation). **Max 3

--- a/skills/skills-codex/shared-references/review-scope-limits.md
+++ b/skills/skills-codex/shared-references/review-scope-limits.md
@@ -1,0 +1,77 @@
+# Review Scope Limits — what a reviewer may propose
+
+ARIS is a research-workflow tool. Its reviewers exist to find what is **actually
+wrong**, not to harden a codebase against what is not happening.
+
+This contract is about what a reviewer may **propose**. It never limits what a
+reviewer may **look for** — see *Find vs propose* below.
+
+## The block
+
+Every reviewer prompt that can result in a proposed change to code, prompts, or
+mechanism carries this verbatim:
+
+```
+=== SCOPE LIMITS (these bound what you PROPOSE, never what you look for) ===
+Report anything that is actually wrong here — including a rare-looking case, if
+this repo actually produces it. Then keep the fix in scope:
+1. This is a RESEARCH-WORKFLOW tool, not a security paper. Verification is
+   welcome; over-defense is not. Assume a cooperating operator on their own
+   machine — a malicious local user is NOT in the threat model.
+2. Do NOT propose SHA / hash / content-fingerprint / digest-binding schemes.
+   Reporting a real defect in hashing code that already exists is fine.
+3. NO defensive scaffolding: no feature flags, migration frameworks, compat
+   layers, or wrappers added for cases that do not occur in practice.
+4. NO corner-case obsession: exotic encodings, symlink races, RTL text and
+   millisecond races are out of scope unless you can show the case arises here.
+5. Where a rubric or checklist is genuinely needed, do not over-mechanize
+   judgement. A clear sentence a human reads beats a scored table nobody
+   maintains.
+Exception: code that runs remote commands, starts a network service, or installs
+an MCP server runs on the user's machine with their credentials — trust-boundary
+findings there are in scope and the default is strict.
+Say plainly when something is correct. Do not manufacture findings.
+```
+
+## Find vs propose
+
+These limits bound the **fix**, never the **search**. A reviewer should still
+report:
+
+- a bug that only fires on an unusual input, **if that input actually occurs**
+  here (a documented example that produces it counts as occurring);
+- a real defect in existing hash/fingerprint code — the ban is on *proposing new*
+  binding, not on reading what exists;
+- a case where the code and its own documentation disagree.
+
+Worded the wrong way, "no corner cases" would suppress real findings. The test is
+not *how rare does this sound*, it is **does this happen here**.
+
+## The one exception
+
+Code that **executes remote commands, starts a network service, or installs an
+MCP server** is different. Trust-boundary findings there are in scope and the
+default is strict — that code runs on a user's GPU box with their credentials.
+`/experiment-queue`, `/run-experiment`, `/vast-gpu`, `/serverless-modal`,
+`mcp-servers/*` and the installers are the surfaces this covers.
+
+## Why this exists
+
+Not a style preference. Measured over one day of real maintenance review
+(2026-08-10, ~10 rounds of gpt-5.6-sol at xhigh/ultra), every discarded proposal
+fell in these categories: adding hash binding to a gate that already had four
+layers, adding a lint to mechanize a rule the corpus deliberately keeps as prose,
+adding a dual-spelling compatibility layer for what was a typo, and hardening a
+race that closes in milliseconds. None was self-limiting; each had to be refused
+by hand.
+
+The same reviewer, in the same rounds, found five genuine defects that had shipped
+— including one that killed every job in the experiment queue at 60 seconds. The
+reviewer is worth its cost. This contract is how that value arrives without the
+tax.
+
+## Related
+
+- [`acceptance-gate.md`](acceptance-gate.md) — what a reviewer verdict may and may not settle.
+- [`reviewer-independence.md`](reviewer-independence.md) — what the reviewer is allowed to see.
+- [`reviewer-routing.md`](reviewer-routing.md) — which backend, which effort tier.

--- a/tests/test_codex_skill_mirror.py
+++ b/tests/test_codex_skill_mirror.py
@@ -42,7 +42,7 @@ def test_codex_skill_set_matches_mainline() -> None:
 def test_codex_shared_reference_set_matches_mainline() -> None:
     main_refs = {p.name for p in (MAIN_SKILLS / "shared-references").glob("*.md")}
     codex_refs = {p.name for p in (CODEX_SKILLS / "shared-references").glob("*.md")}
-    assert len(main_refs) == 30
+    assert len(main_refs) == 31
     assert codex_refs == main_refs
 
 

--- a/tools/generate_codex_claude_review_overrides.py
+++ b/tools/generate_codex_claude_review_overrides.py
@@ -163,6 +163,12 @@ def transform_body(text: str) -> str:
         text,
         count=1,
     )
+    # The acquittal receipt example is a literal the overlay would copy verbatim.
+    # This pack's backend is claude-review, so leaving the source's "codex" in it
+    # makes every overlay run write a false receipt.
+    text = text.replace('"backend":"codex","effort":"xhigh"', '"backend":"claude-review","effort":"high-rigor"')
+    text = text.replace('"backend": "codex", "effort": "xhigh"', '"backend": "claude-review", "effort": "high-rigor"')
+    text = text.replace('"backend":"codex"', '"backend":"claude-review"')
     text = text.replace("secondary Codex agent", "Claude reviewer via `claude-review` MCP")
     text = text.replace("via a Claude reviewer via `claude-review` MCP (xhigh reasoning)", "via `claude-review` MCP (high-rigor review)")
     text = text.replace("secondary Codex agent (xhigh reasoning)", "Claude reviewer via `claude-review` MCP")


### PR DESCRIPTION
## Why

`gpt-5.6-sol` over-defends, systematically. Measured over one day of real maintenance review (2026-08-10, ~10 rounds at xhigh/ultra), **every** proposal that got discarded fell into the same four categories:

- adding hash binding to a gate that already had four layers
- adding a lint to mechanize a rule this corpus deliberately keeps as prose
- adding a dual-spelling compatibility layer for what was a typo
- hardening a race that closes in milliseconds

None of them was self-limiting; each had to be refused by hand. The **same** reviewer, in the **same** rounds, found five genuine shipped defects — including the one that killed every job in `/experiment-queue` at 60 seconds. The reviewer earns its cost. This is how that value arrives without the tax.

## What lands

New shared reference `skills/shared-references/review-scope-limits.md` holds the contract. Its block is framed as bounding what a reviewer may **propose**, never what it may **look for**, and says so in its first line:

> Report anything that is actually wrong here — including a rare-looking case, if this repo actually produces it.

That line is load-bearing. Worded as *"do not report corner cases"*, this contract would have suppressed the bare-string `depends_on` hang found yesterday — which sounds rare but which **our own SKILL.md examples produce**. The test is not *how rare does this sound*, it is *does this happen here*.

Inserted at the prompt bodies where the reviewer audits code or mechanism: `auto-review-loop` (all five bodies — medium, hard, the nightmare `codex exec` heredoc, and both round-2+ templates), `paper-writing` Phase 1.5, `experiment-bridge` Phase 2.5, `meta-optimize` Step 4, and `meta-apply`'s jury — plus the Codex mirrors and the gemini overlay of the same skills.

## What deliberately does NOT get it

A survey classified all **47** reviewer call sites in the corpus: 8 apply, 21 partly, 18 no. Two of the exclusions are not cosmetic:

- **The patent suite would be inverted by it.** `patent-review`'s prompt says *"Be rigorous and specific. This is a real examination."* For an examiner persona, defensive rigor **is** the deliverable — "over-defense is forbidden" reads as "reject less aggressively".
- **`experiment-audit` would contradict itself.** Its prompt is a deliberately mechanized A–F checklist returning PASS/WARN/FAIL, and clause 5 tells the reviewer not to over-mechanize judgement.

The rest are proof checks, citation lookups and retrieval calls where the block is dead text.

## Two wording constraints, both load-bearing

The hash clause says do **not propose new** binding. `meta-apply`'s own provenance stamp carries a `content_hash` and `integrity-forensics` is commit-pinned; a literal-minded jury could otherwise KILL a patch for touching the stamp — **and the human cannot override a KILL**.

The block contains none of the tokens the corpus lints forbid: no `reasoning_effort` (`test_reviewer_pins` takes the first match in the block), no `mcp__codex__` or `model: gpt-` (`test_llm_chat_converter` runs the real `patent-review` through the converter), no `spawn_agent`/`send_input`/`agent_id` (the claude-review overlay scan), and none of the six banned cross-model phrases in the mirror check.

**No lint enforces the block's presence.** Adding one would be the exact failure the contract exists to prevent.

## Two bugs this exposed

**The claude-review overlay was stale since 2026-07-13** while its `skills-codex` source changed 2026-07-15. It is a *generated* file and nobody re-ran the generator; regenerating brought 113 lines with it. Spot-checked that the drift is genuine upstream content (`ACQUITTAL_LOG.jsonl` appears 8× in the source), so overlay users have been running a four-week-old loop — missing the append-only acquittal receipt, the `run_id` binding, and the Phase B.5 memory change. Nothing catches this today; `test_codex_skill_mirror` checks set equality and the spawn/send partition, not whether a generated file matches what the generator would produce.

**A regression I introduced, then fixed.** That regeneration pulled the source's `{"backend":"codex","effort":"xhigh"}` acquittal example into a pack whose backend is `claude-review` — verified 0 occurrences before, 3 after. Every overlay run following that example would have written a receipt naming the wrong reviewer. Fixed **in the generator**, not the generated file.

**And one site I missed.** The mirror's nightmare tier is prose, not a heredoc: *"ask an additional fresh adversarial reviewer to verify claims against repository files..."*. That reviewer is **fresh**, inherits nothing from the medium/hard prompt, and has the widest repository access — the mode most likely to produce exactly the proposals this bounds. Both found by the cross-model review of the first two commits.

## Validation

610 passed, 17 skipped; `check_skills_inventory.py` consistent. `test_codex_skill_mirror`'s reference count goes 30 → 31 with the mirror twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
