### PR TITLE
fix(aris-cli): honor Windows and macOS system proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -518,9 +528,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1152,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1355,6 +1367,27 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1739,6 +1772,35 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/aris-cli/Cargo.toml
+++ b/crates/aris-cli/Cargo.toml
@@ -16,7 +16,9 @@ compat-harness = { path = "../compat-harness" }
 crossterm = "0.28"
 ctrlc = "3"
 serde = { version = "1", features = ["derive"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
+# Keep OS proxy discovery explicit: disabling reqwest's defaults also disables
+# its `system-proxy` feature, which Windows/macOS desktop proxy users rely on.
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls", "system-proxy"] }
 pulldown-cmark = "0.13"
 runtime = { path = "../runtime" }
 serde_json = "1"


### PR DESCRIPTION
## Summary

- explicitly enable the reqwest `system-proxy` feature for the final ARIS CLI dependency graph
- restore Windows and macOS desktop proxy discovery that was disabled together with reqwest default features
- update the lockfile with the platform-specific proxy dependencies

## Why

ARIS intentionally disables reqwest default features in order to select `native-tls`. In reqwest 0.12.28, that also disables `system-proxy`, so users who configure a proxy only through Windows or macOS settings can bypass that proxy and hit a direct-connect timeout.

This keeps the existing TLS choice while enabling only the missing proxy feature. The CLI owns the Gemini executor, and Cargo feature unification enables it for the shared reqwest version in the final binary.

## Validation

- `cargo build --workspace --all-targets`
- `cargo test --workspace -- --test-threads=1` — 559 passed, 1 ignored
- `cargo tree -p aris-cli -e features -i reqwest` confirms `reqwest feature "system-proxy"`
- a focused `x86_64-pc-windows-msvc` cargo check using the same pinned reqwest 0.12.28 feature set passes, including `windows-registry`

A Windows system-proxy runtime smoke test was not available locally. A full workspace cross-check from macOS reaches the existing `onig_sys` C dependency and requires Windows SDK headers, so the repository Windows build job remains the authoritative platform compile gate.

Related to #163