### PR TITLE
fix(arxiv): reject non-PDF downloads

### DIFF
--- a/tests/test_arxiv_fetch.py
+++ b/tests/test_arxiv_fetch.py
@@ -240,7 +240,8 @@ def test_download_rejects_cached_non_pdf_response(tmp_path):
     with pytest.raises(ValueError, match="not a PDF"):
         mod.download("2509.14933", output_dir=str(tmp_path))
 
-    assert cached.read_bytes() == html_error
+    # The poisoned entry is evicted so the next call re-downloads.
+    assert not cached.exists()
 
 
 def test_download_retries_on_429_then_succeeds(monkeypatch, tmp_path):

--- a/tests/test_arxiv_fetch.py
+++ b/tests/test_arxiv_fetch.py
@@ -220,6 +220,29 @@ def test_user_agent_no_contact_when_env_unset(monkeypatch):
 _FAKE_PDF = b"%PDF-1.4\n" + b"x" * 20_000  # > _MIN_PDF_BYTES
 
 
+def test_download_rejects_large_non_pdf_response(monkeypatch, tmp_path):
+    mod = load_module()
+    html_error = b"<!doctype html><title>Service unavailable</title>" + b"x" * 20_000
+    _patch_urlopen(monkeypatch, mod, [html_error])
+
+    with pytest.raises(ValueError, match="not a PDF"):
+        mod.download("2509.14933", output_dir=str(tmp_path))
+
+    assert not (tmp_path / "2509.14933.pdf").exists()
+
+
+def test_download_rejects_cached_non_pdf_response(tmp_path):
+    mod = load_module()
+    cached = tmp_path / "2509.14933.pdf"
+    html_error = b"<!doctype html><title>Service unavailable</title>" + b"x" * 20_000
+    cached.write_bytes(html_error)
+
+    with pytest.raises(ValueError, match="not a PDF"):
+        mod.download("2509.14933", output_dir=str(tmp_path))
+
+    assert cached.read_bytes() == html_error
+
+
 def test_download_retries_on_429_then_succeeds(monkeypatch, tmp_path):
     mod = load_module()
     calls = _patch_urlopen(monkeypatch, mod, [_http_error_429(), _FAKE_PDF])

--- a/tools/arxiv_fetch.py
+++ b/tools/arxiv_fetch.py
@@ -34,6 +34,16 @@ _API_BASE = "http://export.arxiv.org/api/query"
 _MIN_PDF_BYTES = 10_240
 
 
+def _validate_pdf(size_bytes: int, first_bytes: bytes) -> None:
+    """Reject truncated downloads and non-PDF response bodies."""
+    if size_bytes < _MIN_PDF_BYTES:
+        raise ValueError(
+            f"Downloaded file is only {size_bytes} bytes - likely an error page, not a PDF"
+        )
+    if b"%PDF-" not in first_bytes[:1024]:
+        raise ValueError("Downloaded file has no PDF header - likely an error page, not a PDF")
+
+
 def _arxiv_user_agent() -> str:
     """Descriptive User-Agent for arXiv API calls.
 
@@ -170,10 +180,13 @@ def download(arxiv_id: str, output_dir: str = "papers") -> dict:
     dest = dest_dir / f"{safe_id}.pdf"
 
     if dest.exists():
+        size_bytes = dest.stat().st_size
+        with dest.open("rb") as cached_file:
+            _validate_pdf(size_bytes, cached_file.read(1024))
         return {
             "id": clean_id,
             "path": str(dest),
-            "size_kb": dest.stat().st_size // 1024,
+            "size_kb": size_bytes // 1024,
             "skipped": True,
         }
 
@@ -199,10 +212,7 @@ def download(arxiv_id: str, output_dir: str = "papers") -> dict:
     else:
         raise RuntimeError(f"Failed to download {pdf_url} after 3 attempts")
 
-    if len(data) < _MIN_PDF_BYTES:
-        raise ValueError(
-            f"Downloaded file is only {len(data)} bytes - likely an error page, not a PDF"
-        )
+    _validate_pdf(len(data), data)
 
     dest.write_bytes(data)
     return {

--- a/tools/arxiv_fetch.py
+++ b/tools/arxiv_fetch.py
@@ -182,7 +182,15 @@ def download(arxiv_id: str, output_dir: str = "papers") -> dict:
     if dest.exists():
         size_bytes = dest.stat().st_size
         with dest.open("rb") as cached_file:
-            _validate_pdf(size_bytes, cached_file.read(1024))
+            first_bytes = cached_file.read(1024)
+        try:
+            _validate_pdf(size_bytes, first_bytes)
+        except ValueError:
+            # Poisoned cache entry (e.g. an HTML error page saved as .pdf by an
+            # older version): drop it so the next call re-downloads instead of
+            # failing forever.
+            dest.unlink()
+            raise
         return {
             "id": clean_id,
             "path": str(dest),


### PR DESCRIPTION
## Summary

- Fixes: When arXiv or its CDN returns an HTML error body larger than 10 KiB, the downloader writes it with a .pdf extension, reports success, and later treats the invalid file as a successful cached download.
- Root cause: The download path validates only response length before writing, while the existing-file path returns immediately without validating content, so neither path verifies the PDF header.

## Regression evidence

- Before: `uv run --with pytest python -m pytest tests/test_arxiv_fetch.py::test_download_rejects_large_non_pdf_response tests/test_arxiv_fetch.py::test_download_rejects_cached_non_pdf_response -q` exited `1`

- After: `uv run --with pytest python -m pytest tests/test_arxiv_fetch.py::test_download_rejects_large_non_pdf_response tests/test_arxiv_fetch.py::test_download_rejects_cached_non_pdf_response -q` exited `0`

## Verification

- `uv run --with pytest python -m pytest tests/test_arxiv_fetch.py -q`
- `uv run --with pytest --with 'httpx>=0.27,<1.0' python -m pytest tests/ -q`
- `python3 -m compileall -q tools tests`
- `git diff --cached --check`

## Scope

- 2 files changed, +38 / -5 lines
