### PR TITLE
fix(claude-review): prevent overlay YAML escape regression

### DIFF
--- a/skills/skills-codex-claude-review/paper-figure/SKILL.md
+++ b/skills/skills-codex-claude-review/paper-figure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "paper-figure"
-description: "Generate publication-quality figures and tables from experiment results. Use when user says \\"画图\\", \\"作图\\", \\"generate figures\\", \\"paper figures\\", or needs plots for a paper."
+description: "Generate publication-quality figures and tables from experiment results. Use when user says \"画图\", \"作图\", \"generate figures\", \"paper figures\", or needs plots for a paper."
 ---
 
 > Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.

--- a/skills/skills-codex-claude-review/paper-plan/SKILL.md
+++ b/skills/skills-codex-claude-review/paper-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "paper-plan"
-description: "Generate a structured paper outline from review conclusions and experiment results. Use when user says \\"写大纲\\", \\"paper outline\\", \\"plan the paper\\", \\"论文规划\\", or wants to create a paper plan before writing."
+description: "Generate a structured paper outline from review conclusions and experiment results. Use when user says \"写大纲\", \"paper outline\", \"plan the paper\", \"论文规划\", or wants to create a paper plan before writing."
 ---
 
 > Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.

--- a/skills/skills-codex-claude-review/paper-write/SKILL.md
+++ b/skills/skills-codex-claude-review/paper-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "paper-write"
-description: "Draft LaTeX paper section by section from an outline. Use when user says \\"写论文\\", \\"write paper\\", \\"draft LaTeX\\", \\"开始写\\", or wants to generate LaTeX content from a paper plan."
+description: "Draft LaTeX paper section by section from an outline. Use when user says \"写论文\", \"write paper\", \"draft LaTeX\", \"开始写\", or wants to generate LaTeX content from a paper plan."
 ---
 
 > Override for Codex users who want **Claude Code**, not a second Codex agent, to act as the reviewer. Install this package **after** `skills/skills-codex/*`.

--- a/tests/test_claude_review_generator.py
+++ b/tests/test_claude_review_generator.py
@@ -1,0 +1,51 @@
+"""Regression tests for Claude-review overlay frontmatter generation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.generate_codex_claude_review_overrides import (
+    FRONTMATTER_RE,
+    TARGET_SKILLS,
+    build_frontmatter,
+    extract_field,
+    normalize_description,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CODEX_SKILLS = REPO_ROOT / "skills" / "skills-codex"
+CLAUDE_OVERLAY = REPO_ROOT / "skills" / "skills-codex-claude-review"
+
+
+def _frontmatter_value(text: str, field: str) -> str:
+    match = FRONTMATTER_RE.match(text)
+    assert match is not None
+    line = next(
+        line for line in match.group(1).splitlines()
+        if line.startswith(f"{field}:")
+    )
+    return line.split(":", 1)[1].strip()
+
+
+def test_generator_emits_parseable_string_frontmatter() -> None:
+    """Legacy double-escaped descriptions must not return on regeneration."""
+    for skill in TARGET_SKILLS:
+        source = (CODEX_SKILLS / skill / "SKILL.md").read_text(encoding="utf-8")
+        source_match = FRONTMATTER_RE.match(source)
+        assert source_match is not None
+        description = normalize_description(
+            extract_field(source_match.group(1), "description")
+        )
+        generated = build_frontmatter(skill, description)
+
+        assert isinstance(json.loads(_frontmatter_value(generated, "name")), str)
+        assert isinstance(json.loads(_frontmatter_value(generated, "description")), str)
+
+
+def test_checked_in_claude_overlay_frontmatter_is_parseable() -> None:
+    for skill in TARGET_SKILLS:
+        text = (CLAUDE_OVERLAY / skill / "SKILL.md").read_text(encoding="utf-8")
+        assert isinstance(json.loads(_frontmatter_value(text, "name")), str)
+        assert isinstance(json.loads(_frontmatter_value(text, "description")), str)

--- a/tools/generate_codex_claude_review_overrides.py
+++ b/tools/generate_codex_claude_review_overrides.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import re
 import shutil
 from pathlib import Path
@@ -69,12 +70,21 @@ def extract_field(frontmatter: str, field: str) -> str:
 
 
 def build_frontmatter(name: str, description: str) -> str:
-    safe_desc = description.replace('"', '\\"')
-    return f'---\nname: "{name}"\ndescription: "{safe_desc}"\n---\n\n'
+    # JSON strings are a valid subset of YAML double-quoted scalars. Using a
+    # serializer here keeps backslashes and quotes from being escaped twice.
+    return (
+        f'---\nname: {json.dumps(name, ensure_ascii=False)}\n'
+        f'description: {json.dumps(description, ensure_ascii=False)}\n'
+        '---\n\n'
+    )
 
 
 def normalize_description(text: str) -> str:
     text = text or "Claude-review override for a Codex-native ARIS skill."
+    # A few legacy Codex-mirror descriptions contain an extra escape layer
+    # (the parsed value is `\\\"` instead of `\"`). Remove that layer before
+    # serializing the Claude overlay so regeneration stays idempotent.
+    text = text.replace('\\\"', '"')
     text = text.replace("GPT using a secondary Codex agent", "Claude via claude-review MCP")
     text = text.replace("using a secondary Codex agent", "using Claude Code via claude-review MCP")
     text = text.replace("via GPT-5.6-Sol xhigh review", "via Claude review through claude-review MCP")


### PR DESCRIPTION
## Problem

Regenerating the Claude-review overlay produces invalid YAML frontmatter in `paper-figure`, `paper-plan`, and `paper-write`. Strict loaders skip these three skills, reducing the discovered Codex skill set from 82 to 79.

This is a regression of the quote-escaping fix from #58, introduced when the overlay was regenerated in #354.

## Root cause

`tools/generate_codex_claude_review_overrides.py` parses legacy escaped descriptions and then manually escapes quotes a second time, emitting `\\"` sequences that are not valid JSON/YAML double-quoted scalars.

## Fix

- Normalize the legacy escape layer before serialization.
- Serialize frontmatter values with `json.dumps(..., ensure_ascii=False)`; JSON strings are a valid YAML subset and handle quotes/backslashes consistently.
- Regenerate the three affected Claude overlay skills.
- Add dependency-free regression tests for generated and checked-in overlay frontmatter.

No reviewer behavior, MCP configuration, or non-overlay skill logic changes.

## Verification

- `python3 -m pytest tests/ -q` — 634 passed, 20 skipped, 4 subtests passed
- Targeted overlay/generator/mirror tests — 24 passed
- `python3 tools/check_skills_inventory.py` — passed
- Overlay forbidden-token scan — passed
- Re-running the generator is idempotent
- `git diff --check` — passed

Follow-up to [#58](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/pull/58); regression introduced by [#354](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/pull/354).