### PR TITLE
fix(idea-discovery): require durable reviewer evidence

### DIFF
--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -45,7 +45,8 @@ helper chain used by `/research-pipeline`: `.aris/tools/` → `tools/` →
 the final report is `BLOCKED`; do not silently continue without a state record.
 
 For a new run, derive `<run_id>` from the direction slug and date, then start
-this ordered state record:
+this ordered state record with `--executor <actual-Claude-model>` (for example,
+`claude-sonnet-4.5`):
 
 ```text
 research-lit,idea-creator,novelty-check,research-review,research-refine-pipeline
@@ -63,6 +64,25 @@ check the canonical report rather than scattered scratch files:
 | `research-review` | `idea-stage/IDEA_REPORT.md#external-critical-review` |
 | `research-refine-pipeline` | `refine-logs/FINAL_PROPOSAL.md` |
 
+`novelty-check` and `research-review` are **reviewer-bearing phases**. A
+`done` status or a heading alone is not review evidence. After each phase has
+folded substantive findings into its anchored report section, first record it
+`done`, then, only after the configured reviewer actually returns a positive,
+identity-bearing verdict, record the cross-family receipt using the actual
+returned model and durable thread/trace id:
+
+```text
+<resolved-python> <resolved-run_state.py> accept . <run_id> novelty-check --verdict-id "<thread-or-trace-id>" --reviewer "<actual-reviewer-model>"
+<resolved-python> <resolved-run_state.py> accept . <run_id> research-review --verdict-id "<thread-or-trace-id>" --reviewer "<actual-reviewer-model>"
+```
+
+Never invent either value and never call `accept` without the positive verdict
+required by the run-state contract. A negative verdict does not grant a review receipt.
+Leave the phase `done` and the final gate `BLOCKED`, select a surviving
+or new idea, then re-run that reviewer-bearing phase. Do the same if the
+reviewer is unavailable, returns no valid identity/response, or its output was
+not folded into the report.
+
 At the end of Phase 5, run:
 
 ```text
@@ -70,12 +90,12 @@ At the end of Phase 5, run:
 ```
 
 The gate writes its result to `gates.idea-discovery-evidence` in the run state.
-On `PASS`, it records the gate verdict under `gates.idea-discovery-evidence` —
-per-phase acceptance stays with each stage's own cross-model or deterministic
-gate (the evidence gate proves execution, never quality). On a
-non-zero exit, it writes explicit `BLOCKED: <stage> evidence missing` lines to
-the report; do not present the workflow as complete. On `— resume <run_id>`,
-start from the first non-terminal phase and re-run the gate before finalizing.
+On `PASS`, it has validated (but never created) the two review receipts, all
+required artifacts, and non-empty anchored report sections. Per-phase
+acceptance stays with each stage's own cross-model gate. On a non-zero exit, it
+writes explicit `BLOCKED: <stage> evidence missing` lines to the report; do not
+present the workflow as complete. On `— resume <run_id>`, start from the first
+non-terminal phase and re-run the gate before finalizing.
 
 ## Pipeline
 

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -43,8 +43,8 @@ unavailable, the final report is `BLOCKED`; do not silently continue without a
 state record.
 
 For a new run, derive `<run_id>` from the direction slug and date, then start
-this ordered state record with `--executor codex-gpt-5.6-sol
---provisional-advances`:
+this ordered state record with `--executor <actual-Codex-model>
+--provisional-advances` (for example, `codex-gpt-5.6-sol`):
 
 ```text
 research-lit,idea-creator,novelty-check,research-review,research-refine-pipeline

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -62,6 +62,33 @@ check the canonical report rather than scattered scratch files:
 | `research-review` | `idea-stage/IDEA_REPORT.md#external-critical-review` |
 | `research-refine-pipeline` | `refine-logs/FINAL_PROPOSAL.md` |
 
+`novelty-check` and `research-review` are **reviewer-bearing phases**. A
+`done` status or a heading alone is not review evidence. After each phase has
+folded substantive findings into its anchored report section, first record it
+`done`, then, only after the secondary Codex reviewer actually returns a
+positive, identity-bearing verdict, record its honest same-family receipt using the
+actual reviewer model and durable agent/trace id:
+
+```text
+python3 <resolved-run_state.py> mark-provisional . <run_id> novelty-check --verdict-id "<agent-or-trace-id>" --reviewer "<actual-Codex-reviewer-model>"
+python3 <resolved-run_state.py> mark-provisional . <run_id> research-review --verdict-id "<agent-or-trace-id>" --reviewer "<actual-Codex-reviewer-model>"
+```
+
+Never invent either value and never mark a phase provisional without the
+positive verdict required by the run-state contract. A negative verdict does not grant a review receipt.
+Leave the phase `done` and the final gate `BLOCKED`,
+select a surviving or new idea, then re-run that reviewer-bearing phase. Do the
+same if the reviewer is unavailable, returns no valid identity/response, or its
+output was not folded into the report. `--provisional-advances` is required
+because these same-family receipts are explicitly provisional, not
+cross-family acceptance.
+
+If a reviewer overlay actually returns a recognized **different-family** model
+(for example Claude reviewing a Codex run), use `accept` with that overlay's
+real model and trace id instead. Do not mislabel a cross-family receipt as
+provisional; the evidence gate validates either honest route from the recorded
+families.
+
 At the end of Phase 5, run:
 
 ```text
@@ -69,12 +96,13 @@ python3 <resolved-idea_discovery_gate.py> . <run_id> --report idea-stage/IDEA_RE
 ```
 
 The gate writes its result to `gates.idea-discovery-evidence` in the run state.
-On `PASS`, it records the gate verdict under `gates.idea-discovery-evidence` —
-per-phase acceptance stays with each stage's own cross-model or deterministic
-gate (the evidence gate proves execution, never quality). On a
-non-zero exit, it writes explicit `BLOCKED: <stage> evidence missing` lines to
-the report; do not present the workflow as complete. On `— resume <run_id>`,
-start from the first non-terminal phase and re-run the gate before finalizing.
+On `PASS`, it has validated (but never created) the two review receipts, all
+required artifacts, and non-empty anchored report sections. Per-phase
+acceptance or provisional status stays with the reviewer route that produced
+the receipt. On a non-zero exit, the gate writes explicit
+`BLOCKED: <stage> evidence missing` lines to the report; do not present the
+workflow as complete. On `— resume <run_id>`, start from the first non-terminal
+phase and re-run the gate before finalizing.
 
 ## Pipeline
 

--- a/tests/test_idea_discovery_gate.py
+++ b/tests/test_idea_discovery_gate.py
@@ -446,6 +446,19 @@ def test_gate_blocks_artifact_outside_project_root():
         assert any("artifact escapes project root" in reason for reason in result.reasons)
 
 
+@pytest.mark.parametrize("artifact", ["idea-stage/IDEA_REPORT.md#", "idea-stage/IDEA_REPORT.md#   "])
+def test_gate_blocks_artifact_with_empty_anchor(artifact: str):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        run_state.set_status(root, "idea-run", "research-lit", "done", artifact=artifact)
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "BLOCKED"
+        assert any("artifact anchor is empty" in reason for reason in result.reasons)
+
+
 def test_gate_never_grants_review_status(monkeypatch):
     # Doctrine: the gate records its verdict under gates.<name> and must not
     # confer phase-level acceptance — that belongs to each stage's own gate.
@@ -505,5 +518,6 @@ def test_idea_discovery_mirrors_require_the_evidence_gate():
 
     assert " accept . <run_id> novelty-check" in mainline
     assert " accept . <run_id> research-review" in mainline
+    assert "--executor <actual-Codex-model>" in codex
     assert "mark-provisional . <run_id> novelty-check" in codex
     assert "mark-provisional . <run_id> research-review" in codex

--- a/tests/test_idea_discovery_gate.py
+++ b/tests/test_idea_discovery_gate.py
@@ -4,6 +4,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 
 TOOLS = Path(__file__).resolve().parents[1] / "tools"
 REPO_ROOT = TOOLS.parent
@@ -18,20 +20,36 @@ def _write(root: Path, relative: str, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def _complete_run(root: Path, run_id: str = "idea-run") -> None:
-    run_state.start_run(root, run_id, list(gate.REQUIRED_PHASES))
+def _complete_run(
+    root: Path,
+    run_id: str = "idea-run",
+    *,
+    review_status: str | None = "accepted",
+) -> None:
+    is_provisional = review_status == "provisional"
+    run_state.start_run(
+        root,
+        run_id,
+        list(gate.REQUIRED_PHASES),
+        executor="codex-gpt-5.6-sol" if is_provisional else "claude-sonnet-4.5",
+        provisional_advances=is_provisional,
+    )
     _write(
         root,
         "idea-stage/IDEA_REPORT.md",
         """# Idea Discovery Report
 
 ## Literature Landscape
+Recent work leaves a measurable gap.
 
 ## Ranked Ideas
+1. Test the strongest candidate.
 
 ## Novelty Verification
+The closest prior work differs in its training objective.
 
 ## External Critical Review
+The reviewer recommends proceeding after one ablation.
 """,
     )
     _write(root, "refine-logs/FINAL_PROPOSAL.md", "# Final Proposal\n")
@@ -44,25 +62,182 @@ def _complete_run(root: Path, run_id: str = "idea-run") -> None:
     }
     for phase, artifact in artifacts.items():
         run_state.set_status(root, run_id, phase, "done", artifact=artifact)
+    for phase in gate.REVIEW_REQUIRED_PHASES:
+        if review_status == "accepted":
+            run_state.accept(
+                root,
+                run_id,
+                phase,
+                verdict_id=f"trace:{phase}:accepted",
+                reviewer="gpt-5.6-sol",
+            )
+        elif review_status == "provisional":
+            run_state.mark_provisional(
+                root,
+                run_id,
+                phase,
+                verdict_id=f"trace:{phase}:provisional",
+                reviewer="gpt-5.6-sol",
+            )
 
 
 def test_gate_accepts_complete_evidence_and_records_pass():
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         _complete_run(root)
+        before = run_state.load_run(root, "idea-run")["phases"]
 
         result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
 
         assert result.verdict == "PASS"
         state = run_state.load_run(root, "idea-run")
         assert state["gates"][gate.GATE_NAME]["verdict"] == "PASS"
-        # The gate proves execution evidence only — it must NOT upgrade the
-        # semantic phases to `accepted` (resumable-runs.md: done-but-not-
-        # accepted marks a stage whose own audit is still pending).
-        assert all(phase["status"] == "done" for phase in state["phases"])
+        # The gate validates existing receipts but must not grant or otherwise
+        # rewrite per-phase acceptance itself.
+        assert state["phases"] == before
         report = (root / "idea-stage/IDEA_REPORT.md").read_text(encoding="utf-8")
         assert "## Evidence Gate" in report
         assert "**Status:** PASS" in report
+
+
+def test_gate_accepts_codex_same_family_provisional_receipts_when_policy_allows():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root, review_status="provisional")
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "PASS"
+        phases = {
+            phase["phase"]: phase
+            for phase in run_state.load_run(root, "idea-run")["phases"]
+        }
+        assert phases["novelty-check"]["status"] == "provisional"
+        assert phases["research-review"]["status"] == "provisional"
+
+
+def test_gate_blocks_done_reviews_with_empty_report_headings():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root, review_status=None)
+        _write(
+            root,
+            "idea-stage/IDEA_REPORT.md",
+            """# Idea Discovery Report
+
+## Literature Landscape
+## Ranked Ideas
+## Novelty Verification
+## External Critical Review
+""",
+        )
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "BLOCKED"
+        assert "novelty-check review evidence missing (status=done)" in result.reasons
+        assert "research-review review evidence missing (status=done)" in result.reasons
+
+
+@pytest.mark.parametrize("field", ["verdict_id", "reviewer"])
+def test_gate_blocks_review_receipt_with_missing_credentials(field: str):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        state = run_state.load_run(root, "idea-run")
+        phase = next(
+            phase for phase in state["phases"] if phase["phase"] == "research-review"
+        )
+        phase[field] = "   "
+
+        result = gate.evaluate(root, state)
+
+        assert result.verdict == "BLOCKED"
+        assert any(field in reason for reason in result.reasons)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "reason_fragment"),
+    [
+        ("acceptance_status", "provisional", "acceptance_status inconsistent"),
+        ("review_independence", "same-family", "review_independence inconsistent"),
+        ("reviewer_family", "anthropic", "reviewer_family inconsistent"),
+        ("executor_family", "openai", "executor_family inconsistent"),
+    ],
+)
+def test_gate_blocks_inconsistent_accepted_provenance(
+    field: str, value: str, reason_fragment: str
+):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        state = run_state.load_run(root, "idea-run")
+        phase = next(
+            phase for phase in state["phases"] if phase["phase"] == "research-review"
+        )
+        phase[field] = value
+
+        result = gate.evaluate(root, state)
+
+        assert result.verdict == "BLOCKED"
+        assert any(reason_fragment in reason for reason in result.reasons)
+
+
+def test_gate_blocks_forged_same_family_acceptance():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        state = run_state.load_run(root, "idea-run")
+        phase = next(
+            phase for phase in state["phases"] if phase["phase"] == "research-review"
+        )
+        # Make the executor/reviewer family fields internally coherent while
+        # retaining the false `accepted`/`cross-family` claim.
+        phase["executor_model"] = "codex-gpt-5.6-sol"
+        phase["executor_family"] = "openai"
+
+        result = gate.evaluate(root, state)
+
+        assert result.verdict == "BLOCKED"
+        assert any(
+            "accepted review is same-family" in reason for reason in result.reasons
+        )
+
+
+def test_gate_blocks_deterministic_receipt_for_model_review_phase():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        state = run_state.load_run(root, "idea-run")
+        phase = next(
+            phase for phase in state["phases"] if phase["phase"] == "research-review"
+        )
+        phase["reviewer"] = "deterministic:file-exists"
+        phase["reviewer_family"] = "deterministic"
+        phase["review_independence"] = "deterministic"
+
+        result = gate.evaluate(root, state)
+
+        assert result.verdict == "BLOCKED"
+        assert any(
+            "cannot establish a model review" in reason for reason in result.reasons
+        )
+
+
+def test_gate_blocks_provisional_receipt_when_run_policy_disallows_advancing():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root, review_status="provisional")
+        state = run_state.load_run(root, "idea-run")
+        state["policy"]["provisional_advances"] = False
+
+        result = gate.evaluate(root, state)
+
+        assert result.verdict == "BLOCKED"
+        assert any(
+            "provisional review cannot advance this run" in reason
+            for reason in result.reasons
+        )
 
 
 def test_gate_blocks_missing_phase_and_writes_visible_report_section():
@@ -93,7 +268,10 @@ def test_gate_blocks_missing_report_section_without_duplicate_gate_block():
         root = Path(tmp)
         _complete_run(root)
         report_path = root / "idea-stage/IDEA_REPORT.md"
-        report_path.write_text("# Idea Discovery Report\n## Literature Landscape\n", encoding="utf-8")
+        report_path.write_text(
+            "# Idea Discovery Report\n## Literature Landscape\nEvidence.\n",
+            encoding="utf-8",
+        )
 
         first = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
         second = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
@@ -102,6 +280,152 @@ def test_gate_blocks_missing_report_section_without_duplicate_gate_block():
         report = report_path.read_text(encoding="utf-8")
         assert report.count(gate.START_MARKER) == 1
         assert "BLOCKED: idea-creator evidence missing (section absent: #ranked-ideas)" in report
+
+
+def test_gate_blocks_present_but_empty_anchored_report_section():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root)
+        report_path = root / "idea-stage/IDEA_REPORT.md"
+        report_path.write_text(
+            report_path.read_text(encoding="utf-8").replace(
+                "## Novelty Verification\n"
+                "The closest prior work differs in its training objective.\n",
+                "## Novelty Verification\n<!-- review output was never folded -->\n",
+            ),
+            encoding="utf-8",
+        )
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "BLOCKED"
+        assert (
+            "novelty-check evidence missing (section empty: #novelty-verification)"
+            in result.reasons
+        )
+
+
+def test_anchored_section_ignores_heading_inside_fenced_code():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "report.md",
+            """# Report
+
+```markdown
+## External Critical Review
+This is example text, not the report section.
+```
+""",
+        )
+
+        assert gate._section_has_content(
+            root / "report.md", "external-critical-review"
+        ) == (False, False)
+
+
+def test_anchored_section_ignores_heading_inside_multiline_html_comment():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "report.md",
+            """# Report
+
+<!--
+## External Critical Review
+Placeholder review text.
+-->
+""",
+        )
+
+        assert gate._section_has_content(
+            root / "report.md", "external-critical-review"
+        ) == (False, False)
+
+
+def test_anchored_section_does_not_join_heading_tokens_across_html_comment():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "report.md",
+            "# Report\n\n#<!-- hidden separator --># External Critical Review\n",
+        )
+
+        assert gate._section_has_content(
+            root / "report.md", "external-critical-review"
+        ) == (False, False)
+
+
+def test_anchored_section_finds_real_heading_after_ignored_examples():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "report.md",
+            """# Report
+
+```markdown
+## External Critical Review
+Example only.
+```
+
+<!-- ## External Critical Review -->
+
+   ## External Critical Review
+The actual review was folded into the report.
+""",
+        )
+
+        assert gate._section_has_content(
+            root / "report.md", "external-critical-review"
+        ) == (True, True)
+
+
+def test_anchored_section_does_not_use_later_duplicate_to_fill_first():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "report.md",
+            """# Report
+
+## External Critical Review
+
+## External Critical Review
+This later duplicate must not satisfy the first anchor.
+""",
+        )
+
+        assert gate._section_has_content(
+            root / "report.md", "external-critical-review"
+        ) == (True, False)
+
+
+def test_anchored_section_counts_fenced_markdown_body_as_content():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "report.md",
+            """# Report
+
+## External Critical Review
+
+```markdown
+## Reviewer Findings
+- The ablation is required.
+```
+
+## Next Section
+""",
+        )
+
+        assert gate._section_has_content(
+            root / "report.md", "external-critical-review"
+        ) == (True, True)
 
 
 def test_gate_blocks_artifact_outside_project_root():
@@ -122,7 +446,7 @@ def test_gate_blocks_artifact_outside_project_root():
         assert any("artifact escapes project root" in reason for reason in result.reasons)
 
 
-def test_gate_never_calls_accept(monkeypatch):
+def test_gate_never_grants_review_status(monkeypatch):
     # Doctrine: the gate records its verdict under gates.<name> and must not
     # confer phase-level acceptance — that belongs to each stage's own gate.
     with tempfile.TemporaryDirectory() as tmp:
@@ -130,22 +454,56 @@ def test_gate_never_calls_accept(monkeypatch):
         _complete_run(root)
 
         def forbidden_accept(*args, **kwargs):
-            raise AssertionError("gate must not call run_state.accept")
+            raise AssertionError("gate must not grant phase-level review status")
 
         monkeypatch.setattr(gate.run_state, "accept", forbidden_accept)
+        monkeypatch.setattr(gate.run_state, "mark_provisional", forbidden_accept)
         result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
 
         assert result.verdict == "PASS"
 
 
+def test_negative_review_stays_done_and_blocked_without_granting_receipt(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _complete_run(root, review_status=None)
+
+        def forbidden_accept(*args, **kwargs):
+            raise AssertionError("a blocked gate must not grant a review receipt")
+
+        monkeypatch.setattr(gate.run_state, "accept", forbidden_accept)
+        monkeypatch.setattr(gate.run_state, "mark_provisional", forbidden_accept)
+
+        result = gate.run(root, "idea-run", "idea-stage/IDEA_REPORT.md")
+
+        assert result.verdict == "BLOCKED"
+        state = run_state.load_run(root, "idea-run")
+        phases = {phase["phase"]: phase for phase in state["phases"]}
+        for name in gate.REVIEW_REQUIRED_PHASES:
+            assert phases[name]["status"] == "done"
+            assert phases[name]["verdict_id"] is None
+            assert phases[name]["reviewer"] is None
+        assert state["gates"][gate.GATE_NAME]["verdict"] == "BLOCKED"
+
+
 def test_idea_discovery_mirrors_require_the_evidence_gate():
-    paths = (
-        REPO_ROOT / "skills" / "idea-discovery" / "SKILL.md",
-        REPO_ROOT / "skills" / "skills-codex" / "idea-discovery" / "SKILL.md",
-    )
-    for path in paths:
-        text = path.read_text(encoding="utf-8")
+    mainline = (
+        REPO_ROOT / "skills" / "idea-discovery" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    codex = (
+        REPO_ROOT / "skills" / "skills-codex" / "idea-discovery" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    for text in (mainline, codex):
         assert "Per-stage evidence gate" in text
         assert "idea_discovery_gate.py" in text
         assert "BLOCKED: <stage> evidence missing" in text
         assert "research-refine-pipeline" in text
+        assert "reviewer-bearing phases" in text
+        assert "novelty-check" in text and "research-review" in text
+        assert "Never invent either value" in text
+        assert "A negative verdict does not grant a review receipt" in text
+
+    assert " accept . <run_id> novelty-check" in mainline
+    assert " accept . <run_id> research-review" in mainline
+    assert "mark-provisional . <run_id> novelty-check" in codex
+    assert "mark-provisional . <run_id> research-review" in codex

--- a/tests/test_idea_discovery_gate.py
+++ b/tests/test_idea_discovery_gate.py
@@ -291,7 +291,7 @@ def test_gate_blocks_present_but_empty_anchored_report_section():
             report_path.read_text(encoding="utf-8").replace(
                 "## Novelty Verification\n"
                 "The closest prior work differs in its training objective.\n",
-                "## Novelty Verification\n<!-- review output was never folded -->\n",
+                "## Novelty Verification\n",
             ),
             encoding="utf-8",
         )
@@ -303,129 +303,6 @@ def test_gate_blocks_present_but_empty_anchored_report_section():
             "novelty-check evidence missing (section empty: #novelty-verification)"
             in result.reasons
         )
-
-
-def test_anchored_section_ignores_heading_inside_fenced_code():
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        _write(
-            root,
-            "report.md",
-            """# Report
-
-```markdown
-## External Critical Review
-This is example text, not the report section.
-```
-""",
-        )
-
-        assert gate._section_has_content(
-            root / "report.md", "external-critical-review"
-        ) == (False, False)
-
-
-def test_anchored_section_ignores_heading_inside_multiline_html_comment():
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        _write(
-            root,
-            "report.md",
-            """# Report
-
-<!--
-## External Critical Review
-Placeholder review text.
--->
-""",
-        )
-
-        assert gate._section_has_content(
-            root / "report.md", "external-critical-review"
-        ) == (False, False)
-
-
-def test_anchored_section_does_not_join_heading_tokens_across_html_comment():
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        _write(
-            root,
-            "report.md",
-            "# Report\n\n#<!-- hidden separator --># External Critical Review\n",
-        )
-
-        assert gate._section_has_content(
-            root / "report.md", "external-critical-review"
-        ) == (False, False)
-
-
-def test_anchored_section_finds_real_heading_after_ignored_examples():
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        _write(
-            root,
-            "report.md",
-            """# Report
-
-```markdown
-## External Critical Review
-Example only.
-```
-
-<!-- ## External Critical Review -->
-
-   ## External Critical Review
-The actual review was folded into the report.
-""",
-        )
-
-        assert gate._section_has_content(
-            root / "report.md", "external-critical-review"
-        ) == (True, True)
-
-
-def test_anchored_section_does_not_use_later_duplicate_to_fill_first():
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        _write(
-            root,
-            "report.md",
-            """# Report
-
-## External Critical Review
-
-## External Critical Review
-This later duplicate must not satisfy the first anchor.
-""",
-        )
-
-        assert gate._section_has_content(
-            root / "report.md", "external-critical-review"
-        ) == (True, False)
-
-
-def test_anchored_section_counts_fenced_markdown_body_as_content():
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        _write(
-            root,
-            "report.md",
-            """# Report
-
-## External Critical Review
-
-```markdown
-## Reviewer Findings
-- The ablation is required.
-```
-
-## Next Section
-""",
-        )
-
-        assert gate._section_has_content(
-            root / "report.md", "external-critical-review"
-        ) == (True, True)
 
 
 def test_gate_blocks_artifact_outside_project_root():

--- a/tools/idea_discovery_gate.py
+++ b/tools/idea_discovery_gate.py
@@ -23,8 +23,14 @@ REQUIRED_PHASES = (
     "research-review",
     "research-refine-pipeline",
 )
+# These phases promise a model review, not merely executor-produced prose.  A
+# heading and a ``done`` self-report therefore cannot satisfy their evidence
+# obligation: the run state must contain the receipt written by ``accept`` or
+# ``mark-provisional``.
+REVIEW_REQUIRED_PHASES = frozenset({"novelty-check", "research-review"})
 START_MARKER = "<!-- ARIS_IDEA_DISCOVERY_EVIDENCE_GATE:START -->"
 END_MARKER = "<!-- ARIS_IDEA_DISCOVERY_EVIDENCE_GATE:END -->"
+_COMMENT_SENTINEL = "\0"
 
 
 @dataclass(frozen=True)
@@ -45,16 +51,170 @@ def _artifact_target(root: Path, artifact: str) -> tuple[Path, str | None]:
     return candidate, anchor if separator else None
 
 
-def _heading_slugs(path: Path) -> set[str]:
-    headings = set()
-    for line in path.read_text(encoding="utf-8").splitlines():
-        match = re.match(r"^#{1,6}\s+(.+?)\s*#*\s*$", line)
-        if not match:
+def _heading(line: str) -> tuple[int, str] | None:
+    # CommonMark permits up to three leading spaces before an ATX heading.
+    # Tabs are valid separators after the opening sequence, but not indentation
+    # here: treating an indented code block as a report heading would let
+    # examples satisfy an evidence locator.
+    match = re.match(r"^ {0,3}(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$", line)
+    if not match:
+        return None
+    text = match.group(2).strip().lower()
+    slug = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    return len(match.group(1)), re.sub(r"[\s-]+", "-", slug).strip("-")
+
+
+def _without_html_comments(line: str, in_comment: bool) -> tuple[str, bool]:
+    """Mask HTML comments while preserving text outside comment spans.
+
+    A sentinel, rather than an empty string, keeps comment-separated Markdown
+    tokens separate.  For example, ``#<!-- hidden --># Review`` must not turn
+    into the synthetic heading ``## Review`` after comment removal.
+    """
+    visible: list[str] = []
+    position = 0
+    while position < len(line):
+        if in_comment:
+            visible.append(_COMMENT_SENTINEL)
+            end = line.find("-->", position)
+            if end < 0:
+                return "".join(visible), True
+            position = end + 3
+            in_comment = False
             continue
-        text = match.group(1).strip().lower()
-        slug = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
-        headings.add(re.sub(r"[\s-]+", "-", slug).strip("-"))
-    return headings
+        start = line.find("<!--", position)
+        if start < 0:
+            visible.append(line[position:])
+            break
+        visible.append(line[position:start])
+        visible.append(_COMMENT_SENTINEL)
+        position = start + 4
+        in_comment = True
+    return "".join(visible), in_comment
+
+
+def _opening_fence(line: str) -> tuple[str, int] | None:
+    match = re.match(r"^ {0,3}(`{3,}|~{3,})(?:[^\r\n]*)$", line)
+    if not match:
+        return None
+    marker = match.group(1)
+    return marker[0], len(marker)
+
+
+def _is_closing_fence(line: str, marker: str, minimum: int) -> bool:
+    return bool(
+        re.fullmatch(rf" {{0,3}}{re.escape(marker)}{{{minimum},}}[ \t]*", line)
+    )
+
+
+def _plain_line_has_content(line: str) -> bool:
+    stripped = line.replace(_COMMENT_SENTINEL, "").strip()
+    if not stripped or _heading(line) is not None:
+        return False
+    return re.fullmatch(r"(?:[#>*_~`|+\-]|\d+[.)]|\s)+", stripped) is None
+
+
+def _section_has_content(path: Path, anchor: str) -> tuple[bool, bool]:
+    """Return whether an anchored Markdown section exists and has real body text.
+
+    A heading by itself is only a locator, not stage evidence.  HTML comments,
+    nested headings, empty fences, and Markdown-only separators do not make an
+    otherwise empty section substantive.
+    """
+    found = False
+    level: int | None = None
+    has_content = False
+    in_comment = False
+    fence_marker: str | None = None
+    fence_minimum = 0
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if fence_marker is not None:
+            if _is_closing_fence(raw_line, fence_marker, fence_minimum):
+                fence_marker = None
+                fence_minimum = 0
+            elif found and raw_line.strip():
+                # Content inside a fenced block is substantive, but Markdown
+                # headings inside it never open or terminate report sections.
+                has_content = True
+            continue
+
+        visible, in_comment = _without_html_comments(raw_line, in_comment)
+        opening_fence = _opening_fence(visible)
+        if opening_fence is not None:
+            fence_marker, fence_minimum = opening_fence
+            continue
+
+        parsed = _heading(visible)
+        if not found:
+            if parsed is not None and parsed[1] == anchor:
+                found = True
+                level = parsed[0]
+            continue
+
+        if parsed is not None:
+            if parsed[0] <= level:
+                # GitHub-style anchors resolve to the first matching heading;
+                # a later duplicate must not supply evidence for an empty one.
+                return True, has_content
+            continue
+        if _plain_line_has_content(visible):
+            has_content = True
+
+    return found, has_content
+
+
+def _review_provenance_reason(name: str, phase: dict, state: dict) -> str | None:
+    """Validate a reviewer receipt without granting or repairing acceptance."""
+    status = phase.get("status")
+    if status not in {"accepted", "provisional"}:
+        return f"{name} review evidence missing (status={status or 'unknown'})"
+
+    verdict_id = phase.get("verdict_id")
+    reviewer = phase.get("reviewer")
+    if not isinstance(verdict_id, str) or not verdict_id.strip():
+        return f"{name} review evidence missing (verdict_id not recorded)"
+    if not isinstance(reviewer, str) or not reviewer.strip():
+        return f"{name} review evidence missing (reviewer not recorded)"
+
+    executor = phase.get("executor_model")
+    if not isinstance(executor, str) or not executor.strip():
+        return f"{name} review provenance invalid (executor_model not recorded)"
+
+    executor_family = run_state.model_family(executor)
+    reviewer_family = run_state.model_family(reviewer)
+    if executor_family == "unknown" or reviewer_family in {"unknown", "deterministic"}:
+        return (
+            f"{name} review provenance invalid (model families cannot establish "
+            "a model review)"
+        )
+    if phase.get("executor_family") != executor_family:
+        return f"{name} review provenance invalid (executor_family inconsistent)"
+    if phase.get("reviewer_family") != reviewer_family:
+        return f"{name} review provenance invalid (reviewer_family inconsistent)"
+
+    if status == "accepted":
+        if phase.get("acceptance_status") != "accepted":
+            return f"{name} review provenance invalid (acceptance_status inconsistent)"
+        if executor_family == reviewer_family:
+            return f"{name} review provenance invalid (accepted review is same-family)"
+        if phase.get("review_independence") != "cross-family":
+            return f"{name} review provenance invalid (review_independence inconsistent)"
+        return None
+
+    if phase.get("acceptance_status") != "provisional":
+        return f"{name} review provenance invalid (acceptance_status inconsistent)"
+    if executor_family != reviewer_family:
+        return f"{name} review provenance invalid (provisional review is not same-family)"
+    if phase.get("review_independence") != "same-family":
+        return f"{name} review provenance invalid (review_independence inconsistent)"
+    policy = state.get("policy")
+    if not isinstance(policy, dict) or policy.get("provisional_advances") is not True:
+        return (
+            f"{name} review provenance invalid "
+            "(provisional review cannot advance this run)"
+        )
+    return None
 
 
 def evaluate(root: str | Path, state: dict) -> GateResult:
@@ -73,6 +233,11 @@ def evaluate(root: str | Path, state: dict) -> GateResult:
                 f"{name} evidence missing (status={phase.get('status', 'unknown')})"
             )
             continue
+        if name in REVIEW_REQUIRED_PHASES:
+            provenance_reason = _review_provenance_reason(name, phase, state)
+            if provenance_reason is not None:
+                reasons.append(provenance_reason)
+                continue
         artifact = phase.get("artifact")
         if not artifact:
             reasons.append(f"{name} evidence missing (artifact not recorded)")
@@ -85,8 +250,14 @@ def evaluate(root: str | Path, state: dict) -> GateResult:
         if not artifact_path.is_file():
             reasons.append(f"{name} evidence missing (artifact absent: {artifact})")
             continue
-        if anchor and anchor not in _heading_slugs(artifact_path):
-            reasons.append(f"{name} evidence missing (section absent: #{anchor})")
+        if anchor:
+            section_exists, section_has_content = _section_has_content(
+                artifact_path, anchor
+            )
+            if not section_exists:
+                reasons.append(f"{name} evidence missing (section absent: #{anchor})")
+            elif not section_has_content:
+                reasons.append(f"{name} evidence missing (section empty: #{anchor})")
 
     return GateResult("PASS" if not reasons else "BLOCKED", tuple(reasons))
 
@@ -94,7 +265,10 @@ def evaluate(root: str | Path, state: dict) -> GateResult:
 def _gate_section(result: GateResult) -> str:
     lines = [START_MARKER, "## Evidence Gate", f"**Status:** {result.verdict}", ""]
     if result.verdict == "PASS":
-        lines.append("All required stage records, artifacts, and report sections are present.")
+        lines.append(
+            "All required stage records, review receipts, artifacts, and report "
+            "sections are present."
+        )
     else:
         lines.append("The workflow is not complete. Required stage evidence is missing:")
         lines.extend(f"- BLOCKED: {reason}" for reason in result.reasons)
@@ -137,9 +311,9 @@ def run(root: str | Path, run_id: str, report: str | Path) -> GateResult:
     # The gate's verdict lives ONLY in gates.<GATE_NAME>. It must not mark the
     # semantic phases `accepted`: per resumable-runs.md, file-exists evidence
     # can accept a purely mechanical phase, while these five stages carry
-    # quality semantics whose acceptance belongs to their own cross-model or
-    # stage-level deterministic gates — and resume relies on done-but-not-
-    # accepted to know a stage still needs its audit.
+    # quality semantics whose acceptance/provisional receipt belongs to their
+    # own reviewer gate — and resume relies on done-but-not-reviewed to know a
+    # stage still needs its audit.
     run_state.record_gate_result(str(root), run_id, GATE_NAME, result.verdict, list(result.reasons))
     write_report_gate(root, report, result)
     return result

--- a/tools/idea_discovery_gate.py
+++ b/tools/idea_discovery_gate.py
@@ -30,7 +30,6 @@ REQUIRED_PHASES = (
 REVIEW_REQUIRED_PHASES = frozenset({"novelty-check", "research-review"})
 START_MARKER = "<!-- ARIS_IDEA_DISCOVERY_EVIDENCE_GATE:START -->"
 END_MARKER = "<!-- ARIS_IDEA_DISCOVERY_EVIDENCE_GATE:END -->"
-_COMMENT_SENTINEL = "\0"
 
 
 @dataclass(frozen=True)
@@ -53,117 +52,29 @@ def _artifact_target(root: Path, artifact: str) -> tuple[Path, str | None]:
     return candidate, anchor if separator else None
 
 
-def _heading(line: str) -> tuple[int, str] | None:
-    # CommonMark permits up to three leading spaces before an ATX heading.
-    # Tabs are valid separators after the opening sequence, but not indentation
-    # here: treating an indented code block as a report heading would let
-    # examples satisfy an evidence locator.
-    match = re.match(r"^ {0,3}(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$", line)
+def _heading_slug(line: str) -> str | None:
+    match = re.match(r"^#{1,6}\s+(.+?)\s*#*\s*$", line)
     if not match:
         return None
-    text = match.group(2).strip().lower()
+    text = match.group(1).strip().lower()
     slug = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
-    return len(match.group(1)), re.sub(r"[\s-]+", "-", slug).strip("-")
-
-
-def _without_html_comments(line: str, in_comment: bool) -> tuple[str, bool]:
-    """Mask HTML comments while preserving text outside comment spans.
-
-    A sentinel, rather than an empty string, keeps comment-separated Markdown
-    tokens separate.  For example, ``#<!-- hidden --># Review`` must not turn
-    into the synthetic heading ``## Review`` after comment removal.
-    """
-    visible: list[str] = []
-    position = 0
-    while position < len(line):
-        if in_comment:
-            visible.append(_COMMENT_SENTINEL)
-            end = line.find("-->", position)
-            if end < 0:
-                return "".join(visible), True
-            position = end + 3
-            in_comment = False
-            continue
-        start = line.find("<!--", position)
-        if start < 0:
-            visible.append(line[position:])
-            break
-        visible.append(line[position:start])
-        visible.append(_COMMENT_SENTINEL)
-        position = start + 4
-        in_comment = True
-    return "".join(visible), in_comment
-
-
-def _opening_fence(line: str) -> tuple[str, int] | None:
-    match = re.match(r"^ {0,3}(`{3,}|~{3,})(?:[^\r\n]*)$", line)
-    if not match:
-        return None
-    marker = match.group(1)
-    return marker[0], len(marker)
-
-
-def _is_closing_fence(line: str, marker: str, minimum: int) -> bool:
-    return bool(
-        re.fullmatch(rf" {{0,3}}{re.escape(marker)}{{{minimum},}}[ \t]*", line)
-    )
-
-
-def _plain_line_has_content(line: str) -> bool:
-    stripped = line.replace(_COMMENT_SENTINEL, "").strip()
-    if not stripped or _heading(line) is not None:
-        return False
-    return re.fullmatch(r"(?:[#>*_~`|+\-]|\d+[.)]|\s)+", stripped) is None
+    return re.sub(r"[\s-]+", "-", slug).strip("-")
 
 
 def _section_has_content(path: Path, anchor: str) -> tuple[bool, bool]:
-    """Return whether an anchored Markdown section exists and has real body text.
-
-    A heading by itself is only a locator, not stage evidence.  HTML comments,
-    nested headings, empty fences, and Markdown-only separators do not make an
-    otherwise empty section substantive.
-    """
+    """Return whether the first matching section exists and has a non-empty body."""
     found = False
-    level: int | None = None
-    has_content = False
-    in_comment = False
-    fence_marker: str | None = None
-    fence_minimum = 0
-
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        if fence_marker is not None:
-            if _is_closing_fence(raw_line, fence_marker, fence_minimum):
-                fence_marker = None
-                fence_minimum = 0
-            elif found and raw_line.strip():
-                # Content inside a fenced block is substantive, but Markdown
-                # headings inside it never open or terminate report sections.
-                has_content = True
-            continue
-
-        visible, in_comment = _without_html_comments(raw_line, in_comment)
-        opening_fence = _opening_fence(visible)
-        if opening_fence is not None:
-            fence_marker, fence_minimum = opening_fence
-            continue
-
-        parsed = _heading(visible)
+    for line in path.read_text(encoding="utf-8").splitlines():
+        heading = _heading_slug(line)
         if not found:
-            if parsed is not None and parsed[1] == anchor:
+            if heading == anchor:
                 found = True
-                level = parsed[0]
             continue
-
-        if parsed is not None:
-            if parsed[0] <= level:
-                # GitHub-style anchors resolve to the first matching heading;
-                # a later duplicate must not supply evidence for an empty one.
-                return True, has_content
-            continue
-        if _plain_line_has_content(visible):
-            has_content = True
-
-    return found, has_content
+        if heading is not None:
+            return True, False
+        if line.strip():
+            return True, True
+    return found, False
 
 
 def _review_provenance_reason(name: str, phase: dict, state: dict) -> str | None:

--- a/tools/idea_discovery_gate.py
+++ b/tools/idea_discovery_gate.py
@@ -43,6 +43,8 @@ def _artifact_target(root: Path, artifact: str) -> tuple[Path, str | None]:
     path_text, separator, anchor = artifact.partition("#")
     if not path_text:
         raise ValueError("artifact path is empty")
+    if separator and not anchor.strip():
+        raise ValueError(f"artifact anchor is empty: {artifact}")
     candidate = (root / path_text).resolve()
     try:
         candidate.relative_to(root.resolve())


### PR DESCRIPTION
## Summary

- require durable, identity-bearing review receipts for `novelty-check` and `research-review` before the idea-discovery evidence gate can pass
- validate recorded reviewer provenance and a plain non-empty first-match report section
- document honest Claude/Codex receipt paths: only positive verdicts may call `accept` or `mark-provisional`; negative verdicts remain `done` and keep the workflow `BLOCKED`

## Tests

- `uv run --with pytest pytest -q tests/test_idea_discovery_gate.py` (21 passed)
- `uv run --with pytest --with "httpx>=0.27,<1.0" pytest -q` (647 passed, 17 skipped, 4 subtests passed)
- `git diff --check origin/main`

Fixes #375