### PR TITLE
feat(llm-chat): add safe Atlas Cloud configuration

### DIFF
--- a/docs/LLM_API_MIX_MATCH_GUIDE.md
+++ b/docs/LLM_API_MIX_MATCH_GUIDE.md
@@ -108,10 +108,34 @@
 
 ### 常用审查器提供商
 
-| 提供商 | LLM_BASE_URL | LLM_MODEL |
-|--------|--------------|-----------|
-| DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` |
-| MiniMax | `https://api.minimax.io/v1` | `MiniMax-M3` |
+| 提供商 | LLM_BASE_URL | LLM_MODEL | 附加设置 |
+|--------|--------------|-----------|----------|
+| DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` | - |
+| MiniMax | `https://api.minimax.io/v1` | `MiniMax-M3` | - |
+| Atlas Cloud | `https://api.atlascloud.ai/v1` | `deepseek-ai/deepseek-v4-pro` | `LLM_RETRY_ON_504=false` |
+
+Atlas Cloud 使用同一个 OpenAI-compatible Chat Completions 协议。对于可能产生计费的
+POST 请求，请关闭 504 自动重试，避免在网关超时后重复提交：
+
+```json
+{
+  "mcpServers": {
+    "llm-chat": {
+      "command": "/usr/bin/python3",
+      "args": ["/Users/yourname/.claude/mcp-servers/llm-chat/server.py"],
+      "env": {
+        "LLM_API_KEY": "your-atlascloud-api-key",
+        "LLM_BASE_URL": "https://api.atlascloud.ai/v1",
+        "LLM_MODEL": "deepseek-ai/deepseek-v4-pro",
+        "LLM_FALLBACK_MODEL": "deepseek-ai/deepseek-v4-pro",
+        "LLM_RETRY_ON_504": "false"
+      }
+    }
+  }
+}
+```
+
+`LLM_RETRY_ON_504` 默认为 `true`，因此现有配置的重试与 fallback 行为保持不变。
 
 ---
 

--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -6,6 +6,7 @@ Environment Variables:
     LLM_BASE_URL        - API base URL (default: https://api.openai.com/v1)
     LLM_MODEL           - Model name (default: gpt-4o)
     LLM_FALLBACK_MODEL  - Fallback model on 504 timeout (default: gpt-4o)
+    LLM_RETRY_ON_504    - Retry POST requests after 504 responses (default: true)
     LLM_SERVER_NAME     - Server name for MCP (default: llm-chat)
 
 Supported Providers (examples):
@@ -13,6 +14,7 @@ Supported Providers (examples):
     DeepSeek:    LLM_BASE_URL=https://api.deepseek.com/v1 LLM_MODEL=deepseek-chat
     Kimi:        LLM_BASE_URL=https://api.moonshot.cn/v1 LLM_MODEL=moonshot-v1-32k
     MiniMax:     LLM_BASE_URL=https://api.minimax.io/v1 LLM_MODEL=MiniMax-M3
+    Atlas Cloud: LLM_BASE_URL=https://api.atlascloud.ai/v1 LLM_MODEL=deepseek-ai/deepseek-v4-pro
 """
 
 import datetime
@@ -48,6 +50,9 @@ API_KEY = os.environ.get("LLM_API_KEY", "")
 BASE_URL = os.environ.get("LLM_BASE_URL", "https://api.openai.com/v1")
 DEFAULT_MODEL = os.environ.get("LLM_MODEL", "gpt-4o")
 FALLBACK_MODEL = os.environ.get("LLM_FALLBACK_MODEL", "gpt-4o")
+RETRY_ON_504 = os.environ.get("LLM_RETRY_ON_504", "true").lower() not in {
+    "0", "false", "no", "off"
+}
 SERVER_NAME = os.environ.get("LLM_SERVER_NAME", "llm-chat")
 
 # Debug logging
@@ -72,6 +77,7 @@ debug_log(f"=== {SERVER_NAME} MCP Server Starting (v2.1) ===")
 debug_log(f"BASE_URL: {BASE_URL}")
 debug_log(f"MODEL: {DEFAULT_MODEL}")
 debug_log(f"FALLBACK_MODEL: {FALLBACK_MODEL}")
+debug_log(f"RETRY_ON_504: {RETRY_ON_504}")
 debug_log(f"API_KEY set: {bool(API_KEY)}")
 
 _use_ndjson = False
@@ -102,8 +108,10 @@ def call_llm(messages, model=None):
         "Authorization": f"Bearer {API_KEY}"
     }
 
-    # Try: original model → retry same model → fallback model
-    for attempt in range(3):
+    max_attempts = 3 if RETRY_ON_504 else 1
+
+    # When enabled: original model → retry same model → fallback model.
+    for attempt in range(max_attempts):
         current_model = use_model if attempt < 2 else FALLBACK_MODEL
         payload = {
             "model": current_model,
@@ -119,7 +127,7 @@ def call_llm(messages, model=None):
 
                 if response.status_code == 504:
                     debug_log(f"504 Gateway Timeout on attempt {attempt + 1} with model {current_model}")
-                    if attempt < 2:
+                    if attempt < max_attempts - 1:
                         continue  # retry or fallback
 
                 if response.status_code != 200:

--- a/tests/_llm_chat_helpers.py
+++ b/tests/_llm_chat_helpers.py
@@ -11,6 +11,9 @@ LLM_API_KEY = os.environ.get("LLM_API_KEY", "")
 BASE_URL = os.environ.get("LLM_BASE_URL", "https://api.openai.com/v1")
 DEFAULT_MODEL = os.environ.get("LLM_MODEL", "gpt-4o")
 FALLBACK_MODEL = os.environ.get("LLM_FALLBACK_MODEL", "gpt-4o")
+RETRY_ON_504 = os.environ.get("LLM_RETRY_ON_504", "true").lower() not in {
+    "0", "false", "no", "off"
+}
 SERVER_NAME = os.environ.get("LLM_SERVER_NAME", "llm-chat")
 
 DEBUG_LOG = os.path.join(tempfile.gettempdir(), f"{SERVER_NAME}-mcp-debug.log")
@@ -36,8 +39,10 @@ def call_llm(messages, model=None):
         "Authorization": f"Bearer {LLM_API_KEY}"
     }
 
-    # Try: original model → retry same model → fallback model
-    for attempt in range(3):
+    max_attempts = 3 if RETRY_ON_504 else 1
+
+    # When enabled: original model → retry same model → fallback model.
+    for attempt in range(max_attempts):
         current_model = use_model if attempt < 2 else FALLBACK_MODEL
         payload = {
             "model": current_model,
@@ -50,7 +55,7 @@ def call_llm(messages, model=None):
                 response = client.post(url, headers=headers, json=payload)
 
                 if response.status_code == 504:
-                    if attempt < 2:
+                    if attempt < max_attempts - 1:
                         continue  # retry or fallback
 
                 if response.status_code != 200:

--- a/tests/test_llm_chat_server.py
+++ b/tests/test_llm_chat_server.py
@@ -303,6 +303,28 @@ class TestCallLlm504Retry(unittest.TestCase):
         third_call_payload = mock_client.post.call_args_list[2][1]["json"]
         self.assertEqual(third_call_payload["model"], "fallback-model")
 
+    @patch("tests._llm_chat_helpers.LLM_API_KEY", "test-key")
+    @patch("tests._llm_chat_helpers.RETRY_ON_504", False)
+    @patch("httpx.Client")
+    def test_retry_can_be_disabled_for_non_idempotent_post(self, mock_client_cls):
+        """A 504 should return immediately when POST retries are disabled."""
+        resp_504 = MagicMock()
+        resp_504.status_code = 504
+        resp_504.text = "Gateway Timeout"
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = resp_504
+        mock_client_cls.return_value = mock_client
+
+        from tests._llm_chat_helpers import call_llm
+        content, error = call_llm([{"role": "user", "content": "test"}])
+
+        self.assertIsNone(content)
+        self.assertIn("504", error)
+        self.assertEqual(mock_client.post.call_count, 1)
+
 
 class TestToolCallFullFlow(unittest.TestCase):
     """Test the complete tools/call path through handle_request."""


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an OpenAI-compatible `llm-chat` reviewer configuration
- add `LLM_RETRY_ON_504` so paid POST calls can opt out of automatic 504 retries
- preserve the existing retry and fallback behavior by default

## Testing

- `python3 -m unittest tests.test_llm_chat_server -v` (25 passed)
- `python3 -m unittest discover -s tests -v` (273 passed, 4 skipped, 2 pre-existing Python 3.9 import errors; reproduced on the unmodified base)
- `python3 -m py_compile mcp-servers/llm-chat/server.py tests/_llm_chat_helpers.py`
- `git diff --check`

No live generation request was sent. The Atlas model catalog was read to confirm `deepseek-ai/deepseek-v4-pro` supports `openai.chat.completions`.