### PR TITLE
feat: add opt-in HTTP reviewer fallback for Codex MCP failures

### DIFF
--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -308,7 +308,8 @@ def _handle_review(arguments, request_id):
         "reviewer_family": model_family(actual_model),
         "executor_model": executor_model,
         "executor_family": model_family(executor_model),
-        "independence_verified": True,
+        "family_relation": "different",
+        "independence_verified": "unverified",
     })
 
 def _handle_review_reply(arguments, request_id):
@@ -326,6 +327,8 @@ def _handle_review_reply(arguments, request_id):
     if executor_model != thread["executor_model"]:
         return _tool_error(request_id, "executor_model cannot change within a review thread")
     model = str(arguments.get("model", thread["model"])).strip() or thread["model"]
+    if model != thread["model"]:
+        return _tool_error(request_id, "reviewer model cannot change within a review thread")
     system = str(arguments.get("system", thread["system"])).strip()
     files = arguments.get("files", [])
 
@@ -356,7 +359,8 @@ def _handle_review_reply(arguments, request_id):
         "reviewer_family": model_family(actual_model),
         "executor_model": executor_model,
         "executor_family": model_family(executor_model),
-        "independence_verified": True,
+        "family_relation": "different",
+        "independence_verified": "unverified",
     })
 
 def _review_tool_definitions():

--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generic LLM Chat MCP Server - Supports any OpenAI-compatible API.
+"""Generic LLM Chat MCP Server - Supports any OpenAI-compatible API
 
 Environment Variables:
     LLM_API_KEY         - API key (required)
@@ -8,15 +8,14 @@ Environment Variables:
     LLM_FALLBACK_MODEL  - Fallback model on 504 timeout (default: gpt-4o)
     LLM_SERVER_NAME     - Server name for MCP (default: llm-chat)
     LLM_REVIEW_FALLBACK_ENABLED
-                        - Expose review/review_reply tools when true. Default false.
+                        - Expose review/review_reply tools when true (default: false)
 
-The optional review tools are intended as a fail-closed HTTP reviewer transport
-for ARIS. They preserve multi-round context and return the actual model used so
-the caller can enforce cross-model review. The ordinary ``chat`` tool remains
-backward compatible and is always available.
+Supported Providers (examples):
+    OpenAI:      LLM_BASE_URL=https://api.openai.com/v1 LLM_MODEL=gpt-4o
+    DeepSeek:    LLM_BASE_URL=https://api.deepseek.com/v1 LLM_MODEL=deepseek-chat
+    Kimi:        LLM_BASE_URL=https://api.moonshot.cn/v1 LLM_MODEL=moonshot-v1-32k
+    MiniMax:     LLM_BASE_URL=https://api.minimax.io/v1 LLM_MODEL=MiniMax-M3
 """
-
-from __future__ import annotations
 
 import datetime
 import json
@@ -26,7 +25,6 @@ import sys
 import tempfile
 import uuid
 from pathlib import Path
-
 import httpx
 
 _stdio_initialized = False
@@ -41,15 +39,14 @@ def _init_stdio():
     time under a test harness that captures stdio (pytest fd-capture) closes the
     harness's capture fd and corrupts capture for every subsequent test. Real
     server launch (python server.py) still calls this first via main(), so
-    runtime behavior is unchanged. Idempotent.
-    """
+    runtime behavior is unchanged. Idempotent."""
     global _stdio_initialized
     if _stdio_initialized:
         return
-    sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)
-    sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)
+    # Force unbuffered stdout/stdin
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', buffering=0)
+    sys.stdin = os.fdopen(sys.stdin.fileno(), 'rb', buffering=0)
     _stdio_initialized = True
-
 
 # Configuration from environment
 API_KEY = os.environ.get("LLM_API_KEY", "")
@@ -64,23 +61,20 @@ REVIEW_FALLBACK_ENABLED = os.environ.get(
 # Debug logging
 DEBUG_LOG = os.path.join(tempfile.gettempdir(), f"{SERVER_NAME}-mcp-debug.log")
 
-
 def debug_log(msg):
     try:
-        with open(DEBUG_LOG, "a", encoding="utf-8") as f:
+        with open(DEBUG_LOG, "a") as f:
             f.write(f"{datetime.datetime.now()}: {msg}\n")
             f.flush()
     except Exception:
         pass
 
-
 def log_error(msg):
     try:
-        with open(DEBUG_LOG, "a", encoding="utf-8") as f:
+        with open(DEBUG_LOG, "a") as f:
             f.write(f"{datetime.datetime.now()}: ERROR: {msg}\n")
     except Exception:
         pass
-
 
 debug_log(f"=== {SERVER_NAME} MCP Server Starting (v2.2) ===")
 debug_log(f"BASE_URL: {BASE_URL}")
@@ -90,30 +84,24 @@ debug_log(f"REVIEW_FALLBACK_ENABLED: {REVIEW_FALLBACK_ENABLED}")
 debug_log(f"API_KEY set: {bool(API_KEY)}")
 
 _use_ndjson = False
-_review_threads: dict[str, dict] = {}
-
+_review_threads = {}
 
 def send_response(response):
     global _use_ndjson
-    json_str = json.dumps(response, separators=(",", ":"))
-    json_bytes = json_str.encode("utf-8")
+    json_str = json.dumps(response, separators=(',', ':'))
+    json_bytes = json_str.encode('utf-8')
 
     if _use_ndjson:
-        output = json_bytes + b"\n"
+        output = json_bytes + b'\n'
     else:
-        header = f"Content-Length: {len(json_bytes)}\r\n\r\n".encode("utf-8")
+        header = f"Content-Length: {len(json_bytes)}\r\n\r\n".encode('utf-8')
         output = header + json_bytes
 
     sys.stdout.write(output)
     sys.stdout.flush()
 
-
 def _call_llm_detailed(messages, model=None):
-    """Call Chat Completions and return (content, error, actual_model).
-
-    The legacy ``call_llm`` wrapper below intentionally keeps its original
-    two-value return contract.
-    """
+    """Call LLM Chat Completions API and return content, error, actual model."""
     if not API_KEY:
         return None, "LLM_API_KEY environment variable not set", None
 
@@ -121,38 +109,31 @@ def _call_llm_detailed(messages, model=None):
     url = f"{BASE_URL.rstrip('/')}/chat/completions"
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {API_KEY}",
+        "Authorization": f"Bearer {API_KEY}"
     }
 
-    # Existing behavior: original model -> retry same model -> fallback model.
+    # Try: original model → retry same model → fallback model
     for attempt in range(3):
         current_model = use_model if attempt < 2 else FALLBACK_MODEL
         payload = {
             "model": current_model,
             "messages": messages,
-            "max_tokens": 4096,
+            "max_tokens": 4096
         }
 
-        debug_log(
-            f"Calling LLM API (attempt {attempt + 1}): model={current_model}"
-        )
+        debug_log(f"Calling LLM API (attempt {attempt + 1}): model={current_model}")
 
         try:
             with httpx.Client(timeout=300.0) as client:
                 response = client.post(url, headers=headers, json=payload)
 
                 if response.status_code == 504:
-                    debug_log(
-                        "504 Gateway Timeout on attempt "
-                        f"{attempt + 1} with model {current_model}"
-                    )
+                    debug_log(f"504 Gateway Timeout on attempt {attempt + 1} with model {current_model}")
                     if attempt < 2:
-                        continue
+                        continue  # retry or fallback
 
                 if response.status_code != 200:
-                    error_msg = (
-                        f"API error {response.status_code}: {response.text[:500]}"
-                    )
+                    error_msg = f"API error {response.status_code}: {response.text[:500]}"
                     debug_log(f"API error: {error_msg}")
                     return None, error_msg, None
 
@@ -160,52 +141,35 @@ def _call_llm_detailed(messages, model=None):
                 try:
                     content = data["choices"][0]["message"]["content"]
                 except (KeyError, IndexError, TypeError) as e:
-                    return (
-                        None,
-                        f"Unexpected API response structure: {e}",
-                        None,
-                    )
+                    return None, f"Unexpected API response structure: {e}", None
 
-                # Prefer provider-reported model identity when present, but fall
-                # back to the exact model id sent in the request.
+                # Prefer the model identity reported by the provider. If absent,
+                # use the exact model id sent in this successful request.
                 actual_model = str(data.get("model") or current_model).strip()
 
                 if current_model != use_model:
-                    fallback_note = (
-                        "\n\n[Note: Used fallback model "
-                        f"{current_model} after 504 timeout with {use_model}]"
-                    )
+                    fallback_note = f"\n\n[Note: Used fallback model {current_model} after 504 timeout with {use_model}]"
                     content = fallback_note + "\n" + content
-                    debug_log(
-                        "API success with fallback model "
-                        f"{actual_model}, response length: {len(content)}"
-                    )
+                    debug_log(f"API success with fallback model {actual_model}, response length: {len(content)}")
                 elif attempt > 0:
-                    debug_log(
-                        "API success on retry "
-                        f"(attempt {attempt + 1}), response length: {len(content)}"
-                    )
+                    debug_log(f"API success on retry (attempt {attempt + 1}), response length: {len(content)}")
                 else:
-                    debug_log(
-                        f"API success, response length: {len(content)}"
-                    )
+                    debug_log(f"API success, response length: {len(content)}")
                 return content, None, actual_model
         except Exception as e:
-            debug_log(
-                f"API exception on attempt {attempt + 1}: {str(e)}"
-            )
+            debug_log(f"API exception on attempt {attempt + 1}: {str(e)}")
             if attempt == 2:
                 return None, str(e), None
 
     return None, "All attempts failed with 504 Gateway Timeout", None
 
-
 def call_llm(messages, model=None):
-    """Backward-compatible two-value Chat Completions API wrapper."""
+    """Backward-compatible two-value wrapper for the existing chat tool."""
     content, error, _actual_model = _call_llm_detailed(messages, model)
     return content, error
 
 
+# Coarse model families used only by the opt-in verdict-bearing review tools.
 _FAMILY = [
     ("anthropic", ("claude", "opus", "sonnet", "haiku", "anthropic")),
     ("openai", ("gpt", "codex", "chatgpt", "o1", "o3", "o4", "openai")),
@@ -223,82 +187,52 @@ _FAMILY = [
 ]
 _SHORT = {"o1", "o3", "o4"}
 
-
 def model_family(name):
-    """Map a model id to a coarse family, failing closed on collisions."""
+    """Map a model id to a coarse family; collisions fail closed."""
     n = str(name or "").strip().lower()
     tokens = set(re.split(r"[^a-z0-9.]+", n))
     matched = set()
     for family, needles in _FAMILY:
-        if any(
-            (needle in tokens) if needle in _SHORT else (needle in n)
-            for needle in needles
-        ):
+        if any((needle in tokens) if needle in _SHORT else (needle in n)
+               for needle in needles):
             matched.add(family)
     return next(iter(matched)) if len(matched) == 1 else "unknown"
-
 
 def _cross_family_error(executor_model, reviewer_model):
     executor_family = model_family(executor_model)
     reviewer_family = model_family(reviewer_model)
     if executor_family == "unknown":
-        return (
-            "Cannot verify HTTP reviewer independence: executor_model is "
-            f"missing or unrecognized ({executor_model!r})"
-        )
+        return (f"Cannot verify HTTP reviewer independence: executor_model is "
+                f"missing or unrecognized ({executor_model!r})")
     if reviewer_family == "unknown":
-        return (
-            "Cannot verify HTTP reviewer model family: "
-            f"{reviewer_model!r}"
-        )
+        return f"Cannot verify HTTP reviewer model family: {reviewer_model!r}"
     if executor_family == reviewer_family:
-        return (
-            "HTTP reviewer must use a different model family: "
-            f"executor={executor_model} ({executor_family}), "
-            f"reviewer={reviewer_model} ({reviewer_family})"
-        )
+        return (f"HTTP reviewer must use a different model family: "
+                f"executor={executor_model} ({executor_family}), "
+                f"reviewer={reviewer_model} ({reviewer_family})")
     return None
-
 
 def _tool_success(request_id, payload):
     return {
         "jsonrpc": "2.0",
         "id": request_id,
         "result": {
-            "content": [
-                {
-                    "type": "text",
-                    "text": json.dumps(payload, ensure_ascii=False),
-                }
-            ]
-        },
+            "content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False)}]
+        }
     }
-
 
 def _tool_error(request_id, message):
     return {
         "jsonrpc": "2.0",
         "id": request_id,
         "result": {
-            "content": [
-                {
-                    "type": "text",
-                    "text": json.dumps(
-                        {"error": message}, ensure_ascii=False
-                    ),
-                }
-            ],
-            "isError": True,
-        },
+            "content": [{"type": "text", "text": json.dumps({"error": message}, ensure_ascii=False)}],
+            "isError": True
+        }
     }
 
-
 def _read_review_files(paths):
-    """Read explicit local text artifacts for the HTTP reviewer transport.
-
-    This is only reachable through the opt-in review tools. Callers must pass
-    primary artifacts, not executor summaries, to preserve reviewer independence.
-    """
+    """Read explicit primary artifacts that will be sent to the HTTP endpoint."""
     if paths is None:
         return ""
     if not isinstance(paths, list):
@@ -319,10 +253,8 @@ def _read_review_files(paths):
         )
     return "".join(sections)
 
-
 def _review_user_content(prompt, files):
     return prompt + _read_review_files(files)
-
 
 def _review_messages(history, prompt, system=""):
     messages = []
@@ -331,7 +263,6 @@ def _review_messages(history, prompt, system=""):
     messages.extend(history)
     messages.append({"role": "user", "content": prompt})
     return messages
-
 
 def _handle_review(arguments, request_id):
     prompt = str(arguments.get("prompt", "")).strip()
@@ -343,24 +274,20 @@ def _handle_review(arguments, request_id):
     if not prompt:
         return _tool_error(request_id, "prompt is required")
     if not executor_model:
-        return _tool_error(
-            request_id,
-            "executor_model is required for cross-family review",
-        )
+        return _tool_error(request_id, "executor_model is required for cross-family review")
 
     try:
         user_content = _review_user_content(prompt, files)
     except ValueError as exc:
         return _tool_error(request_id, str(exc))
 
-    messages = _review_messages([], user_content, system)
-    content, error, actual_model = _call_llm_detailed(messages, model)
+    content, error, actual_model = _call_llm_detailed(
+        _review_messages([], user_content, system), model
+    )
     if error:
         return _tool_error(request_id, error)
 
-    independence_error = _cross_family_error(
-        executor_model, actual_model
-    )
+    independence_error = _cross_family_error(executor_model, actual_model)
     if independence_error:
         return _tool_error(request_id, independence_error)
 
@@ -374,19 +301,15 @@ def _handle_review(arguments, request_id):
         "system": system,
         "executor_model": executor_model,
     }
-    return _tool_success(
-        request_id,
-        {
-            "threadId": thread_id,
-            "content": content,
-            "reviewer_model": actual_model,
-            "reviewer_family": model_family(actual_model),
-            "executor_model": executor_model,
-            "executor_family": model_family(executor_model),
-            "independence_verified": True,
-        },
-    )
-
+    return _tool_success(request_id, {
+        "threadId": thread_id,
+        "content": content,
+        "reviewer_model": actual_model,
+        "reviewer_family": model_family(actual_model),
+        "executor_model": executor_model,
+        "executor_family": model_family(executor_model),
+        "independence_verified": True,
+    })
 
 def _handle_review_reply(arguments, request_id):
     thread_id = str(arguments.get("threadId", "")).strip()
@@ -399,17 +322,12 @@ def _handle_review_reply(arguments, request_id):
         return _tool_error(request_id, "prompt is required")
 
     thread = _review_threads[thread_id]
-    executor_model = str(
-        arguments.get("executor_model", thread["executor_model"])
-    ).strip()
+    executor_model = str(arguments.get("executor_model", thread["executor_model"])).strip()
+    if executor_model != thread["executor_model"]:
+        return _tool_error(request_id, "executor_model cannot change within a review thread")
     model = str(arguments.get("model", thread["model"])).strip() or thread["model"]
     system = str(arguments.get("system", thread["system"])).strip()
     files = arguments.get("files", [])
-    if not executor_model:
-        return _tool_error(
-            request_id,
-            "executor_model is required for cross-family review",
-        )
 
     try:
         user_content = _review_user_content(prompt, files)
@@ -417,138 +335,78 @@ def _handle_review_reply(arguments, request_id):
         return _tool_error(request_id, str(exc))
 
     history = list(thread["messages"])
-    messages = _review_messages(history, user_content, system)
-    content, error, actual_model = _call_llm_detailed(messages, model)
+    content, error, actual_model = _call_llm_detailed(
+        _review_messages(history, user_content, system), model
+    )
     if error:
         return _tool_error(request_id, error)
 
-    independence_error = _cross_family_error(
-        executor_model, actual_model
-    )
+    independence_error = _cross_family_error(executor_model, actual_model)
     if independence_error:
         return _tool_error(request_id, independence_error)
 
-    thread["messages"].extend(
-        [
-            {"role": "user", "content": user_content},
-            {"role": "assistant", "content": content},
-        ]
-    )
-    return _tool_success(
-        request_id,
-        {
-            "threadId": thread_id,
-            "content": content,
-            "reviewer_model": actual_model,
-            "reviewer_family": model_family(actual_model),
-            "executor_model": executor_model,
-            "executor_family": model_family(executor_model),
-            "independence_verified": True,
-        },
-    )
-
-
-def _chat_tool_definition():
-    return {
-        "name": "chat",
-        "description": (
-            f"Send a message to {DEFAULT_MODEL} and get a response. "
-            "Use this for research reviews, code analysis, and general AI tasks."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "prompt": {
-                    "type": "string",
-                    "description": "The prompt to send",
-                },
-                "model": {
-                    "type": "string",
-                    "description": f"Model to use (default: {DEFAULT_MODEL})",
-                },
-                "system": {
-                    "type": "string",
-                    "description": "Optional system prompt",
-                },
-            },
-            "required": ["prompt"],
-        },
-    }
-
+    thread["messages"].extend([
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": content},
+    ])
+    return _tool_success(request_id, {
+        "threadId": thread_id,
+        "content": content,
+        "reviewer_model": actual_model,
+        "reviewer_family": model_family(actual_model),
+        "executor_model": executor_model,
+        "executor_family": model_family(executor_model),
+        "independence_verified": True,
+    })
 
 def _review_tool_definitions():
-    common_properties = {
-        "prompt": {
-            "type": "string",
-            "description": "The substantive ARIS review prompt",
-        },
+    common = {
+        "prompt": {"type": "string", "description": "The substantive ARIS review prompt"},
         "executor_model": {
             "type": "string",
-            "description": (
-                "Actual executor model id; required to enforce cross-family "
-                "review"
-            ),
+            "description": "Actual executor model id; required to enforce cross-family review"
         },
-        "model": {
-            "type": "string",
-            "description": f"Reviewer model (default: {DEFAULT_MODEL})",
-        },
-        "system": {
-            "type": "string",
-            "description": "Optional reviewer system prompt",
-        },
+        "model": {"type": "string", "description": f"Reviewer model (default: {DEFAULT_MODEL})"},
+        "system": {"type": "string", "description": "Optional reviewer system prompt"},
         "files": {
             "type": "array",
             "items": {"type": "string"},
-            "description": (
-                "Local primary-artifact file paths to read verbatim and send "
-                "to the configured HTTP reviewer endpoint"
-            ),
+            "description": "Local primary-artifact paths to send verbatim to the HTTP reviewer"
         },
     }
     return [
         {
             "name": "review",
-            "description": (
-                "Start an HTTP reviewer thread. Returns the actual reviewer "
-                "model and fails closed unless it is from a different family "
-                "than executor_model."
-            ),
+            "description": "Start an independent HTTP reviewer thread.",
             "inputSchema": {
                 "type": "object",
-                "properties": dict(common_properties),
-                "required": ["prompt", "executor_model"],
-            },
+                "properties": dict(common),
+                "required": ["prompt", "executor_model"]
+            }
         },
         {
             "name": "review_reply",
-            "description": (
-                "Continue an HTTP reviewer thread with full prior message "
-                "history."
-            ),
+            "description": "Continue an HTTP reviewer thread with prior message history.",
             "inputSchema": {
                 "type": "object",
-                "properties": {
-                    **common_properties,
-                    "threadId": {
-                        "type": "string",
-                        "description": "threadId returned by review",
-                    },
-                },
-                "required": ["threadId", "prompt"],
-            },
-        },
+                "properties": dict(common, threadId={
+                    "type": "string",
+                    "description": "threadId returned by review"
+                }),
+                "required": ["threadId", "prompt"]
+            }
+        }
     ]
 
-
 def handle_request(request):
-    """Handle a JSON-RPC request."""
+    """Handle a JSON-RPC request"""
     method = request.get("method", "")
     params = request.get("params", {})
     request_id = request.get("id")
 
     debug_log(f"Handling method: {method}, id: {request_id}")
 
+    # Handle notifications (no id, no response needed)
     if request_id is None:
         if method == "notifications/initialized":
             debug_log("Client initialized successfully")
@@ -560,28 +418,51 @@ def handle_request(request):
             "id": request_id,
             "result": {
                 "protocolVersion": "2024-11-05",
-                "capabilities": {"tools": {}},
+                "capabilities": {
+                    "tools": {}
+                },
                 "serverInfo": {
                     "name": SERVER_NAME,
-                    "version": "2.2.0",
-                },
-            },
+                    "version": "2.2.0"
+                }
+            }
         }
 
-    if method == "ping":
+    elif method == "ping":
         return {"jsonrpc": "2.0", "id": request_id, "result": {}}
 
-    if method == "tools/list":
-        tools = [_chat_tool_definition()]
+    elif method == "tools/list":
+        tools = [{
+            "name": "chat",
+            "description": f"Send a message to {DEFAULT_MODEL} and get a response. Use this for research reviews, code analysis, and general AI tasks.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "The prompt to send"
+                    },
+                    "model": {
+                        "type": "string",
+                        "description": f"Model to use (default: {DEFAULT_MODEL})"
+                    },
+                    "system": {
+                        "type": "string",
+                        "description": "Optional system prompt"
+                    }
+                },
+                "required": ["prompt"]
+            }
+        }]
         if REVIEW_FALLBACK_ENABLED:
             tools.extend(_review_tool_definitions())
         return {
             "jsonrpc": "2.0",
             "id": request_id,
-            "result": {"tools": tools},
+            "result": {"tools": tools}
         }
 
-    if method == "tools/call":
+    elif method == "tools/call":
         tool_name = params.get("name", "")
         arguments = params.get("arguments", {})
 
@@ -603,11 +484,9 @@ def handle_request(request):
                     "jsonrpc": "2.0",
                     "id": request_id,
                     "result": {
-                        "content": [
-                            {"type": "text", "text": f"Error: {error}"}
-                        ],
-                        "isError": True,
-                    },
+                        "content": [{"type": "text", "text": f"Error: {error}"}],
+                        "isError": True
+                    }
                 }
 
             return {
@@ -615,7 +494,7 @@ def handle_request(request):
                 "id": request_id,
                 "result": {
                     "content": [{"type": "text", "text": content}]
-                },
+                }
             }
 
         if tool_name == "review":
@@ -623,8 +502,7 @@ def handle_request(request):
                 return _tool_error(
                     request_id,
                     "HTTP reviewer fallback is disabled. Set "
-                    "LLM_REVIEW_FALLBACK_ENABLED=true and restart the MCP "
-                    "server.",
+                    "LLM_REVIEW_FALLBACK_ENABLED=true and restart the MCP server."
                 )
             return _handle_review(arguments, request_id)
 
@@ -633,29 +511,22 @@ def handle_request(request):
                 return _tool_error(
                     request_id,
                     "HTTP reviewer fallback is disabled. Set "
-                    "LLM_REVIEW_FALLBACK_ENABLED=true and restart the MCP "
-                    "server.",
+                    "LLM_REVIEW_FALLBACK_ENABLED=true and restart the MCP server."
                 )
             return _handle_review_reply(arguments, request_id)
 
         return {
             "jsonrpc": "2.0",
             "id": request_id,
-            "error": {
-                "code": -32601,
-                "message": f"Unknown tool: {tool_name}",
-            },
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
         }
 
-    return {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {
-            "code": -32601,
-            "message": f"Unknown method: {method}",
-        },
-    }
-
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"Unknown method: {method}"}
+        }
 
 def read_message():
     """Read a single JSON-RPC message from stdin."""
@@ -665,7 +536,7 @@ def read_message():
     if not line:
         return None
 
-    line = line.decode("utf-8").rstrip("\r\n")
+    line = line.decode('utf-8').rstrip('\r\n')
 
     if line.lower().startswith("content-length:"):
         try:
@@ -677,17 +548,17 @@ def read_message():
             hdr = sys.stdin.readline()
             if not hdr:
                 return None
-            hdr = hdr.decode("utf-8").rstrip("\r\n")
+            hdr = hdr.decode('utf-8').rstrip('\r\n')
             if hdr == "":
                 break
 
         body = sys.stdin.read(content_length)
         try:
-            return json.loads(body.decode("utf-8"))
+            return json.loads(body.decode('utf-8'))
         except Exception:
             return None
 
-    if line.startswith("{") or line.startswith("["):
+    elif line.startswith("{") or line.startswith("["):
         _use_ndjson = True
         try:
             return json.loads(line)
@@ -696,9 +567,8 @@ def read_message():
 
     return None
 
-
 def main():
-    """Main loop - read JSON-RPC messages from stdin."""
+    """Main loop - read JSON-RPC messages from stdin"""
     _init_stdio()
     debug_log("Entering main loop")
 
@@ -717,7 +587,6 @@ def main():
             log_error(f"Exception: {e}")
 
     debug_log("=== Server Exiting ===")
-
 
 if __name__ == "__main__":
     main()

--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generic LLM Chat MCP Server - Supports any OpenAI-compatible API
+"""Generic LLM Chat MCP Server - Supports any OpenAI-compatible API.
 
 Environment Variables:
     LLM_API_KEY         - API key (required)
@@ -7,19 +7,25 @@ Environment Variables:
     LLM_MODEL           - Model name (default: gpt-4o)
     LLM_FALLBACK_MODEL  - Fallback model on 504 timeout (default: gpt-4o)
     LLM_SERVER_NAME     - Server name for MCP (default: llm-chat)
+    LLM_REVIEW_FALLBACK_ENABLED
+                        - Expose review/review_reply tools when true. Default false.
 
-Supported Providers (examples):
-    OpenAI:      LLM_BASE_URL=https://api.openai.com/v1 LLM_MODEL=gpt-4o
-    DeepSeek:    LLM_BASE_URL=https://api.deepseek.com/v1 LLM_MODEL=deepseek-chat
-    Kimi:        LLM_BASE_URL=https://api.moonshot.cn/v1 LLM_MODEL=moonshot-v1-32k
-    MiniMax:     LLM_BASE_URL=https://api.minimax.io/v1 LLM_MODEL=MiniMax-M3
+The optional review tools are intended as a fail-closed HTTP reviewer transport
+for ARIS. They preserve multi-round context and return the actual model used so
+the caller can enforce cross-model review. The ordinary ``chat`` tool remains
+backward compatible and is always available.
 """
+
+from __future__ import annotations
 
 import datetime
 import json
 import os
+import re
 import sys
 import tempfile
+import uuid
+
 import httpx
 
 _stdio_initialized = False
@@ -34,14 +40,15 @@ def _init_stdio():
     time under a test harness that captures stdio (pytest fd-capture) closes the
     harness's capture fd and corrupts capture for every subsequent test. Real
     server launch (python server.py) still calls this first via main(), so
-    runtime behavior is unchanged. Idempotent."""
+    runtime behavior is unchanged. Idempotent.
+    """
     global _stdio_initialized
     if _stdio_initialized:
         return
-    # Force unbuffered stdout/stdin
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', buffering=0)
-    sys.stdin = os.fdopen(sys.stdin.fileno(), 'rb', buffering=0)
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)
+    sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)
     _stdio_initialized = True
+
 
 # Configuration from environment
 API_KEY = os.environ.get("LLM_API_KEY", "")
@@ -49,114 +56,447 @@ BASE_URL = os.environ.get("LLM_BASE_URL", "https://api.openai.com/v1")
 DEFAULT_MODEL = os.environ.get("LLM_MODEL", "gpt-4o")
 FALLBACK_MODEL = os.environ.get("LLM_FALLBACK_MODEL", "gpt-4o")
 SERVER_NAME = os.environ.get("LLM_SERVER_NAME", "llm-chat")
+REVIEW_FALLBACK_ENABLED = os.environ.get(
+    "LLM_REVIEW_FALLBACK_ENABLED", "false"
+).strip().lower() in {"1", "true", "yes", "on"}
 
 # Debug logging
 DEBUG_LOG = os.path.join(tempfile.gettempdir(), f"{SERVER_NAME}-mcp-debug.log")
 
+
 def debug_log(msg):
     try:
-        with open(DEBUG_LOG, "a") as f:
+        with open(DEBUG_LOG, "a", encoding="utf-8") as f:
             f.write(f"{datetime.datetime.now()}: {msg}\n")
             f.flush()
     except Exception:
         pass
 
+
 def log_error(msg):
     try:
-        with open(DEBUG_LOG, "a") as f:
+        with open(DEBUG_LOG, "a", encoding="utf-8") as f:
             f.write(f"{datetime.datetime.now()}: ERROR: {msg}\n")
     except Exception:
         pass
 
-debug_log(f"=== {SERVER_NAME} MCP Server Starting (v2.1) ===")
+
+debug_log(f"=== {SERVER_NAME} MCP Server Starting (v2.2) ===")
 debug_log(f"BASE_URL: {BASE_URL}")
 debug_log(f"MODEL: {DEFAULT_MODEL}")
 debug_log(f"FALLBACK_MODEL: {FALLBACK_MODEL}")
+debug_log(f"REVIEW_FALLBACK_ENABLED: {REVIEW_FALLBACK_ENABLED}")
 debug_log(f"API_KEY set: {bool(API_KEY)}")
 
 _use_ndjson = False
+_review_threads: dict[str, dict] = {}
+
 
 def send_response(response):
     global _use_ndjson
-    json_str = json.dumps(response, separators=(',', ':'))
-    json_bytes = json_str.encode('utf-8')
+    json_str = json.dumps(response, separators=(",", ":"))
+    json_bytes = json_str.encode("utf-8")
 
     if _use_ndjson:
-        output = json_bytes + b'\n'
+        output = json_bytes + b"\n"
     else:
-        header = f"Content-Length: {len(json_bytes)}\r\n\r\n".encode('utf-8')
+        header = f"Content-Length: {len(json_bytes)}\r\n\r\n".encode("utf-8")
         output = header + json_bytes
 
     sys.stdout.write(output)
     sys.stdout.flush()
 
-def call_llm(messages, model=None):
-    """Call LLM Chat Completions API with 504 retry and fallback"""
+
+def _call_llm_detailed(messages, model=None):
+    """Call Chat Completions and return (content, error, actual_model).
+
+    The legacy ``call_llm`` wrapper below intentionally keeps its original
+    two-value return contract.
+    """
     if not API_KEY:
-        return None, "LLM_API_KEY environment variable not set"
+        return None, "LLM_API_KEY environment variable not set", None
 
     use_model = model or DEFAULT_MODEL
     url = f"{BASE_URL.rstrip('/')}/chat/completions"
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {API_KEY}"
+        "Authorization": f"Bearer {API_KEY}",
     }
 
-    # Try: original model → retry same model → fallback model
+    # Existing behavior: original model -> retry same model -> fallback model.
     for attempt in range(3):
         current_model = use_model if attempt < 2 else FALLBACK_MODEL
         payload = {
             "model": current_model,
             "messages": messages,
-            "max_tokens": 4096
+            "max_tokens": 4096,
         }
 
-        debug_log(f"Calling LLM API (attempt {attempt + 1}): model={current_model}")
+        debug_log(
+            f"Calling LLM API (attempt {attempt + 1}): model={current_model}"
+        )
 
         try:
             with httpx.Client(timeout=300.0) as client:
                 response = client.post(url, headers=headers, json=payload)
 
                 if response.status_code == 504:
-                    debug_log(f"504 Gateway Timeout on attempt {attempt + 1} with model {current_model}")
+                    debug_log(
+                        "504 Gateway Timeout on attempt "
+                        f"{attempt + 1} with model {current_model}"
+                    )
                     if attempt < 2:
-                        continue  # retry or fallback
+                        continue
 
                 if response.status_code != 200:
-                    error_msg = f"API error {response.status_code}: {response.text[:500]}"
+                    error_msg = (
+                        f"API error {response.status_code}: {response.text[:500]}"
+                    )
                     debug_log(f"API error: {error_msg}")
-                    return None, error_msg
+                    return None, error_msg, None
 
                 data = response.json()
                 try:
                     content = data["choices"][0]["message"]["content"]
                 except (KeyError, IndexError, TypeError) as e:
-                    return None, f"Unexpected API response structure: {e}"
-                if current_model != use_model:
-                    fallback_note = f"\n\n[Note: Used fallback model {current_model} after 504 timeout with {use_model}]"
-                    content = fallback_note + "\n" + content
-                    debug_log(f"API success with fallback model {current_model}, response length: {len(content)}")
-                elif attempt > 0:
-                    debug_log(f"API success on retry (attempt {attempt + 1}), response length: {len(content)}")
-                else:
-                    debug_log(f"API success, response length: {len(content)}")
-                return content, None
-        except Exception as e:
-            debug_log(f"API exception on attempt {attempt + 1}: {str(e)}")
-            if attempt == 2:
-                return None, str(e)
+                    return (
+                        None,
+                        f"Unexpected API response structure: {e}",
+                        None,
+                    )
 
-    return None, "All attempts failed with 504 Gateway Timeout"
+                # Prefer provider-reported model identity when present, but fall
+                # back to the exact model id sent in the request.
+                actual_model = str(data.get("model") or current_model).strip()
+
+                if current_model != use_model:
+                    fallback_note = (
+                        "\n\n[Note: Used fallback model "
+                        f"{current_model} after 504 timeout with {use_model}]"
+                    )
+                    content = fallback_note + "\n" + content
+                    debug_log(
+                        "API success with fallback model "
+                        f"{actual_model}, response length: {len(content)}"
+                    )
+                elif attempt > 0:
+                    debug_log(
+                        "API success on retry "
+                        f"(attempt {attempt + 1}), response length: {len(content)}"
+                    )
+                else:
+                    debug_log(
+                        f"API success, response length: {len(content)}"
+                    )
+                return content, None, actual_model
+        except Exception as e:
+            debug_log(
+                f"API exception on attempt {attempt + 1}: {str(e)}"
+            )
+            if attempt == 2:
+                return None, str(e), None
+
+    return None, "All attempts failed with 504 Gateway Timeout", None
+
+
+def call_llm(messages, model=None):
+    """Backward-compatible two-value Chat Completions API wrapper."""
+    content, error, _actual_model = _call_llm_detailed(messages, model)
+    return content, error
+
+
+_FAMILY = [
+    ("anthropic", ("claude", "opus", "sonnet", "haiku", "anthropic")),
+    ("openai", ("gpt", "codex", "chatgpt", "o1", "o3", "o4", "openai")),
+    ("google", ("gemini", "google", "palm", "bard")),
+    ("deepseek", ("deepseek",)),
+    ("zhipu", ("glm", "zhipu")),
+    ("minimax", ("minimax", "abab")),
+    ("moonshot", ("kimi", "moonshot")),
+    ("qwen", ("qwen", "tongyi")),
+    ("xiaomi", ("mimo", "xiaomi")),
+    ("bytedance", ("doubao", "bytedance", "volcengine")),
+    ("xai", ("grok",)),
+    ("meta", ("llama",)),
+    ("mistral", ("mistral", "mixtral")),
+]
+_SHORT = {"o1", "o3", "o4"}
+
+
+def model_family(name):
+    """Map a model id to a coarse family, failing closed on collisions."""
+    n = str(name or "").strip().lower()
+    tokens = set(re.split(r"[^a-z0-9.]+", n))
+    matched = set()
+    for family, needles in _FAMILY:
+        if any(
+            (needle in tokens) if needle in _SHORT else (needle in n)
+            for needle in needles
+        ):
+            matched.add(family)
+    return next(iter(matched)) if len(matched) == 1 else "unknown"
+
+
+def _cross_family_error(executor_model, reviewer_model):
+    executor_family = model_family(executor_model)
+    reviewer_family = model_family(reviewer_model)
+    if executor_family == "unknown":
+        return (
+            "Cannot verify HTTP reviewer independence: executor_model is "
+            f"missing or unrecognized ({executor_model!r})"
+        )
+    if reviewer_family == "unknown":
+        return (
+            "Cannot verify HTTP reviewer model family: "
+            f"{reviewer_model!r}"
+        )
+    if executor_family == reviewer_family:
+        return (
+            "HTTP reviewer must use a different model family: "
+            f"executor={executor_model} ({executor_family}), "
+            f"reviewer={reviewer_model} ({reviewer_family})"
+        )
+    return None
+
+
+def _tool_success(request_id, payload):
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(payload, ensure_ascii=False),
+                }
+            ]
+        },
+    }
+
+
+def _tool_error(request_id, message):
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {"error": message}, ensure_ascii=False
+                    ),
+                }
+            ],
+            "isError": True,
+        },
+    }
+
+
+def _review_messages(history, prompt, system=""):
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.extend(history)
+    messages.append({"role": "user", "content": prompt})
+    return messages
+
+
+def _handle_review(arguments, request_id):
+    prompt = str(arguments.get("prompt", "")).strip()
+    executor_model = str(arguments.get("executor_model", "")).strip()
+    model = str(arguments.get("model", DEFAULT_MODEL)).strip() or DEFAULT_MODEL
+    system = str(arguments.get("system", "")).strip()
+
+    if not prompt:
+        return _tool_error(request_id, "prompt is required")
+    if not executor_model:
+        return _tool_error(
+            request_id,
+            "executor_model is required for cross-family review",
+        )
+
+    messages = _review_messages([], prompt, system)
+    content, error, actual_model = _call_llm_detailed(messages, model)
+    if error:
+        return _tool_error(request_id, error)
+
+    independence_error = _cross_family_error(
+        executor_model, actual_model
+    )
+    if independence_error:
+        return _tool_error(request_id, independence_error)
+
+    thread_id = uuid.uuid4().hex[:12]
+    _review_threads[thread_id] = {
+        "messages": [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": content},
+        ],
+        "model": model,
+        "system": system,
+        "executor_model": executor_model,
+    }
+    return _tool_success(
+        request_id,
+        {
+            "threadId": thread_id,
+            "content": content,
+            "reviewer_model": actual_model,
+            "reviewer_family": model_family(actual_model),
+            "executor_model": executor_model,
+            "executor_family": model_family(executor_model),
+            "independence_verified": True,
+        },
+    )
+
+
+def _handle_review_reply(arguments, request_id):
+    thread_id = str(arguments.get("threadId", "")).strip()
+    prompt = str(arguments.get("prompt", "")).strip()
+    if not thread_id:
+        return _tool_error(request_id, "threadId is required")
+    if thread_id not in _review_threads:
+        return _tool_error(request_id, f"Unknown threadId: {thread_id}")
+    if not prompt:
+        return _tool_error(request_id, "prompt is required")
+
+    thread = _review_threads[thread_id]
+    executor_model = str(
+        arguments.get("executor_model", thread["executor_model"])
+    ).strip()
+    model = str(arguments.get("model", thread["model"])).strip() or thread["model"]
+    system = str(arguments.get("system", thread["system"])).strip()
+    if not executor_model:
+        return _tool_error(
+            request_id,
+            "executor_model is required for cross-family review",
+        )
+
+    history = list(thread["messages"])
+    messages = _review_messages(history, prompt, system)
+    content, error, actual_model = _call_llm_detailed(messages, model)
+    if error:
+        return _tool_error(request_id, error)
+
+    independence_error = _cross_family_error(
+        executor_model, actual_model
+    )
+    if independence_error:
+        return _tool_error(request_id, independence_error)
+
+    thread["messages"].extend(
+        [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": content},
+        ]
+    )
+    return _tool_success(
+        request_id,
+        {
+            "threadId": thread_id,
+            "content": content,
+            "reviewer_model": actual_model,
+            "reviewer_family": model_family(actual_model),
+            "executor_model": executor_model,
+            "executor_family": model_family(executor_model),
+            "independence_verified": True,
+        },
+    )
+
+
+def _chat_tool_definition():
+    return {
+        "name": "chat",
+        "description": (
+            f"Send a message to {DEFAULT_MODEL} and get a response. "
+            "Use this for research reviews, code analysis, and general AI tasks."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "The prompt to send",
+                },
+                "model": {
+                    "type": "string",
+                    "description": f"Model to use (default: {DEFAULT_MODEL})",
+                },
+                "system": {
+                    "type": "string",
+                    "description": "Optional system prompt",
+                },
+            },
+            "required": ["prompt"],
+        },
+    }
+
+
+def _review_tool_definitions():
+    common_properties = {
+        "prompt": {
+            "type": "string",
+            "description": "The substantive ARIS review prompt",
+        },
+        "executor_model": {
+            "type": "string",
+            "description": (
+                "Actual executor model id; required to enforce cross-family "
+                "review"
+            ),
+        },
+        "model": {
+            "type": "string",
+            "description": f"Reviewer model (default: {DEFAULT_MODEL})",
+        },
+        "system": {
+            "type": "string",
+            "description": "Optional reviewer system prompt",
+        },
+    }
+    return [
+        {
+            "name": "review",
+            "description": (
+                "Start an HTTP reviewer thread. Returns the actual reviewer "
+                "model and fails closed unless it is from a different family "
+                "than executor_model."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": dict(common_properties),
+                "required": ["prompt", "executor_model"],
+            },
+        },
+        {
+            "name": "review_reply",
+            "description": (
+                "Continue an HTTP reviewer thread with full prior message "
+                "history."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    **common_properties,
+                    "threadId": {
+                        "type": "string",
+                        "description": "threadId returned by review",
+                    },
+                },
+                "required": ["threadId", "prompt"],
+            },
+        },
+    ]
+
 
 def handle_request(request):
-    """Handle a JSON-RPC request"""
+    """Handle a JSON-RPC request."""
     method = request.get("method", "")
     params = request.get("params", {})
     request_id = request.get("id")
 
     debug_log(f"Handling method: {method}, id: {request_id}")
 
-    # Handle notifications (no id, no response needed)
     if request_id is None:
         if method == "notifications/initialized":
             debug_log("Client initialized successfully")
@@ -168,50 +508,28 @@ def handle_request(request):
             "id": request_id,
             "result": {
                 "protocolVersion": "2024-11-05",
-                "capabilities": {
-                    "tools": {}
-                },
+                "capabilities": {"tools": {}},
                 "serverInfo": {
                     "name": SERVER_NAME,
-                    "version": "2.0.0"
-                }
-            }
+                    "version": "2.2.0",
+                },
+            },
         }
 
-    elif method == "ping":
+    if method == "ping":
         return {"jsonrpc": "2.0", "id": request_id, "result": {}}
 
-    elif method == "tools/list":
+    if method == "tools/list":
+        tools = [_chat_tool_definition()]
+        if REVIEW_FALLBACK_ENABLED:
+            tools.extend(_review_tool_definitions())
         return {
             "jsonrpc": "2.0",
             "id": request_id,
-            "result": {
-                "tools": [{
-                    "name": "chat",
-                    "description": f"Send a message to {DEFAULT_MODEL} and get a response. Use this for research reviews, code analysis, and general AI tasks.",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "prompt": {
-                                "type": "string",
-                                "description": "The prompt to send"
-                            },
-                            "model": {
-                                "type": "string",
-                                "description": f"Model to use (default: {DEFAULT_MODEL})"
-                            },
-                            "system": {
-                                "type": "string",
-                                "description": "Optional system prompt"
-                            }
-                        },
-                        "required": ["prompt"]
-                    }
-                }]
-            }
+            "result": {"tools": tools},
         }
 
-    elif method == "tools/call":
+    if method == "tools/call":
         tool_name = params.get("name", "")
         arguments = params.get("arguments", {})
 
@@ -233,9 +551,11 @@ def handle_request(request):
                     "jsonrpc": "2.0",
                     "id": request_id,
                     "result": {
-                        "content": [{"type": "text", "text": f"Error: {error}"}],
-                        "isError": True
-                    }
+                        "content": [
+                            {"type": "text", "text": f"Error: {error}"}
+                        ],
+                        "isError": True,
+                    },
                 }
 
             return {
@@ -243,21 +563,47 @@ def handle_request(request):
                 "id": request_id,
                 "result": {
                     "content": [{"type": "text", "text": content}]
-                }
+                },
             }
 
+        if tool_name == "review":
+            if not REVIEW_FALLBACK_ENABLED:
+                return _tool_error(
+                    request_id,
+                    "HTTP reviewer fallback is disabled. Set "
+                    "LLM_REVIEW_FALLBACK_ENABLED=true and restart the MCP "
+                    "server.",
+                )
+            return _handle_review(arguments, request_id)
+
+        if tool_name == "review_reply":
+            if not REVIEW_FALLBACK_ENABLED:
+                return _tool_error(
+                    request_id,
+                    "HTTP reviewer fallback is disabled. Set "
+                    "LLM_REVIEW_FALLBACK_ENABLED=true and restart the MCP "
+                    "server.",
+                )
+            return _handle_review_reply(arguments, request_id)
+
         return {
             "jsonrpc": "2.0",
             "id": request_id,
-            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
+            "error": {
+                "code": -32601,
+                "message": f"Unknown tool: {tool_name}",
+            },
         }
 
-    else:
-        return {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "error": {"code": -32601, "message": f"Unknown method: {method}"}
-        }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {
+            "code": -32601,
+            "message": f"Unknown method: {method}",
+        },
+    }
+
 
 def read_message():
     """Read a single JSON-RPC message from stdin."""
@@ -267,7 +613,7 @@ def read_message():
     if not line:
         return None
 
-    line = line.decode('utf-8').rstrip('\r\n')
+    line = line.decode("utf-8").rstrip("\r\n")
 
     if line.lower().startswith("content-length:"):
         try:
@@ -279,17 +625,17 @@ def read_message():
             hdr = sys.stdin.readline()
             if not hdr:
                 return None
-            hdr = hdr.decode('utf-8').rstrip('\r\n')
+            hdr = hdr.decode("utf-8").rstrip("\r\n")
             if hdr == "":
                 break
 
         body = sys.stdin.read(content_length)
         try:
-            return json.loads(body.decode('utf-8'))
+            return json.loads(body.decode("utf-8"))
         except Exception:
             return None
 
-    elif line.startswith("{") or line.startswith("["):
+    if line.startswith("{") or line.startswith("["):
         _use_ndjson = True
         try:
             return json.loads(line)
@@ -298,8 +644,9 @@ def read_message():
 
     return None
 
+
 def main():
-    """Main loop - read JSON-RPC messages from stdin"""
+    """Main loop - read JSON-RPC messages from stdin."""
     _init_stdio()
     debug_log("Entering main loop")
 
@@ -318,6 +665,7 @@ def main():
             log_error(f"Exception: {e}")
 
     debug_log("=== Server Exiting ===")
+
 
 if __name__ == "__main__":
     main()

--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -112,7 +112,10 @@ def _call_llm_detailed(messages, model=None):
         "Authorization": f"Bearer {API_KEY}"
     }
 
-    # Try: original model → retry same model → fallback model
+    # Try: original model → retry same model → fallback model.
+    # This retrying behavior is intentionally legacy-chat-only. Verdict-bearing
+    # review/review_reply calls use _call_llm_review_once below so ambiguous
+    # failures can never duplicate a paid review or produce conflicting verdicts.
     for attempt in range(3):
         current_model = use_model if attempt < 2 else FALLBACK_MODEL
         payload = {
@@ -169,6 +172,64 @@ def call_llm(messages, model=None):
     return content, error
 
 
+def _call_llm_review_once(messages, model=None):
+    """Single-attempt, fail-closed call for verdict-bearing reviewer tools.
+
+    Once the HTTP request is dispatched, a timeout, 504, malformed response, or
+    transport exception is ambiguous: the remote reviewer may already have run.
+    Never retry or switch to FALLBACK_MODEL here. Surface the error so the
+    orchestrator/gate records REVIEW_UNAVAILABLE instead of issuing a duplicate
+    paid review with a potentially conflicting verdict.
+    """
+    if not API_KEY:
+        return None, "LLM_API_KEY environment variable not set", None
+
+    use_model = model or DEFAULT_MODEL
+    url = f"{BASE_URL.rstrip('/')}/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {API_KEY}"
+    }
+    payload = {
+        "model": use_model,
+        "messages": messages,
+        "max_tokens": 4096
+    }
+
+    debug_log(f"Calling verdict-bearing LLM review once: model={use_model}")
+    try:
+        with httpx.Client(timeout=300.0) as client:
+            response = client.post(url, headers=headers, json=payload)
+            if response.status_code != 200:
+                error_msg = f"API error {response.status_code}: {response.text[:500]}"
+                debug_log(f"Review API error (no retry): {error_msg}")
+                return None, error_msg, None
+
+            try:
+                data = response.json()
+            except Exception as exc:
+                error_msg = f"Invalid API JSON response: {exc}"
+                debug_log(f"Review API parse error (no retry): {error_msg}")
+                return None, error_msg, None
+
+            try:
+                content = data["choices"][0]["message"]["content"]
+            except (KeyError, IndexError, TypeError) as exc:
+                error_msg = f"Unexpected API response structure: {exc}"
+                debug_log(f"Review API structure error (no retry): {error_msg}")
+                return None, error_msg, None
+
+            actual_model = str(data.get("model") or use_model).strip()
+            debug_log(
+                f"Verdict-bearing API success: model={actual_model}, "
+                f"response length={len(content)}"
+            )
+            return content, None, actual_model
+    except Exception as exc:
+        debug_log(f"Review API exception (no retry): {str(exc)}")
+        return None, str(exc), None
+
+
 # Coarse model families used only by the opt-in verdict-bearing review tools.
 _FAMILY = [
     ("anthropic", ("claude", "opus", "sonnet", "haiku", "anthropic")),
@@ -188,14 +249,21 @@ _FAMILY = [
 _SHORT = {"o1", "o3", "o4"}
 
 def model_family(name):
-    """Map a model id to a coarse family; collisions fail closed."""
+    """Map a model id to a coarse family; collisions fail closed.
+
+    Match family needles at token boundaries, mirroring review_gate.py, so a
+    provider prefix such as ``ollama/deepseek-r1`` does not accidentally match
+    the ``llama`` model family inside ``ollama``.
+    """
     n = str(name or "").strip().lower()
-    tokens = set(re.split(r"[^a-z0-9.]+", n))
     matched = set()
     for family, needles in _FAMILY:
-        if any((needle in tokens) if needle in _SHORT else (needle in n)
-               for needle in needles):
-            matched.add(family)
+        for needle in needles:
+            suffix = "" if needle in _SHORT else r"[0-9.]*"
+            pattern = rf"(^|[^a-z0-9]){re.escape(needle)}{suffix}([^a-z0-9]|$)"
+            if re.search(pattern, n):
+                matched.add(family)
+                break
     return next(iter(matched)) if len(matched) == 1 else "unknown"
 
 def _cross_family_error(executor_model, reviewer_model):
@@ -281,7 +349,7 @@ def _handle_review(arguments, request_id):
     except ValueError as exc:
         return _tool_error(request_id, str(exc))
 
-    content, error, actual_model = _call_llm_detailed(
+    content, error, actual_model = _call_llm_review_once(
         _review_messages([], user_content, system), model
     )
     if error:
@@ -338,7 +406,7 @@ def _handle_review_reply(arguments, request_id):
         return _tool_error(request_id, str(exc))
 
     history = list(thread["messages"])
-    content, error, actual_model = _call_llm_detailed(
+    content, error, actual_model = _call_llm_review_once(
         _review_messages(history, user_content, system), model
     )
     if error:

--- a/mcp-servers/llm-chat/server.py
+++ b/mcp-servers/llm-chat/server.py
@@ -25,6 +25,7 @@ import re
 import sys
 import tempfile
 import uuid
+from pathlib import Path
 
 import httpx
 
@@ -292,6 +293,37 @@ def _tool_error(request_id, message):
     }
 
 
+def _read_review_files(paths):
+    """Read explicit local text artifacts for the HTTP reviewer transport.
+
+    This is only reachable through the opt-in review tools. Callers must pass
+    primary artifacts, not executor summaries, to preserve reviewer independence.
+    """
+    if paths is None:
+        return ""
+    if not isinstance(paths, list):
+        raise ValueError("files must be an array of file paths")
+
+    sections = []
+    for raw_path in paths:
+        path = Path(str(raw_path)).expanduser()
+        if not path.is_file():
+            raise ValueError(f"review file not found or not a regular file: {path}")
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            raise ValueError(f"cannot read review file {path}: {exc}") from exc
+        sections.append(
+            f"\n\n--- ARIS PRIMARY ARTIFACT: {path} ---\n{text}"
+            f"\n--- END ARIS PRIMARY ARTIFACT: {path} ---"
+        )
+    return "".join(sections)
+
+
+def _review_user_content(prompt, files):
+    return prompt + _read_review_files(files)
+
+
 def _review_messages(history, prompt, system=""):
     messages = []
     if system:
@@ -306,6 +338,7 @@ def _handle_review(arguments, request_id):
     executor_model = str(arguments.get("executor_model", "")).strip()
     model = str(arguments.get("model", DEFAULT_MODEL)).strip() or DEFAULT_MODEL
     system = str(arguments.get("system", "")).strip()
+    files = arguments.get("files", [])
 
     if not prompt:
         return _tool_error(request_id, "prompt is required")
@@ -315,7 +348,12 @@ def _handle_review(arguments, request_id):
             "executor_model is required for cross-family review",
         )
 
-    messages = _review_messages([], prompt, system)
+    try:
+        user_content = _review_user_content(prompt, files)
+    except ValueError as exc:
+        return _tool_error(request_id, str(exc))
+
+    messages = _review_messages([], user_content, system)
     content, error, actual_model = _call_llm_detailed(messages, model)
     if error:
         return _tool_error(request_id, error)
@@ -329,7 +367,7 @@ def _handle_review(arguments, request_id):
     thread_id = uuid.uuid4().hex[:12]
     _review_threads[thread_id] = {
         "messages": [
-            {"role": "user", "content": prompt},
+            {"role": "user", "content": user_content},
             {"role": "assistant", "content": content},
         ],
         "model": model,
@@ -366,14 +404,20 @@ def _handle_review_reply(arguments, request_id):
     ).strip()
     model = str(arguments.get("model", thread["model"])).strip() or thread["model"]
     system = str(arguments.get("system", thread["system"])).strip()
+    files = arguments.get("files", [])
     if not executor_model:
         return _tool_error(
             request_id,
             "executor_model is required for cross-family review",
         )
 
+    try:
+        user_content = _review_user_content(prompt, files)
+    except ValueError as exc:
+        return _tool_error(request_id, str(exc))
+
     history = list(thread["messages"])
-    messages = _review_messages(history, prompt, system)
+    messages = _review_messages(history, user_content, system)
     content, error, actual_model = _call_llm_detailed(messages, model)
     if error:
         return _tool_error(request_id, error)
@@ -386,7 +430,7 @@ def _handle_review_reply(arguments, request_id):
 
     thread["messages"].extend(
         [
-            {"role": "user", "content": prompt},
+            {"role": "user", "content": user_content},
             {"role": "assistant", "content": content},
         ]
     )
@@ -452,6 +496,14 @@ def _review_tool_definitions():
         "system": {
             "type": "string",
             "description": "Optional reviewer system prompt",
+        },
+        "files": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Local primary-artifact file paths to read verbatim and send "
+                "to the configured HTTP reviewer endpoint"
+            ),
         },
     }
     return [

--- a/skills/shared-references/reviewer-routing.md
+++ b/skills/shared-references/reviewer-routing.md
@@ -64,6 +64,8 @@ The user must explicitly configure the `llm-chat` server with
 `LLM_REVIEW_FALLBACK_ENABLED=true`; only then does it expose
 `mcp__llm-chat__review` and `mcp__llm-chat__review_reply`. The legacy
 `mcp__llm-chat__chat` tool by itself is **not** a verdict-bearing fallback.
+This transport fallback applies to Codex **MCP** review calls; Codex-exec
+nightmare-mode behavior is unchanged.
 
 #### Safe switch boundary
 
@@ -110,7 +112,8 @@ endpoint; this is necessary because a remote OpenAI-compatible API cannot read
 local Linux paths. Pass primary artifacts, not executor-written summaries, per
 `reviewer-independence.md`.
 
-For round 2+ after the HTTP fallback owns the reviewer thread, use:
+For every follow-up after the HTTP fallback owns the reviewer thread — including
+round 2+ and a hard-mode rebuttal ruling in the same round — use:
 
 ```
 mcp__llm-chat__review_reply:
@@ -122,6 +125,21 @@ mcp__llm-chat__review_reply:
 
 `review_reply` carries the prior user/reviewer exchanges in the MCP server, so
 multi-round skills do not silently lose continuity when the fallback activates.
+
+For `/auto-review-loop`, a safe HTTP fallback means the HTTP reviewer is the
+backend that actually ran the current round. **Before the HTTP call**, replace
+the current-round snapshot as well as the forward-looking backend:
+
+```
+REVIEWER_BACKEND=llm-chat
+round_backend=llm-chat
+round_requires_external_acquittal=false
+```
+
+Then pass the returned `reviewer_model` (not merely the requested alias) to
+`review_gate.py --round-backend llm-chat`. The fallback is not a Copilot
+compatibility finalizer and must not inherit a stale external-acquittal
+obligation from some unrelated round.
 
 The HTTP reviewer transport fails closed unless it can derive known, different
 families for `executor_model` and the **actual reviewer model**. The response
@@ -274,7 +292,7 @@ If `— reviewer: agy`:
 - `— reviewer: agy` ONLY takes effect when explicitly passed.
 - **Cross-model family holds by construction.** The `agy` backend is fail-closed on ARIS's invariant: it recovers the *actual* Gemini-family model id from the current invocation's Antigravity transcript, **refuses** to return a verdict if the routed model is non-Gemini (no `"agy-cli"` placeholder), and binds the recovered transcript to *this* call via a **user-event nonce** (a model echo can't spoof the binding). So when the executor is Claude, `— reviewer: agy` (Gemini) satisfies the cross-model gate.
 - Reviewer independence still applies — pass prompt context only (the `tools` arg is accepted for compatibility but ignored).
-- `effort` and `difficulty` are orthogonal — they don't change reviewer backend.
+- `effort` and `difficulty` are orthogonal — they don't change the reviewer backend.
 
 ### Install
 
@@ -309,7 +327,7 @@ If `— reviewer: manual`:
           config: {"model_reasoning_effort": "xhigh", "executor_model": "<actual executor model>", "require_reviewer_model": true}
         For round 2+ in multi-round skills:
           Use mcp__manual_review__review_reply with:
-            threadId: [saved manual-review threadId]
+            threadId: [saved from prior call]
             prompt: [follow-up prompt]
             config: {"model_reasoning_effort": "xhigh", "executor_model": "<actual executor model>", "require_reviewer_model": true}
     → If NOT available:
@@ -578,6 +596,7 @@ The selected reviewer model family MUST differ from the family derived from the 
 Unlike the previous broken model-inheritance approach, the router reads the selected profile's `model:` field and passes that same value through the subprocess-level `--model` flag. This outer pin is mandatory because Copilot CLI may ignore a custom agent's model when the session model is Auto.
 
 **Family detection requires `--executor-model`:**
+
 The skill MUST receive `--executor-model` as a parameter. From it, derive `executor_family`:
 - Model names containing `gpt`, `o1`, `o3`, `o4`, `chatgpt` → `openai`
 - Model names containing `claude`, `sonnet`, `opus`, `haiku` → `anthropic`

--- a/skills/shared-references/reviewer-routing.md
+++ b/skills/shared-references/reviewer-routing.md
@@ -55,6 +55,107 @@ Resolve the reviewer pair on the **first new Codex session of each tier** in a r
 - If no allowed pair succeeds, emit `REVIEW_UNAVAILABLE` (or, for a mandatory audit gate, `ERROR`) — never a substantive verdict.
 - This automatic chain applies only when no explicit reviewer-model override was supplied.
 
+### Optional HTTP API fallback for Codex pre-dispatch failures
+
+Claude Code + ARIS Skills may use the existing `llm-chat` MCP as an **opt-in
+transport fallback** when the Codex reviewer cannot be started safely. This does
+not replace the Codex capability chain above and it is disabled by default.
+The user must explicitly configure the `llm-chat` server with
+`LLM_REVIEW_FALLBACK_ENABLED=true`; only then does it expose
+`mcp__llm-chat__review` and `mcp__llm-chat__review_reply`. The legacy
+`mcp__llm-chat__chat` tool by itself is **not** a verdict-bearing fallback.
+
+#### Safe switch boundary
+
+The fallback is intentionally **pre-dispatch-only**, matching ARIS-Code's
+reviewer fallback safety rule:
+
+- First apply the Codex model/effort capability fallback above.
+- HTTP fallback MAY run when the Codex path is known not to have produced a
+  review: the Codex MCP tool is absent/unregistered, the local MCP process
+  cannot spawn or initialize, or an error explicitly proves the reviewer
+  request was rejected before model execution.
+- HTTP fallback MUST NOT run merely because a dispatched Codex call timed out,
+  disconnected, returned an ambiguous transport/server/parse failure, or
+  otherwise might have executed without returning a usable thread. Keep the
+  existing `REVIEW_UNAVAILABLE` / `ERROR` behavior in those cases; silently
+  issuing a second paid review risks double-running and conflicting verdicts.
+- The existing `NEVER downgrade on ...` list above remains authoritative. An
+  error from that list may activate HTTP fallback only when the error itself
+  positively establishes that no model request was dispatched.
+
+This boundary is deliberately narrower than "Codex returned any error." Users
+who explicitly want a different reviewer regardless of Codex state should pick
+that backend directly (`oracle-pro`, `agy`, or `manual`) instead of relying on
+fallback.
+
+#### HTTP fallback call contract
+
+For a fresh fallback review, use:
+
+```
+mcp__llm-chat__review:
+  prompt: [same substantive review task Codex would receive]
+  executor_model: <actual executor model id>
+  files:
+    - <primary artifact path 1>
+    - <primary artifact path 2>
+```
+
+Do **not** pass Codex-only fields such as `config.model_reasoning_effort`,
+`sandbox`, `approval-policy`, `cwd`, `threadId`, base/developer instructions, or
+other Codex transport parameters. `llm-chat` reads each explicit `files:` entry
+locally and sends the primary artifact contents verbatim to the configured HTTP
+endpoint; this is necessary because a remote OpenAI-compatible API cannot read
+local Linux paths. Pass primary artifacts, not executor-written summaries, per
+`reviewer-independence.md`.
+
+For round 2+ after the HTTP fallback owns the reviewer thread, use:
+
+```
+mcp__llm-chat__review_reply:
+  threadId: <saved llm-chat threadId>
+  prompt: [follow-up review task]
+  files:
+    - <changed/current primary artifacts the reviewer must inspect>
+```
+
+`review_reply` carries the prior user/reviewer exchanges in the MCP server, so
+multi-round skills do not silently lose continuity when the fallback activates.
+
+The HTTP reviewer transport fails closed unless it can derive known, different
+families for `executor_model` and the **actual reviewer model**. The response
+includes `reviewer_model`, `reviewer_family`, `executor_model`,
+`executor_family`, and `independence_verified`. Prefer the provider-reported
+model id when available; if the configured HTTP provider internally switches to
+`LLM_FALLBACK_MODEL`, trace the model that actually served the review. Missing,
+unknown, ambiguous, or same-family identity is `REVIEW_UNAVAILABLE` for an
+acceptance gate.
+
+#### Configuration and privacy
+
+Example Claude Code registration:
+
+```bash
+claude mcp add llm-chat -s user \
+  --env LLM_API_KEY=<key> \
+  --env LLM_BASE_URL=https://example.com/v1 \
+  --env LLM_MODEL=gemini-2.5-pro \
+  --env LLM_REVIEW_FALLBACK_ENABLED=true \
+  -- python3 /path/to/mcp-servers/llm-chat/server.py
+```
+
+Restart Claude Code after changing MCP configuration. Enabling this fallback
+means the explicit primary artifacts passed in `files:` are sent to the
+configured third-party HTTP endpoint. Keep it disabled for repositories whose
+contents must not leave the machine/provider boundary.
+
+Trace the failed Codex attempt and the HTTP call separately. The verdict trace
+must name backend `llm-chat`, the actual returned reviewer model, its family,
+and the reason the safe fallback activated. If `mcp__llm-chat__review` is not
+available, its call fails, or cross-family identity cannot be verified, emit
+`REVIEW_UNAVAILABLE` (or `ERROR` for a mandatory gate) exactly as before.
+
 ### After upgrading codex-cli
 
 MCP servers are spawned per session: after upgrading codex-cli (e.g. to 0.144.1 for `ultra`/`max`), **restart the Claude Code session** so `codex mcp-server` runs the new binary — an old server process rejects the new effort enums even though the CLI on disk is new.
@@ -173,7 +274,7 @@ If `— reviewer: agy`:
 - `— reviewer: agy` ONLY takes effect when explicitly passed.
 - **Cross-model family holds by construction.** The `agy` backend is fail-closed on ARIS's invariant: it recovers the *actual* Gemini-family model id from the current invocation's Antigravity transcript, **refuses** to return a verdict if the routed model is non-Gemini (no `"agy-cli"` placeholder), and binds the recovered transcript to *this* call via a **user-event nonce** (a model echo can't spoof the binding). So when the executor is Claude, `— reviewer: agy` (Gemini) satisfies the cross-model gate.
 - Reviewer independence still applies — pass prompt context only (the `tools` arg is accepted for compatibility but ignored).
-- `effort` and `difficulty` are orthogonal — they don't change the reviewer backend.
+- `effort` and `difficulty` are orthogonal — they don't change reviewer backend.
 
 ### Install
 
@@ -208,7 +309,7 @@ If `— reviewer: manual`:
           config: {"model_reasoning_effort": "xhigh", "executor_model": "<actual executor model>", "require_reviewer_model": true}
         For round 2+ in multi-round skills:
           Use mcp__manual_review__review_reply with:
-            threadId: [saved from prior call]
+            threadId: [saved manual-review threadId]
             prompt: [follow-up prompt]
             config: {"model_reasoning_effort": "xhigh", "executor_model": "<actual executor model>", "require_reviewer_model": true}
     → If NOT available:
@@ -477,7 +578,6 @@ The selected reviewer model family MUST differ from the family derived from the 
 Unlike the previous broken model-inheritance approach, the router reads the selected profile's `model:` field and passes that same value through the subprocess-level `--model` flag. This outer pin is mandatory because Copilot CLI may ignore a custom agent's model when the session model is Auto.
 
 **Family detection requires `--executor-model`:**
-
 The skill MUST receive `--executor-model` as a parameter. From it, derive `executor_family`:
 - Model names containing `gpt`, `o1`, `o3`, `o4`, `chatgpt` → `openai`
 - Model names containing `claude`, `sonnet`, `opus`, `haiku` → `anthropic`

--- a/tests/test_http_reviewer_fallback_contract.py
+++ b/tests/test_http_reviewer_fallback_contract.py
@@ -16,6 +16,7 @@ def test_http_fallback_is_explicit_opt_in_and_pre_dispatch_only():
     assert "pre-dispatch-only" in ROUTING
     assert "mcp__llm-chat__review" in ROUTING
     assert "mcp__llm-chat__review_reply" in ROUTING
+    assert "Codex-exec\nnightmare-mode behavior is unchanged" in ROUTING
 
 
 def test_http_fallback_keeps_ambiguous_codex_failures_closed():
@@ -28,3 +29,15 @@ def test_http_fallback_requires_primary_artifacts_and_cross_family_identity():
     assert "Pass primary artifacts, not executor-written summaries" in ROUTING
     assert "actual reviewer model" in ROUTING
     assert "same-family identity is `REVIEW_UNAVAILABLE`" in ROUTING
+
+
+def test_http_fallback_preserves_multi_round_and_rebuttal_continuity():
+    assert "hard-mode rebuttal ruling in the same round" in ROUTING
+    assert "review_reply` carries the prior user/reviewer exchanges" in ROUTING
+
+
+def test_auto_review_loop_relabels_the_backend_that_actually_ran():
+    assert "REVIEWER_BACKEND=llm-chat" in ROUTING
+    assert "round_backend=llm-chat" in ROUTING
+    assert "round_requires_external_acquittal=false" in ROUTING
+    assert "review_gate.py --round-backend llm-chat" in ROUTING

--- a/tests/test_http_reviewer_fallback_contract.py
+++ b/tests/test_http_reviewer_fallback_contract.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Regression checks for the shared Codex -> HTTP reviewer fallback contract."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROUTING = (
+    REPO_ROOT / "skills" / "shared-references" / "reviewer-routing.md"
+).read_text(encoding="utf-8")
+
+
+def test_http_fallback_is_explicit_opt_in_and_pre_dispatch_only():
+    assert "Optional HTTP API fallback for Codex pre-dispatch failures" in ROUTING
+    assert "LLM_REVIEW_FALLBACK_ENABLED=true" in ROUTING
+    assert "pre-dispatch-only" in ROUTING
+    assert "mcp__llm-chat__review" in ROUTING
+    assert "mcp__llm-chat__review_reply" in ROUTING
+
+
+def test_http_fallback_keeps_ambiguous_codex_failures_closed():
+    assert "MUST NOT run merely because a dispatched Codex call timed out" in ROUTING
+    assert "risks double-running and conflicting verdicts" in ROUTING
+    assert "NEVER downgrade on" in ROUTING
+
+
+def test_http_fallback_requires_primary_artifacts_and_cross_family_identity():
+    assert "Pass primary artifacts, not executor-written summaries" in ROUTING
+    assert "actual reviewer model" in ROUTING
+    assert "same-family identity is `REVIEW_UNAVAILABLE`" in ROUTING

--- a/tests/test_http_reviewer_provenance_alignment.py
+++ b/tests/test_http_reviewer_provenance_alignment.py
@@ -1,0 +1,25 @@
+"""Regression coverage for HTTP reviewer/provenance family alignment."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import provenance as pv  # noqa: E402
+
+
+def test_http_reviewer_families_are_recordable_in_provenance():
+    assert pv.model_family("glm-5") == "zhipu"
+    assert pv.model_family("zhipu/glm-4.5") == "zhipu"
+    assert pv.model_family("mimo-v2") == "xiaomi"
+    assert pv.model_family("xiaomi/mimo") == "xiaomi"
+    assert pv.model_family("doubao-1.5-pro") == "bytedance"
+    assert pv.model_family("volcengine/doubao") == "bytedance"
+
+
+def test_provenance_family_matching_uses_boundaries():
+    assert pv.model_family("ollama/deepseek-r1") == "deepseek"
+    assert pv.model_family("meta/llama-3.3") == "meta"
+    assert pv.model_family("claude-gpt-4") == "unknown"

--- a/tests/test_http_reviewer_review_gate.py
+++ b/tests/test_http_reviewer_review_gate.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Review-gate coverage for the llm-chat HTTP fallback backend."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "tools" / "review_gate.py"
+SPEC = importlib.util.spec_from_file_location("http_fallback_review_gate", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+review_gate = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = review_gate
+SPEC.loader.exec_module(review_gate)
+
+
+def test_llm_chat_positive_cross_family_verdict_stops() -> None:
+    transition = review_gate.evaluate_transition(
+        round_backend="llm-chat",
+        score=8,
+        verdict="ready",
+        executor_model="shangtang-glm",
+        reviewer_model="gemini-2.5-pro",
+    )
+
+    assert transition.decision == "stop"
+    assert transition.next_backend is None
+    assert transition.requires_external_acquittal is False
+    assert transition.identity_assurance == "caller_declared"
+
+
+def test_llm_chat_same_family_verdict_fails_closed() -> None:
+    transition = review_gate.evaluate_transition(
+        round_backend="llm-chat",
+        score=8,
+        verdict="ready",
+        executor_model="shangtang-glm",
+        reviewer_model="zhipu-glm",
+    )
+
+    assert transition.decision == "review_unavailable"
+    assert transition.identity_assurance == "failed"
+
+
+def test_llm_chat_unknown_family_verdict_fails_closed() -> None:
+    transition = review_gate.evaluate_transition(
+        round_backend="llm-chat",
+        score=8,
+        verdict="ready",
+        executor_model="shangtang-glm",
+        reviewer_model="mystery-reviewer",
+    )
+
+    assert transition.decision == "review_unavailable"
+
+
+def test_llm_chat_negative_verdict_continues_on_same_backend() -> None:
+    transition = review_gate.evaluate_transition(
+        round_backend="llm-chat",
+        score=5,
+        verdict="not ready",
+        executor_model="shangtang-glm",
+        reviewer_model="gemini-2.5-pro",
+    )
+
+    assert transition.decision == "continue"
+    assert transition.next_backend == "llm-chat"
+
+
+def test_llm_chat_is_not_implicitly_allowed_as_copilot_finalizer() -> None:
+    transition = review_gate.evaluate_transition(
+        round_backend="llm-chat",
+        score=8,
+        verdict="ready",
+        requires_external_acquittal=True,
+        executor_model="claude-sonnet-4-5",
+        reviewer_model="gemini-2.5-pro",
+    )
+
+    assert transition.decision == "review_unavailable"
+
+
+@pytest.mark.parametrize(
+    ("model", "family"),
+    [
+        ("shangtang-glm", "zhipu"),
+        ("GLM-5", "zhipu"),
+        ("MiniMax-M2.7", "minimax"),
+        ("kimi-k2.5", "moonshot"),
+        ("qwen3.6-plus", "qwen"),
+        ("mimo-v2.5-pro", "xiaomi"),
+        ("doubao-pro-4k", "bytedance"),
+        ("grok-4", "xai"),
+        ("llama-4", "meta"),
+        ("mistral-large", "mistral"),
+    ],
+)
+def test_review_gate_recognizes_http_provider_families(model: str, family: str) -> None:
+    assert review_gate.derive_model_family(model) == family
+
+
+def test_review_gate_parser_accepts_llm_chat_backend() -> None:
+    action = next(
+        action for action in review_gate.build_parser()._actions
+        if action.dest == "round_backend"
+    )
+    assert "llm-chat" in action.choices

--- a/tests/test_llm_chat_review_fallback.py
+++ b/tests/test_llm_chat_review_fallback.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Tests for opt-in ARIS HTTP reviewer fallback in llm-chat MCP."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_PATH = REPO_ROOT / "mcp-servers" / "llm-chat" / "server.py"
+
+
+def load_server():
+    spec = importlib.util.spec_from_file_location("llm_chat_review_server", SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module._review_threads.clear()
+    return module
+
+
+def tool_names(module):
+    resp = module.handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    )
+    return [tool["name"] for tool in resp["result"]["tools"]]
+
+
+def parse_tool_payload(resp):
+    return json.loads(resp["result"]["content"][0]["text"])
+
+
+def mock_http_response(content, model, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = content if status_code != 200 else ""
+    response.json.return_value = {
+        "model": model,
+        "choices": [{"message": {"content": content}}],
+    }
+    return response
+
+
+def mock_client_with(*responses):
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    if len(responses) > 1:
+        client.post.side_effect = list(responses)
+    else:
+        client.post.return_value = responses[0]
+    return client
+
+
+def test_review_tools_are_opt_in():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = False
+    assert tool_names(server) == ["chat"]
+
+    server.REVIEW_FALLBACK_ENABLED = True
+    assert tool_names(server) == ["chat", "review", "review_reply"]
+
+
+def test_review_returns_identity_and_thread_for_cross_family_model():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    response = mock_http_response("Strict review", "gemini-2.5-pro")
+    client = mock_client_with(response)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Review this artifact.",
+                        "executor_model": "claude-sonnet-4-5",
+                        "model": "gemini-2.5-pro",
+                    },
+                },
+            }
+        )
+
+    assert not resp["result"].get("isError", False)
+    payload = parse_tool_payload(resp)
+    assert payload["content"] == "Strict review"
+    assert payload["reviewer_model"] == "gemini-2.5-pro"
+    assert payload["reviewer_family"] == "google"
+    assert payload["executor_family"] == "anthropic"
+    assert payload["independence_verified"] is True
+    assert payload["threadId"] in server._review_threads
+
+
+def test_review_rejects_same_family():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    response = mock_http_response("Looks good", "glm-5")
+    client = mock_client_with(response)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Review.",
+                        "executor_model": "shangtang-glm",
+                        "model": "glm-5",
+                    },
+                },
+            }
+        )
+
+    assert resp["result"]["isError"] is True
+    assert "different model family" in parse_tool_payload(resp)["error"]
+
+
+def test_review_rejects_unknown_executor_family():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    response = mock_http_response("Review", "gpt-5.5")
+    client = mock_client_with(response)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Review.",
+                        "executor_model": "mystery-model-xyz",
+                    },
+                },
+            }
+        )
+
+    assert resp["result"]["isError"] is True
+    assert "executor_model" in parse_tool_payload(resp)["error"]
+
+
+def test_review_reply_preserves_thread_history_and_model():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    first = mock_http_response("Round one", "gemini-2.5-pro")
+    second = mock_http_response("Round two", "gemini-2.5-pro")
+    client = mock_client_with(first, second)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        initial = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Initial review.",
+                        "executor_model": "claude-opus-4-1",
+                        "model": "gemini-2.5-pro",
+                    },
+                },
+            }
+        )
+        thread_id = parse_tool_payload(initial)["threadId"]
+
+        reply = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "review_reply",
+                    "arguments": {
+                        "threadId": thread_id,
+                        "prompt": "Re-check the revision.",
+                    },
+                },
+            }
+        )
+
+    assert not reply["result"].get("isError", False)
+    payload = parse_tool_payload(reply)
+    assert payload["threadId"] == thread_id
+    assert payload["content"] == "Round two"
+
+    second_payload = client.post.call_args_list[1].kwargs["json"]
+    messages = second_payload["messages"]
+    assert messages == [
+        {"role": "user", "content": "Initial review."},
+        {"role": "assistant", "content": "Round one"},
+        {"role": "user", "content": "Re-check the revision."},
+    ]
+    assert second_payload["model"] == "gemini-2.5-pro"
+
+
+def test_review_reports_actual_internal_fallback_model_after_504s():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+    server.DEFAULT_MODEL = "gpt-5.5"
+    server.FALLBACK_MODEL = "gemini-2.5-pro"
+
+    timeout_1 = MagicMock(status_code=504)
+    timeout_2 = MagicMock(status_code=504)
+    success = mock_http_response("Fallback review", "gemini-2.5-pro")
+    client = mock_client_with(timeout_1, timeout_2, success)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Review.",
+                        "executor_model": "claude-sonnet-4-5",
+                    },
+                },
+            }
+        )
+
+    assert not resp["result"].get("isError", False)
+    payload = parse_tool_payload(resp)
+    assert payload["reviewer_model"] == "gemini-2.5-pro"
+    assert payload["reviewer_family"] == "google"
+    assert "Used fallback model gemini-2.5-pro" in payload["content"]
+
+
+def test_review_rejects_provider_reported_same_family_alias():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    # The request asks for a Gemini alias, but the endpoint reports that the
+    # actual model serving the request was Claude. The actual identity wins.
+    response = mock_http_response("Review", "claude-sonnet-4-5")
+    client = mock_client_with(response)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Review.",
+                        "executor_model": "claude-opus-4-1",
+                        "model": "gemini-alias",
+                    },
+                },
+            }
+        )
+
+    assert resp["result"]["isError"] is True
+    assert "different model family" in parse_tool_payload(resp)["error"]
+
+
+def test_disabled_review_call_fails_with_opt_in_instruction():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = False
+
+    resp = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "review",
+                "arguments": {
+                    "prompt": "Review.",
+                    "executor_model": "claude-sonnet-4-5",
+                },
+            },
+        }
+    )
+    assert resp["result"]["isError"] is True
+    assert "LLM_REVIEW_FALLBACK_ENABLED=true" in parse_tool_payload(resp)["error"]

--- a/tests/test_llm_chat_review_fallback.py
+++ b/tests/test_llm_chat_review_fallback.py
@@ -279,6 +279,41 @@ def test_review_rejects_provider_reported_same_family_alias():
     assert "different model family" in parse_tool_payload(resp)["error"]
 
 
+def test_review_sends_primary_files_verbatim(tmp_path):
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    artifact = tmp_path / "paper.md"
+    artifact.write_text("PRIMARY_EVIDENCE=42\n", encoding="utf-8")
+    response = mock_http_response("Reviewed evidence", "gemini-2.5-pro")
+    client = mock_client_with(response)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Review the attached primary artifact.",
+                        "executor_model": "claude-sonnet-4-5",
+                        "model": "gemini-2.5-pro",
+                        "files": [str(artifact)],
+                    },
+                },
+            }
+        )
+
+    assert not resp["result"].get("isError", False)
+    api_payload = client.post.call_args.kwargs["json"]
+    user_content = api_payload["messages"][-1]["content"]
+    assert "PRIMARY_EVIDENCE=42" in user_content
+    assert f"ARIS PRIMARY ARTIFACT: {artifact}" in user_content
+
+
 def test_disabled_review_call_fails_with_opt_in_instruction():
     server = load_server()
     server.REVIEW_FALLBACK_ENABLED = False

--- a/tests/test_llm_chat_review_fallback.py
+++ b/tests/test_llm_chat_review_fallback.py
@@ -279,17 +279,15 @@ def test_review_reply_rejects_identity_changes():
     assert client.post.call_count == 1
 
 
-def test_review_reports_actual_internal_fallback_model_after_504s():
+def test_review_504_is_single_attempt_fail_closed():
     server = load_server()
     server.REVIEW_FALLBACK_ENABLED = True
     server.API_KEY = "test-key"
     server.DEFAULT_MODEL = "gpt-5.5"
     server.FALLBACK_MODEL = "gemini-2.5-pro"
 
-    timeout_1 = MagicMock(status_code=504)
-    timeout_2 = MagicMock(status_code=504)
-    success = mock_http_response("Fallback review", "gemini-2.5-pro")
-    client = mock_client_with(timeout_1, timeout_2, success)
+    timeout = MagicMock(status_code=504, text="Gateway Timeout")
+    client = mock_client_with(timeout)
 
     with patch.object(server.httpx, "Client", return_value=client):
         resp = server.handle_request(
@@ -307,12 +305,129 @@ def test_review_reports_actual_internal_fallback_model_after_504s():
             }
         )
 
+    assert resp["result"]["isError"] is True
+    assert "API error 504" in parse_tool_payload(resp)["error"]
+    assert client.post.call_count == 1
+    assert server._review_threads == {}
+    assert client.post.call_args.kwargs["json"]["model"] == "gpt-5.5"
+
+
+def test_review_timeout_is_single_attempt_fail_closed():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    client.post.side_effect = server.httpx.ReadTimeout("ambiguous timeout")
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 71,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Review.",
+                        "executor_model": "claude-sonnet-4-5",
+                        "model": "gemini-2.5-pro",
+                    },
+                },
+            }
+        )
+
+    assert resp["result"]["isError"] is True
+    assert "ambiguous timeout" in parse_tool_payload(resp)["error"]
+    assert client.post.call_count == 1
+    assert server._review_threads == {}
+
+
+def test_review_reply_failure_does_not_mutate_thread_history():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    first = mock_http_response("Round one", "gemini-2.5-pro")
+    timeout = MagicMock(status_code=504, text="Gateway Timeout")
+    client = mock_client_with(first, timeout)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        initial = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 72,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Initial review.",
+                        "executor_model": "claude-opus-4-1",
+                        "model": "gemini-2.5-pro",
+                    },
+                },
+            }
+        )
+        thread_id = parse_tool_payload(initial)["threadId"]
+        before = list(server._review_threads[thread_id]["messages"])
+        reply = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 73,
+                "method": "tools/call",
+                "params": {
+                    "name": "review_reply",
+                    "arguments": {
+                        "threadId": thread_id,
+                        "prompt": "Re-check.",
+                    },
+                },
+            }
+        )
+
+    assert reply["result"]["isError"] is True
+    assert client.post.call_count == 2
+    assert server._review_threads[thread_id]["messages"] == before
+
+
+def test_legacy_chat_keeps_retry_and_fallback_behavior():
+    server = load_server()
+    server.API_KEY = "test-key"
+    server.FALLBACK_MODEL = "gemini-2.5-pro"
+
+    timeout_1 = MagicMock(status_code=504)
+    timeout_2 = MagicMock(status_code=504)
+    success = mock_http_response("Fallback chat", "gemini-2.5-pro")
+    client = mock_client_with(timeout_1, timeout_2, success)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 74,
+                "method": "tools/call",
+                "params": {
+                    "name": "chat",
+                    "arguments": {
+                        "prompt": "Chat.",
+                        "model": "gpt-5.5",
+                    },
+                },
+            }
+        )
+
     assert not resp["result"].get("isError", False)
-    payload = parse_tool_payload(resp)
-    assert payload["reviewer_model"] == "gemini-2.5-pro"
-    assert payload["reviewer_family"] == "google"
-    assert payload["independence_verified"] == "unverified"
-    assert "Used fallback model gemini-2.5-pro" in payload["content"]
+    assert client.post.call_count == 3
+    assert "Used fallback model gemini-2.5-pro" in resp["result"]["content"][0]["text"]
+
+
+def test_model_family_uses_boundaries_for_ollama_wrapper():
+    server = load_server()
+    assert server.model_family("ollama/deepseek-r1") == "deepseek"
+    assert server.model_family("meta/llama-3.3") == "meta"
+    assert server.model_family("claude-gpt-4") == "unknown"
 
 
 def test_review_rejects_provider_reported_same_family_alias():
@@ -320,8 +435,6 @@ def test_review_rejects_provider_reported_same_family_alias():
     server.REVIEW_FALLBACK_ENABLED = True
     server.API_KEY = "test-key"
 
-    # The request asks for a Gemini alias, but the endpoint reports that the
-    # actual model serving the request was Claude. The actual identity wins.
     response = mock_http_response("Review", "claude-sonnet-4-5")
     client = mock_client_with(response)
 

--- a/tests/test_llm_chat_review_fallback.py
+++ b/tests/test_llm_chat_review_fallback.py
@@ -95,7 +95,8 @@ def test_review_returns_identity_and_thread_for_cross_family_model():
     assert payload["reviewer_model"] == "gemini-2.5-pro"
     assert payload["reviewer_family"] == "google"
     assert payload["executor_family"] == "anthropic"
-    assert payload["independence_verified"] is True
+    assert payload["family_relation"] == "different"
+    assert payload["independence_verified"] == "unverified"
     assert payload["threadId"] in server._review_threads
 
 
@@ -202,6 +203,7 @@ def test_review_reply_preserves_thread_history_and_model():
     payload = parse_tool_payload(reply)
     assert payload["threadId"] == thread_id
     assert payload["content"] == "Round two"
+    assert payload["independence_verified"] == "unverified"
 
     second_payload = client.post.call_args_list[1].kwargs["json"]
     messages = second_payload["messages"]
@@ -211,6 +213,70 @@ def test_review_reply_preserves_thread_history_and_model():
         {"role": "user", "content": "Re-check the revision."},
     ]
     assert second_payload["model"] == "gemini-2.5-pro"
+
+
+def test_review_reply_rejects_identity_changes():
+    server = load_server()
+    server.REVIEW_FALLBACK_ENABLED = True
+    server.API_KEY = "test-key"
+
+    first = mock_http_response("Round one", "gemini-2.5-pro")
+    client = mock_client_with(first)
+
+    with patch.object(server.httpx, "Client", return_value=client):
+        initial = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 61,
+                "method": "tools/call",
+                "params": {
+                    "name": "review",
+                    "arguments": {
+                        "prompt": "Initial review.",
+                        "executor_model": "claude-opus-4-1",
+                        "model": "gemini-2.5-pro",
+                    },
+                },
+            }
+        )
+        thread_id = parse_tool_payload(initial)["threadId"]
+
+        changed_executor = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 62,
+                "method": "tools/call",
+                "params": {
+                    "name": "review_reply",
+                    "arguments": {
+                        "threadId": thread_id,
+                        "prompt": "Continue.",
+                        "executor_model": "gpt-5.5",
+                    },
+                },
+            }
+        )
+        changed_model = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 63,
+                "method": "tools/call",
+                "params": {
+                    "name": "review_reply",
+                    "arguments": {
+                        "threadId": thread_id,
+                        "prompt": "Continue.",
+                        "model": "gpt-5.5",
+                    },
+                },
+            }
+        )
+
+    assert changed_executor["result"]["isError"] is True
+    assert "executor_model cannot change" in parse_tool_payload(changed_executor)["error"]
+    assert changed_model["result"]["isError"] is True
+    assert "reviewer model cannot change" in parse_tool_payload(changed_model)["error"]
+    assert client.post.call_count == 1
 
 
 def test_review_reports_actual_internal_fallback_model_after_504s():
@@ -245,6 +311,7 @@ def test_review_reports_actual_internal_fallback_model_after_504s():
     payload = parse_tool_payload(resp)
     assert payload["reviewer_model"] == "gemini-2.5-pro"
     assert payload["reviewer_family"] == "google"
+    assert payload["independence_verified"] == "unverified"
     assert "Used fallback model gemini-2.5-pro" in payload["content"]
 
 

--- a/tools/provenance.py
+++ b/tools/provenance.py
@@ -28,19 +28,23 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-# Model-name → family. Vendor words match as substrings ("gpt5" → openai); the
-# short, ambiguous o-series needles (_SHORT) match only as EXACT tokens, so they
-# can't substring-bleed into an unrelated name. ARIS routes oracle-pro to a
-# GPT-Pro tier, so `oracle` is the OPENAI family (NOT a separate one) — getting
-# this wrong would let oracle "cross-check" a GPT executor.
+# Model-name → family. Match model/vendor needles at token boundaries so wrapper
+# or provider names cannot substring-bleed into unrelated families (for example,
+# ``ollama/deepseek-r1`` must be DeepSeek only, not DeepSeek + Llama). Version
+# suffixes remain supported. ARIS routes oracle-pro to a GPT-Pro tier, so
+# `oracle` is the OPENAI family (NOT a separate one) — getting this wrong would
+# let oracle "cross-check" a GPT executor.
 _FAMILY = [
     ("anthropic", ("claude", "opus", "sonnet", "haiku")),
     ("openai", ("gpt", "codex", "oracle", "chatgpt", "o1", "o3", "o4")),
     ("google", ("gemini", "palm", "bard")),
     ("deepseek", ("deepseek",)),
+    ("zhipu", ("glm", "zhipu")),
     ("minimax", ("minimax", "abab")),
     ("moonshot", ("kimi", "moonshot")),
     ("qwen", ("qwen", "tongyi")),
+    ("xiaomi", ("mimo", "xiaomi")),
+    ("bytedance", ("doubao", "bytedance", "volcengine")),
     ("xai", ("grok",)),
     ("meta", ("llama",)),
     ("mistral", ("mistral", "mixtral")),
@@ -62,11 +66,14 @@ def model_family(name: str) -> str:
     n = (name or "").strip().lower()
     if n.startswith("deterministic:") or n == "deterministic":
         return "deterministic"
-    tokens = set(re.split(r"[^a-z0-9.]+", n))
     matched = set()
     for fam, needles in _FAMILY:
-        if any((k in tokens) if k in _SHORT else (k in n) for k in needles):
-            matched.add(fam)
+        for needle in needles:
+            suffix = "" if needle in _SHORT else r"[0-9.]*"
+            pattern = rf"(^|[^a-z0-9]){re.escape(needle)}{suffix}([^a-z0-9]|$)"
+            if re.search(pattern, n):
+                matched.add(fam)
+                break
     return next(iter(matched)) if len(matched) == 1 else "unknown"
 
 

--- a/tools/review_gate.py
+++ b/tools/review_gate.py
@@ -21,9 +21,12 @@ TOOLS_DIR = str(Path(__file__).resolve().parent)
 if TOOLS_DIR not in sys.path:
     sys.path.insert(0, TOOLS_DIR)
 
-KNOWN_FAMILIES = {"openai", "anthropic", "google", "deepseek", "moonshot", "qwen"}
+KNOWN_FAMILIES = {
+    "openai", "anthropic", "google", "deepseek", "moonshot", "qwen",
+    "zhipu", "minimax", "xiaomi", "bytedance", "xai", "meta", "mistral",
+}
 POSITIVE_VERDICTS = {"ready", "almost"}
-VALID_BACKENDS = {"codex", "manual", "copilot", "copilot-native", "oracle-pro", "agy"}
+VALID_BACKENDS = {"codex", "manual", "copilot", "copilot-native", "oracle-pro", "agy", "llm-chat"}
 VALID_VERDICTS = POSITIVE_VERDICTS | {"not ready"}
 
 
@@ -69,6 +72,20 @@ def derive_model_family(model: str) -> str:
         families.add("moonshot")
     if re.search(r"(^|[^a-z0-9])(qwen|tongyi)[0-9.]*([^a-z0-9]|$)", name):
         families.add("qwen")
+    if re.search(r"(^|[^a-z0-9])(glm|zhipu)[0-9.]*([^a-z0-9]|$)", name):
+        families.add("zhipu")
+    if re.search(r"(^|[^a-z0-9])(minimax|abab)[0-9.]*([^a-z0-9]|$)", name):
+        families.add("minimax")
+    if re.search(r"(^|[^a-z0-9])(mimo|xiaomi)[0-9.]*([^a-z0-9]|$)", name):
+        families.add("xiaomi")
+    if re.search(r"(^|[^a-z0-9])(doubao|bytedance|volcengine)[0-9.]*([^a-z0-9]|$)", name):
+        families.add("bytedance")
+    if re.search(r"(^|[^a-z0-9])(grok)[0-9.]*([^a-z0-9]|$)", name):
+        families.add("xai")
+    if re.search(r"(^|[^a-z0-9])(llama)[0-9.]*([^a-z0-9]|$)", name):
+        families.add("meta")
+    if re.search(r"(^|[^a-z0-9])(mistral|mixtral)[0-9.]*([^a-z0-9]|$)", name):
+        families.add("mistral")
     return next(iter(families)) if len(families) == 1 else "unknown"
 
 
@@ -311,6 +328,39 @@ def evaluate_transition(
             requires_external_acquittal,
             "unverified",
             "positive threshold not met",
+        )
+
+    if backend == "llm-chat":
+        if requires_external_acquittal:
+            return Transition(
+                "review_unavailable",
+                None,
+                True,
+                "unverified",
+                "Copilot finalizer state permits only codex or manual",
+            )
+        if executor not in KNOWN_FAMILIES or reviewer not in KNOWN_FAMILIES:
+            return Transition(
+                "review_unavailable",
+                None,
+                False,
+                "unverified",
+                "HTTP reviewer family relation cannot be derived",
+            )
+        if executor == reviewer:
+            return Transition(
+                "review_unavailable",
+                None,
+                False,
+                "failed",
+                "HTTP reviewer is same-family as the declared executor model",
+            )
+        return Transition(
+            "stop",
+            None,
+            False,
+            "caller_declared",
+            "HTTP reviewer returned a positive cross-family verdict; executor identity remains caller-declared",
         )
 
     if backend in {"codex", "oracle-pro", "agy"} and not requires_external_acquittal:


### PR DESCRIPTION
Closes #412

## Summary

Add an **opt-in HTTP API reviewer fallback** for the **Claude Code + ARIS Skills** workflow when Codex MCP cannot safely start a reviewer request.

The implementation reuses the existing `llm-chat` MCP server instead of introducing a new reviewer stack. The current default behavior remains unchanged unless fallback is explicitly enabled.

## Motivation

Mainline ARIS already has model/effort capability fallbacks inside the Codex reviewer path, but if the Codex MCP transport itself is unavailable, reviewer-aware workflows can still end in `REVIEW_UNAVAILABLE` / `ERROR` even when another OpenAI-compatible reviewer endpoint is configured.

ARIS-Code already supports a primary Codex reviewer plus an HTTP fallback reviewer. This PR brings a comparable fault-tolerance option to the Claude Code + Skills workflow.

## Behavior

The fallback is **disabled by default** and must be explicitly enabled on the existing `llm-chat` MCP server:

```bash
LLM_REVIEW_FALLBACK_ENABLED=true
````

When enabled, `llm-chat` exposes:

```text
mcp__llm-chat__review
mcp__llm-chat__review_reply
```

The intended flow is:

```text
Codex MCP
   |
   | safe pre-dispatch failure
   v
llm-chat MCP
   |
   v
OpenAI-compatible HTTP reviewer
   |
   | failure / identity cannot be verified
   v
REVIEW_UNAVAILABLE / ERROR
```

## Safe fallback boundary

This PR deliberately does **not** implement:

```text
Codex returned any error
    ->
run the same review again over HTTP
```

HTTP fallback is allowed only when ARIS can establish that the Codex path did not produce a reviewer request, for example when the MCP tool/server is unavailable or the request is explicitly rejected before model execution.

If a Codex request was dispatched and then times out, disconnects, or fails ambiguously, ARIS remains fail-closed instead of silently issuing a second review.

This avoids:

* double-running
* double-billing
* conflicting reviewer verdicts

The existing Codex capability fallback rules remain unchanged and run before transport fallback.

## Cross-model independence

The HTTP reviewer reports the actual model ID returned by the provider when available.

ARIS derives both executor and reviewer model families and fails closed when the relation is unknown or same-family.

Examples:

```text
executor: shangtang-glm
reviewer: gemini-2.5-pro
=> allowed cross-family review
```

```text
executor: shangtang-glm
reviewer: zhipu-glm / glm-*
=> REVIEW_UNAVAILABLE
```

The HTTP path does not claim runtime attestation of the executor identity. The review gate records that limitation rather than promoting a caller-declared executor ID to verified provenance.

## Reviewer independence and local artifacts

A remote OpenAI-compatible API cannot read repository paths on the Linux host.

The new review tools therefore accept explicit `files:` containing **primary artifacts** and send their contents verbatim to the configured reviewer endpoint.

This avoids falling back with a Codex-oriented prompt that merely asks the remote model to read local filesystem paths.

The routing contract requires primary artifacts rather than executor-written summaries, consistent with `reviewer-independence.md`.

## Multi-round continuity

`mcp__llm-chat__review` returns a `threadId` and the MCP server keeps prior prompt/reviewer exchanges.

Later rounds use:

```text
mcp__llm-chat__review_reply
```

so multi-round workflows do not silently lose reviewer context after switching from Codex.

The executor model and reviewer model cannot change inside an existing HTTP review thread.

## Review-gate integration

`tools/review_gate.py` now recognizes `llm-chat` as a reviewer backend and applies fail-closed family checks before a positive HTTP verdict can stop a loop.

A positive known cross-family HTTP verdict may stop normally.

Same-family or unknown-family verdicts resolve to:

```text
review_unavailable
```

The HTTP backend is not implicitly accepted as a Copilot compatibility finalizer; existing finalizer policy remains unchanged.

## Configuration example

```bash
claude mcp add llm-chat -s user \
  --env LLM_API_KEY=<key> \
  --env LLM_BASE_URL=https://example.com/v1 \
  --env LLM_MODEL=gemini-2.5-pro \
  --env LLM_REVIEW_FALLBACK_ENABLED=true \
  -- python3 /path/to/mcp-servers/llm-chat/server.py
```

Enabling this fallback means the primary artifacts explicitly passed through `files:` are sent to that third-party endpoint, so the feature remains opt-in for privacy reasons.

## Implementation

This PR updates:

* `mcp-servers/llm-chat/server.py`

  * opt-in `review` / `review_reply` tools
  * actual reviewer model reporting
  * model-family checks
  * multi-round thread continuity
  * primary-artifact attachment support

* `skills/shared-references/reviewer-routing.md`

  * Codex -> HTTP fallback contract
  * safe pre-dispatch boundary
  * configuration/privacy documentation

* `tools/review_gate.py`

  * `llm-chat` backend support
  * cross-family acceptance checks

* regression tests for transport behavior, routing contract, and review-gate decisions

## Compatibility

* Existing `mcp__llm-chat__chat` behavior remains available.
* HTTP reviewer fallback is disabled unless `LLM_REVIEW_FALLBACK_ENABLED=true` is explicitly configured.
* Existing Codex model/effort fallback behavior is unchanged.
* Oracle, Antigravity/Gemini, Manual Review, and Copilot reviewer routes are unchanged.

## Tests

Added regression coverage for:

* fallback tools hidden by default
* explicit opt-in exposure
* cross-family HTTP review acceptance
* same-family rejection
* unknown-family rejection
* provider-reported actual reviewer model identity
* `LLM_FALLBACK_MODEL` identity after 504 fallback
* multi-round thread continuity
* primary artifact forwarding
* `review_gate.py` acceptance/rejection behavior
* routing-contract safety invariants

The design is intentionally conservative:

**use HTTP redundancy when Codex is known not to have run, while keeping ambiguous dispatched failures fail-closed.**
