### PR TITLE
fix(readme): restore the broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,7 +1749,7 @@ If you use ARIS in your research, please cite:
 
 ![GitHub stars](https://img.shields.io/github/stars/wanshuiyin/Auto-claude-code-research-in-sleep?style=social)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wanshuiyin/Auto-claude-code-research-in-sleep&type=Date&v=20260328)](https://star-history.com/#wanshuiyin/Auto-claude-code-research-in-sleep&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=wanshuiyin/Auto-claude-code-research-in-sleep&type=Date&v=20260328)](https://star-history.dera.page/#wanshuiyin/Auto-claude-code-research-in-sleep&type=Date)
 
 <a id="acknowledgements"></a>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1533,7 +1533,7 @@ Skills 都是纯 Markdown,fork 了随便改。各 skill 的环境变量(GPU 目�
 
 ![GitHub stars](https://img.shields.io/github/stars/wanshuiyin/Auto-claude-code-research-in-sleep?style=social)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wanshuiyin/Auto-claude-code-research-in-sleep&type=Date&v=20260328)](https://star-history.com/#wanshuiyin/Auto-claude-code-research-in-sleep&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=wanshuiyin/Auto-claude-code-research-in-sleep&type=Date&v=20260328)](https://star-history.dera.page/#wanshuiyin/Auto-claude-code-research-in-sleep&type=Date)
 
 <a id="acknowledgements"></a>
 


### PR DESCRIPTION
The Star History chart in both README.md and README_CN.md no longer renders. Switching the chart image and its link to the maintained provider so the chart displays again. The GitHub stars badge is left on its original provider.