### PR TITLE
fix(idea-pipeline): stop killing ideas for having neighbors

### DIFF
--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -252,6 +252,24 @@ mcp__codex__codex:
     idea-stage/codex_brainstorm_bundle.md> and follow all instructions in it.
 ```
 
+Run the bundle through **two reviewer models** and take the union — the two
+fail differently as generators, and the union keeps either model's taste from
+capping the pool:
+
+1. Once with the default reviewer model (`gpt-5.6-sol` today), as above.
+2. Once more with `model: "gpt-5.5"` — same `xhigh` effort, same bundle, a
+   fresh thread. Save both threadIds; Phase 4's triage follow-up goes to the
+   default-model thread.
+
+Tag each candidate with the model that produced it, then merge both sets the
+same way the lens shards merge: union, cluster near-identical ideas by
+hypothesis, and never drop a candidate for being "weak" — weakness is a
+Phase-4 verdict, not a merge step.
+
+If the second call errors (older codex-cli, or the model is unavailable on
+this account), print one WARN line and continue single-model. The union is an
+upgrade, not a new requirement.
+
 *For `manual` backend:* use `mcp__manual_review__review` with the same bundle
 contents. If the manual-review UI supports attachments, attach
 `idea-stage/codex_brainstorm_bundle.md`; otherwise paste the bundle contents
@@ -281,13 +299,23 @@ Bundle contents:
     Prioritize ideas that are:
     - Testable with moderate compute (8x RTX 3090 or less)
     - Likely to produce a clear positive OR negative result (both are publishable)
-    - Not "apply X to Y" unless the application reveals genuinely surprising insights
-    - Differentiated from the 10-15 papers above
+    - Simple at the core: one mechanism, few moving parts — an idea a colleague
+      could restate after hearing it once. If the novelty only appears once a
+      second module or an extra gate is added, that is packaging, not novelty.
+    - Aware of the 10-15 papers above — awareness, not avoidance. Differentiation
+      is the novelty check's job later, not a constraint on brainstorming.
 
-    Be creative but grounded. A great idea is one where the answer matters regardless of which way it goes.
+    "Apply X to Y" is legitimate when the application would reveal something
+    non-obvious — judge it by what it reveals, not by the template. A direct,
+    well-executed attack on a central problem is a valid idea when nobody has
+    executed it well; do not steer around crowded areas — proximity to strong
+    work is a sign the problem matters, not that it is taken.
+
+    Generate first, filter later — the filters come after you, and they are
+    strict enough. A bold, simple idea with a named risk beats a hedged,
+    complicated one with none. A great idea is one where the answer matters
+    regardless of which way it goes.
 ```
-
-Save the threadId for follow-up.
 
 ### Phase 3: Mechanical consolidation + objective feasibility gate
 
@@ -336,7 +364,9 @@ per-idea novelty search:
 
 1. **Cross-model triage (devil's advocate) — ranks ALL candidates first.**
    Use the selected reviewer backend (see Reviewer Calling Convention). For
-   `codex`, use `mcp__codex__codex-reply` (same thread). For `manual`, use
+   `codex`, use `mcp__codex__codex-reply` on the **default-model thread**
+   from Phase 2 (the triage bundle carries the full union, so no context is
+   lost from the second model's thread). For `manual`, use
    `mcp__manual_review__review_reply` with the saved threadId. For the
    `codex` backend, write the full annotated candidate set to
    `idea-stage/codex_triage_bundle.md` and send only a path-based follow-up:
@@ -350,12 +380,19 @@ per-idea novelty search:
    Here is the full annotated candidate set (deduped, budget-feasible):
    [write all candidates with their prior_work / so_what / effort_note notes]
 
-   For each, play devil's advocate:
+   For each, make the strongest case both ways:
+   - What is the best case FOR it — what would make this the paper people cite?
    - What's the strongest objection a reviewer would raise?
    - What's the most likely failure mode?
    - Is the prior_work note a real novelty problem, or differentiable?
    - How would you rank these for a top venue submission?
    - Which 2-3 would you actually work on, and why?
+
+   Rank; do not rewrite. An objection is answered or recorded as a named
+   risk on the idea — never absorbed by adding a module, a gate, or a
+   qualifier. A bold idea with a named risk outranks a hedged idea with
+   none, and complexity added since the brainstorm is a red flag, not
+   progress.
    ```
    The reviewer's ranking is the authoritative quality verdict. The executor
    does not eliminate candidates on its own taste before or instead of this.

--- a/skills/novelty-check/SKILL.md
+++ b/skills/novelty-check/SKILL.md
@@ -59,6 +59,31 @@ Dossier contents should include:
 - The proposed method description
 - All papers found in Phase B
 - Ask: "Is this method novel? What is the closest prior work? What is the delta?"
+- The NOVELTY VERDICT LIMITS block below, verbatim — the reviewer judges under it
+
+### The verdict limits
+
+Copy this block **verbatim** into the reviewer's briefing; the report in
+Phase D is judged under it too.
+
+```
+=== NOVELTY VERDICT LIMITS (these bound how you judge, never how widely you search) ===
+Search exhaustively; judge calibrated. Two failures waste months equally:
+passing an idea a published paper already contains, and killing a viable idea
+because the territory has neighbors.
+1. Proximity is information, not a verdict. Someone working nearby goes in the
+   report; it is not by itself a reason to reject.
+2. ABANDON has exactly one qualification: a specific published paper already
+   contains this result — name that paper. No named paper, no ABANDON.
+3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
+   could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
+   would make it carry, not why it should die.
+4. Concurrent or competing work is not a veto. That is a race — report it and
+   let the user decide whether to run it.
+5. A direct attack on a central problem is legitimate novelty when nobody has
+   executed it well. "This area is hot" does not mean "this area is taken."
+Say plainly when an idea clears the check. Do not manufacture overlap.
+```
 
 ### Phase D: Novelty Report
 Output a structured report:
@@ -79,18 +104,24 @@ Output a structured report:
 |-------|------|-------|---------|----------------|
 
 ### Overall Novelty Assessment
-- Score: X/10
-- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON
+- Score: X/10 (anchor: 5/10 = has clear neighbors but a defensible delta worth
+  a pilot; reserve 1-3 for results a named published paper already contains)
+- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON (per the verdict
+  limits: crowded-but-deltaed ground is PROCEED; ABANDON must name the paper)
 - Key differentiator: [what makes this unique, if anything]
 - Risk: [what a reviewer would cite as prior work]
 
 ### Suggested Positioning
-[How to frame the contribution to maximize novelty perception]
+[State the delta honestly in one sentence a reviewer could verify]
 ```
 
 ### Important Rules
-- Be BRUTALLY honest — false novelty claims waste months of research time
-- "Applying X to Y" is NOT novel unless the application reveals surprising insights
+- Two failures waste months equally: a false novelty claim, and a viable idea
+  abandoned because the territory has neighbors. Be brutally honest in both
+  directions — and when an idea clears the check, say so plainly.
+- "Applying X to Y" earns novelty by what the application reveals — a
+  non-obvious interaction, failure mode, or insight. Judge the revelation, not
+  the template.
 - Check both the method AND the experimental setting for novelty
 - If the method is not novel but the FINDING would be, say so explicitly
 - Always check the most recent 6 months of arXiv — the field moves fast

--- a/skills/skills-codex-claude-review/novelty-check/SKILL.md
+++ b/skills/skills-codex-claude-review/novelty-check/SKILL.md
@@ -61,6 +61,31 @@ Prompt should include:
 - The proposed method description
 - All papers found in Phase B
 - Ask: "Is this method novel? What is the closest prior work? What is the delta?"
+- The NOVELTY VERDICT LIMITS block below, verbatim — the reviewer judges under it
+
+### The verdict limits
+
+Copy this block **verbatim** into the reviewer's briefing; the report in
+Phase D is judged under it too.
+
+```
+=== NOVELTY VERDICT LIMITS (these bound how you judge, never how widely you search) ===
+Search exhaustively; judge calibrated. Two failures waste months equally:
+passing an idea a published paper already contains, and killing a viable idea
+because the territory has neighbors.
+1. Proximity is information, not a verdict. Someone working nearby goes in the
+   report; it is not by itself a reason to reject.
+2. ABANDON has exactly one qualification: a specific published paper already
+   contains this result — name that paper. No named paper, no ABANDON.
+3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
+   could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
+   would make it carry, not why it should die.
+4. Concurrent or competing work is not a veto. That is a race — report it and
+   let the user decide whether to run it.
+5. A direct attack on a central problem is legitimate novelty when nobody has
+   executed it well. "This area is hot" does not mean "this area is taken."
+Say plainly when an idea clears the check. Do not manufacture overlap.
+```
 
 ### Phase D: Novelty Report
 Output a structured report:
@@ -81,18 +106,24 @@ Output a structured report:
 |-------|------|-------|---------|----------------|
 
 ### Overall Novelty Assessment
-- Score: X/10
-- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON
+- Score: X/10 (anchor: 5/10 = has clear neighbors but a defensible delta worth
+  a pilot; reserve 1-3 for results a named published paper already contains)
+- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON (per the verdict
+  limits: crowded-but-deltaed ground is PROCEED; ABANDON must name the paper)
 - Key differentiator: [what makes this unique, if anything]
 - Risk: [what a reviewer would cite as prior work]
 
 ### Suggested Positioning
-[How to frame the contribution to maximize novelty perception]
+[State the delta honestly in one sentence a reviewer could verify]
 ```
 
 ### Important Rules
-- Be BRUTALLY honest — false novelty claims waste months of research time
-- "Applying X to Y" is NOT novel unless the application reveals surprising insights
+- Two failures waste months equally: a false novelty claim, and a viable idea
+  abandoned because the territory has neighbors. Be brutally honest in both
+  directions — and when an idea clears the check, say so plainly.
+- "Applying X to Y" earns novelty by what the application reveals — a
+  non-obvious interaction, failure mode, or insight. Judge the revelation, not
+  the template.
 - Check both the method AND the experimental setting for novelty
 - If the method is not novel but the FINDING would be, say so explicitly
 - Always check the most recent 6 months of arXiv — the field moves fast

--- a/skills/skills-codex-gemini-review/idea-creator/SKILL.md
+++ b/skills/skills-codex-gemini-review/idea-creator/SKILL.md
@@ -82,10 +82,22 @@ mcp__gemini-review__review_start:
     Prioritize ideas that are:
     - Testable with moderate compute (8x RTX 3090 or less)
     - Likely to produce a clear positive OR negative result (both are publishable)
-    - Not "apply X to Y" unless the application reveals genuinely surprising insights
-    - Differentiated from the 10-15 papers above
+    - Simple at the core: one mechanism, few moving parts — an idea a colleague
+      could restate after hearing it once. If the novelty only appears once a
+      second module or an extra gate is added, that is packaging, not novelty.
+    - Aware of the 10-15 papers above — awareness, not avoidance. Differentiation
+      is the novelty check's job later, not a constraint on brainstorming.
 
-    Be creative but grounded. A great idea is one where the answer matters regardless of which way it goes.
+    "Apply X to Y" is legitimate when the application would reveal something
+    non-obvious — judge it by what it reveals, not by the template. A direct,
+    well-executed attack on a central problem is a valid idea when nobody has
+    executed it well; do not steer around crowded areas — proximity to strong
+    work is a sign the problem matters, not that it is taken.
+
+    Generate first, filter later — the filters come after you, and they are
+    strict enough. A bold, simple idea with a named risk beats a hedged,
+    complicated one with none. A great idea is one where the answer matters
+    regardless of which way it goes.
 ```
 
 After this start call, immediately save the returned `jobId` and poll `mcp__gemini-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the brainstorm output, and save the completed `threadId` for follow-up critique in Phase 4.
@@ -133,11 +145,18 @@ For each surviving idea, run a deeper evaluation:
        Here are our top ideas after filtering:
        [paste surviving ideas with novelty check results]
 
-       For each, play devil's advocate:
+       For each, make the strongest case both ways:
+       - What is the best case FOR it — what would make this the paper people cite?
        - What's the strongest objection a reviewer would raise?
        - What's the most likely failure mode?
        - How would you rank these for a top venue submission?
        - Which 2-3 would you actually work on?
+
+       Rank; do not rewrite. An objection is answered or recorded as a named
+       risk on the idea — never absorbed by adding a module, a gate, or a
+       qualifier. A bold idea with a named risk outranks a hedged idea with
+       none, and complexity added since the brainstorm is a red flag, not
+       progress.
    ```
 
    After this start call, immediately save the returned `jobId` and poll `mcp__gemini-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the follow-up critique.

--- a/skills/skills-codex-gemini-review/novelty-check/SKILL.md
+++ b/skills/skills-codex-gemini-review/novelty-check/SKILL.md
@@ -55,6 +55,31 @@ Prompt should include:
 - The proposed method description
 - All papers found in Phase B
 - Ask: "Is this method novel? What is the closest prior work? What is the delta?"
+- The NOVELTY VERDICT LIMITS block below, verbatim — the reviewer judges under it
+
+### The verdict limits
+
+Copy this block **verbatim** into the reviewer's briefing; the report in
+Phase D is judged under it too.
+
+```
+=== NOVELTY VERDICT LIMITS (these bound how you judge, never how widely you search) ===
+Search exhaustively; judge calibrated. Two failures waste months equally:
+passing an idea a published paper already contains, and killing a viable idea
+because the territory has neighbors.
+1. Proximity is information, not a verdict. Someone working nearby goes in the
+   report; it is not by itself a reason to reject.
+2. ABANDON has exactly one qualification: a specific published paper already
+   contains this result — name that paper. No named paper, no ABANDON.
+3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
+   could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
+   would make it carry, not why it should die.
+4. Concurrent or competing work is not a veto. That is a race — report it and
+   let the user decide whether to run it.
+5. A direct attack on a central problem is legitimate novelty when nobody has
+   executed it well. "This area is hot" does not mean "this area is taken."
+Say plainly when an idea clears the check. Do not manufacture overlap.
+```
 
 ### Phase D: Novelty Report
 Output a structured report:
@@ -75,18 +100,24 @@ Output a structured report:
 |-------|------|-------|---------|----------------|
 
 ### Overall Novelty Assessment
-- Score: X/10
-- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON
+- Score: X/10 (anchor: 5/10 = has clear neighbors but a defensible delta worth
+  a pilot; reserve 1-3 for results a named published paper already contains)
+- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON (per the verdict
+  limits: crowded-but-deltaed ground is PROCEED; ABANDON must name the paper)
 - Key differentiator: [what makes this unique, if anything]
 - Risk: [what a reviewer would cite as prior work]
 
 ### Suggested Positioning
-[How to frame the contribution to maximize novelty perception]
+[State the delta honestly in one sentence a reviewer could verify]
 ```
 
 ### Important Rules
-- Be BRUTALLY honest — false novelty claims waste months of research time
-- "Applying X to Y" is NOT novel unless the application reveals surprising insights
+- Two failures waste months equally: a false novelty claim, and a viable idea
+  abandoned because the territory has neighbors. Be brutally honest in both
+  directions — and when an idea clears the check, say so plainly.
+- "Applying X to Y" earns novelty by what the application reveals — a
+  non-obvious interaction, failure mode, or insight. Judge the revelation, not
+  the template.
 - Check both the method AND the experimental setting for novelty
 - If the method is not novel but the FINDING would be, say so explicitly
 - Always check the most recent 6 months of arXiv — the field moves fast

--- a/skills/skills-codex/idea-creator/SKILL.md
+++ b/skills/skills-codex/idea-creator/SKILL.md
@@ -181,13 +181,34 @@ spawn_agent:
     Prioritize ideas that are:
     - Testable with moderate compute (8x RTX 3090 or less)
     - Likely to produce a clear positive OR negative result (both are publishable)
-    - Not "apply X to Y" unless the application reveals genuinely surprising insights
-    - Differentiated from the 10-15 papers above
+    - Simple at the core: one mechanism, few moving parts — an idea a colleague
+      could restate after hearing it once. If the novelty only appears once a
+      second module or an extra gate is added, that is packaging, not novelty.
+    - Aware of the 10-15 papers above — awareness, not avoidance. Differentiation
+      is the novelty check's job later, not a constraint on brainstorming.
 
-    Be creative but grounded. A great idea is one where the answer matters regardless of which way it goes.
+    "Apply X to Y" is legitimate when the application would reveal something
+    non-obvious — judge it by what it reveals, not by the template. A direct,
+    well-executed attack on a central problem is a valid idea when nobody has
+    executed it well; do not steer around crowded areas — proximity to strong
+    work is a sign the problem matters, not that it is taken.
+
+    Generate first, filter later — the filters come after you, and they are
+    strict enough. A bold, simple idea with a named risk beats a hedged,
+    complicated one with none. A great idea is one where the answer matters
+    regardless of which way it goes.
 ```
 
 Save the agent id for follow-up.
+
+Then spawn the **same bundle once more** with `model: gpt-5.5` (same xhigh
+reasoning, a fresh agent) and take the union — the two models fail differently
+as generators, and the union keeps either model's taste from capping the pool.
+Save both agent ids; Phase 4's `send_input` follow-ups go to the default-model
+agent. Tag each candidate with the model that produced it; merge both sets by
+mechanical dedup only — never drop a candidate for being "weak" (that is the
+Phase-4 verdict). If the second spawn errors (model unavailable on this
+account), print one WARN line and continue single-model.
 
 Save a Review Tracing record for this `spawn_agent` call following `../shared-references/review-tracing.md`, including the landscape summary, prompt summary, raw idea list path, reviewer route, and saved agent id.
 
@@ -234,11 +255,18 @@ For each surviving idea, run a deeper evaluation:
        Here are our top ideas after filtering:
        [paste surviving ideas with novelty check results]
 
-       For each, play devil's advocate:
+       For each, make the strongest case both ways:
+       - What is the best case FOR it — what would make this the paper people cite?
        - What's the strongest objection a reviewer would raise?
        - What's the most likely failure mode?
        - How would you rank these for a top venue submission?
        - Which 2-3 would you actually work on?
+
+       Rank; do not rewrite. An objection is answered or recorded as a named
+       risk on the idea — never absorbed by adding a module, a gate, or a
+       qualifier. A bold idea with a named risk outranks a hedged idea with
+       none, and complexity added since the brainstorm is a red flag, not
+       progress.
    ```
 
 3. **Combine rankings**: Merge your assessment with GPT-5.6-Sol's ranking. Select top 2-3 ideas for pilot experiments.

--- a/skills/skills-codex/novelty-check/SKILL.md
+++ b/skills/skills-codex/novelty-check/SKILL.md
@@ -48,6 +48,31 @@ Prompt should include:
 - The proposed method description
 - All papers found in Phase B
 - Ask: "Is this method novel? What is the closest prior work? What is the delta?"
+- The NOVELTY VERDICT LIMITS block below, verbatim — the reviewer judges under it
+
+### The verdict limits
+
+Copy this block **verbatim** into the reviewer's briefing; the report in
+Phase D is judged under it too.
+
+```
+=== NOVELTY VERDICT LIMITS (these bound how you judge, never how widely you search) ===
+Search exhaustively; judge calibrated. Two failures waste months equally:
+passing an idea a published paper already contains, and killing a viable idea
+because the territory has neighbors.
+1. Proximity is information, not a verdict. Someone working nearby goes in the
+   report; it is not by itself a reason to reject.
+2. ABANDON has exactly one qualification: a specific published paper already
+   contains this result — name that paper. No named paper, no ABANDON.
+3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
+   could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
+   would make it carry, not why it should die.
+4. Concurrent or competing work is not a veto. That is a race — report it and
+   let the user decide whether to run it.
+5. A direct attack on a central problem is legitimate novelty when nobody has
+   executed it well. "This area is hot" does not mean "this area is taken."
+Say plainly when an idea clears the check. Do not manufacture overlap.
+```
 
 ### Phase D: Novelty Report
 Output a structured report:
@@ -68,18 +93,24 @@ Output a structured report:
 |-------|------|-------|---------|----------------|
 
 ### Overall Novelty Assessment
-- Score: X/10
-- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON
+- Score: X/10 (anchor: 5/10 = has clear neighbors but a defensible delta worth
+  a pilot; reserve 1-3 for results a named published paper already contains)
+- Recommendation: PROCEED / PROCEED WITH CAUTION / ABANDON (per the verdict
+  limits: crowded-but-deltaed ground is PROCEED; ABANDON must name the paper)
 - Key differentiator: [what makes this unique, if anything]
 - Risk: [what a reviewer would cite as prior work]
 
 ### Suggested Positioning
-[How to frame the contribution to maximize novelty perception]
+[State the delta honestly in one sentence a reviewer could verify]
 ```
 
 ### Important Rules
-- Be BRUTALLY honest — false novelty claims waste months of research time
-- "Applying X to Y" is NOT novel unless the application reveals surprising insights
+- Two failures waste months equally: a false novelty claim, and a viable idea
+  abandoned because the territory has neighbors. Be brutally honest in both
+  directions — and when an idea clears the check, say so plainly.
+- "Applying X to Y" earns novelty by what the application reveals — a
+  non-obvious interaction, failure mode, or insight. Judge the revelation, not
+  the template.
 - Check both the method AND the experimental setting for novelty
 - If the method is not novel but the FINDING would be, say so explicitly
 - Always check the most recent 6 months of arXiv — the field moves fast


### PR DESCRIPTION
Answers the community reports (multiple independent users): novelty check so defensive every field looks full, survivors are obscure corner ideas stacked with modules, legible ideas die while illegible ones pass, iterating with the reviewer sands ideas flat.

**novelty-check** (×3 + regenerated claude-review overlay): a NOVELTY VERDICT LIMITS block the reviewer receives verbatim — proximity is information, not a verdict; **ABANDON requires naming the published paper that already contains the result**; crowded-but-deltaed is PROCEED; **concurrent work is a race for the user to decide, not a veto**; hot ≠ taken. X/10 stays, anchored. "Brutally honest" cuts both ways now.

**idea-creator** (×3): brainstorm asks for simple-at-the-core ideas and direct attacks on central problems — *aware* of the papers, not steered by them; generate first, filter later. Mainline + codex mirror run the brainstorm through **two models (gpt-5.6-sol + gpt-5.5), union merged** by the existing mechanical dedup, WARN-and-continue if the second is unavailable. Triage asks the best case FOR each idea before the objections, ranks without rewriting, records objections as named risks.

**Search untouched** — Phase A/B, verify_papers, 6-month arXiv rule all stay. The limits bound the verdict, not the looking.

Tests: 677 passed full suite; mirror 21/21; inventory clean; claude-review overlay regenerated idempotently; zero stale wording (`git grep` clean).