### PR TITLE
fix(idea-pipeline): loosen further — the reviewer's own list

### DIFF
--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -392,7 +392,9 @@ per-idea novelty search:
    risk on the idea — never absorbed by adding a module, a gate, or a
    qualifier. A bold idea with a named risk outranks a hedged idea with
    none, and complexity added since the brainstorm is a red flag, not
-   progress.
+   progress. And do not let your picks be uniformly the safest — if the
+   top set is all LOW-risk, name the high-upside idea that most deserves a
+   pilot slot and what result would convince you.
    ```
    The reviewer's ranking is the authoritative quality verdict. The executor
    does not eliminate candidates on its own taste before or instead of this.

--- a/skills/idea-creator/SKILL.md
+++ b/skills/idea-creator/SKILL.md
@@ -385,7 +385,7 @@ per-idea novelty search:
    - What's the strongest objection a reviewer would raise?
    - What's the most likely failure mode?
    - Is the prior_work note a real novelty problem, or differentiable?
-   - How would you rank these for a top venue submission?
+   - Rank by expected information and upside within the pilot budget — which results would matter most, whichever way they come out?
    - Which 2-3 would you actually work on, and why?
 
    Rank; do not rewrite. An objection is answered or recorded as a named
@@ -396,7 +396,7 @@ per-idea novelty search:
    top set is all LOW-risk, name the high-upside idea that most deserves a
    pilot slot and what result would convince you.
    ```
-   The reviewer's ranking is the authoritative quality verdict. The executor
+   The reviewer's ranking allocates the scarce pilot slots; it is not an elimination verdict — feasible ideas not selected remain candidates. The executor
    does not eliminate candidates on its own taste before or instead of this.
 
 2. **Novelty check — on the reviewer's top picks only.** Run the
@@ -416,7 +416,7 @@ Before committing to a full research effort, run cheap pilot experiments to get 
    - Single seed, small scale (e.g., small dataset subset, fewer epochs)
    - Target: 30 min - PILOT_MAX_HOURS per pilot on 1 GPU
    - **Estimate GPU-hours BEFORE launching.** If estimated time > PILOT_MAX_HOURS, reduce scale (fewer epochs, smaller subset) or flag as "needs manual pilot"
-   - Clear success metric defined upfront (e.g., "if metric improves by > 1%, signal is positive")
+   - Decision criterion defined upfront — including what a positive, negative, and null outcome would each teach. Metric improvement is not required for a diagnostic contribution.
 
 2. **Deploy in parallel**: Use `/run-experiment` to launch pilots on different GPUs simultaneously:
    ```
@@ -428,7 +428,7 @@ Before committing to a full research effort, run cheap pilot experiments to get 
 
 3. **Collect results**: Use `/monitor-experiment` to check progress. If any pilot exceeds PILOT_TIMEOUT_HOURS, kill it and collect partial results. Once all pilots complete (or timeout), compare:
    - Which ideas showed positive signal?
-   - Which showed null/negative results? (eliminate or deprioritize)
+   - Which showed null/negative results? Classify each: core-hypothesis refuted, informative negative (often publishable), or underpowered pilot — do not eliminate by sign alone.
    - Any surprising findings that suggest a pivot?
    - Total GPU-hours consumed (track against MAX_TOTAL_GPU_HOURS budget)
 
@@ -485,7 +485,7 @@ Write a structured report to `idea-stage/IDEA_REPORT.md`:
 | Idea 3 | GPU 2 | 1.5 hr | +0.8% CE | WEAK POSITIVE |
 
 ## Suggested Execution Order
-1. Start with Idea 1 (positive pilot signal, lowest risk)
+1. Start with Idea 1 (highest decision value after the pilot)
 2. Idea 3 as backup (weak signal, may need larger scale to confirm)
 3. Idea 2 eliminated by pilot — negative result documented
 
@@ -555,13 +555,13 @@ elif research-wiki/ exists AND [ -z "$WIKI_SCRIPT" ]:
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
 
 - The user provides a DIRECTION, not an idea. Your job is to generate the ideas.
-- Quantity first, quality second: brainstorm broadly, then filter ruthlessly.
+- Quantity first, quality second: brainstorm broadly, then narrow only to allocate pilot budget — annotate the rest, don't paper-kill them.
 - A good negative result is just as publishable as a positive one. Prioritize ideas where the answer matters regardless of direction.
-- Don't fall in love with any idea before validating it. Be willing to kill ideas.
+- Don't fall in love with any idea before validating it — but let evidence do the killing, not anticipated objections.
 - Always estimate compute cost. An idea that needs 1000 GPU-hours is not actionable for most researchers.
-- "Apply X to Y" is the lowest form of research idea. Push for deeper questions.
+- "Apply X to Y" is legitimate when Y can reveal a non-obvious interaction, failure mode, or finding — judge the revelation, not the template.
 - Include eliminated ideas in the report — they save future time by documenting dead ends.
-- **If the user's direction is too broad (e.g., "NLP", "computer vision", "reinforcement learning"), STOP and ask them to narrow it.** A good direction is 1-2 sentences specifying the problem, domain, and constraint — e.g., "factorized gap in discrete diffusion LMs" or "sample efficiency of offline RL with image observations". Without sufficient specificity, generated ideas will be too vague to run experiments on.
+- **If the user's direction is broad (e.g., "NLP"), use Phase 1 to derive 2-3 concrete frames and generate across them — ask the user only when a missing constraint would materially change the pilot slate.** A good direction is 1-2 sentences specifying the problem, domain, and constraint — e.g., "factorized gap in discrete diffusion LMs" or "sample efficiency of offline RL with image observations". Without sufficient specificity, generated ideas will be too vague to run experiments on.
 - **Anti-hallucination for cited papers.** When the landscape survey or novelty justification cites specific papers, every cited paper must pass pre-search verification (`verify_papers.py`, canonical name resolved per [`shared-references/integration-contract.md`](../shared-references/integration-contract.md) §2; 3-layer arXiv / CrossRef / S2 fallback inside the helper itself). Policy D1 (primary + degraded-output fallback): if the helper is unresolved **or** its invocation fails, mark candidates `[UNVERIFIED]` and continue rather than dropping or guessing. Never fabricate arXiv IDs, DOIs, or titles from memory. Full protocol in [`shared-references/citation-discipline.md`](../shared-references/citation-discipline.md) § Pre-Search Verification Protocol.
 
 ## Composing with Other Skills

--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -306,7 +306,7 @@ For each top idea (positive pilot signal), run a thorough novelty check:
 
 ### Phase 4: External Critical Review
 
-For the surviving top idea(s), get brutal feedback:
+For the surviving top idea(s), get a sharp outside read — strongest case, named risks, and the cheapest discriminating next experiment; the core hypothesis is not up for rewriting:
 
 ```
 /research-review "[top idea with hypothesis + pilot results]" — composed: idea-stage/IDEA_REPORT.md
@@ -331,7 +331,7 @@ After review, refine the top idea into a concrete proposal and plan experiments:
 
 **What this does:**
 - Freeze a **Problem Anchor** to prevent scope drift
-- Iteratively refine the method via GPT-5.6-Sol review (up to 5 rounds, until score ≥ 9)
+- Refine the method via GPT-5.6-Sol review — reviewer risks choose the next tests, they do not add components; the score is advisory, and preserving the core hypothesis outranks pleasing the reviewer
 - Generate a claim-driven experiment roadmap with ablations, budgets, and run order
 - Output: `refine-logs/FINAL_PROPOSAL.md`, `refine-logs/EXPERIMENT_PLAN.md`, `refine-logs/EXPERIMENT_TRACKER.md`
 
@@ -356,7 +356,7 @@ AUTO_PROCEED: accepted the top proposal. Continuing to Final Report.
 
 - **User approves** → proceed to Final Report.
 - **User requests changes** → pass feedback to `/research-refine` for another round.
-- **Lite mode:** If reviewer score < 6 or pilot was weak, run `/research-refine` only (skip `/experiment-plan`) and note remaining risks in the report.
+- **Lite mode:** If the pilot was inconclusive, still produce the smallest discriminating next-experiment plan — a reviewer score alone never downgrades an idea.
 
 ### Phase 5: Final Report
 

--- a/skills/idea-discovery/SKILL.md
+++ b/skills/idea-discovery/SKILL.md
@@ -99,7 +99,9 @@ returned model and durable thread/trace id:
 ```
 
 Never invent either value and never call `accept` without the positive verdict
-required by the run-state contract. A negative verdict does not grant a review receipt.
+required by the run-state contract. For `novelty-check`, **both PROCEED and
+PROCEED WITH CAUTION are positive verdicts** — caution is guidance for the
+pilot, not a rejection; only ABANDON is negative. A negative verdict does not grant a review receipt.
 Leave the phase `done` and the final gate `BLOCKED`, select a surviving
 or new idea, then re-run that reviewer-bearing phase. Do the same if the
 reviewer is unavailable, returns no valid identity/response, or its output was
@@ -502,7 +504,7 @@ Skip this step if `RENDER_HTML = false`.
 
 - **Don't skip phases.** Each phase filters and validates — skipping leads to wasted effort later.
 - **Checkpoint between phases.** Briefly summarize what was found. With `AUTO_PROCEED=true`, state the selected next action and keep executing in the same turn; with `false`, ask and end the turn.
-- **Kill ideas early.** It's better to kill 10 bad ideas in Phase 3 than to implement one and fail.
+- **Let pilots kill, not vibes.** A cheap pilot that says no beats a month of implementation that says no — but the kill needs empirical signal or a named published paper, not taste. Talking yourself out of ideas on paper is how pipelines end up with nothing to run.
 - **Empirical signal > theoretical appeal.** An idea with a positive pilot outranks a "sounds great" idea without evidence.
 - **Document everything — inside the one report, not in scattered files.** Dead ends and eliminated ideas are valuable, so record them as sections of `idea-stage/IDEA_REPORT.md` (see *Output hygiene* above). Do not spawn a separate `.md` per phase.
 - **Be honest with the reviewer.** Include negative results and failed pilots in the review prompt.

--- a/skills/novelty-check/SKILL.md
+++ b/skills/novelty-check/SKILL.md
@@ -19,7 +19,7 @@ Given a method description, systematically verify its novelty:
 
 ### Phase A: Extract Key Claims
 1. Read the user's method description
-2. Identify 3-5 core technical claims that would need to be novel:
+2. Identify 3-5 core technical claims that carry the claimed delta:
    - What is the method?
    - What problem does it solve?
    - What is the mechanism?
@@ -77,11 +77,17 @@ because the territory has neighbors.
    contains this result — name that paper. No named paper, no ABANDON.
 3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
    could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
-   would make it carry, not why it should die.
+   would make it carry, not why it should die. CAUTION is not a safe middle:
+   if you cannot name the specific thing that makes the delta thin, the
+   verdict is PROCEED.
 4. Concurrent or competing work is not a veto. That is a race — report it and
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
+6. This check is the FIRST gate, not the last — triage, pilots, and external
+   review all run after it. A wrongly passed idea dies cheaply at the next
+   gate; a wrongly killed idea is never seen again. When torn between two
+   verdicts, choose the more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -119,6 +125,9 @@ Output a structured report:
 - Two failures waste months equally: a false novelty claim, and a viable idea
   abandoned because the territory has neighbors. Be brutally honest in both
   directions — and when an idea clears the check, say so plainly.
+- Novelty can live in the combination or the finding even when every
+  individual claim rates LOW — judge the idea, not each claim in isolation.
+  Known parts arranged to reveal something unknown are novel.
 - "Applying X to Y" earns novelty by what the application reveals — a
   non-obvious interaction, failure mode, or insight. Judge the revelation, not
   the template.

--- a/skills/novelty-check/SKILL.md
+++ b/skills/novelty-check/SKILL.md
@@ -84,10 +84,11 @@ because the territory has neighbors.
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
-6. This check is the FIRST gate, not the last — triage, pilots, and external
-   review all run after it. A wrongly passed idea dies cheaply at the next
-   gate; a wrongly killed idea is never seen again. When torn between two
-   verdicts, choose the more permissive one.
+6. This check is an early gate, never the last one — more triage, pilots, or
+   external review still stand between any idea and a paper, whatever order
+   this run uses. A wrongly passed idea dies cheaply at one of them; a wrongly
+   killed idea is never seen again. When torn between two verdicts, choose the
+   more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -101,8 +102,8 @@ Output a structured report:
 [1-2 sentence description]
 
 ### Core Claims
-1. [Claim 1] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
-2. [Claim 2] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
+1. [Claim 1] — Closest: [paper] — What stays unknown or different: [delta]
+2. [Claim 2] — Closest: [paper] — What stays unknown or different: [delta]
 ...
 
 ### Closest Prior Work

--- a/skills/skills-codex-claude-review/novelty-check/SKILL.md
+++ b/skills/skills-codex-claude-review/novelty-check/SKILL.md
@@ -86,10 +86,11 @@ because the territory has neighbors.
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
-6. This check is the FIRST gate, not the last — triage, pilots, and external
-   review all run after it. A wrongly passed idea dies cheaply at the next
-   gate; a wrongly killed idea is never seen again. When torn between two
-   verdicts, choose the more permissive one.
+6. This check is an early gate, never the last one — more triage, pilots, or
+   external review still stand between any idea and a paper, whatever order
+   this run uses. A wrongly passed idea dies cheaply at one of them; a wrongly
+   killed idea is never seen again. When torn between two verdicts, choose the
+   more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -103,8 +104,8 @@ Output a structured report:
 [1-2 sentence description]
 
 ### Core Claims
-1. [Claim 1] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
-2. [Claim 2] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
+1. [Claim 1] — Closest: [paper] — What stays unknown or different: [delta]
+2. [Claim 2] — Closest: [paper] — What stays unknown or different: [delta]
 ...
 
 ### Closest Prior Work

--- a/skills/skills-codex-claude-review/novelty-check/SKILL.md
+++ b/skills/skills-codex-claude-review/novelty-check/SKILL.md
@@ -27,7 +27,7 @@ Given a method description, systematically verify its novelty:
 
 ### Phase A: Extract Key Claims
 1. Read the user's method description
-2. Identify 3-5 core technical claims that would need to be novel:
+2. Identify 3-5 core technical claims that carry the claimed delta:
    - What is the method?
    - What problem does it solve?
    - What is the mechanism?
@@ -79,11 +79,17 @@ because the territory has neighbors.
    contains this result — name that paper. No named paper, no ABANDON.
 3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
    could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
-   would make it carry, not why it should die.
+   would make it carry, not why it should die. CAUTION is not a safe middle:
+   if you cannot name the specific thing that makes the delta thin, the
+   verdict is PROCEED.
 4. Concurrent or competing work is not a veto. That is a race — report it and
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
+6. This check is the FIRST gate, not the last — triage, pilots, and external
+   review all run after it. A wrongly passed idea dies cheaply at the next
+   gate; a wrongly killed idea is never seen again. When torn between two
+   verdicts, choose the more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -121,6 +127,9 @@ Output a structured report:
 - Two failures waste months equally: a false novelty claim, and a viable idea
   abandoned because the territory has neighbors. Be brutally honest in both
   directions — and when an idea clears the check, say so plainly.
+- Novelty can live in the combination or the finding even when every
+  individual claim rates LOW — judge the idea, not each claim in isolation.
+  Known parts arranged to reveal something unknown are novel.
 - "Applying X to Y" earns novelty by what the application reveals — a
   non-obvious interaction, failure mode, or insight. Judge the revelation, not
   the template.

--- a/skills/skills-codex-gemini-review/idea-creator/SKILL.md
+++ b/skills/skills-codex-gemini-review/idea-creator/SKILL.md
@@ -156,7 +156,9 @@ For each surviving idea, run a deeper evaluation:
        risk on the idea — never absorbed by adding a module, a gate, or a
        qualifier. A bold idea with a named risk outranks a hedged idea with
        none, and complexity added since the brainstorm is a red flag, not
-       progress.
+       progress. And do not let your picks be uniformly the safest — if
+       the top set is all LOW-risk, name the high-upside idea that most
+       deserves a pilot slot and what result would convince you.
    ```
 
    After this start call, immediately save the returned `jobId` and poll `mcp__gemini-review__review_status` with a bounded `waitSeconds` until `done=true`. Treat the completed status payload's `response` as the follow-up critique.

--- a/skills/skills-codex-gemini-review/idea-creator/SKILL.md
+++ b/skills/skills-codex-gemini-review/idea-creator/SKILL.md
@@ -149,7 +149,7 @@ For each surviving idea, run a deeper evaluation:
        - What is the best case FOR it — what would make this the paper people cite?
        - What's the strongest objection a reviewer would raise?
        - What's the most likely failure mode?
-       - How would you rank these for a top venue submission?
+       - Rank by expected information and upside within the pilot budget — which results would matter most, whichever way they come out?
        - Which 2-3 would you actually work on?
 
        Rank; do not rewrite. An objection is answered or recorded as a named
@@ -173,7 +173,7 @@ Before committing to a full research effort, run cheap pilot experiments to get 
    - Single seed, small scale (e.g., small dataset subset, fewer epochs)
    - Target: 30 min - PILOT_MAX_HOURS per pilot on 1 GPU
    - **Estimate GPU-hours BEFORE launching.** If estimated time > PILOT_MAX_HOURS, reduce scale (fewer epochs, smaller subset) or flag as "needs manual pilot"
-   - Clear success metric defined upfront (e.g., "if metric improves by > 1%, signal is positive")
+   - Decision criterion defined upfront — including what a positive, negative, and null outcome would each teach. Metric improvement is not required for a diagnostic contribution.
 
 2. **Deploy in parallel**: Use `/run-experiment` to launch pilots on different GPUs simultaneously:
    ```
@@ -185,7 +185,7 @@ Before committing to a full research effort, run cheap pilot experiments to get 
 
 3. **Collect results**: Use `/monitor-experiment` to check progress. If any pilot exceeds PILOT_TIMEOUT_HOURS, kill it and collect partial results. Once all pilots complete (or timeout), compare:
    - Which ideas showed positive signal?
-   - Which showed null/negative results? (eliminate or deprioritize)
+   - Which showed null/negative results? Classify each: core-hypothesis refuted, informative negative (often publishable), or underpowered pilot — do not eliminate by sign alone.
    - Any surprising findings that suggest a pivot?
    - Total GPU-hours consumed (track against MAX_TOTAL_GPU_HOURS budget)
 
@@ -242,7 +242,7 @@ Write a structured report to `idea-stage/IDEA_REPORT.md`:
 | Idea 3 | GPU 2 | 1.5 hr | +0.8% CE | WEAK POSITIVE |
 
 ## Suggested Execution Order
-1. Start with Idea 1 (positive pilot signal, lowest risk)
+1. Start with Idea 1 (highest decision value after the pilot)
 2. Idea 3 as backup (weak signal, may need larger scale to confirm)
 3. Idea 2 eliminated by pilot — negative result documented
 
@@ -263,13 +263,13 @@ Write a structured report to `idea-stage/IDEA_REPORT.md`:
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
 
 - The user provides a DIRECTION, not an idea. Your job is to generate the ideas.
-- Quantity first, quality second: brainstorm broadly, then filter ruthlessly.
+- Quantity first, quality second: brainstorm broadly, then narrow only to allocate pilot budget — annotate the rest, don't paper-kill them.
 - A good negative result is just as publishable as a positive one. Prioritize ideas where the answer matters regardless of direction.
-- Don't fall in love with any idea before validating it. Be willing to kill ideas.
+- Don't fall in love with any idea before validating it — but let evidence do the killing, not anticipated objections.
 - Always estimate compute cost. An idea that needs 1000 GPU-hours is not actionable for most researchers.
-- "Apply X to Y" is the lowest form of research idea. Push for deeper questions.
+- "Apply X to Y" is legitimate when Y can reveal a non-obvious interaction, failure mode, or finding — judge the revelation, not the template.
 - Include eliminated ideas in the report — they save future time by documenting dead ends.
-- **If the user's direction is too broad (e.g., "NLP", "computer vision", "reinforcement learning"), STOP and ask them to narrow it.** A good direction is 1-2 sentences specifying the problem, domain, and constraint — e.g., "factorized gap in discrete diffusion LMs" or "sample efficiency of offline RL with image observations". Without sufficient specificity, generated ideas will be too vague to run experiments on.
+- **If the user's direction is broad (e.g., "NLP"), use Phase 1 to derive 2-3 concrete frames and generate across them — ask the user only when a missing constraint would materially change the pilot slate.** A good direction is 1-2 sentences specifying the problem, domain, and constraint — e.g., "factorized gap in discrete diffusion LMs" or "sample efficiency of offline RL with image observations". Without sufficient specificity, generated ideas will be too vague to run experiments on.
 
 ## Composing with Other Skills
 

--- a/skills/skills-codex-gemini-review/idea-discovery/SKILL.md
+++ b/skills/skills-codex-gemini-review/idea-discovery/SKILL.md
@@ -256,7 +256,7 @@ Finalize `idea-stage/IDEA_REPORT.md` with all accumulated information:
 
 - **Don't skip phases.** Each phase filters and validates — skipping leads to wasted effort later.
 - **Checkpoint between phases.** Briefly summarize what was found. With `AUTO_PROCEED=true`, state the selected next action and keep executing in the same turn; with `false`, ask and end the turn.
-- **Kill ideas early.** It's better to kill 10 bad ideas in Phase 3 than to implement one and fail.
+- **Let pilots kill, not vibes.** A cheap pilot that says no beats a month of implementation that says no — but the kill needs empirical signal or a named published paper, not taste. Talking yourself out of ideas on paper is how pipelines end up with nothing to run.
 - **Empirical signal > theoretical appeal.** An idea with a positive pilot outranks a "sounds great" idea without evidence.
 - **Document everything.** Dead ends are just as valuable as successes for future reference.
 - **Be honest with the reviewer.** Include negative results and failed pilots in the review prompt.

--- a/skills/skills-codex-gemini-review/idea-discovery/SKILL.md
+++ b/skills/skills-codex-gemini-review/idea-discovery/SKILL.md
@@ -150,7 +150,7 @@ For each top idea (positive pilot signal), run a thorough novelty check:
 
 ### Phase 4: External Critical Review
 
-For the surviving top idea(s), get brutal feedback:
+For the surviving top idea(s), get a sharp outside read — strongest case, named risks, and the cheapest discriminating next experiment; the core hypothesis is not up for rewriting:
 
 ```
 /research-review "[top idea with hypothesis + pilot results]"
@@ -173,7 +173,7 @@ After review, refine the top idea into a concrete proposal and plan experiments:
 
 **What this does:**
 - Freeze a **Problem Anchor** to prevent scope drift
-- Iteratively refine the method via Gemini review (up to 5 rounds, until score ≥ 9)
+- Refine the method via Gemini review — reviewer risks choose the next tests, they do not add components; the score is advisory, and preserving the core hypothesis outranks pleasing the reviewer
 - Generate a claim-driven experiment roadmap with ablations, budgets, and run order
 - Output: `refine-logs/FINAL_PROPOSAL.md`, `refine-logs/EXPERIMENT_PLAN.md`, `refine-logs/EXPERIMENT_TRACKER.md`
 
@@ -198,7 +198,7 @@ AUTO_PROCEED: accepted the top proposal. Continuing to Final Report.
 
 - **User approves** → proceed to Final Report.
 - **User requests changes** → pass feedback to `/research-refine` for another round.
-- **Lite mode:** If reviewer score < 6 or pilot was weak, run `/research-refine` only (skip `/experiment-plan`) and note remaining risks in the report.
+- **Lite mode:** If the pilot was inconclusive, still produce the smallest discriminating next-experiment plan — a reviewer score alone never downgrades an idea.
 
 ### Phase 5: Final Report
 

--- a/skills/skills-codex-gemini-review/novelty-check/SKILL.md
+++ b/skills/skills-codex-gemini-review/novelty-check/SKILL.md
@@ -21,7 +21,7 @@ Given a method description, systematically verify its novelty:
 
 ### Phase A: Extract Key Claims
 1. Read the user's method description
-2. Identify 3-5 core technical claims that would need to be novel:
+2. Identify 3-5 core technical claims that carry the claimed delta:
    - What is the method?
    - What problem does it solve?
    - What is the mechanism?
@@ -73,11 +73,17 @@ because the territory has neighbors.
    contains this result — name that paper. No named paper, no ABANDON.
 3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
    could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
-   would make it carry, not why it should die.
+   would make it carry, not why it should die. CAUTION is not a safe middle:
+   if you cannot name the specific thing that makes the delta thin, the
+   verdict is PROCEED.
 4. Concurrent or competing work is not a veto. That is a race — report it and
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
+6. This check is the FIRST gate, not the last — triage, pilots, and external
+   review all run after it. A wrongly passed idea dies cheaply at the next
+   gate; a wrongly killed idea is never seen again. When torn between two
+   verdicts, choose the more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -115,6 +121,9 @@ Output a structured report:
 - Two failures waste months equally: a false novelty claim, and a viable idea
   abandoned because the territory has neighbors. Be brutally honest in both
   directions — and when an idea clears the check, say so plainly.
+- Novelty can live in the combination or the finding even when every
+  individual claim rates LOW — judge the idea, not each claim in isolation.
+  Known parts arranged to reveal something unknown are novel.
 - "Applying X to Y" earns novelty by what the application reveals — a
   non-obvious interaction, failure mode, or insight. Judge the revelation, not
   the template.

--- a/skills/skills-codex-gemini-review/novelty-check/SKILL.md
+++ b/skills/skills-codex-gemini-review/novelty-check/SKILL.md
@@ -80,10 +80,11 @@ because the territory has neighbors.
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
-6. This check is the FIRST gate, not the last — triage, pilots, and external
-   review all run after it. A wrongly passed idea dies cheaply at the next
-   gate; a wrongly killed idea is never seen again. When torn between two
-   verdicts, choose the more permissive one.
+6. This check is an early gate, never the last one — more triage, pilots, or
+   external review still stand between any idea and a paper, whatever order
+   this run uses. A wrongly passed idea dies cheaply at one of them; a wrongly
+   killed idea is never seen again. When torn between two verdicts, choose the
+   more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -97,8 +98,8 @@ Output a structured report:
 [1-2 sentence description]
 
 ### Core Claims
-1. [Claim 1] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
-2. [Claim 2] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
+1. [Claim 1] — Closest: [paper] — What stays unknown or different: [delta]
+2. [Claim 2] — Closest: [paper] — What stays unknown or different: [delta]
 ...
 
 ### Closest Prior Work

--- a/skills/skills-codex/idea-creator/SKILL.md
+++ b/skills/skills-codex/idea-creator/SKILL.md
@@ -266,7 +266,9 @@ For each surviving idea, run a deeper evaluation:
        risk on the idea — never absorbed by adding a module, a gate, or a
        qualifier. A bold idea with a named risk outranks a hedged idea with
        none, and complexity added since the brainstorm is a red flag, not
-       progress.
+       progress. And do not let your picks be uniformly the safest — if
+       the top set is all LOW-risk, name the high-upside idea that most
+       deserves a pilot slot and what result would convince you.
    ```
 
 3. **Combine rankings**: Merge your assessment with GPT-5.6-Sol's ranking. Select top 2-3 ideas for pilot experiments.

--- a/skills/skills-codex/idea-creator/SKILL.md
+++ b/skills/skills-codex/idea-creator/SKILL.md
@@ -259,7 +259,7 @@ For each surviving idea, run a deeper evaluation:
        - What is the best case FOR it — what would make this the paper people cite?
        - What's the strongest objection a reviewer would raise?
        - What's the most likely failure mode?
-       - How would you rank these for a top venue submission?
+       - Rank by expected information and upside within the pilot budget — which results would matter most, whichever way they come out?
        - Which 2-3 would you actually work on?
 
        Rank; do not rewrite. An objection is answered or recorded as a named
@@ -281,7 +281,7 @@ Before committing to a full research effort, run cheap pilot experiments to get 
    - Single seed, small scale (e.g., small dataset subset, fewer epochs)
    - Target: 30 min - PILOT_MAX_HOURS per pilot on 1 GPU
    - **Estimate GPU-hours BEFORE launching.** If estimated time > PILOT_MAX_HOURS, reduce scale (fewer epochs, smaller subset) or flag as "needs manual pilot"
-   - Clear success metric defined upfront (e.g., "if metric improves by > 1%, signal is positive")
+   - Decision criterion defined upfront — including what a positive, negative, and null outcome would each teach. Metric improvement is not required for a diagnostic contribution.
 
 2. **Deploy in parallel**: Use `/run-experiment` to launch pilots on different GPUs simultaneously:
    ```
@@ -293,7 +293,7 @@ Before committing to a full research effort, run cheap pilot experiments to get 
 
 3. **Collect results**: Use `/monitor-experiment` to check progress. If any pilot exceeds PILOT_TIMEOUT_HOURS, kill it and collect partial results. Once all pilots complete (or timeout), compare:
    - Which ideas showed positive signal?
-   - Which showed null/negative results? (eliminate or deprioritize)
+   - Which showed null/negative results? Classify each: core-hypothesis refuted, informative negative (often publishable), or underpowered pilot — do not eliminate by sign alone.
    - Any surprising findings that suggest a pivot?
    - Total GPU-hours consumed (track against MAX_TOTAL_GPU_HOURS budget)
 
@@ -350,7 +350,7 @@ Write a structured report to `idea-stage/IDEA_REPORT.md`:
 | Idea 3 | GPU 2 | 1.5 hr | +0.8% CE | WEAK POSITIVE |
 
 ## Suggested Execution Order
-1. Start with Idea 1 (positive pilot signal, lowest risk)
+1. Start with Idea 1 (highest decision value after the pilot)
 2. Idea 3 as backup (weak signal, may need larger scale to confirm)
 3. Idea 2 eliminated by pilot — negative result documented
 
@@ -410,13 +410,13 @@ See [`output-composition.md`](../shared-references/output-composition.md).
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
 
 - The user provides a DIRECTION, not an idea. Your job is to generate the ideas.
-- Quantity first, quality second: brainstorm broadly, then filter ruthlessly.
+- Quantity first, quality second: brainstorm broadly, then narrow only to allocate pilot budget — annotate the rest, don't paper-kill them.
 - A good negative result is just as publishable as a positive one. Prioritize ideas where the answer matters regardless of direction.
-- Don't fall in love with any idea before validating it. Be willing to kill ideas.
+- Don't fall in love with any idea before validating it — but let evidence do the killing, not anticipated objections.
 - Always estimate compute cost. An idea that needs 1000 GPU-hours is not actionable for most researchers.
-- "Apply X to Y" is the lowest form of research idea. Push for deeper questions.
+- "Apply X to Y" is legitimate when Y can reveal a non-obvious interaction, failure mode, or finding — judge the revelation, not the template.
 - Include eliminated ideas in the report — they save future time by documenting dead ends.
-- **If the user's direction is too broad (e.g., "NLP", "computer vision", "reinforcement learning"), STOP and ask them to narrow it.** A good direction is 1-2 sentences specifying the problem, domain, and constraint — e.g., "factorized gap in discrete diffusion LMs" or "sample efficiency of offline RL with image observations". Without sufficient specificity, generated ideas will be too vague to run experiments on.
+- **If the user's direction is broad (e.g., "NLP"), use Phase 1 to derive 2-3 concrete frames and generate across them — ask the user only when a missing constraint would materially change the pilot slate.** A good direction is 1-2 sentences specifying the problem, domain, and constraint — e.g., "factorized gap in discrete diffusion LMs" or "sample efficiency of offline RL with image observations". Without sufficient specificity, generated ideas will be too vague to run experiments on.
 
 ## Composing with Other Skills
 

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -294,7 +294,7 @@ For each top idea (positive pilot signal), run a thorough novelty check:
 
 ### Phase 4: External Critical Review
 
-For the surviving top idea(s), get brutal feedback:
+For the surviving top idea(s), get a sharp outside read — strongest case, named risks, and the cheapest discriminating next experiment; the core hypothesis is not up for rewriting:
 
 ```
 /research-review "[top idea with hypothesis + pilot results]" — composed: idea-stage/IDEA_REPORT.md
@@ -323,7 +323,7 @@ After review, refine the top idea into a concrete proposal and plan experiments:
 
 **What this does:**
 - Freeze a **Problem Anchor** to prevent scope drift
-- Iteratively refine the method via GPT-5.6-Sol review (up to 5 rounds, until score ≥ 9)
+- Refine the method via GPT-5.6-Sol review — reviewer risks choose the next tests, they do not add components; the score is advisory, and preserving the core hypothesis outranks pleasing the reviewer
 - Generate a claim-driven experiment roadmap with ablations, budgets, and run order
 - Output: `refine-logs/FINAL_PROPOSAL.md`, `refine-logs/EXPERIMENT_PLAN.md`, `refine-logs/EXPERIMENT_TRACKER.md`
 
@@ -348,7 +348,7 @@ AUTO_PROCEED: accepted the top proposal. Continuing to Final Report.
 
 - **User approves** → proceed to Final Report.
 - **User requests changes** → pass feedback to `/research-refine` for another round.
-- **Lite mode:** If reviewer score < 6 or pilot was weak, run `/research-refine` only (skip `/experiment-plan`) and note remaining risks in the report.
+- **Lite mode:** If the pilot was inconclusive, still produce the smallest discriminating next-experiment plan — a reviewer score alone never downgrades an idea.
 
 ### Phase 5: Final Report
 

--- a/skills/skills-codex/idea-discovery/SKILL.md
+++ b/skills/skills-codex/idea-discovery/SKILL.md
@@ -97,7 +97,9 @@ python3 <resolved-run_state.py> mark-provisional . <run_id> research-review --ve
 ```
 
 Never invent either value and never mark a phase provisional without the
-positive verdict required by the run-state contract. A negative verdict does not grant a review receipt.
+positive verdict required by the run-state contract. For `novelty-check`,
+**both PROCEED and PROCEED WITH CAUTION are positive verdicts** — caution is
+guidance for the pilot, not a rejection; only ABANDON is negative. A negative verdict does not grant a review receipt.
 Leave the phase `done` and the final gate `BLOCKED`,
 select a surviving or new idea, then re-run that reviewer-bearing phase. Do the
 same if the reviewer is unavailable, returns no valid identity/response, or its
@@ -456,7 +458,7 @@ After finalizing `idea-stage/IDEA_REPORT.md` (and the optional `IDEA_CANDIDATES.
 
 - **Don't skip phases.** Each phase filters and validates — skipping leads to wasted effort later.
 - **Checkpoint between phases.** Briefly summarize what was found. With `AUTO_PROCEED=true`, state the selected next action and keep executing in the same turn; with `false`, ask and end the turn.
-- **Kill ideas early.** It's better to kill 10 bad ideas in Phase 3 than to implement one and fail.
+- **Let pilots kill, not vibes.** A cheap pilot that says no beats a month of implementation that says no — but the kill needs empirical signal or a named published paper, not taste. Talking yourself out of ideas on paper is how pipelines end up with nothing to run.
 - **Empirical signal > theoretical appeal.** An idea with a positive pilot outranks a "sounds great" idea without evidence.
 - **Document everything.** Dead ends are just as valuable as successes for future reference.
 - **Be honest with the reviewer.** Include negative results and failed pilots in the review prompt.

--- a/skills/skills-codex/novelty-check/SKILL.md
+++ b/skills/skills-codex/novelty-check/SKILL.md
@@ -73,10 +73,11 @@ because the territory has neighbors.
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
-6. This check is the FIRST gate, not the last — triage, pilots, and external
-   review all run after it. A wrongly passed idea dies cheaply at the next
-   gate; a wrongly killed idea is never seen again. When torn between two
-   verdicts, choose the more permissive one.
+6. This check is an early gate, never the last one — more triage, pilots, or
+   external review still stand between any idea and a paper, whatever order
+   this run uses. A wrongly passed idea dies cheaply at one of them; a wrongly
+   killed idea is never seen again. When torn between two verdicts, choose the
+   more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -90,8 +91,8 @@ Output a structured report:
 [1-2 sentence description]
 
 ### Core Claims
-1. [Claim 1] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
-2. [Claim 2] — Novelty: HIGH/MEDIUM/LOW — Closest: [paper]
+1. [Claim 1] — Closest: [paper] — What stays unknown or different: [delta]
+2. [Claim 2] — Closest: [paper] — What stays unknown or different: [delta]
 ...
 
 ### Closest Prior Work

--- a/skills/skills-codex/novelty-check/SKILL.md
+++ b/skills/skills-codex/novelty-check/SKILL.md
@@ -18,7 +18,7 @@ Given a method description, systematically verify its novelty:
 
 ### Phase A: Extract Key Claims
 1. Read the user's method description
-2. Identify 3-5 core technical claims that would need to be novel:
+2. Identify 3-5 core technical claims that carry the claimed delta:
    - What is the method?
    - What problem does it solve?
    - What is the mechanism?
@@ -66,11 +66,17 @@ because the territory has neighbors.
    contains this result — name that paper. No named paper, no ABANDON.
 3. Crowded-but-deltaed is PROCEED: state the delta in one sentence a reviewer
    could verify. Thin or contested delta is PROCEED WITH CAUTION — say what
-   would make it carry, not why it should die.
+   would make it carry, not why it should die. CAUTION is not a safe middle:
+   if you cannot name the specific thing that makes the delta thin, the
+   verdict is PROCEED.
 4. Concurrent or competing work is not a veto. That is a race — report it and
    let the user decide whether to run it.
 5. A direct attack on a central problem is legitimate novelty when nobody has
    executed it well. "This area is hot" does not mean "this area is taken."
+6. This check is the FIRST gate, not the last — triage, pilots, and external
+   review all run after it. A wrongly passed idea dies cheaply at the next
+   gate; a wrongly killed idea is never seen again. When torn between two
+   verdicts, choose the more permissive one.
 Say plainly when an idea clears the check. Do not manufacture overlap.
 ```
 
@@ -108,6 +114,9 @@ Output a structured report:
 - Two failures waste months equally: a false novelty claim, and a viable idea
   abandoned because the territory has neighbors. Be brutally honest in both
   directions — and when an idea clears the check, say so plainly.
+- Novelty can live in the combination or the finding even when every
+  individual claim rates LOW — judge the idea, not each claim in isolation.
+  Known parts arranged to reveal something unknown are novel.
 - "Applying X to Y" earns novelty by what the application reveals — a
   non-obvious interaction, failure mode, or insight. Judge the revelation, not
   the template.


### PR DESCRIPTION
Follow-up to #419, two more rounds of loosening. Round two: the verdict-limits block gains the structural tie-break (this is an early gate — a wrong pass dies cheaply downstream, a wrong kill is never seen again; when torn, pick the more permissive verdict), CAUTION stops being a safe middle, combination novelty counts even when every claim rates LOW, PROCEED WITH CAUTION explicitly counts as a positive verdict at the idea-discovery receipt, and 'kill ideas early' becomes 'let pilots kill, not vibes'.

Round three came from inverting the review brief: gpt-5.6-sol was asked what STILL suppresses ideas, not what risks the loosening carries. 39 replacements across mainline + codex mirror + gemini overlay: the closing-notes kill trio ('filter ruthlessly' / 'be willing to kill ideas' / 'apply X to Y is the lowest form') is gone, triage ranks by expected information instead of venue prestige and no longer holds 'the authoritative quality verdict', negative pilots classify as refuted / informative-negative / underpowered instead of 'eliminate', broad directions no longer STOP the run, and the refinement loop stops chasing score>=9 over 5 rounds. Sol's self-report on the community's example class: now PROCEED.

Also fixes a bug sol caught in our own #419 text: verdict-limits rule 6 asserted a fixed phase order no workflow actually has; now order-agnostic.

Tests: mirror 21/21, generator, gate, query-pack — 50 passed; inventory clean; claude-review overlay regenerated.