### PR TITLE
fix(writing): confident prose, honest limits — papers stop reading like confessions

### DIFF
--- a/skills/auto-paper-improvement-loop/SKILL.md
+++ b/skills/auto-paper-improvement-loop/SKILL.md
@@ -255,6 +255,13 @@ mcp__codex__codex:
   prompt: |
     You are reviewing a [VENUE] paper. Please provide a detailed, structured review.
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     ## Paper Files:
     - LaTeX source: [list all section .tex files]
     - Compiled PDF: paper/main.pdf
@@ -315,12 +322,18 @@ Parse the review and implement fixes by severity:
 
 **Edit-whitelist gate (if set):** If `EDIT_WHITELIST` is set, before applying each proposed edit, check the target path against `allowed_paths` / `forbidden_paths` and the new-lines diff against `forbidden_operations` per the "Optional: Edit Whitelist" section. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 1)` with file, reason (`path` or `operation`), the offending pattern, and the original reviewer concern. The loop continues with remaining edits — a rejection never aborts the round. Surface a rejection summary at the end of the round.
 
+**Before applying any fix:** calibrate claims to evidence and state them
+directly; generic caveats belong in Limitations only; writing instructions are
+never manuscript content; tone edits never change what the paper knows.
+
 **Common fix patterns:**
 
 | Issue | Fix Pattern |
 |-------|-------------|
 | Assumption-model mismatch | Rewrite assumption to match the model, add formal proposition bridging the gap |
-| Overclaims | Soften language: "validate" → "demonstrate practical relevance", "comparable" → "qualitatively competitive" |
+| Genuine overclaim | Narrow the claim itself to the supported scope/modality — never substitute a softer-sounding synonym for fixing scope, comparison, or aggregation |
+| Supported claim wrapped in caution | Remove the redundant hedges; keep any scope qualifier that makes the claim true |
+| Scattered generic caveats | Consolidate into Limitations and delete the duplicates |
 | Missing metrics | Add quantitative table with honest parameter counts and caveats |
 | Theorem not self-contained | Add "Interpretation" paragraph listing all dependencies |
 | Notation confusion | Rename conflicting symbols globally, add Notation paragraph |
@@ -393,6 +406,13 @@ mcp__codex__codex:
   config: {"model_reasoning_effort": "xhigh"}
   prompt: |
     You are reviewing a [VENUE] paper. This is a fresh, zero-context review.
+
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
     Ignore any prior review rounds, prior fix lists, or executor explanations.
     Judge the paper only from the current LaTeX source and compiled PDF.
 
@@ -467,9 +487,11 @@ If `/kill-argument` returns `verdict: NOT_APPLICABLE` (paper isn't theory- or sc
 
 Same process as Step 3. Typical Round 2 fixes:
 - Add controlled synthetic experiments validating theory
-- Further soften any remaining overclaims
+- Re-check calibration in both directions: narrow genuine overclaims, state
+  supported claims directly, consolidate scattered generic caveats into
+  Limitations — and do not re-soften claims the evidence already supports
 - Formalize informal arguments (e.g., truncation → formal proposition)
-- Strengthen limitations section
+- Make Limitations more specific only when a material limit is missing
 
 **Edit-whitelist gate (if set):** Same as Step 3 — if `EDIT_WHITELIST` is set, run the path + forbidden-operation checks before applying each proposed edit. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 2)` and the loop continues. Surface a rejection summary at the end of the round.
 
@@ -629,8 +651,8 @@ paper/
 - **Reviewer independence (Round 2+)**: when `REVIEWER_BIAS_GUARD = true` (default), use a **fresh** `mcp__codex__codex` thread for every review round; never use `mcp__codex__codex-reply` and never include "since last round" / fix summaries in the prompt. See the Reviewer Independence Protocol section above.
 - **Always recompile after fixes** — verify 0 errors before proceeding
 - **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
-- **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
-- **Global consistency** — when renaming notation or softening claims, check ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions)
+- **Respect the paper's claims** — narrow genuine overclaims rather than adding unsupported new claims, and state supported claims directly rather than wrapping them in fresh hedges
+- **Global consistency** — when renaming notation or changing a claim's scope, keep every restatement semantically consistent across ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions); consistency means matching scope, not copying disclaimer sentences everywhere
 - **Edit-whitelist rejections are LOGGED, not silently dropped** — when `EDIT_WHITELIST` is set and an edit is rejected for a path or forbidden-operation violation, the rejection MUST be appended to `PAPER_IMPROVEMENT_LOG.md` with file, reason, offending pattern, and the original reviewer concern. The loop reports a rejection summary at the end of every round (and in the checkpoint, if `HUMAN_CHECKPOINT = true`). Never silently swallow a whitelist rejection — the audit trail is the whole point of the parameter.
 
 ## Typical Score Progression

--- a/skills/paper-write/SKILL.md
+++ b/skills/paper-write/SKILL.md
@@ -261,7 +261,7 @@ Before drafting the front matter, re-read the one-sentence contribution from `PA
 
 **§5 Conclusion:**
 - Summarize contributions (NOT copy-paste from intro — rephrase)
-- Limitations (be honest — reviewers appreciate this)
+- Limitations (2-4 material, specific limits — dataset scale, compute regime, assumption X; real ones only, never invented to fill a count. This section is the ONLY home for generic caveats)
 - Future work (1-2 concrete directions)
 - Ethics statement and reproducibility statement (if venue requires)
 - Target: 0.5 pages
@@ -528,6 +528,13 @@ mcp__codex__codex:
   prompt: |
     Review this [VENUE] paper draft (main body, excluding appendix).
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     Focus on:
     1. Does each claim from the intro have supporting evidence?
     2. Is the writing clear, concise, and free of AI-isms?
@@ -577,13 +584,49 @@ Before declaring done:
 
 ## Key Rules
 
+=== CONFIDENT PROSE, HONEST LIMITS (never upgrades claims) ===
+1. Calibrate each claim to the evidence's actual scope and modality, then state
+   that calibrated claim directly. Necessary assumptions, uncertainty, and
+   scope are part of the claim; stacked hedges and defensive throat-clearing
+   are not.
+2. If the current claim is unsupported, narrow it to a version the evidence
+   supports or cut it. Do not substitute a softer-sounding synonym for fixing
+   scope, modality, comparison, or aggregation.
+3. Put generic caveats and broader boundary discussion in one Limitations
+   section. Outside it, remove generic disclaimers such as "further research
+   is needed", "may not generalize", and "should be interpreted with caution".
+   Claim-defining scope, assumptions, and statistical qualifications stay
+   attached to the claims they make true.
+4. Aim for 2-4 material, specific limitations (dataset scale, compute regime,
+   assumption X). Real ones only — never invent one to meet a count, never
+   apologize generically, never repeat the same limitation through the paper.
+5. Writing instructions are not manuscript content. "Do not mention X" means
+   omit X, not write "we do not address/claim/discuss X". Never expose
+   drafting instructions, requested omissions, reviewer feedback, or revision
+   history in manuscript prose.
+6. Replace self-defence ("we do not claim", "our goal is merely") with a
+   positive, evidence-matched statement of what the paper does establish. If
+   the defensive sentence carries a real boundary, keep that boundary in the
+   claim or Limitations; do not delete truth-conditional content.
+7. Tone-only edits never alter facts, negation, modality, scope, assumptions,
+   comparison direction, aggregation, numbers, formulas, or citations. Genuine
+   overclaims must still be narrowed; supported claims wrapped in redundant
+   caution must be stated directly.
+8. One causal spine: gap -> question -> insight -> consequence -> evidence ->
+   implication. Every section advances it. Make the method feel inevitable:
+   the gap creates a concrete question, the key insight answers it, the method
+   follows from the insight, each major experiment tests a consequence of it,
+   and the conclusion states exactly what the evidence establishes.
+   Front-load the contribution; never narrate the drafting or revision process.
+
+
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
 - **Do NOT generate author names, emails, or affiliations** — use anonymous block or placeholder
 - **Write complete sections, not outlines** — the output should be compilable LaTeX
 - **One file per section** — modular structure for easy editing
 - **Every claim must cite evidence** — cross-reference the Claims-Evidence Matrix
 - **Compile-ready** — the output should compile with `latexmk` without errors (modulo missing figures)
-- **No over-claiming** — use hedging language ("suggests", "indicates") for weak evidence
+- **Calibrate, don't hedge** — match each claim to its evidence's actual scope and modality, then state it directly; generic caveats live in Limitations only (the CONFIDENT PROSE, HONEST LIMITS block above is the contract)
 - **Venue style matters** — ML conferences (ICLR/NeurIPS/ICML) use `natbib` (`\citep`/`\citet`); **IEEE venues use `cite` package (`\cite{}`, numeric)**. Never mix.
 - **Page limit rules differ by venue** — ML conferences: main body to Conclusion, references/appendix NOT counted. **IEEE: references ARE counted toward the page limit.**
 - **Clean bib** — references.bib must only contain entries that are actually `\cite`d

--- a/skills/paper-writing/SKILL.md
+++ b/skills/paper-writing/SKILL.md
@@ -359,6 +359,13 @@ These are complementary, not mutually exclusive: you can run multiple generators
 [If all auto]: Shall I proceed with LaTeX writing?
 ```
 
+> **Writing invariant (every drafting and revision step):** calibrate each
+> claim to its evidence and state it directly; generic caveats live in the
+> Limitations section only; writing instructions are never manuscript content
+> ("do not mention X" means omit X, not "we do not address X"); tone edits
+> never change what the paper knows. `/paper-write` carries the full
+> CONFIDENT PROSE, HONEST LIMITS contract.
+
 ### Phase 3: LaTeX Writing
 
 Invoke `/paper-write` to generate section-by-section LaTeX:
@@ -476,13 +483,15 @@ If `— style-ref: <source>` was passed in `$ARGUMENTS` and the helper succeeded
 
 **Round 1:** GPT-5.6-Sol xhigh reviews the full paper → identifies CRITICAL/MAJOR/MINOR issues → Claude Code implements fixes → recompile → save `main_round1.pdf`
 
-**Round 2:** GPT-5.6-Sol xhigh re-reviews with conversation context → identifies remaining issues → Claude Code implements fixes → recompile → save `main_round2.pdf`
+**Round 2:** GPT-5.6-Sol xhigh re-reviews the recompiled draft cold (fresh review — no fix summaries, no conversation carry-over) → identifies remaining issues → Claude Code implements fixes → recompile → save `main_round2.pdf`
 
-**Typical improvements:**
+**Typical improvements (calibration cuts both ways):**
 - Fix assumption-model mismatches
-- Soften overclaims to match evidence
+- Narrow genuine overclaims to the supported scope — and state supported claims
+  directly, removing redundant hedges
+- Consolidate scattered generic caveats into Limitations
 - Add missing interpretations and notation
-- Strengthen limitations section
+- Make Limitations more specific (only when a material limit is missing — never pad)
 - Add theory-aligned experiments if needed
 
 **Output:** Three PDFs for comparison + `PAPER_IMPROVEMENT_LOG.md`.

--- a/skills/skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex-claude-review/auto-paper-improvement-loop/SKILL.md
@@ -205,6 +205,13 @@ mcp__claude-review__review_start:
   prompt: |
     You are reviewing a [VENUE] paper. Please provide a detailed, structured review.
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     ## Paper Files:
     - LaTeX source: [list all section .tex files]
     - Compiled PDF: paper/main.pdf
@@ -267,12 +274,18 @@ Parse the review and implement fixes by severity:
 
 **Edit-whitelist gate (if set):** If `EDIT_WHITELIST` is set, before applying each proposed edit, check the target path against `allowed_paths` / `forbidden_paths` and the new-lines diff against `forbidden_operations` per the "Optional: Edit Whitelist" section. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 1)` with file, reason (`path` or `operation`), the offending pattern, and the original reviewer concern. The loop continues with remaining edits — a rejection never aborts the round. Surface a rejection summary at the end of the round.
 
+**Before applying any fix:** calibrate claims to evidence and state them
+directly; generic caveats belong in Limitations only; writing instructions are
+never manuscript content; tone edits never change what the paper knows.
+
 **Common fix patterns:**
 
 | Issue | Fix Pattern |
 |-------|-------------|
 | Assumption-model mismatch | Rewrite assumption to match the model, add formal proposition bridging the gap |
-| Overclaims | Soften language: "validate" → "demonstrate practical relevance", "comparable" → "qualitatively competitive" |
+| Genuine overclaim | Narrow the claim itself to the supported scope/modality — never substitute a softer-sounding synonym for fixing scope, comparison, or aggregation |
+| Supported claim wrapped in caution | Remove the redundant hedges; keep any scope qualifier that makes the claim true |
+| Scattered generic caveats | Consolidate into Limitations and delete the duplicates |
 | Missing metrics | Add quantitative table with honest parameter counts and caveats |
 | Theorem not self-contained | Add "Interpretation" paragraph listing all dependencies |
 | Notation confusion | Rename conflicting symbols globally, add Notation paragraph |
@@ -333,6 +346,13 @@ If `REVIEWER_BIAS_GUARD = true` (default), use a **fresh** `mcp__claude-review__
 mcp__claude-review__review_start:
   prompt: |
     You are reviewing a [VENUE] paper. This is a fresh, zero-context review.
+
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
     Ignore any prior review rounds, prior fix lists, or executor explanations.
     Judge the paper only from the current LaTeX source and compiled PDF.
 
@@ -397,9 +417,11 @@ If kill-argument returns `verdict: NOT_APPLICABLE`, skip Step 5.5 entirely and p
 
 Same process as Step 3. Typical Round 2 fixes:
 - Add controlled synthetic experiments validating theory
-- Further soften any remaining overclaims
+- Re-check calibration in both directions: narrow genuine overclaims, state
+  supported claims directly, consolidate scattered generic caveats into
+  Limitations — and do not re-soften claims the evidence already supports
 - Formalize informal arguments (e.g., truncation → formal proposition)
-- Strengthen limitations section
+- Make Limitations more specific only when a material limit is missing
 
 **Edit-whitelist gate (if set):** Same as Step 3 — if `EDIT_WHITELIST` is set, run the path + forbidden-operation checks before applying each proposed edit. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 2)` and the loop continues. Surface a rejection summary at the end of the round.
 
@@ -559,8 +581,8 @@ paper/
 - **Reviewer independence (Round 2+)**: when `REVIEWER_BIAS_GUARD = true` (default), use a **fresh** `mcp__claude-review__review_start` reviewer for every review round; never use stale reviewer continuation and never include "since last round" / fix summaries in the prompt. See the Reviewer Independence Protocol section above.
 - **Always recompile after fixes** — verify 0 errors before proceeding
 - **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
-- **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
-- **Global consistency** — when renaming notation or softening claims, check ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions)
+- **Respect the paper's claims** — narrow genuine overclaims rather than adding unsupported new claims, and state supported claims directly rather than wrapping them in fresh hedges
+- **Global consistency** — when renaming notation or changing a claim's scope, keep every restatement semantically consistent across ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions); consistency means matching scope, not copying disclaimer sentences everywhere
 - **Edit-whitelist rejections are LOGGED, not silently dropped** — when `EDIT_WHITELIST` is set and an edit is rejected for a path or forbidden-operation violation, the rejection MUST be appended to `PAPER_IMPROVEMENT_LOG.md` with file, reason, offending pattern, and the original reviewer concern. The loop reports a rejection summary at the end of every round (and in the checkpoint, if `HUMAN_CHECKPOINT = true`). Never silently swallow a whitelist rejection — the audit trail is the whole point of the parameter.
 
 ## Typical Score Progression

--- a/skills/skills-codex-claude-review/paper-write/SKILL.md
+++ b/skills/skills-codex-claude-review/paper-write/SKILL.md
@@ -198,7 +198,7 @@ Before drafting the front matter, re-read the one-sentence contribution from `PA
 
 **§5 Conclusion:**
 - Summarize contributions (NOT copy-paste from intro — rephrase)
-- Limitations (be honest — reviewers appreciate this)
+- Limitations (2-4 material, specific limits — dataset scale, compute regime, assumption X; real ones only, never invented to fill a count. This section is the ONLY home for generic caveats)
 - Future work (1-2 concrete directions)
 - Ethics statement and reproducibility statement (if venue requires)
 - Target: 0.5 pages
@@ -331,6 +331,13 @@ mcp__claude-review__review_start:
   prompt: |
     Review this [VENUE] paper draft (main body, excluding appendix).
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     Focus on:
     1. Does each claim from the intro have supporting evidence?
     2. Is the writing clear, concise, and free of AI-isms?
@@ -381,6 +388,42 @@ Before declaring done:
 
 ## Key Rules
 
+=== CONFIDENT PROSE, HONEST LIMITS (never upgrades claims) ===
+1. Calibrate each claim to the evidence's actual scope and modality, then state
+   that calibrated claim directly. Necessary assumptions, uncertainty, and
+   scope are part of the claim; stacked hedges and defensive throat-clearing
+   are not.
+2. If the current claim is unsupported, narrow it to a version the evidence
+   supports or cut it. Do not substitute a softer-sounding synonym for fixing
+   scope, modality, comparison, or aggregation.
+3. Put generic caveats and broader boundary discussion in one Limitations
+   section. Outside it, remove generic disclaimers such as "further research
+   is needed", "may not generalize", and "should be interpreted with caution".
+   Claim-defining scope, assumptions, and statistical qualifications stay
+   attached to the claims they make true.
+4. Aim for 2-4 material, specific limitations (dataset scale, compute regime,
+   assumption X). Real ones only — never invent one to meet a count, never
+   apologize generically, never repeat the same limitation through the paper.
+5. Writing instructions are not manuscript content. "Do not mention X" means
+   omit X, not write "we do not address/claim/discuss X". Never expose
+   drafting instructions, requested omissions, reviewer feedback, or revision
+   history in manuscript prose.
+6. Replace self-defence ("we do not claim", "our goal is merely") with a
+   positive, evidence-matched statement of what the paper does establish. If
+   the defensive sentence carries a real boundary, keep that boundary in the
+   claim or Limitations; do not delete truth-conditional content.
+7. Tone-only edits never alter facts, negation, modality, scope, assumptions,
+   comparison direction, aggregation, numbers, formulas, or citations. Genuine
+   overclaims must still be narrowed; supported claims wrapped in redundant
+   caution must be stated directly.
+8. One causal spine: gap -> question -> insight -> consequence -> evidence ->
+   implication. Every section advances it. Make the method feel inevitable:
+   the gap creates a concrete question, the key insight answers it, the method
+   follows from the insight, each major experiment tests a consequence of it,
+   and the conclusion states exactly what the evidence establishes.
+   Front-load the contribution; never narrate the drafting or revision process.
+
+
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
 
 - **Do NOT generate author names, emails, or affiliations** — use anonymous block or placeholder
@@ -388,7 +431,7 @@ Before declaring done:
 - **One file per section** — modular structure for easy editing
 - **Every claim must cite evidence** — cross-reference the Claims-Evidence Matrix
 - **Compile-ready** — the output should compile with `latexmk` without errors (modulo missing figures)
-- **No over-claiming** — use hedging language ("suggests", "indicates") for weak evidence
+- **Calibrate, don't hedge** — match each claim to its evidence's actual scope and modality, then state it directly; generic caveats live in Limitations only (the CONFIDENT PROSE, HONEST LIMITS block above is the contract)
 - **Venue style matters** — ML conferences (ICLR/NeurIPS/ICML) use `natbib` (`\citep`/`\citet`); **IEEE venues use `cite` package (`\cite{}`, numeric)**. Never mix.
 - **Page limit rules differ by venue** — ML conferences: main body to Conclusion, references/appendix NOT counted. **IEEE: references ARE counted toward the page limit.**
 - **Clean bib** — references.bib must only contain entries that are actually `\cite`d

--- a/skills/skills-codex-gemini-review/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex-gemini-review/auto-paper-improvement-loop/SKILL.md
@@ -78,6 +78,13 @@ mcp__gemini-review__review_start:
   prompt: |
     You are reviewing a [VENUE] paper. Please provide a detailed, structured review.
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     ## Full Paper Text:
     [paste concatenated sections]
 
@@ -128,12 +135,18 @@ Parse the review and implement fixes by severity:
 2. MAJOR fixes (overclaims, missing content, notation issues)
 3. MINOR fixes (if time permits)
 
+**Before applying any fix:** calibrate claims to evidence and state them
+directly; generic caveats belong in Limitations only; writing instructions are
+never manuscript content; tone edits never change what the paper knows.
+
 **Common fix patterns:**
 
 | Issue | Fix Pattern |
 |-------|-------------|
 | Assumption-model mismatch | Rewrite assumption to match the model, add formal proposition bridging the gap |
-| Overclaims | Soften language: "validate" → "demonstrate practical relevance", "comparable" → "qualitatively competitive" |
+| Genuine overclaim | Narrow the claim itself to the supported scope/modality — never substitute a softer-sounding synonym for fixing scope, comparison, or aggregation |
+| Supported claim wrapped in caution | Remove the redundant hedges; keep any scope qualifier that makes the claim true |
+| Scattered generic caveats | Consolidate into Limitations and delete the duplicates |
 | Missing metrics | Add quantitative table with honest parameter counts and caveats |
 | Theorem not self-contained | Add "Interpretation" paragraph listing all dependencies |
 | Notation confusion | Rename conflicting symbols globally, add Notation paragraph |
@@ -151,20 +164,28 @@ Verify: 0 undefined references, 0 undefined citations.
 
 ### Step 5: Round 2 Review
 
-Use `mcp__gemini-review__review_reply_start` with the saved completed `threadId`:
+Start a **fresh** `mcp__gemini-review__review_start` — do not reuse the Round 1
+thread, do not send fix summaries. The reviewer re-reads the recompiled paper
+cold; executor notes are not evidence, and "since your last review, we
+implemented..." is exactly the self-report path that lets fixes be graded on
+their description instead of their substance:
 
 ```
-mcp__gemini-review__review_reply_start:
-  threadId: [saved from Round 1]
+mcp__gemini-review__review_start:
   prompt: |
-    [Round 2 update]
+    You are reviewing a [VENUE] paper (Round 2 — fresh read of the current
+    manuscript; judge only what is on the page).
 
-    Since your last review, we have implemented:
-    1. [Fix 1]: [description]
-    2. [Fix 2]: [description]
-    ...
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
 
-    Please re-score and re-assess. Same format:
+    [full current paper text]
+
+    Please provide the same structured format:
     Score, Summary, Strengths, Weaknesses, Actionable fixes, Verdict.
 ```
 
@@ -178,9 +199,11 @@ After this start call, immediately save the returned `jobId` and poll `mcp__gemi
 
 Same process as Step 3. Typical Round 2 fixes:
 - Add controlled synthetic experiments validating theory
-- Further soften any remaining overclaims
+- Re-check calibration in both directions: narrow genuine overclaims, state
+  supported claims directly, consolidate scattered generic caveats into
+  Limitations — and do not re-soften claims the evidence already supports
 - Formalize informal arguments (e.g., truncation → formal proposition)
-- Strengthen limitations section
+- Make Limitations more specific only when a material limit is missing
 
 ### Step 7: Recompile Round 2
 
@@ -314,8 +337,8 @@ paper/
 - **Use `mcp__gemini-review__review_reply_start` plus `mcp__gemini-review__review_status`** for Round 2 to maintain conversation context
 - **Always recompile after fixes** — verify 0 errors before proceeding
 - **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
-- **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
-- **Global consistency** — when renaming notation or softening claims, check ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions)
+- **Respect the paper's claims** — narrow genuine overclaims rather than adding unsupported new claims, and state supported claims directly rather than wrapping them in fresh hedges
+- **Global consistency** — when renaming notation or changing a claim's scope, keep every restatement semantically consistent across ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions); consistency means matching scope, not copying disclaimer sentences everywhere
 
 ## Typical Score Progression
 

--- a/skills/skills-codex-gemini-review/paper-write/SKILL.md
+++ b/skills/skills-codex-gemini-review/paper-write/SKILL.md
@@ -166,7 +166,7 @@ Process sections in order. For each section:
 
 **§5 Conclusion:**
 - Summarize contributions (NOT copy-paste from intro — rephrase)
-- Limitations (be honest — reviewers appreciate this)
+- Limitations (2-4 material, specific limits — dataset scale, compute regime, assumption X; real ones only, never invented to fill a count. This section is the ONLY home for generic caveats)
 - Future work (1-2 concrete directions)
 - Ethics statement and reproducibility statement (if venue requires)
 - Target: 0.5 pages
@@ -257,6 +257,13 @@ mcp__gemini-review__review_start:
   prompt: |
     Review this [VENUE] paper draft (main body, excluding appendix).
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     Focus on:
     1. Does each claim from the intro have supporting evidence?
     2. Is the writing clear, concise, and free of AI-isms?
@@ -312,6 +319,42 @@ Before declaring done:
 
 ## Key Rules
 
+=== CONFIDENT PROSE, HONEST LIMITS (never upgrades claims) ===
+1. Calibrate each claim to the evidence's actual scope and modality, then state
+   that calibrated claim directly. Necessary assumptions, uncertainty, and
+   scope are part of the claim; stacked hedges and defensive throat-clearing
+   are not.
+2. If the current claim is unsupported, narrow it to a version the evidence
+   supports or cut it. Do not substitute a softer-sounding synonym for fixing
+   scope, modality, comparison, or aggregation.
+3. Put generic caveats and broader boundary discussion in one Limitations
+   section. Outside it, remove generic disclaimers such as "further research
+   is needed", "may not generalize", and "should be interpreted with caution".
+   Claim-defining scope, assumptions, and statistical qualifications stay
+   attached to the claims they make true.
+4. Aim for 2-4 material, specific limitations (dataset scale, compute regime,
+   assumption X). Real ones only — never invent one to meet a count, never
+   apologize generically, never repeat the same limitation through the paper.
+5. Writing instructions are not manuscript content. "Do not mention X" means
+   omit X, not write "we do not address/claim/discuss X". Never expose
+   drafting instructions, requested omissions, reviewer feedback, or revision
+   history in manuscript prose.
+6. Replace self-defence ("we do not claim", "our goal is merely") with a
+   positive, evidence-matched statement of what the paper does establish. If
+   the defensive sentence carries a real boundary, keep that boundary in the
+   claim or Limitations; do not delete truth-conditional content.
+7. Tone-only edits never alter facts, negation, modality, scope, assumptions,
+   comparison direction, aggregation, numbers, formulas, or citations. Genuine
+   overclaims must still be narrowed; supported claims wrapped in redundant
+   caution must be stated directly.
+8. One causal spine: gap -> question -> insight -> consequence -> evidence ->
+   implication. Every section advances it. Make the method feel inevitable:
+   the gap creates a concrete question, the key insight answers it, the method
+   follows from the insight, each major experiment tests a consequence of it,
+   and the conclusion states exactly what the evidence establishes.
+   Front-load the contribution; never narrate the drafting or revision process.
+
+
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
 
 - **Do NOT generate author names, emails, or affiliations** — use anonymous block or placeholder
@@ -319,7 +362,7 @@ Before declaring done:
 - **One file per section** — modular structure for easy editing
 - **Every claim must cite evidence** — cross-reference the Claims-Evidence Matrix
 - **Compile-ready** — the output should compile with `latexmk` without errors (modulo missing figures)
-- **No over-claiming** — use hedging language ("suggests", "indicates") for weak evidence
+- **Calibrate, don't hedge** — match each claim to its evidence's actual scope and modality, then state it directly; generic caveats live in Limitations only (the CONFIDENT PROSE, HONEST LIMITS block above is the contract)
 - **Venue style matters** — all three venues (ICLR/NeurIPS/ICML) use `natbib` (`\citep`/`\citet`)
 - **Page limit = main body to Conclusion** — references and appendix do NOT count
 - **Clean bib** — references.bib must only contain entries that are actually `\cite`d

--- a/skills/skills-codex-gemini-review/paper-writing/SKILL.md
+++ b/skills/skills-codex-gemini-review/paper-writing/SKILL.md
@@ -124,6 +124,13 @@ If the paper plan includes architecture diagrams, pipeline figures, or method il
 [If all auto]: Shall I proceed with LaTeX writing?
 ```
 
+> **Writing invariant (every drafting and revision step):** calibrate each
+> claim to its evidence and state it directly; generic caveats live in the
+> Limitations section only; writing instructions are never manuscript content
+> ("do not mention X" means omit X, not "we do not address X"); tone edits
+> never change what the paper knows. `/paper-write` carries the full
+> CONFIDENT PROSE, HONEST LIMITS contract.
+
 ### Phase 3: LaTeX Writing
 
 Invoke `/paper-write` to generate section-by-section LaTeX:
@@ -197,13 +204,15 @@ Invoke `/auto-paper-improvement-loop` to polish the paper:
 
 **Round 1:** Gemini reviews the full paper → identifies CRITICAL/MAJOR/MINOR issues → Codex implements fixes → recompile → save `main_round1.pdf`
 
-**Round 2:** Gemini re-reviews with conversation context → identifies remaining issues → Codex implements fixes → recompile → save `main_round2.pdf`
+**Round 2:** Gemini re-reviews the recompiled draft cold (fresh review — no fix summaries, no conversation carry-over) → identifies remaining issues → Codex implements fixes → recompile → save `main_round2.pdf`
 
-**Typical improvements:**
+**Typical improvements (calibration cuts both ways):**
 - Fix assumption-model mismatches
-- Soften overclaims to match evidence
+- Narrow genuine overclaims to the supported scope — and state supported claims
+  directly, removing redundant hedges
+- Consolidate scattered generic caveats into Limitations
 - Add missing interpretations and notation
-- Strengthen limitations section
+- Make Limitations more specific (only when a material limit is missing — never pad)
 - Add theory-aligned experiments if needed
 
 **Output:** Three PDFs for comparison + `PAPER_IMPROVEMENT_LOG.md`.

--- a/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
+++ b/skills/skills-codex/auto-paper-improvement-loop/SKILL.md
@@ -200,6 +200,13 @@ spawn_agent:
   message: |
     You are reviewing a [VENUE] paper. Please provide a detailed, structured review.
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     ## Paper Files:
     - LaTeX source: [list all section .tex files]
     - Compiled PDF: paper/main.pdf
@@ -260,12 +267,18 @@ Parse the review and implement fixes by severity:
 
 **Edit-whitelist gate (if set):** If `EDIT_WHITELIST` is set, before applying each proposed edit, check the target path against `allowed_paths` / `forbidden_paths` and the new-lines diff against `forbidden_operations` per the "Optional: Edit Whitelist" section. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 1)` with file, reason (`path` or `operation`), the offending pattern, and the original reviewer concern. The loop continues with remaining edits — a rejection never aborts the round. Surface a rejection summary at the end of the round.
 
+**Before applying any fix:** calibrate claims to evidence and state them
+directly; generic caveats belong in Limitations only; writing instructions are
+never manuscript content; tone edits never change what the paper knows.
+
 **Common fix patterns:**
 
 | Issue | Fix Pattern |
 |-------|-------------|
 | Assumption-model mismatch | Rewrite assumption to match the model, add formal proposition bridging the gap |
-| Overclaims | Soften language: "validate" → "demonstrate practical relevance", "comparable" → "qualitatively competitive" |
+| Genuine overclaim | Narrow the claim itself to the supported scope/modality — never substitute a softer-sounding synonym for fixing scope, comparison, or aggregation |
+| Supported claim wrapped in caution | Remove the redundant hedges; keep any scope qualifier that makes the claim true |
+| Scattered generic caveats | Consolidate into Limitations and delete the duplicates |
 | Missing metrics | Add quantitative table with honest parameter counts and caveats |
 | Theorem not self-contained | Add "Interpretation" paragraph listing all dependencies |
 | Notation confusion | Rename conflicting symbols globally, add Notation paragraph |
@@ -328,6 +341,13 @@ spawn_agent:
   reasoning_effort: xhigh
   message: |
     You are reviewing a [VENUE] paper. This is a fresh, zero-context review.
+
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
     Ignore any prior review rounds, prior fix lists, or executor explanations.
     Judge the paper only from the current LaTeX source and compiled PDF.
 
@@ -390,9 +410,11 @@ If kill-argument returns `verdict: NOT_APPLICABLE`, skip Step 5.5 entirely and p
 
 Same process as Step 3. Typical Round 2 fixes:
 - Add controlled synthetic experiments validating theory
-- Further soften any remaining overclaims
+- Re-check calibration in both directions: narrow genuine overclaims, state
+  supported claims directly, consolidate scattered generic caveats into
+  Limitations — and do not re-soften claims the evidence already supports
 - Formalize informal arguments (e.g., truncation → formal proposition)
-- Strengthen limitations section
+- Make Limitations more specific only when a material limit is missing
 
 **Edit-whitelist gate (if set):** Same as Step 3 — if `EDIT_WHITELIST` is set, run the path + forbidden-operation checks before applying each proposed edit. Rejections are logged to `PAPER_IMPROVEMENT_LOG.md` under `## Rejected by edit_whitelist (Round 2)` and the loop continues. Surface a rejection summary at the end of the round.
 
@@ -552,8 +574,8 @@ paper/
 - **Reviewer independence (Round 2+)**: when `REVIEWER_BIAS_GUARD = true` (default), use a **fresh** `spawn_agent` reviewer for every review round; never use stale reviewer continuation and never include "since last round" / fix summaries in the prompt. See the Reviewer Independence Protocol section above.
 - **Always recompile after fixes** — verify 0 errors before proceeding
 - **Do not fabricate experimental results** — synthetic validation must describe methodology, not invent numbers
-- **Respect the paper's claims** — soften overclaims rather than adding unsupported new claims
-- **Global consistency** — when renaming notation or softening claims, check ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions)
+- **Respect the paper's claims** — narrow genuine overclaims rather than adding unsupported new claims, and state supported claims directly rather than wrapping them in fresh hedges
+- **Global consistency** — when renaming notation or changing a claim's scope, keep every restatement semantically consistent across ALL files (abstract, intro, method, experiments, theory sections, conclusion, tables, figure captions); consistency means matching scope, not copying disclaimer sentences everywhere
 - **Edit-whitelist rejections are LOGGED, not silently dropped** — when `EDIT_WHITELIST` is set and an edit is rejected for a path or forbidden-operation violation, the rejection MUST be appended to `PAPER_IMPROVEMENT_LOG.md` with file, reason, offending pattern, and the original reviewer concern. The loop reports a rejection summary at the end of every round (and in the checkpoint, if `HUMAN_CHECKPOINT = true`). Never silently swallow a whitelist rejection — the audit trail is the whole point of the parameter.
 
 ## Typical Score Progression

--- a/skills/skills-codex/paper-write/SKILL.md
+++ b/skills/skills-codex/paper-write/SKILL.md
@@ -189,7 +189,7 @@ Before drafting the front matter, re-read the one-sentence contribution from `PA
 
 **§5 Conclusion:**
 - Summarize contributions (NOT copy-paste from intro — rephrase)
-- Limitations (be honest — reviewers appreciate this)
+- Limitations (2-4 material, specific limits — dataset scale, compute regime, assumption X; real ones only, never invented to fill a count. This section is the ONLY home for generic caveats)
 - Future work (1-2 concrete directions)
 - Ethics statement and reproducibility statement (if venue requires)
 - Target: 0.5 pages
@@ -324,6 +324,13 @@ spawn_agent:
   message: |
     Review this [VENUE] paper draft (main body, excluding appendix).
 
+    Judge claim calibration in BOTH directions. Recommend narrowing only when the
+    current scope or modality exceeds the evidence; do not ask for extra hedges
+    around a supported result. Flag stacked hedges, self-defence ("we do not
+    claim"), instruction confessions ("we do not address X"), and generic caveats
+    outside Limitations as writing defects to remove. Tone fixes must never alter
+    facts, negation, modality, scope, comparison direction, or numbers.
+
     Focus on:
     1. Does each claim from the intro have supporting evidence?
     2. Is the writing clear, concise, and free of AI-isms?
@@ -372,6 +379,42 @@ Before declaring done:
 
 ## Key Rules
 
+=== CONFIDENT PROSE, HONEST LIMITS (never upgrades claims) ===
+1. Calibrate each claim to the evidence's actual scope and modality, then state
+   that calibrated claim directly. Necessary assumptions, uncertainty, and
+   scope are part of the claim; stacked hedges and defensive throat-clearing
+   are not.
+2. If the current claim is unsupported, narrow it to a version the evidence
+   supports or cut it. Do not substitute a softer-sounding synonym for fixing
+   scope, modality, comparison, or aggregation.
+3. Put generic caveats and broader boundary discussion in one Limitations
+   section. Outside it, remove generic disclaimers such as "further research
+   is needed", "may not generalize", and "should be interpreted with caution".
+   Claim-defining scope, assumptions, and statistical qualifications stay
+   attached to the claims they make true.
+4. Aim for 2-4 material, specific limitations (dataset scale, compute regime,
+   assumption X). Real ones only — never invent one to meet a count, never
+   apologize generically, never repeat the same limitation through the paper.
+5. Writing instructions are not manuscript content. "Do not mention X" means
+   omit X, not write "we do not address/claim/discuss X". Never expose
+   drafting instructions, requested omissions, reviewer feedback, or revision
+   history in manuscript prose.
+6. Replace self-defence ("we do not claim", "our goal is merely") with a
+   positive, evidence-matched statement of what the paper does establish. If
+   the defensive sentence carries a real boundary, keep that boundary in the
+   claim or Limitations; do not delete truth-conditional content.
+7. Tone-only edits never alter facts, negation, modality, scope, assumptions,
+   comparison direction, aggregation, numbers, formulas, or citations. Genuine
+   overclaims must still be narrowed; supported claims wrapped in redundant
+   caution must be stated directly.
+8. One causal spine: gap -> question -> insight -> consequence -> evidence ->
+   implication. Every section advances it. Make the method feel inevitable:
+   the gap creates a concrete question, the key insight answers it, the method
+   follows from the insight, each major experiment tests a consequence of it,
+   and the conclusion states exactly what the evidence establishes.
+   Front-load the contribution; never narrate the drafting or revision process.
+
+
 - **Large file handling**: If the Write tool fails due to file size, immediately retry using Bash (`cat << 'EOF' > file`) to write in chunks. Do NOT ask the user for permission — just do it silently.
 
 - **Do NOT generate author names, emails, or affiliations** — use anonymous block or placeholder
@@ -379,7 +422,7 @@ Before declaring done:
 - **One file per section** — modular structure for easy editing
 - **Every claim must cite evidence** — cross-reference the Claims-Evidence Matrix
 - **Compile-ready** — the output should compile with `latexmk` without errors (modulo missing figures)
-- **No over-claiming** — use hedging language ("suggests", "indicates") for weak evidence
+- **Calibrate, don't hedge** — match each claim to its evidence's actual scope and modality, then state it directly; generic caveats live in Limitations only (the CONFIDENT PROSE, HONEST LIMITS block above is the contract)
 - **Venue style matters** — ML conferences (ICLR/NeurIPS/ICML) use `natbib` (`\citep`/`\citet`); **IEEE venues use `cite` package (`\cite{}`, numeric)**. Never mix.
 - **Page limit rules differ by venue** — ML conferences: main body to Conclusion, references/appendix NOT counted. **IEEE: references ARE counted toward the page limit.**
 - **Clean bib** — references.bib must only contain entries that are actually `\cite`d

--- a/skills/skills-codex/paper-writing/SKILL.md
+++ b/skills/skills-codex/paper-writing/SKILL.md
@@ -258,6 +258,13 @@ These are complementary, not mutually exclusive: you can run multiple generators
 [If all auto]: Shall I proceed with LaTeX writing?
 ```
 
+> **Writing invariant (every drafting and revision step):** calibrate each
+> claim to its evidence and state it directly; generic caveats live in the
+> Limitations section only; writing instructions are never manuscript content
+> ("do not mention X" means omit X, not "we do not address X"); tone edits
+> never change what the paper knows. `/paper-write` carries the full
+> CONFIDENT PROSE, HONEST LIMITS contract.
+
 ### Phase 3: LaTeX Writing
 
 Invoke `/paper-write` to generate section-by-section LaTeX:
@@ -371,13 +378,15 @@ Invoke `/auto-paper-improvement-loop` to polish the paper:
 
 **Round 1:** GPT-5.6-Sol xhigh reviews the full paper → identifies CRITICAL/MAJOR/MINOR issues → Claude Code implements fixes → recompile → save `main_round1.pdf`
 
-**Round 2:** GPT-5.6-Sol xhigh re-reviews with conversation context → identifies remaining issues → Claude Code implements fixes → recompile → save `main_round2.pdf`
+**Round 2:** GPT-5.6-Sol xhigh re-reviews the recompiled draft cold (fresh review — no fix summaries, no conversation carry-over) → identifies remaining issues → Claude Code implements fixes → recompile → save `main_round2.pdf`
 
-**Typical improvements:**
+**Typical improvements (calibration cuts both ways):**
 - Fix assumption-model mismatches
-- Soften overclaims to match evidence
+- Narrow genuine overclaims to the supported scope — and state supported claims
+  directly, removing redundant hedges
+- Consolidate scattered generic caveats into Limitations
 - Add missing interpretations and notation
-- Strengthen limitations section
+- Make Limitations more specific (only when a material limit is missing — never pad)
 - Add theory-aligned experiments if needed
 
 **Output:** Three PDFs for comparison + `PAPER_IMPROVEMENT_LOG.md`.


### PR DESCRIPTION
Community reports: papers read like 忏悔书 — every caveat confessed in every paragraph, 'don't mention X' becomes 'we do not address X' in the manuscript, scattered 'further research is needed' everywhere, and no story. Root causes were our own lines: paper-write taught hedging with no placement rule, the improvement loops' only claim-tone operation was 'soften' — with a Round-2 ratchet ('FURTHER soften any remaining overclaims') and an amplifier ('when softening, check ALL files') that copies caution into every section.

The CONFIDENT PROSE, HONEST LIMITS contract now lives in paper-write and is enforced in both directions by every reviewer prompt: calibrate claims to evidence and state them directly; generic caveats live in Limitations only (claim-defining scope stays with the claim); writing instructions are never manuscript content; tone edits never change what the paper knows; one causal spine — make the method feel inevitable. The overclaim fix-table becomes a three-way judgment (genuine overclaim → narrow the claim itself; supported-but-hedged → remove hedges; scattered caveats → consolidate), and the old lexical row is gone because it violated the lock ('validate'→'demonstrate practical relevance' changes the proposition).

Also fixes a real reviewer-independence bug found in the same pass: the gemini overlay's improvement-loop Round 2 reused the Round-1 thread with 'Since your last review, we have implemented…' — the self-report path mainline was specifically rewritten to eliminate. Now a fresh cold read.

9 files + 2 regenerated overlays; 677 full suite green; zero stale wording.