### PR TITLE
fix(claude-review): let artifact-grounded reviews read their artifacts

### DIFF
--- a/mcp-servers/claude-review/README.md
+++ b/mcp-servers/claude-review/README.md
@@ -47,6 +47,9 @@ codex mcp add claude-review -- ~/.codex/mcp-servers/claude-review/run_with_claud
 
 - The bridge runs Claude in non-interactive `-p` mode.
 - By default the reviewer gets **no tools**. This matches the original ARIS pattern where the external reviewer only sees the prompt context prepared by the executor.
+- A prompt that hands the reviewer **artifact paths** instead of pasted context must therefore opt in per call, e.g. `"tools": "Read,Grep,Glob"`. Without it the reviewer is asked to read files it has no tool to open, and it answers from your framing alone — exactly what artifact-grounded review is meant to avoid. The `skills-codex-claude-review` overlay passes this on its artifact-grounded review blocks; the server default stays tool-free, so prompt-only reviews are unchanged.
+- The opt-in is **per call, not per thread**: every call re-sends `--tools`, so a `review_reply` / `review_reply_start` continuing an artifact-grounded thread has to repeat it.
+- Keep the opt-in read-only. The bridge already runs Claude with `--permission-mode plan`, and a reviewer has no reason to hold `Bash`, `Edit`, or `Write`.
 - `threadId` is the native Claude session id and can be passed directly to `review_reply`.
 - `jobId` is a bridge-local background task id stored on disk under `~/.codex/state/claude-review/jobs/` by default, so status can be resumed across MCP server restarts.
 

--- a/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
+++ b/skills/skills-codex-claude-review/auto-review-loop/SKILL.md
@@ -134,6 +134,9 @@ Send comprehensive context to the external reviewer:
 
 ```
 mcp__claude-review__review_start:
+  # the bridge grants the reviewer no tools by default; this prompt passes
+  # artifact paths, so it has to ask for read-only access explicitly
+  tools: "Read,Grep,Glob"
   prompt: |
     [Round N/MAX_ROUNDS of autonomous review loop]
 
@@ -434,6 +437,9 @@ When loop ends (positive assessment or max rounds):
 
 ```
 mcp__claude-review__review_reply_start:
+  # the bridge grants the reviewer no tools by default; this prompt passes
+  # artifact paths, so it has to ask for read-only access explicitly
+  tools: "Read,Grep,Glob"
   threadId: [saved from round 1]
   # inherits the agent's model/effort — do not re-send
   prompt: |

--- a/skills/skills-codex-claude-review/research-review/SKILL.md
+++ b/skills/skills-codex-claude-review/research-review/SKILL.md
@@ -94,6 +94,9 @@ Use `mcp__claude-review__review_reply_start` with the saved completed `threadId`
 
 ```
 mcp__claude-review__review_reply_start:
+  # the bridge grants the reviewer no tools by default; this prompt passes
+  # artifact paths, so it has to ask for read-only access explicitly
+  tools: "Read,Grep,Glob"
   threadId: [saved reviewer id from Step 2]
   prompt: |
     Please continue the review using the revised materials below.

--- a/tests/test_claude_review_artifact_tools.py
+++ b/tests/test_claude_review_artifact_tools.py
@@ -1,0 +1,168 @@
+"""The artifact-grounded review path must be able to open its artifacts.
+
+`auto-review-loop` and `research-review` stopped pasting evidence into the
+reviewer prompt and now hand over artifact paths ("read the files yourself").
+The claude-review bridge, meanwhile, runs Claude with `--tools ""` by default,
+which is correct for the prompt-only reviews it was built for but leaves an
+artifact-grounded reviewer with no tool to open what the prompt points at — it
+answers from the executor's framing, the one thing artifact-grounded review
+exists to prevent.
+
+The fix is per-call, not a new global default: blocks that pass paths opt into
+read-only tools, prompt-only blocks stay tool-free. These tests pin both halves.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.generate_codex_claude_review_overrides import (
+    ARTIFACT_REVIEW_TOOLS,
+    REVIEW_CALL_BLOCK_RE,
+    TOOLS_KEY_RE,
+    is_artifact_grounded,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OVERLAY = REPO_ROOT / "skills" / "skills-codex-claude-review"
+SERVER_PATH = REPO_ROOT / "mcp-servers" / "claude-review" / "server.py"
+
+SPEC = importlib.util.spec_from_file_location("claude_review_server", SERVER_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+# Which overlay skills hand the reviewer artifact paths, and how many review
+# calls in each do so. A base-skill edit that adds or removes artifact-grounded
+# review prompts should land here deliberately, not silently.
+EXPECTED_ARTIFACT_BLOCKS = {
+    "auto-review-loop": 2,      # round-1 artifact review + round-2 changed-files reply
+    "research-review": 1,       # "Revised files:" follow-up round
+}
+
+# Read-only means read-only: a reviewer never edits the work it reviews.
+WRITE_TOOLS = ("Bash", "Edit", "Write", "NotebookEdit", "WebFetch", "Task")
+
+
+def _review_blocks() -> list[tuple[str, str]]:
+    """Every claude-review call block in the overlay, as (skill, block)."""
+    blocks = []
+    for skill_file in sorted(OVERLAY.rglob("SKILL.md")):
+        text = skill_file.read_text(encoding="utf-8")
+        for match in REVIEW_CALL_BLOCK_RE.finditer(text):
+            blocks.append((skill_file.parent.name, match.group(0)))
+    return blocks
+
+
+class OverlayOptInTests(unittest.TestCase):
+    def test_overlay_has_review_blocks_to_check(self) -> None:
+        """Guard against a regex/layout change silently emptying every case below."""
+        self.assertGreater(len(_review_blocks()), 5)
+
+    def test_tools_opt_in_tracks_artifact_grounded_prompts(self) -> None:
+        for skill, block in _review_blocks():
+            header = block.splitlines()[1]
+            with self.subTest(skill=skill, header=header, prompt=block[:200]):
+                self.assertEqual(
+                    bool(TOOLS_KEY_RE.search(block)),
+                    is_artifact_grounded(block),
+                    "a review block must request tools exactly when its prompt "
+                    "hands the reviewer artifact paths",
+                )
+
+    def test_opt_in_blocks_request_the_readonly_preset(self) -> None:
+        for skill, block in _review_blocks():
+            if not TOOLS_KEY_RE.search(block):
+                continue
+            with self.subTest(skill=skill):
+                self.assertIn(f'tools: "{ARTIFACT_REVIEW_TOOLS}"', block)
+
+    def test_expected_skills_opt_in(self) -> None:
+        counts: dict[str, int] = {}
+        for skill, block in _review_blocks():
+            if TOOLS_KEY_RE.search(block):
+                counts[skill] = counts.get(skill, 0) + 1
+        self.assertEqual(
+            counts,
+            EXPECTED_ARTIFACT_BLOCKS,
+            "artifact-grounded review blocks changed; regenerate the overlay "
+            "(python tools/generate_codex_claude_review_overrides.py) and update "
+            "EXPECTED_ARTIFACT_BLOCKS if the change is intended",
+        )
+
+
+class ReadOnlyPresetTests(unittest.TestCase):
+    def test_preset_is_readonly(self) -> None:
+        granted = ARTIFACT_REVIEW_TOOLS.split(",")
+        self.assertEqual(granted, ["Read", "Grep", "Glob"])
+        for tool in WRITE_TOOLS:
+            self.assertNotIn(tool, granted)
+
+
+class BridgeDefaultTests(unittest.TestCase):
+    """The bridge default must not move: prompt-only reviews stay tool-free."""
+
+    def _cmd(self, **kwargs) -> list[str]:
+        with mock.patch.object(MODULE, "find_claude_bin", return_value="/fake/claude"):
+            return MODULE.build_command("review this", **kwargs)
+
+    def test_default_disables_all_tools(self) -> None:
+        cmd = self._cmd()
+        self.assertEqual(cmd[cmd.index("--tools") + 1], "")
+
+    def test_explicit_readonly_tools_are_forwarded(self) -> None:
+        cmd = self._cmd(tools=ARTIFACT_REVIEW_TOOLS)
+        self.assertEqual(cmd[cmd.index("--tools") + 1], "Read,Grep,Glob")
+
+    def test_explicit_empty_string_still_disables_tools(self) -> None:
+        """`tools: ""` is an explicit prompt-only request, not "unset"."""
+        cmd = self._cmd(tools="")
+        self.assertEqual(cmd[cmd.index("--tools") + 1], "")
+
+    def test_reviewer_stays_in_plan_permission_mode(self) -> None:
+        """Read-only tools plus plan mode: the reviewer cannot write either way."""
+        cmd = self._cmd(tools=ARTIFACT_REVIEW_TOOLS)
+        self.assertEqual(cmd[cmd.index("--permission-mode") + 1], "plan")
+
+    def test_tools_are_resent_on_every_resumed_call(self) -> None:
+        """Each reply is a fresh `--resume` process, so the opt-in cannot be
+        inherited from the round that opened the thread."""
+        cmd = self._cmd(session_id="sess-1", tools=ARTIFACT_REVIEW_TOOLS)
+        self.assertIn("--resume", cmd)
+        self.assertEqual(cmd[cmd.index("--tools") + 1], "Read,Grep,Glob")
+
+
+class GeneratorDriftTests(unittest.TestCase):
+    def test_checked_in_overlay_matches_generator_output(self) -> None:
+        """The overlay is generated; hand-edits to SKILL.md would be lost."""
+        from tools import generate_codex_claude_review_overrides as gen
+
+        for skill in gen.TARGET_SKILLS:
+            source = (gen.SRC_ROOT / skill / "SKILL.md").read_text(encoding="utf-8")
+            match = gen.FRONTMATTER_RE.match(source)
+            assert match is not None
+            body = source[match.end():].lstrip("\n")
+            name = gen.extract_field(match.group(1), "name") or skill
+            description = gen.normalize_description(
+                gen.extract_field(match.group(1), "description")
+            )
+            expected = gen.build_frontmatter(name, description)
+            expected += gen.OVERRIDE_NOTE + "\n\n"
+            expected += gen.transform_body(body).rstrip() + "\n"
+
+            actual = (gen.DEST_ROOT / skill / "SKILL.md").read_text(encoding="utf-8")
+            with self.subTest(skill=skill):
+                self.assertEqual(
+                    actual,
+                    expected,
+                    f"{skill} overlay is stale; run "
+                    "python tools/generate_codex_claude_review_overrides.py",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/generate_codex_claude_review_overrides.py
+++ b/tools/generate_codex_claude_review_overrides.py
@@ -28,6 +28,32 @@ TARGET_SKILLS = [
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
 SPAWN_BLOCK_RE = re.compile(r"```(?:yaml|text)?\nspawn_agent:\n([\s\S]*?)```")
 SEND_BLOCK_RE = re.compile(r"```(?:yaml|text)?\nsend_input:\n([\s\S]*?)```")
+REVIEW_CALL_BLOCK_RE = re.compile(
+    r"```(?:yaml|text)?\n(?:mcp__claude-review__review_start:|mcp__claude-review__review_reply_start:)[\s\S]*?```"
+)
+TOOLS_KEY_RE = re.compile(r"^\s{2}tools:", re.MULTILINE)
+
+# The claude-review bridge runs the reviewer with `--tools ""` by default: the
+# executor pastes every piece of evidence into the prompt, so the reviewer needs
+# no filesystem access at all. Some review prompts instead hand the reviewer
+# artifact paths and tell it to open them itself. Those calls have to opt into
+# read-only tools, or the reviewer is told to read files it has no tool to read.
+ARTIFACT_REVIEW_TOOLS = "Read,Grep,Glob"
+ARTIFACT_TOOLS_COMMENT = (
+    "  # the bridge grants the reviewer no tools by default; this prompt passes\n"
+    "  # artifact paths, so it has to ask for read-only access explicitly\n"
+)
+
+# A review block is artifact-grounded when its prompt points the reviewer at a
+# path instead of pasting the evidence inline.
+ARTIFACT_PROMPT_CUES = (
+    "read the files yourself",
+    "read them yourself",
+    "read the diff",
+    "read the raw diff",
+    "verbatim files",
+    "/absolute/path/to/",
+)
 
 OVERRIDE_NOTE = (
     "> Override for Codex users who want **Claude Code**, not a second Codex agent, "
@@ -157,11 +183,30 @@ def append_async_notes(text: str) -> str:
             return block
         return f"{block}\n\n{note}"
 
-    return re.sub(
-        r"```(?:yaml|text)?\n(?:mcp__claude-review__review_start:|mcp__claude-review__review_reply_start:)[\s\S]*?```",
-        repl,
-        text,
-    )
+    return REVIEW_CALL_BLOCK_RE.sub(repl, text)
+
+
+def is_artifact_grounded(block: str) -> bool:
+    lowered = block.lower()
+    return any(cue in lowered for cue in ARTIFACT_PROMPT_CUES)
+
+
+def add_artifact_review_tools(text: str) -> str:
+    """Opt artifact-grounded review calls into read-only reviewer tools.
+
+    Prompt-only blocks are left alone so the bridge default (`--tools ""`)
+    keeps covering them.
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        block = match.group(0)
+        if TOOLS_KEY_RE.search(block) or not is_artifact_grounded(block):
+            return block
+        header_end = block.index("\n", block.index("mcp__claude-review__review_")) + 1
+        opt_in = f'{ARTIFACT_TOOLS_COMMENT}  tools: "{ARTIFACT_REVIEW_TOOLS}"\n'
+        return f"{block[:header_end]}{opt_in}{block[header_end:]}"
+
+    return REVIEW_CALL_BLOCK_RE.sub(repl, text)
 
 
 def transform_body(text: str) -> str:
@@ -263,7 +308,7 @@ def transform_body(text: str) -> str:
     text = text.replace("agent id", "completed threadId")
     text = text.replace("agent ID", "completed threadId")
     text = text.replace("same agent", "same completed threadId")
-    return append_async_notes(text)
+    return append_async_notes(add_artifact_review_tools(text))
 
 
 def generate_one(skill_name: str) -> None:


### PR DESCRIPTION
## Problem

The `claude-review` bridge runs Claude with `--tools ""` by default. That is the
right default for the reviews it was built for: the executor pastes every piece
of evidence into the prompt, so the reviewer needs no filesystem access at all.
The README states this as the intended contract.

Three review calls in the `skills-codex-claude-review` overlay no longer work
that way. They hand the reviewer artifact **paths** and tell it to open them
itself:

| Skill | Prompt |
|---|---|
| `auto-review-loop` (round 1) | "read the files yourself rather than trusting my framing" · `- Claims / paper draft: <path>` |
| `auto-review-loop` (round 2+) | "these files changed — read them yourself; do not take my word for what changed or whether it worked" |
| `research-review` (step 3) | "Please continue the review using the revised materials below. Revised files: `- /absolute/path/to/file1`" |

None of them passes `tools`, so each runs on the tool-free default and the
reviewer has no tool to open what the prompt points at.

The failure is silent, and it defeats the point of the prompts themselves: an
artifact-grounded reviewer that cannot reach the artifacts falls back to the
executor's framing — the one thing those prompts exist not to trust.

## Reproduction

Against the real CLI, with the same prompt shape and permission mode the bridge
builds in `build_command`:

```
$ claude -p "Read the file <path> and reply with ONLY the token it contains. Do not guess." \
    --output-format json --permission-mode plan --tools ""
**Read**
*Path: `_probe_artifact.txt`*
```

The reviewer emits a *textual imitation* of a `Read` call and never sees the
file. With read-only tools granted:

```
$ claude -p "<same prompt>" --output-format json --permission-mode plan --tools "Read,Grep,Glob"
The token contained in the file is: **SECRET_MARKER_ARIS_9f31**
```

## Root cause

Workflow semantics and reviewer capability drifted apart. The review prompts
moved from pasted context to artifact paths; the capability configuration those
calls run under did not follow.

## This is specific to `claude-review`

I checked every reviewer backend before assuming a systemic gap — there isn't
one. `claude-review` is the only backend that runs artifact-path prompts
without the capability to act on them:

| Backend | Reads artifacts? | Runs artifact-path prompts? |
|---|---|---|
| `codex` (`mcp__codex__codex`) | yes — "Reads listed files" per the capability table in `reviewer-routing.md` | yes |
| `copilot` (`copilot --agent`) | yes — explicitly `--allow-tool=read` | yes |
| `manual` | yes — a human opens them | yes |
| **`claude-review`** | **no — `--tools ""`** | **yes** |
| `gemini-review` (agy) | no — `tools` "accepted for compatibility but ignored" | no |
| `llm-chat` / `minimax-chat` | no — plain HTTP API | no |

The API-backed reviewers are self-consistent: their skills paste evidence into
the prompt and never pass paths, so a tool-free reviewer is exactly right.

The interesting row is `copilot`. It is the other reviewer that runs as a CLI
subprocess against these same prompts, and it already does what this PR adds —
`--allow-tool=read` per review call, with "File reading … **Verified** —
profile + `--allow-tool=read`" recorded in the capability table in
`skills/shared-references/reviewer-routing.md`.

So the read-only opt-in for artifact-grounded review is an established
convention here, not a new design. `claude-review` is the one backend that
never got it.

## Fix

Per call, not by moving the default. The overlay generator now adds an explicit
read-only opt-in to review blocks whose prompt hands over paths:

```
mcp__claude-review__review_start:
  # the bridge grants the reviewer no tools by default; this prompt passes
  # artifact paths, so it has to ask for read-only access explicitly
  tools: "Read,Grep,Glob"
  prompt: |
    ...
```

`skills/skills-codex-claude-review/` is generated, so the change is in
`tools/generate_codex_claude_review_overrides.py` and the overlay is
regenerated. A block is treated as artifact-grounded when its prompt points the
reviewer at a path instead of pasting the evidence inline; 3 of the 13 review
blocks in the overlay match, the other 10 are untouched.

**No server change.** `tools` was already accepted, forwarded, and persisted
across the async job path for all four review tools
(`review` / `review_reply` / `review_start` / `review_reply_start` →
job state → worker → `build_command` → `--tools`). The bug was only that the
skill never asked.

## Compatibility

- Bridge default stays `--tools ""` — prompt-only review behaviour is unchanged.
- Prompt-only blocks keep running tool-free; only the 3 artifact-grounded blocks opt in.
- No write capability anywhere: no `Bash`, no `Edit`, no `Write`. The bridge already pins `--permission-mode plan` as a second layer.
- No new environment variable, flag, or config surface.

## One gotcha, now documented

The opt-in is **per call, not per thread**. Every call re-sends `--tools`, so a
`review_reply_start` continuing an artifact-grounded thread has to repeat it —
otherwise the reviewer silently loses file access mid-thread. Round-2 blocks
carry the opt-in for this reason, and the bridge README now says so next to the
default it qualifies.

## Tests

New `tests/test_claude_review_artifact_tools.py` (11 tests) pins both halves of
the contract:

- bridge default stays tool-free; explicit `""` still disables tools
- explicit read-only tools are forwarded, and re-sent on resumed (`--resume`) calls
- reviewer stays in `plan` permission mode
- opt-in tracks artifact-grounded prompts **exactly** — artifact blocks request tools, prompt-only blocks do not
- the granted preset contains no write tools
- the checked-in overlay matches generator output (guards hand-edits to generated files)

Verified the tests actually catch the bug: **3 of 11 fail** against the
pre-fix overlay, all pass after.

Full suite locally: `582 → 593 passed`, no new failures. Pre-existing failures
on my machine are Windows-only (encoding, bash helpers, tty) and reproduce on a
clean checkout; CI runs Linux/macOS. `python tools/check_skills_inventory.py`
passes.

## Out of scope

Nothing else needs the same treatment — see the backend table above. In
particular `skills-codex-gemini-review` has the same overlay shape but does not
use artifact-path prompts, so its tool-free reviewer stays correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
